### PR TITLE
docs: add hard rule against inferring repo state from partial evidence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -275,6 +275,20 @@ Cause for this rule: commit `932ff25` swapped the recommend model Opus → Sonne
 
 ---
 
+## Hard rule: never infer repo state from partial evidence
+
+Migrations files, seed scripts, `.env.example` and code comments only show what lives in Git. They do NOT show what's actually in the production DB, what was seeded manually on the VPS, or what happened outside the repo. Do not extrapolate.
+
+1. **Never quote a row count, table size, or dataset size from a migration file alone.** A migration showing 33 INSERTs does not mean the table has 33 rows. The bulk data may have been loaded directly on the VPS with no script in Git. If asked, say "I can only see what's in the migrations; for the real count, run `SELECT count(*) FROM <table>` on the VPS."
+2. **Search broadly before answering.** Before claiming "X doesn't exist" or "the repo only contains Y": grep across `scripts/`, code comments (real numbers often live there), `meta/_journal.json` (can diverge from the file list — manual `psql` migrations don't register), and any data files (`*.csv`, `*.json`, `*.sql`). Only after that, answer.
+3. **Mark inference as inference.** "X lives only in production" is not the same as "I found nothing in the repo that explains X." Stating the first when only the second is true is hallucination. Use phrases like "no evidence in the repo" or "inference, not verified" — not assertive claims.
+4. **Flag your own inconsistencies immediately.** If you produce two different numbers for the same thing in one session (12 vs. 13, 33 vs. 34), call it out openly and re-verify — do not silently overwrite the earlier number.
+5. **When the user pushes back ("that's wrong, we have X"), do not defend.** Re-open the search, surface the path that led to the wrong conclusion ("I only checked Y, that's why I missed Z"), correct cleanly. Apologize once, fix, move on.
+
+Cause for this rule: claimed "~33 cafés in the places table" based on counting INSERTs in three migration files, when the production DB actually holds ~6,200 places loaded outside the repo (see `scripts/geocode-places.mjs` comment "Takes ~2 hours for 6000+ places"). The Drizzle `meta/_journal.json` only registers `0000_init` — all place migrations are applied manually via `psql` on the VPS, and the bulk dataset has no import script in Git at all. Do not extrapolate from migrations to reality.
+
+---
+
 ## Conventions
 
 ### Code


### PR DESCRIPTION
Adds a second `## Hard rule` block to `CLAUDE.md`, alongside the existing "validate before changing AI behavior" rule.

**What:** five sub-rules against extrapolating repo state from partial evidence (migrations, seed scripts, code comments).

**Why:** during a verification chat I claimed the `places` table holds ~33 rows, based only on counting INSERTs in the migration files. Reality: ~6,200 rows, loaded outside the repo. The bulk dataset has no import script in Git at all; `meta/_journal.json` only registers `0000_init`; all place migrations are applied manually via `psql` on the VPS. Repo files are not the same as production state — codifying that.

No code changes, docs only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01967psqKg3aUCRsfKFQid1R)_