### PR TITLE
fix: surface commonNotes on coffee detail + weekly cron

### DIFF
--- a/deploy/ofelia.ini
+++ b/deploy/ofelia.ini
@@ -8,7 +8,7 @@ command = curl -sf -X POST http://localhost:3000/api/research -H "Authorization:
 no-overlap = true
 
 [job-exec "coffees-compact"]
-schedule = 0 3 1 * *
+schedule = 0 3 * * 1
 container = brewlog-app-1
 command = curl -sf -X POST http://localhost:3000/api/coffees/compact -H "Authorization: Bearer ${CRON_SECRET}"
 no-overlap = true

--- a/src/app/api/coffees/compact/route.ts
+++ b/src/app/api/coffees/compact/route.ts
@@ -95,7 +95,7 @@ export async function POST(req: NextRequest) {
   try {
     const coffeeRows = await db.select().from(coffees);
     const now = Date.now();
-    const twentyEightDaysMs = 28 * 24 * 60 * 60 * 1000;
+    const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
 
     for (const row of coffeeRows) {
       const coffee = rowToCoffee(row);
@@ -107,7 +107,7 @@ export async function POST(req: NextRequest) {
 
       if (coffee.lastSummarizedAt) {
         const lastMs = new Date(coffee.lastSummarizedAt).getTime();
-        if (now - lastMs < twentyEightDaysMs) {
+        if (now - lastMs < sevenDaysMs) {
           skipped++;
           continue;
         }

--- a/src/app/coffees/[id]/page.tsx
+++ b/src/app/coffees/[id]/page.tsx
@@ -125,6 +125,7 @@ export default function CoffeeDetailPage() {
   const roastLevel = latestCoffee?.roastLevel;
   const region = latestCoffee?.region;
   const tastingNotes = latestCoffee?.tastingNotesFromBag ?? [];
+  const commonNotes = coffee.commonNotes ?? [];
   const origin = latestCoffee?.origin || coffee.origin;
 
   return (
@@ -195,7 +196,7 @@ export default function CoffeeDetailPage() {
       </div>
 
       {/* Coffee scan details */}
-      {(roastDate || variety || roastLevel || region || tastingNotes.length > 0) && (
+      {(roastDate || variety || roastLevel || region || tastingNotes.length > 0 || commonNotes.length > 0) && (
         <div className="px-5 py-4 border-b border-brew-border space-y-2">
           <p className="text-brew-muted text-xs uppercase tracking-widest mb-3">Coffee Details</p>
           {variety && <DetailRow label="Variety" value={variety} />}
@@ -213,6 +214,18 @@ export default function CoffeeDetailPage() {
               <div className="flex flex-wrap gap-1.5">
                 {tastingNotes.map(note => (
                   <span key={note} className="text-xs capitalize px-2 py-0.5 rounded-full border border-brew-border text-white/60">
+                    {note}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+          {commonNotes.length > 0 && (
+            <div className="flex items-baseline gap-3 pt-0.5">
+              <span className="text-brew-muted text-sm shrink-0 w-24">You taste</span>
+              <div className="flex flex-wrap gap-1.5">
+                {commonNotes.map(note => (
+                  <span key={note} className="text-xs capitalize px-2 py-0.5 rounded-full bg-white/10 text-white/80">
                     {note}
                   </span>
                 ))}


### PR DESCRIPTION
## Summary

`coffees.common_notes` was a dead field in production: `/api/coffees/compact` (monthly cron) writes it, but nothing reads it. Data computed monthly and silently discarded.

Three small fixes:

1. **Coffee detail page** (`/coffees/[id]`) — new "You taste" row alongside the existing "Bag notes" row. Filled-pill chips contrast with the outlined chips for roaster claims, so "what the bag says" vs "what you actually taste over N sessions" reads at a glance.
2. **Cron schedule** — `coffees-compact` job moves from monthly (`0 3 1 * *`) to weekly (`0 3 * * 1`). Monthly was wildly too infrequent for a single-user app where 5+ sessions on one bag can happen in a week.
3. **Skip threshold** — `lastSummarizedAt` skip in the compact route goes from 28d to 7d, matching the new cron cadence.

**Deliberately not in scope:** wiring `commonNotes` into `/recommend`. It lives on the persistent `Coffee` library record, not on the `CoffeeIdentity` the recommend route receives — would need a DB lookup plus another AI behavioral change requiring validation. Can be a follow-up if the UI signal proves useful.

## Test plan

- [ ] Open `/coffees/[id]` for a coffee with ≥2 logged sessions and `lastSummarizedAt` set (post-next-cron-run). Confirm "You taste" row appears with the top 5 flavor notes.
- [ ] Coffees with <2 sessions: row absent (existing skip in compact route preserves this).
- [ ] First Monday after merge: confirm Ofelia fires `coffees-compact` at 03:00 and `common_notes` populates for eligible coffees.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VcbF8sZcC7V657C9BRqw16)_