### PR TITLE
fix: surface session validation errors + strip nulls from clarify response

### DIFF
--- a/src/app/api/analyze-bag/clarify/route.ts
+++ b/src/app/api/analyze-bag/clarify/route.ts
@@ -28,7 +28,12 @@ Update the coffee data with this new information and return the updated JSON obj
 
     const text = response.content[0].type === "text" ? response.content[0].text : "{}";
     const match = text.match(/\{[\s\S]*\}/);
-    const updated = match ? JSON.parse(match[0]) : currentCoffeeData;
+    const parsed = match ? JSON.parse(match[0]) : currentCoffeeData;
+    const updated = parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? Object.fromEntries(
+          Object.entries(parsed).filter(([, v]) => v !== null && v !== undefined)
+        )
+      : parsed;
 
     return NextResponse.json({ updated });
   } catch (err) {

--- a/src/components/flow/StepScan.tsx
+++ b/src/components/flow/StepScan.tsx
@@ -216,7 +216,10 @@ export default function StepScan() {
         body: JSON.stringify({ currentCoffeeData: draft.coffee, question, answer }),
       });
       const { updated } = await res.json();
-      setCoffee(updated);
+      const clean = Object.fromEntries(
+        Object.entries(updated ?? {}).filter(([, v]) => v !== null && v !== undefined)
+      ) as Parameters<typeof setCoffee>[0];
+      setCoffee(clean);
     } catch {}
 
     const next = clarificationIndex + 1;

--- a/src/components/flow/StepSummary.tsx
+++ b/src/components/flow/StepSummary.tsx
@@ -47,8 +47,17 @@ export default function StepSummary() {
         }),
       });
       if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error((body as { error?: string }).error || `Save failed (${res.status})`);
+        const body = await res.json().catch(() => ({})) as {
+          error?: string;
+          details?: { fieldErrors?: Record<string, string[]>; formErrors?: string[] };
+        };
+        const fieldErrors = body.details?.fieldErrors ?? {};
+        const firstField = Object.entries(fieldErrors).find(([, msgs]) => msgs && msgs.length > 0);
+        const detailMsg = firstField
+          ? `${firstField[0]}: ${firstField[1][0]}`
+          : body.details?.formErrors?.[0];
+        const baseMsg = body.error || `Save failed (${res.status})`;
+        throw new Error(detailMsg ? `${baseMsg} — ${detailMsg}` : baseMsg);
       }
       setSaved(true);
       setTimeout(() => { reset(); router.push("/"); }, 1500);


### PR DESCRIPTION
## Summary
- Café session save was failing silently with "Invalid session data" because the client only read `body.error` and threw away the `body.details` field that names the offending Zod path. `StepSummary` now surfaces e.g. `coffee.cuppingScore: ...` so future schema mismatches diagnose themselves.
- `/api/analyze-bag/clarify` returns whatever JSON Claude emits, and `StepScan:219` piped it straight into `setCoffee` with no null filter (unlike the initial scan, which filters via `cleanExtracted`). If Claude included `cuppingScore`/`region`/`variety: null` in the clarification round-trip, those landed in the draft and broke the POST `/api/sessions` schema. Strip null/undefined in both the client receive and the server response for defence in depth.

## Test plan
- [ ] Trigger a café save with a known-bad draft (or just retry the failing Pacas session) — error message should now name the failing field instead of the generic string.
- [ ] Walk a bag through the scan + clarification step and save as a café session — should save cleanly.

https://claude.ai/code/session_01EHRsxePmKiWDMiNEDR6rpZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHRsxePmKiWDMiNEDR6rpZ)_