### PR TITLE
docs: correct AI model assignments in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -327,8 +327,9 @@ Cause for this rule: claimed "~33 cafés in the places table" based on counting 
 - Numeric fields (ratingSum, avgRating, cuppingScore) stored as `numeric` in Postgres, use `String()` when inserting
 
 ### AI models
-- `claude-sonnet-4-6` — recommend, analyze-bag, match, explore
-- `claude-haiku-4-5` — brew-insight, taste-summary, research, clarify
+- `claude-opus-4-7` — recommend (engineered for Opus; do NOT swap to Sonnet without re-validating outputs — see Hard Rule above)
+- `claude-sonnet-4-6` — analyze-bag, match, explore, explore-agent, escher (post-brew insight helper)
+- `claude-haiku-4-5` — brew-insight, taste-summary, research, analyze-bag/clarify, analyze-url, coffees/compact, roasters/generate, translate (tasting-notes ↔ SCA helper)
 
 ### Git / Deploy
 - **"Done" means shipped** — merged to `main`, auto-deploy runs on Hetzner, live on the iPhone PWA. "Pushed to a feature branch" is NOT done. Stopping at a branch leaves the user staring at the still-broken app, re-reporting the bug, and re-fixing what is already fixed. That is chaos and it is not acceptable.


### PR DESCRIPTION
## Why

Follow-up audit after PR #30. The "AI models" section in CLAUDE.md had drifted from reality after the Sonnet→Opus revert on `/recommend` (the same revert that motivated Hard Rule #1).

Verified by greping every `model:` string under `src/app/api/` and `src/lib/claude/`.

## Changes (docs only)

- `recommend` was listed under Sonnet 4.6 — **actually uses `claude-opus-4-7`** (`src/lib/claude/recommend.ts:674`). Added inline pointer to the Hard Rule so the next person doesn't repeat the swap.
- Added missing entries: `explore-agent` (Sonnet), `escher` (Sonnet, post-brew insight helper), `analyze-url`, `coffees/compact`, `roasters/generate`, `translate` (all Haiku).

## Validation

- `grep "model:" src/app/api/**/*.ts src/lib/claude/*.ts` — every entry in the new table corresponds to an actual line of code.
- No code changes; CLAUDE.md only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01967psqKg3aUCRsfKFQid1R)_