### PR TITLE
fix: chat + bottom-nav UX feedback from live PWA

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -263,6 +263,17 @@ function AskTab() {
     }
   }, [messages, loading]);
 
+  // Auto-grow the textarea so the input pill expands with content (DOT
+  // Chat_Type_Long pattern). We reset to "auto" first so shrinking on
+  // delete works, then snap to scrollHeight up to the cap.
+  useEffect(() => {
+    const ta = inputRef.current;
+    if (!ta) return;
+    ta.style.height = "auto";
+    const cap = 140;
+    ta.style.height = Math.min(ta.scrollHeight, cap) + "px";
+  }, [input]);
+
   const sendMessage = async (text: string) => {
     const trimmed = text.trim();
     // Allow image-only sends (no text) when an image is attached.
@@ -874,7 +885,7 @@ function AskTab() {
       {/* Coffee picker — search sheet, spec §6.4 */}
       {coffeePickerOpen && (
         <div
-          className="fixed inset-0 z-50 flex items-end justify-center"
+          className="fixed inset-0 z-[60] flex items-end justify-center"
           style={{ background: "var(--scrim-dialog)", backdropFilter: "blur(4px)" }}
           onClick={() => setCoffeePickerOpen(false)}
         >
@@ -942,7 +953,7 @@ function AskTab() {
       {/* Attach sheet — bottom modal, spec §6.4 */}
       {attachSheetOpen && (
         <div
-          className="fixed inset-0 z-50 flex items-end justify-center"
+          className="fixed inset-0 z-[60] flex items-end justify-center"
           style={{ background: "var(--scrim-dialog)", backdropFilter: "blur(4px)" }}
           onClick={() => setAttachSheetOpen(false)}
         >

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -6,37 +6,46 @@ import { Home, Coffee, Radar, Sparkles, Plus } from "lucide-react";
 
 const tabs = [
   { href: "/", label: "Home", Icon: Home },
-  { href: "/coffees", label: "Library", Icon: Coffee, prefixes: ["/coffees", "/library", "/cafes"] },
+  // Library button points at /library (the picker page that lets the user
+  // choose between coffee library and café library).
+  { href: "/library", label: "Library", Icon: Coffee, prefixes: ["/library", "/coffees", "/cafes"] },
   { href: "/taste", label: "Taste", Icon: Radar },
   { href: "/explore", label: "Explore", Icon: Sparkles },
 ];
 
-const EXACT_SHOW = ["/", "/explore", "/taste", "/match"];
+const EXACT_SHOW = ["/", "/taste", "/match"];
 const PREFIX_SHOW = ["/library", "/coffees", "/cafes"];
 
 /**
  * BrewLog bottom navigation — DOT-inspired 4+1 split (spec §7.1).
- * Glass pill with 4 icons (Home, Library, Taste, Explore) sits on the
- * left; warm-accent Brew FAB sits to its right, separated. Both anchor
- * to the safe-area bottom.
+ * 4-icon glass pill (left) + warm-accent Brew FAB (right), separated.
+ * Hidden on /explore so the chat input pill owns the bottom dock —
+ * BottomNav reappears on Insights tab via the explicit show below.
  */
 export default function BottomNav() {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const reset = useFlowStore(s => s.reset);
 
-  const onNearbyMap = pathname === "/explore" && searchParams.get("tab") === "nearby";
-  const showNav = !onNearbyMap && (EXACT_SHOW.includes(pathname) || PREFIX_SHOW.some(p => pathname.startsWith(p)));
+  // /explore: only show on the Insights tab. Ask + Nearby are full-bleed
+  // chat / map surfaces that own their own bottom UI.
+  const onExplore = pathname === "/explore";
+  const exploreInsights = onExplore && searchParams.get("tab") === "insights";
+
+  const showNav =
+    exploreInsights ||
+    (!onExplore && (EXACT_SHOW.includes(pathname) || PREFIX_SHOW.some(p => pathname.startsWith(p))));
   if (!showNav) return null;
 
   return (
     <div
-      className="fixed bottom-0 left-0 right-0 z-50 flex items-center justify-center gap-3.5 px-4 pt-1"
+      className="fixed bottom-0 left-0 right-0 z-40 flex items-center gap-3 px-4 pt-1"
       style={{ paddingBottom: "var(--nav-bottom-padding)" }}
     >
-      {/* Main pill — 4 icons, glass */}
+      {/* Main pill — flex-1 so it stretches to fill the available width
+          (FAB + lateral padding subtracted). Icons distribute evenly. */}
       <div
-        className="flex items-center gap-1 h-[52px] px-2 rounded-full border border-dot-edge backdrop-blur-xl shadow-glow-subtle"
+        className="flex-1 flex items-center justify-around h-[52px] px-2 rounded-full border border-dot-edge backdrop-blur-xl shadow-glow-subtle"
         style={{ background: "var(--surface-pill-input)" }}
       >
         {tabs.map(tab => {
@@ -66,7 +75,7 @@ export default function BottomNav() {
         href="/brew/new"
         onClick={reset}
         aria-label="New brew"
-        className="flex items-center justify-center w-14 h-14 rounded-full shadow-glow-subtle active:scale-95 transition-transform"
+        className="flex items-center justify-center w-14 h-14 rounded-full shadow-glow-subtle active:scale-95 transition-transform shrink-0"
         style={{
           background: "var(--text-accent)",
           color: "var(--bg-base)",

--- a/src/components/layout/ScrollContainer.tsx
+++ b/src/components/layout/ScrollContainer.tsx
@@ -1,15 +1,20 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 
-// Mirrors the BottomNav show rules so the scroll viewport reserves
-// room for the floating 4+1 nav. Keep in sync with BottomNav.tsx.
-const EXACT_SHOW = ["/", "/explore", "/taste", "/match"];
+// Mirror BottomNav's visibility: same routes, same /explore tab nuance.
+// Keep in sync with BottomNav.tsx.
+const EXACT_SHOW = ["/", "/taste", "/match"];
 const PREFIX_SHOW = ["/library", "/coffees", "/cafes"];
 
 export default function ScrollContainer({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const showNav = EXACT_SHOW.includes(pathname) || PREFIX_SHOW.some(p => pathname.startsWith(p));
+  const searchParams = useSearchParams();
+  const onExplore = pathname === "/explore";
+  const exploreInsights = onExplore && searchParams.get("tab") === "insights";
+  const showNav =
+    exploreInsights ||
+    (!onExplore && (EXACT_SHOW.includes(pathname) || PREFIX_SHOW.some(p => pathname.startsWith(p))));
   return (
     <div
       style={{


### PR DESCRIPTION
## Summary
Five surgical fixes after eyeballing the live PWA:

1. **Hide BottomNav on `/explore` Ask + Nearby tabs** (per spec §7.1 — chat input owns the bottom dock). The 22-px gap between the input pill and the floating BottomNav was reading as a visible "internal rectangle." BottomNav reappears on the Insights tab. `ScrollContainer`'s bottom padding mirrors the same logic so it doesn't reserve dead space when the nav is hidden.

2. **Auto-grow chat textarea** (DOT `Chat_Type_Long` pattern). `useEffect` on `input` resets `style.height` to "auto" and snaps to `scrollHeight` up to a 140 px cap. Single-line stays compact; long messages expand the input pill in place.

3. **Bump attach + coffee-picker sheet z-index** to `z-[60]` so they always render above any floating nav (defensive — even with #1 the sheet was rendering behind the nav while transitioning between tabs).

4. **Widen BottomNav main pill**: now `flex-1`, fills the available width minus the FAB and lateral padding. Icons distribute via `justify-around` so the tap targets sit further apart.

5. **Restore Library nav target to `/library`** (the picker page that lets users choose between coffee + café libraries). Was incorrectly jumping straight to `/coffees`. The active-prefix list still highlights Library when the user is anywhere under `/library`, `/coffees`, or `/cafes`.

## Test plan
- [ ] `npx tsc --noEmit` clean (verified locally)
- [ ] /explore Ask tab: only the input pill is visible at the bottom (no floating BottomNav)
- [ ] /explore Insights tab: BottomNav reappears
- [ ] / and other surfaces: BottomNav present and pill stretches near full width
- [ ] Type a long message in chat: input pill grows in place, caps around 140 px
- [ ] Tap `+` in chat: attach sheet slides up over everything, no occlusion
- [ ] Tap "Library" in BottomNav: routes to `/library`, not `/coffees`

https://claude.ai/code/session_01YeXEJqQK69ETBQEDfN3EvF

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALX392Z8HNYb5JD5mNh3zw)_