### PR TITLE
fix: deploy hotfix — ScrollContainer SSG bailout + UX polish

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -181,6 +181,10 @@ function AskTab() {
   const [coffeeQuery, setCoffeeQuery] = useState("");
   const [coffeeList, setCoffeeList] = useState<CompactCoffee[]>([]);
   const [referencedCoffee, setReferencedCoffee] = useState<CompactCoffee | null>(null);
+  // Once the user types, taps mic, or otherwise acts, hide the starter
+  // suggestions for the rest of the session — they shouldn't reappear if
+  // the input is cleared back to empty.
+  const [hasInteracted, setHasInteracted] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -500,6 +504,7 @@ function AskTab() {
   // permit subsequent <audio> playback in this session.
   const handleMicTap = () => {
     setVoiceError(null);
+    setHasInteracted(true);
     if (voiceMode) playback.unlock();
     void capture.toggle();
   };
@@ -555,7 +560,11 @@ function AskTab() {
   };
 
   const showStarter =
-    messages.length === 0 && !loading && input.trim() === "" && !capture.recording;
+    !hasInteracted &&
+    messages.length === 0 &&
+    !loading &&
+    input.trim() === "" &&
+    !capture.recording;
 
   return (
     <>
@@ -688,8 +697,9 @@ function AskTab() {
         )}
       </div>
 
-      {/* Input area — DOT-spec glass dock (spec §6.1) */}
-      <div className="shrink-0 px-3" style={{ paddingBottom: "0.75rem", paddingTop: "0.25rem" }}>
+      {/* Input area — DOT-spec glass dock (spec §6.1). ScrollContainer
+          doesn't reserve padding on /explore, so we own safe-area here. */}
+      <div className="shrink-0 px-3" style={{ paddingBottom: "max(0.75rem, env(safe-area-inset-bottom))", paddingTop: "0.25rem" }}>
         {/* Hidden file input for photo attach */}
         <input
           ref={fileInputRef}
@@ -833,7 +843,7 @@ function AskTab() {
           <textarea
             ref={inputRef}
             value={input}
-            onChange={e => setInput(e.target.value)}
+            onChange={e => { setInput(e.target.value); if (e.target.value.length > 0) setHasInteracted(true); }}
             onKeyDown={handleKeyDown}
             placeholder={capture.recording ? "Listening…" : "Ask something"}
             rows={1}
@@ -1161,7 +1171,10 @@ function InsightsTab() {
 
   return (
     <div
-      className="flex-1 overflow-y-auto flex flex-col gap-0 pb-8"
+      className="flex-1 overflow-y-auto flex flex-col gap-0"
+      // ScrollContainer reserves no bottom padding on /explore, so the
+      // Insights tab clears the floating BottomNav itself.
+      style={{ paddingBottom: "calc(78px + env(safe-area-inset-bottom) + 1rem)" }}
     >
       {/* ── News Ticker ─────────────────────────────────────── */}
       {news.length > 0 && (

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -60,11 +60,18 @@ export default function BottomNav() {
               aria-label={tab.label}
               className="relative flex items-center justify-center w-11 h-11 rounded-2xl transition-colors duration-150"
               style={{
-                background: active ? "var(--surface-2)" : "transparent",
-                color: active ? "var(--text-primary)" : "var(--text-secondary)",
+                background: active ? "rgba(232,197,168,0.14)" : "transparent",
+                color: active ? "var(--text-accent)" : "var(--text-secondary)",
               }}
             >
-              <Icon size={20} strokeWidth={active ? 2 : 1.6} />
+              <Icon size={20} strokeWidth={active ? 2.25 : 1.6} />
+              {active && (
+                <span
+                  aria-hidden="true"
+                  className="absolute -top-1 left-1/2 -translate-x-1/2 w-1 h-1 rounded-full"
+                  style={{ background: "var(--text-accent)" }}
+                />
+              )}
             </Link>
           );
         })}

--- a/src/components/layout/ScrollContainer.tsx
+++ b/src/components/layout/ScrollContainer.tsx
@@ -1,20 +1,21 @@
 "use client";
 
-import { usePathname, useSearchParams } from "next/navigation";
+import { usePathname } from "next/navigation";
 
-// Mirror BottomNav's visibility: same routes, same /explore tab nuance.
-// Keep in sync with BottomNav.tsx.
+// Mirrors the BottomNav show rule — except /explore, where the page
+// owns its own bottom padding (the chat input pill on Ask, an internal
+// scrollable list on Insights, full-screen map on Nearby).
+//
+// Critical: do NOT use useSearchParams() here. ScrollContainer wraps
+// children in app/layout.tsx without a Suspense boundary, so any
+// useSearchParams() reference triggers an SSG bailout and breaks the
+// production build for every page.
 const EXACT_SHOW = ["/", "/taste", "/match"];
 const PREFIX_SHOW = ["/library", "/coffees", "/cafes"];
 
 export default function ScrollContainer({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const searchParams = useSearchParams();
-  const onExplore = pathname === "/explore";
-  const exploreInsights = onExplore && searchParams.get("tab") === "insights";
-  const showNav =
-    exploreInsights ||
-    (!onExplore && (EXACT_SHOW.includes(pathname) || PREFIX_SHOW.some(p => pathname.startsWith(p))));
+  const showNav = EXACT_SHOW.includes(pathname) || PREFIX_SHOW.some(p => pathname.startsWith(p));
   return (
     <div
       style={{


### PR DESCRIPTION
## Why
**PR #21 broke production.** Docker build on the VPS fails at `npm run build` with:

> `useSearchParams() should be wrapped in a suspense boundary at page "/explore"`

…and every other page (/, /coffees, /brew/new, /cafes, /login, /library, /match, /onboarding, /taste, /_not-found).

**Root cause:** PR #21 moved `ScrollContainer` to read `useSearchParams()`, but `ScrollContainer` is rendered inside `app/layout.tsx` *without* a Suspense boundary. In Next 14 App Router, any client component using `useSearchParams()` outside Suspense forces a CSR bailout during static generation — which failed the prerender for every page and crashed `npm run build` in the Docker image. `BottomNav` was already Suspense-wrapped in layout.tsx so its own `useSearchParams()` call was fine.

## Hotfix
- **`ScrollContainer` reverts to `usePathname`-only.** Drops `/explore` from the show list entirely (it was never the right home for tab-aware logic). Verified `npx next build` is green again locally.
- **`/explore` owns its own bottom padding per tab:**
  - **Ask**: input pill `paddingBottom: max(0.75rem, env(safe-area-inset-bottom))`.
  - **Insights**: scroll container reserves `78px + safe-area + 1rem` so content clears the floating BottomNav.
  - **Nearby**: full-bleed map, no padding needed.

## Bundled UX fixes (the work that was pending behind this hotfix)
- **Suggested starter questions stay hidden** once the user types a character *or* taps the mic. New `hasInteracted` flag — no more flicker if the user clears the input back to empty.
- **BottomNav active state more recognizable**: active icon switches to `var(--text-accent)` with a subtle 14% accent fill behind it, plus a small 4 px accent dot just above the active tile (spec §7.1 optional indicator). Stroke weight bumps `1.6 → 2.25`.

## Test plan
- [ ] `npx next build` exits 0 (verified locally)
- [ ] `npx tsc --noEmit` clean (verified locally)
- [ ] iPhone PWA refreshes after deploy without showing the old build
- [ ] /explore Ask: only input pill at bottom, no gap above safe area
- [ ] /explore Insights: BottomNav visible, Insights content clears it
- [ ] Type one char in chat → suggestions vanish; clear input → suggestions stay gone
- [ ] Tap mic → suggestions vanish; cancel recording → suggestions stay gone
- [ ] BottomNav active tab is now clearly highlighted (warm accent + tile + dot)

https://claude.ai/code/session_01YeXEJqQK69ETBQEDfN3EvF

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALX392Z8HNYb5JD5mNh3zw)_