### PR TITLE
fix: soft DOT capsule for chat input + softer warm dark on cream user pill

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -790,11 +790,19 @@ function AskTab() {
 
         {/* Recording dock — replaces the input pill while capture is active.
             Spec §6.3: full-width waveform across most of the dock, stop
-            button on the right (filled square in a circle). No timer. */}
+            button on the right (filled square in a circle). No timer.
+            DOT-style soft-cream capsule — no hard border, blends into the
+            gradient via a translucent warm tint. */}
         {capture.recording ? (
           <div
-            className="flex items-center gap-2 rounded-full border border-dot-edge backdrop-blur-xl shadow-glow-strong px-3"
-            style={{ background: "var(--surface-pill-input)", minHeight: 52 }}
+            className="flex items-center gap-2 rounded-full backdrop-blur-xl px-3"
+            style={{
+              background:
+                "linear-gradient(180deg, rgba(255,240,224,0.10) 0%, rgba(255,240,224,0.04) 100%)",
+              boxShadow:
+                "0 10px 32px rgba(0,0,0,0.28), inset 0 1px 0 rgba(255,235,220,0.10)",
+              minHeight: 52,
+            }}
           >
             <span
               className="w-2 h-2 rounded-full animate-pulse shrink-0"
@@ -820,9 +828,15 @@ function AskTab() {
           </div>
         ) : (
         <div
-          className="flex items-center gap-1 rounded-full border border-dot-edge backdrop-blur-xl shadow-glow-subtle"
+          className="flex items-center gap-1 rounded-full backdrop-blur-xl"
           style={{
-            background: "var(--surface-pill-input)",
+            // Soft cream glaze — warm tint that blends into the gradient
+            // rather than reading as a hard glass rectangle. Inner top
+            // highlight + outer drop shadow give definition without an edge.
+            background:
+              "linear-gradient(180deg, rgba(255,240,224,0.10) 0%, rgba(255,240,224,0.04) 100%)",
+            boxShadow:
+              "0 10px 32px rgba(0,0,0,0.28), inset 0 1px 0 rgba(255,235,220,0.10)",
             paddingLeft: 6,
             paddingRight: 6,
             minHeight: 52,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,7 +40,10 @@
   --surface-pill-input: rgba(28,22,19,0.65);
   --surface-pill-attach: rgba(40,30,26,0.7);
   --text-primary: #F0E8E1;
-  --text-on-pill-user: #1A130E;
+  /* Warm dark for text inside the cream user pill. Used to be #1A130E
+     which read as harsh near-black; this is still high contrast on the
+     #F5ECE5 cream but with a softer warm-brown character. */
+  --text-on-pill-user: #2E2118;
   --text-secondary: #B8ADA4;
   --text-muted: #6B635D;
   --text-accent: #E8C5A8;

--- a/src/lib/theme/gradients.ts
+++ b/src/lib/theme/gradients.ts
@@ -30,10 +30,13 @@ export const gradientHeroSurface =
 
 /**
  * Subtle warm-on-warm fill for the cream user message bubble — adds
- * dimensionality without breaking the flat-pill read.
+ * dimensionality without breaking the flat-pill read. Tones down from
+ * the original near-white #FBF4ED start; the spec --surface-pill-user
+ * is #F5ECE5 and the gradient now sits within that warmer cream range
+ * so the dark text-on-pill reads as warm-brown rather than harsh black.
  */
 export const gradientPillUser =
-  "bg-[linear-gradient(135deg,#FBF4ED_0%,#F1E5DA_100%)]";
+  "bg-[linear-gradient(135deg,#F5ECE5_0%,#EBDFD2_100%)]";
 
 /**
  * Primary CTA fill (Phase 2/3 — Brew button, send arrow background).

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -33,7 +33,7 @@ const config: Config = {
           s2: "#1F1A17",
           "pill-user": "#F5ECE5",
           ink: "#F0E8E1",
-          "on-pill": "#1A130E",
+          "on-pill": "#2E2118",
           "ink-soft": "#B8ADA4",
           "ink-mute": "#6B635D",
           accent: "#E8C5A8",


### PR DESCRIPTION
## Summary
Two visual fixes from live PWA feedback.

### 1. Input pill no longer reads as a hard rectangle
The DOT spec wants a **soft cream capsule** that blends into the gradient. My implementation was a dark glass pill with a visible 1 px border — read as a sharp box.

- Drop the visible border (`border-dot-edge` was rendering a faint outline against the warm gradient).
- Swap the dark warm-glass surface for a **warm-cream glaze**: `linear-gradient 180deg` of `rgba(255,240,224,0.10) → rgba(255,240,224,0.04)`. Soft-elevated cream capsule that blends into the chat backdrop rather than a sharp-edged box.
- Replace `shadow-glow-subtle` with a directional drop shadow + inner top highlight (`inset 0 1px 0 rgba(255,235,220,0.10)`) — definition without an outer ring.
- Same treatment applied to the **recording dock** so the capsule stays consistent across states.

### 2. Transcribed text on the cream user pill softer
Was reading as harsh near-black. Two adjustments:

- `--text-on-pill-user`: `#1A130E → #2E2118` — still very dark for contrast, but warm-brown character instead of jet-black.
- `gradientPillUser` tones down from the bright `#FBF4ED → #F1E5DA` range to the **spec-aligned** `#F5ECE5 → #EBDFD2` range. Less stark cream = less harsh contrast with the dark text.
- Tailwind `dot.on-pill` mirrored to keep the two token layers in sync.

## Test plan
- [ ] `npx next build` exits 0 (verified locally)
- [ ] `npx tsc --noEmit` clean (verified locally)
- [ ] Input pill on /explore Ask: no visible border ring; soft cream capsule that floats over the warm gradient
- [ ] Recording dock (tap mic): same soft cream capsule treatment
- [ ] Sent voice transcript: dark warm-brown text on softer cream pill, reads as warm not harsh

https://claude.ai/code/session_01YeXEJqQK69ETBQEDfN3EvF

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALX392Z8HNYb5JD5mNh3zw)_