### PR TITLE
feat: redesign phase 1 — DOT-inspired tokens + Instrument Serif

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -561,7 +561,7 @@ function AskTab() {
       <div className="shrink-0">
         <div
           className="h-6 pointer-events-none"
-          style={{ background: "linear-gradient(to top, #111111 0%, transparent 100%)" }}
+          style={{ background: "linear-gradient(to top, #0E0B0A 0%, transparent 100%)" }}
         />
         <div
           className="px-4 bg-brew-bg"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,20 +4,20 @@
 
 :root {
   /* Dark theme */
-  --background: #111111;
+  --background: #0E0B0A;
   --foreground: #FFFFFF;
-  --card: #1A1A1A;
+  --card: #171311;
   --card-foreground: #FFFFFF;
-  --border: #2E2E2E;
-  --primary: #D4B896;
-  --primary-foreground: #1A1008;
-  --secondary: #2E2E2E;
+  --border: #2E2A27;
+  --primary: #E8C5A8;
+  --primary-foreground: #1A130E;
+  --secondary: #2E2A27;
   --secondary-foreground: #FFFFFF;
-  --muted: #2E2E2E;
-  --muted-foreground: #B8B9B6;
+  --muted: #2E2A27;
+  --muted-foreground: #B8ADA4;
   --destructive: #FF5C33;
-  --ring: #666666;
-  --input: #2E2E2E;
+  --ring: #6B635D;
+  --input: #2E2A27;
   /* Semantic */
   --color-success: #222924;
   --color-success-foreground: #B6FFCE;
@@ -27,8 +27,31 @@
   --color-error-foreground: #FF5C33;
   --color-info: #222229;
   --color-info-foreground: #B2B2FF;
-  /* Radii */
-  --radius-m: 16px;
+  /* DOT-inspired redesign tokens — spec: docs/redesign/spec.md §2.
+     These mirror the spec's --bg-*, --surface-*, --text-*, --border-* names.
+     Tailwind keys under `dot.*` reference these via var(). */
+  --bg-base: #0E0B0A;
+  --bg-gradient-warm: #3A2018;
+  --bg-gradient-glow: #6B4838;
+  --bg-gradient-cool: #1A1614;
+  --surface-1: #171311;
+  --surface-2: #1F1A17;
+  --surface-pill-user: #F5ECE5;
+  --surface-pill-input: rgba(28,22,19,0.65);
+  --surface-pill-attach: rgba(40,30,26,0.7);
+  --text-primary: #F0E8E1;
+  --text-on-pill-user: #1A130E;
+  --text-secondary: #B8ADA4;
+  --text-muted: #6B635D;
+  --text-accent: #E8C5A8;
+  --border-subtle: rgba(255,235,220,0.08);
+  --scrim-dialog: rgba(8,5,4,0.55);
+  /* Radii (spec §4) */
+  --radius-sm: 8px;
+  --radius-md: 14px;
+  --radius-m: 16px; /* legacy alias — pre-redesign components */
+  --radius-lg: 22px;
+  --radius-xl: 28px;
   --radius-pill: 999px;
   /* Font stacks */
   --font-primary: var(--font-jetbrains-mono), 'JetBrains Mono', monospace;
@@ -59,13 +82,13 @@
 
   html {
     height: 100%;
-    background-color: #111111;
+    background-color: #0E0B0A;
   }
 
   body {
     height: 100%;
     overflow: hidden;
-    background-color: #111111;
+    background-color: #0E0B0A;
     color: #FFFFFF;
     font-family: var(--font-geist-sans), system-ui, sans-serif;
     overscroll-behavior: none;
@@ -86,6 +109,14 @@
     font-family: var(--font-geist-sans), system-ui, sans-serif;
     font-weight: 600;
   }
+  /* DOT-inspired editorial face — used by Phase 2/3 hero/loading moments
+     (spec §3). Existing .font-display stays Geist 600 for the 17+ titles
+     already consuming it; that audit is its own slice. */
+  .font-editorial {
+    font-family: var(--font-instrument-serif), Georgia, serif;
+    font-weight: 400;
+    letter-spacing: -0.01em;
+  }
   .font-mono-num {
     font-family: var(--font-geist-mono), var(--font-jetbrains-mono), 'Fira Code', monospace;
   }
@@ -96,8 +127,8 @@
     letter-spacing: 0.08em;
     text-transform: uppercase;
   }
-  .text-gradient-amber {
-    background: linear-gradient(135deg, #D4B896, #ffffff);
+  .text-gradient-warm {
+    background: linear-gradient(135deg, #E8C5A8, #ffffff);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
     background-clip: text;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Suspense } from "react";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
-import { JetBrains_Mono } from "next/font/google";
+import { JetBrains_Mono, Instrument_Serif } from "next/font/google";
 import "./globals.css";
 import BottomNav from "@/components/layout/BottomNav";
 import ScrollContainer from "@/components/layout/ScrollContainer";
@@ -11,6 +11,14 @@ const jetbrainsMono = JetBrains_Mono({
   subsets: ["latin"],
   weight: ["400", "500"],
   variable: "--font-jetbrains-mono",
+});
+
+const instrumentSerif = Instrument_Serif({
+  subsets: ["latin"],
+  weight: ["400"],
+  style: ["normal", "italic"],
+  variable: "--font-instrument-serif",
+  display: "swap",
 });
 
 export const metadata: Metadata = {
@@ -29,12 +37,12 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
-  themeColor: "#111111",
+  themeColor: "#0E0B0A",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable} ${jetbrainsMono.variable}`}>
+    <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable} ${jetbrainsMono.variable} ${instrumentSerif.variable}`}>
       <head>
         <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
         <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />

--- a/src/components/cafes/CafeMap.tsx
+++ b/src/components/cafes/CafeMap.tsx
@@ -44,7 +44,7 @@ async function geocafe(name: string, location?: string): Promise<{ lat: number; 
 }
 
 const PIN_HTML = `<svg width="28" height="36" viewBox="0 0 28 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="#D4B896"/>
+  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="#E8C5A8"/>
   <circle cx="14" cy="14" r="5" fill="#1A1008"/>
 </svg>`;
 
@@ -56,14 +56,14 @@ const PIN_SELECTED_HTML = `<svg width="28" height="36" viewBox="0 0 28 36" fill=
 
 // not-visited + not-selected: no fill, accent outline, hollow inner dot
 const GHOST_PIN_HTML = `<svg width="24" height="31" viewBox="-2 -2 32 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="none" stroke="#D4B896" stroke-width="2.5"/>
-  <circle cx="14" cy="14" r="4" fill="none" stroke="#D4B896" stroke-width="2"/>
+  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="none" stroke="#E8C5A8" stroke-width="2.5"/>
+  <circle cx="14" cy="14" r="4" fill="none" stroke="#E8C5A8" stroke-width="2"/>
 </svg>`;
 
 // not-visited + selected: white body, accent outline, solid accent dot — distinct from all three above
 const GHOST_PIN_SELECTED_HTML = `<svg width="24" height="31" viewBox="-2 -2 32 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="#FFFFFF" stroke="#D4B896" stroke-width="2.5"/>
-  <circle cx="14" cy="14" r="4" fill="#D4B896"/>
+  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="#FFFFFF" stroke="#E8C5A8" stroke-width="2.5"/>
+  <circle cx="14" cy="14" r="4" fill="#E8C5A8"/>
 </svg>`;
 
 const YOU_ARE_HERE_HTML = `

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -36,7 +36,7 @@ export default function BottomNav() {
         paddingLeft: "16px",
         paddingRight: "16px",
         paddingBottom: "env(safe-area-inset-bottom)",
-        background: "#111111",
+        background: "var(--bg-base)",
       }}
     >
       <div

--- a/src/components/ui/CoffeeBeanGlow.tsx
+++ b/src/components/ui/CoffeeBeanGlow.tsx
@@ -62,20 +62,20 @@ export default function CoffeeBeanGlow({
       {/* Dim static bean outline */}
       <path
         d="M 14,50 C 14,26 26,7 50,7 C 74,7 86,26 86,50 C 86,74 74,93 50,93 C 26,93 14,74 14,50 Z"
-        stroke="#D4B896" strokeOpacity={0.2} strokeWidth={1.5}
+        stroke="#E8C5A8" strokeOpacity={0.2} strokeWidth={1.5}
       />
 
       {/* Dim static S-crease */}
       <path
         d={staticCrease}
-        stroke="#D4B896" strokeOpacity={0.15} strokeWidth={1.5}
+        stroke="#E8C5A8" strokeOpacity={0.15} strokeWidth={1.5}
         strokeLinecap="round"
       />
 
       {/* Halo layer — blurred, wider */}
       <path
         d={figurePath}
-        stroke="#D4B896"
+        stroke="#E8C5A8"
         strokeOpacity={0.5}
         strokeWidth={4.5}
         strokeLinecap="round"
@@ -94,7 +94,7 @@ export default function CoffeeBeanGlow({
       {/* Core layer — crisp, bright */}
       <path
         d={figurePath}
-        stroke="#D4B896"
+        stroke="#E8C5A8"
         strokeOpacity={0.92}
         strokeWidth={2}
         strokeLinecap="round"

--- a/src/lib/theme/gradients.ts
+++ b/src/lib/theme/gradients.ts
@@ -1,0 +1,42 @@
+/**
+ * Named gradient class strings for the BrewLog redesign (spec §2.4).
+ *
+ * One source of truth — components import these instead of scattering
+ * `bg-[radial-gradient(...)]` literals. Each gradient pairs a base radial
+ * with optional offset glow rendered via `::before` in the consuming
+ * component's wrapper (see Phase 2 primitives).
+ *
+ * Reference images: docs/redesign/dot-refs/Splashscreen2_*.png +
+ * LoadingScreen_*.png (chat); GradientBackground_*.png (hero).
+ */
+
+/**
+ * Full chat-surface gradient. Two warm radial stops on the dark base.
+ * Use as the wrapper background behind the message scroll area.
+ *
+ * Stops:
+ *  - top-left peak  (warm-peak → warm-mid → base) ~55% radius
+ *  - bottom-right (warm-mid at low alpha) ~70% radius
+ */
+export const gradientChatBg =
+  "bg-[radial-gradient(ellipse_55%_45%_at_15%_10%,var(--bg-gradient-glow)_0%,var(--bg-gradient-warm)_35%,var(--bg-base)_75%),radial-gradient(ellipse_60%_50%_at_85%_90%,rgba(107,72,56,0.35)_0%,transparent_60%)] bg-[color:var(--bg-base)]";
+
+/**
+ * Tighter hero gradient for the home feed hero card and Phase 4 brew
+ * recommend candidates. Single warm stop, less drama than the chat bg.
+ */
+export const gradientHeroSurface =
+  "bg-[radial-gradient(ellipse_70%_60%_at_30%_20%,var(--bg-gradient-warm)_0%,var(--bg-base)_70%)] bg-[color:var(--bg-base)]";
+
+/**
+ * Subtle warm-on-warm fill for the cream user message bubble — adds
+ * dimensionality without breaking the flat-pill read.
+ */
+export const gradientPillUser =
+  "bg-[linear-gradient(135deg,#FBF4ED_0%,#F1E5DA_100%)]";
+
+/**
+ * Primary CTA fill (Phase 2/3 — Brew button, send arrow background).
+ */
+export const gradientButtonPrimary =
+  "bg-[linear-gradient(135deg,#F1D2B6_0%,#E8C5A8_60%,#D4A98A_100%)]";

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,24 +10,59 @@ const config: Config = {
     extend: {
       colors: {
         brew: {
-          bg: "#111111",
-          surface: "#1A1A1A",
-          elevated: "#2A2A2A",
-          accent: "#D4B896",
-          "accent-fg": "#1A1008",
-          muted: "#B8B9B6",
-          subtle: "#666666",
-          border: "#2E2E2E",
+          bg: "#0E0B0A",
+          surface: "#171311",
+          elevated: "#1F1A17",
+          accent: "#E8C5A8",
+          "accent-fg": "#1A130E",
+          muted: "#B8ADA4",
+          subtle: "#6B635D",
+          border: "#2E2A27",
           success: "#5A9E5A",
+        },
+        // DOT-inspired redesign tokens (spec: docs/redesign/spec.md §2).
+        // Each value is a CSS var so :root is the single source of truth.
+        dot: {
+          base: "var(--bg-base)",
+          "warm-mid": "var(--bg-gradient-warm)",
+          "warm-peak": "var(--bg-gradient-glow)",
+          cool: "var(--bg-gradient-cool)",
+          s1: "var(--surface-1)",
+          s2: "var(--surface-2)",
+          "pill-user": "var(--surface-pill-user)",
+          ink: "var(--text-primary)",
+          "on-pill": "var(--text-on-pill-user)",
+          "ink-soft": "var(--text-secondary)",
+          "ink-mute": "var(--text-muted)",
+          accent: "var(--text-accent)",
+          edge: "var(--border-subtle)",
         },
       },
       fontFamily: {
-        serif: ["var(--font-geist-sans)", "system-ui", "sans-serif"],
+        serif: ["var(--font-instrument-serif)", "Georgia", "serif"],
+        display: ["var(--font-instrument-serif)", "Georgia", "serif"],
         sans: ["var(--font-geist-sans)", "Inter", "system-ui", "sans-serif"],
         mono: ["var(--font-geist-mono)", "var(--font-jetbrains-mono)", "Fira Code", "monospace"],
       },
       borderRadius: {
+        sm: "8px",
+        md: "14px",
+        lg: "22px",
+        xl: "28px",
+        pill: "999px",
         "4xl": "2rem",
+      },
+      boxShadow: {
+        "glow-subtle": "0 0 60px rgba(232,197,168,0.08)",
+        "glow-strong": "0 0 90px rgba(232,197,168,0.18)",
+      },
+      transitionTimingFunction: {
+        spring: "cubic-bezier(0.32, 0.72, 0, 1)",
+      },
+      transitionDuration: {
+        quick: "160ms",
+        base: "240ms",
+        slow: "480ms",
       },
       spacing: {
         "safe-bottom": "env(safe-area-inset-bottom)",


### PR DESCRIPTION
## Summary
Lays the foundation primitives (Phase 2) and chat surface (Phase 3) will consume — per `docs/redesign/spec.md` §2, §3, §4.

- **Tailwind**: new `dot.*` namespace pointing at CSS vars (single source). Re-tint legacy `brew.bg` (`#111` → `#0E0B0A`) and `brew.accent` (`#D4B896` → `#E8C5A8`) so the 519 existing consumers visually upgrade without a class-rename sweep. Adds spec radius scale (`sm/md/lg/xl/pill`), `glow-subtle` / `glow-strong` shadows, spring easing, motion durations.
- **globals.css**: full set of `--bg-*`, `--surface-*`, `--text-*`, `--border-subtle`, `--scrim-dialog`, `--radius-*` vars. Renames `.text-gradient-amber` → `.text-gradient-warm` (re-tinted). Adds `.font-editorial` utility for Instrument Serif — only used by Phase 2/3 hero/loading moments. Existing `.font-display` stays Geist 600; flipping the 17 page titles to serif is its own slice.
- **Layout**: load Instrument Serif via `next/font/google` (~30 KB woff2 budget per spec). PWA `themeColor` → `#0E0B0A`.
- **Hex leak cleanup**: `BottomNav` fixed-bg, `/explore` input gradient, `CafeMap` pin SVGs, `CoffeeBeanGlow` strokes — all on the new palette.
- **`src/lib/theme/gradients.ts`**: named exports (`gradientChatBg`, `gradientHeroSurface`, `gradientPillUser`, `gradientButtonPrimary`) so components stop scattering radial-gradient literals.

## Visible delta
The accent shifts slightly warmer/pinker (`#D4B896` → `#E8C5A8`); base shifts marginally warmer (`#111111` → `#0E0B0A`). Visible on every screen on first deploy. No AI prompt or behavioural changes.

## Test plan
- [ ] `npx tsc --noEmit` clean
- [ ] Tailwind builds without warnings
- [ ] PWA themeColor on iOS shows the new warm-black status bar
- [ ] No visual regression in: home feed, brew flow, explore chat, café map (pins now warmer-pink)
- [ ] Instrument Serif loaded (verify in DevTools network tab on first paint)

https://claude.ai/code/session_01YeXEJqQK69ETBQEDfN3EvF

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALX392Z8HNYb5JD5mNh3zw)_