### PR TITLE
feat: redesign phase 3b — live waveform recording dock

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import dynamic from "next/dynamic";
 import CoffeeBeanGlow from "@/components/ui/CoffeeBeanGlow";
 import ThinkingDots from "@/components/ui/ThinkingDots";
+import WaveformBars from "@/components/ui/WaveformBars";
 import type { Session } from "@/lib/types/session";
 import type { CafeSummary } from "@/lib/types/cafes";
 import { ArrowUp, FlaskConical, Thermometer, RotateCcw, Globe, BookOpen, MapPin, Crosshair, User, Mic, Square, Volume2, VolumeX, X, Plus, Camera, Coffee } from "lucide-react";
@@ -766,7 +767,37 @@ function AskTab() {
           </div>
         )}
 
-        {/* The pill itself */}
+        {/* Recording dock — replaces the input pill while capture is active.
+            Spec §6.3: full-width waveform across most of the dock, stop
+            button on the right (filled square in a circle). No timer. */}
+        {capture.recording ? (
+          <div
+            className="flex items-center gap-2 rounded-full border border-dot-edge backdrop-blur-xl shadow-glow-strong px-3"
+            style={{ background: "var(--surface-pill-input)", minHeight: 52 }}
+          >
+            <span
+              className="w-2 h-2 rounded-full animate-pulse shrink-0"
+              style={{ background: "var(--text-accent)" }}
+              aria-label="Recording"
+            />
+            <WaveformBars
+              getLevel={capture.getLevel}
+              bars={32}
+              height={32}
+              className="flex-1 min-w-0"
+            />
+            <button
+              type="button"
+              onClick={() => void capture.stop()}
+              disabled={capture.busy}
+              aria-label="Stop recording"
+              className="w-10 h-10 rounded-full flex items-center justify-center shrink-0 active:scale-95 transition-all disabled:opacity-40"
+              style={{ background: "var(--text-accent)", color: "var(--bg-base)" }}
+            >
+              <Square size={14} fill="currentColor" />
+            </button>
+          </div>
+        ) : (
         <div
           className="flex items-center gap-1 rounded-full border border-dot-edge backdrop-blur-xl shadow-glow-subtle"
           style={{
@@ -837,6 +868,7 @@ function AskTab() {
             </button>
           )}
         </div>
+        )}
       </div>
 
       {/* Coffee picker — search sheet, spec §6.4 */}

--- a/src/components/ui/WaveformBars.tsx
+++ b/src/components/ui/WaveformBars.tsx
@@ -1,0 +1,82 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+interface WaveformBarsProps {
+  /** Returns the current peak amplitude (0..1). */
+  getLevel: () => number;
+  /** Number of bars to render. */
+  bars?: number;
+  /** Tailwind/style color for the bars. */
+  color?: string;
+  /** Container className. */
+  className?: string;
+  /** Bar height ceiling in px. */
+  height?: number;
+}
+
+/**
+ * Live waveform — bars driven by AnalyserNode (spec §6.3). Each frame we
+ * shift the existing levels left by one and push the latest peak on the
+ * right, so bars scroll right-to-left like a tape readout.
+ *
+ * Implementation note: levels live in a ref + we mutate DOM heights
+ * directly via rAF. React state would re-render at 60 fps and choke the
+ * main thread on iOS Safari. This is one of the few cases where direct
+ * DOM mutation beats declarative rendering.
+ */
+export default function WaveformBars({
+  getLevel,
+  bars = 28,
+  color = "var(--text-accent)",
+  className = "",
+  height = 40,
+}: WaveformBarsProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const levelsRef = useRef<number[]>(Array(bars).fill(0));
+
+  useEffect(() => {
+    let raf = 0;
+    const tick = () => {
+      const next = getLevel();
+      const arr = levelsRef.current;
+      // Shift left, append the latest peak (with a tiny floor so silence
+      // shows as a thin baseline rather than disappearing entirely).
+      for (let i = 0; i < arr.length - 1; i++) arr[i] = arr[i + 1];
+      arr[arr.length - 1] = Math.max(next, 0.04);
+      const container = containerRef.current;
+      if (container) {
+        const children = container.children;
+        for (let i = 0; i < children.length && i < arr.length; i++) {
+          const el = children[i] as HTMLElement;
+          el.style.height = `${Math.round(arr[i] * height)}px`;
+        }
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [getLevel, height]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={`flex items-center justify-center gap-[3px] ${className}`}
+      style={{ height }}
+      aria-hidden="true"
+    >
+      {Array.from({ length: bars }).map((_, i) => (
+        <span
+          key={i}
+          className="rounded-full"
+          style={{
+            display: "inline-block",
+            width: 3,
+            height: 2,
+            background: color,
+            transition: "height 60ms linear",
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useVoiceCapture.ts
+++ b/src/hooks/useVoiceCapture.ts
@@ -14,6 +14,8 @@ interface VoiceCapture {
   stop: () => Promise<void>;
   toggle: () => Promise<void>;
   clearError: () => void;
+  /** Snapshot the current input level normalised 0..1, or 0 when idle. */
+  getLevel: () => number;
 }
 
 function pickMimeType(): string | undefined {
@@ -39,11 +41,29 @@ export function useVoiceCapture({ onTranscript, onError }: Options): VoiceCaptur
   const chunksRef = useRef<Blob[]>([]);
   const streamRef = useRef<MediaStream | null>(null);
   const mimeRef = useRef<string | undefined>(undefined);
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const sourceNodeRef = useRef<MediaStreamAudioSourceNode | null>(null);
+  const levelBufferRef = useRef<Uint8Array | null>(null);
+
+  const teardownAnalyser = useCallback(() => {
+    try { sourceNodeRef.current?.disconnect(); } catch { /* ignore */ }
+    sourceNodeRef.current = null;
+    analyserRef.current = null;
+    levelBufferRef.current = null;
+    if (audioCtxRef.current) {
+      const ctx = audioCtxRef.current;
+      audioCtxRef.current = null;
+      // close() is async — fire and forget; errors here don't matter.
+      ctx.close().catch(() => { /* ignore */ });
+    }
+  }, []);
 
   const teardownStream = useCallback(() => {
     streamRef.current?.getTracks().forEach(t => t.stop());
     streamRef.current = null;
-  }, []);
+    teardownAnalyser();
+  }, [teardownAnalyser]);
 
   const surfaceError = useCallback((msg: string) => {
     setError(msg);
@@ -72,6 +92,25 @@ export function useVoiceCapture({ onTranscript, onError }: Options): VoiceCaptur
       return;
     }
     streamRef.current = stream;
+    // Analyser for live waveform rendering. Errors here mustn't block recording —
+    // worst case the waveform sits flat.
+    try {
+      const Ctor: typeof AudioContext | undefined =
+        window.AudioContext ??
+        (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+      if (Ctor) {
+        const ctx = new Ctor();
+        const source = ctx.createMediaStreamSource(stream);
+        const analyser = ctx.createAnalyser();
+        analyser.fftSize = 1024;
+        analyser.smoothingTimeConstant = 0.4;
+        source.connect(analyser);
+        audioCtxRef.current = ctx;
+        sourceNodeRef.current = source;
+        analyserRef.current = analyser;
+        levelBufferRef.current = new Uint8Array(analyser.fftSize);
+      }
+    } catch { /* analyser optional */ }
     const mime = pickMimeType();
     mimeRef.current = mime;
     let recorder: MediaRecorder;
@@ -149,10 +188,28 @@ export function useVoiceCapture({ onTranscript, onError }: Options): VoiceCaptur
 
   const clearError = useCallback(() => setError(null), []);
 
+  // Pulls the current peak amplitude (0..1) from the analyser. Returns 0
+  // when no analyser exists (e.g. browser doesn't support AudioContext).
+  const getLevel = useCallback(() => {
+    const analyser = analyserRef.current;
+    const buf = levelBufferRef.current;
+    if (!analyser || !buf) return 0;
+    // The DOM lib types getByteTimeDomainData more strictly than the
+    // runtime needs; cast through the underlying ArrayBufferView interface.
+    analyser.getByteTimeDomainData(buf as unknown as Uint8Array<ArrayBuffer>);
+    // Peak deviation from 128 (silence midpoint).
+    let peak = 0;
+    for (let i = 0; i < buf.length; i++) {
+      const dev = Math.abs(buf[i] - 128);
+      if (dev > peak) peak = dev;
+    }
+    return Math.min(peak / 128, 1);
+  }, []);
+
   useEffect(() => () => {
     try { recorderRef.current?.stop(); } catch { /* ignore */ }
     teardownStream();
   }, [teardownStream]);
 
-  return { recording, busy, error, start, stop, toggle, clearError };
+  return { recording, busy, error, start, stop, toggle, clearError, getLevel };
 }


### PR DESCRIPTION
## Summary
Replaces the pulsing-mic-square recording feedback in `/explore` with a DOT-spec bottom dock waveform (§6.3). Uses `AnalyserNode` tapped off the existing `MediaStream`, so the bars are sample-accurate — not stock animation.

## Implementation

**`useVoiceCapture` (non-breaking):**
- Sets up an `AudioContext` + `AnalyserNode` whenever recording starts (smoothing 0.4, fft 1024).
- New `getLevel()` returns the current peak deviation from silence (0..1). Falls back to 0 on browsers without `AudioContext` — voice still records, the waveform just sits flat.
- Tears down ctx + source on stop. No leaks across capture cycles.

**UI:**
- New `WaveformBars` primitive: rAF-driven scrolling bars (right-to-left). Mutates DOM heights directly to dodge the 60-fps React re-render that would choke iOS Safari.
- `/explore` input pill is replaced by a recording dock while capture is active: pulsing accent dot on the left, full-width waveform in the middle, filled-square stop button on the right (warm-accent fill, dark glyph). No timer, per spec.

## Spec deviations (deferred)
- Top dynamic-island capsule (§6.3): bottom dock alone is the bigger UX win and sufficient feedback for the typical iPhone PWA user.
- Gradient-intensify overlay during recording: deferred to a polish slice.

## Test plan
- [ ] `npx tsc --noEmit` clean (verified locally)
- [ ] Tap mic → input pill swaps to waveform dock with pulsing dot + bars + stop button
- [ ] Speak → bars dance proportional to volume
- [ ] Tap stop → dock reverts to input pill, transcript inserted as user message
- [ ] Cancel mid-record (e.g. background app) → dock cleans up, no AudioContext leak

https://claude.ai/code/session_01YeXEJqQK69ETBQEDfN3EvF

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALX392Z8HNYb5JD5mNh3zw)_