### PR TITLE
build: add SessionStart hook to install npm deps in web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+echo "[session-start] installing npm dependencies..."
+npm install --no-audit --no-fund --loglevel=error
+
+echo "[session-start] done."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Why

Web Claude Code sessions start with an empty `node_modules`. That means `npx tsc --noEmit`, `node --test`, `next build`, and any tool that needs deps fail on cold start until someone runs `npm install`. Result: I (Claude Code) end up confused about repo state because tools don't work, and have to re-discover this every session.

## What

- `.claude/hooks/session-start.sh` — runs `npm install` on session start, gated on `$CLAUDE_CODE_REMOTE` so local CLI sessions are unaffected.
- `.claude/settings.json` — registers the hook for the `SessionStart` event.

## Mode

**Sync** (blocks session start until install completes, ~25s).

Trade-off: slower session start, but guarantees deps are ready before the agent runs anything. Async would risk race conditions where I'd run `tsc` before `node_modules` exists. Can switch to async later if startup latency becomes a pain.

## Validation

- ✅ Hook ran end-to-end against an empty `node_modules`: `added 645 packages in 24s`
- ✅ `npx tsc --noEmit` clean after install
- ✅ `node --test src/lib/utils/pourSequence.test.mjs` → 17/17 pass
- ⚠️ `next lint` not validated — repo has no `.eslintrc`, would prompt interactively. Existing `npm run lint` script is broken anyway. Separate issue, not blocking this PR.

## Once merged

Every future web session auto-installs deps before the agent starts. No more cold-start tool failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01967psqKg3aUCRsfKFQid1R)_