### PR TITLE
feat: wire coffee tasting history into /recommend + /explore

### DIFF
--- a/src/app/api/recommend/route.ts
+++ b/src/app/api/recommend/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { generateRecommendation } from "@/lib/claude/recommend";
 import { buildEscherTerrain } from "@/lib/claude/escher";
 import { db } from "@/lib/db/client";
-import { preferences as preferencesTable, roasters } from "@/lib/db/schema";
+import { coffees, preferences as preferencesTable, roasters } from "@/lib/db/schema";
 import { requireAuth } from "@/lib/auth/requireAuth";
 import { canonicalRoasterSlug } from "@/lib/roasters/priors";
 import type { UserPreferences } from "@/lib/types/preferences";
@@ -11,6 +11,64 @@ import type { RoasterPrior } from "@/lib/roasters/priors";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 120;
+
+/**
+ * Aggregated tasting history for this coffee — what the user actually
+ * tastes across logged sessions, plus the AI brew memory. Both are
+ * written by the weekly /api/coffees/compact cron and may be undefined
+ * for first brews or coffees with <2 sessions.
+ */
+interface CoffeeHistory {
+  commonNotes?: string[];
+  writtenSummary?: string;
+}
+
+function mapCoffeeHistory(row: {
+  commonNotes: unknown;
+  writtenSummary: string | null;
+}): CoffeeHistory | undefined {
+  const notes = Array.isArray(row.commonNotes) ? (row.commonNotes as string[]) : undefined;
+  const summary = row.writtenSummary ?? undefined;
+  if ((!notes || notes.length === 0) && !summary) return undefined;
+  return {
+    commonNotes: notes && notes.length > 0 ? notes : undefined,
+    writtenSummary: summary,
+  };
+}
+
+async function loadCoffeeHistory(
+  coffeeId: string | undefined,
+  roaster: string | undefined,
+  name: string | undefined,
+): Promise<CoffeeHistory | undefined> {
+  try {
+    if (coffeeId) {
+      const direct = await db
+        .select({
+          commonNotes: coffees.commonNotes,
+          writtenSummary: coffees.writtenSummary,
+        })
+        .from(coffees)
+        .where(eq(coffees.id, coffeeId))
+        .limit(1);
+      if (direct.length > 0) return mapCoffeeHistory(direct[0]);
+    }
+    if (roaster && name) {
+      const fallback = await db
+        .select({
+          commonNotes: coffees.commonNotes,
+          writtenSummary: coffees.writtenSummary,
+        })
+        .from(coffees)
+        .where(and(eq(coffees.roaster, roaster), eq(coffees.name, name)))
+        .limit(1);
+      if (fallback.length > 0) return mapCoffeeHistory(fallback[0]);
+    }
+  } catch (err) {
+    console.error("loadCoffeeHistory error:", err);
+  }
+  return undefined;
+}
 
 export async function POST(req: NextRequest) {
   const authError = await requireAuth(req);
@@ -34,8 +92,9 @@ export async function POST(req: NextRequest) {
 
     const sessions = pastSessions || [];
 
-    // Run DB roaster lookup and Escher terrain in parallel — saves 3–5s vs sequential
-    const [userRoasterPriorResult, terrain] = await Promise.all([
+    // Run DB roaster lookup, Escher terrain, and coffee-history lookup in
+    // parallel — saves 3–5s vs sequential.
+    const [userRoasterPriorResult, terrain, coffeeHistory] = await Promise.all([
       (async (): Promise<RoasterPrior | null> => {
         if (!coffee?.roaster) return null;
         try {
@@ -54,11 +113,18 @@ export async function POST(req: NextRequest) {
       sessions.length >= 3
         ? buildEscherTerrain(sessions, coffee).catch(() => "")
         : Promise.resolve(""),
+      loadCoffeeHistory(coffee?.coffeeId, coffee?.roaster, coffee?.name),
     ]);
     const userRoasterPrior = userRoasterPriorResult;
 
     const { recommendation } = await generateRecommendation(
-      coffee, context, prefs, sessions, userRoasterPrior ?? undefined, terrain || undefined
+      coffee,
+      context,
+      prefs,
+      sessions,
+      userRoasterPrior ?? undefined,
+      terrain || undefined,
+      coffeeHistory,
     );
     return NextResponse.json(recommendation);
   } catch (err) {

--- a/src/lib/claude/coffeeLibrary.ts
+++ b/src/lib/claude/coffeeLibrary.ts
@@ -12,6 +12,10 @@ export interface CompactCoffee {
   firstSeenAt: string;
   sessionCount: number;
   avgRating?: number;
+  /** Top tasted notes across this user's sessions for this coffee (refreshed weekly by /api/coffees/compact). */
+  commonNotes?: string[];
+  /** 2–4 sentence AI brew memory generated weekly by /api/coffees/compact. */
+  writtenSummary?: string;
 }
 
 export async function loadCoffeeLibraryCompact(limit = 30): Promise<CompactCoffee[]> {
@@ -31,6 +35,11 @@ export async function loadCoffeeLibraryCompact(limit = 30): Promise<CompactCoffe
       firstSeenAt: r.firstSeenAt,
       sessionCount: r.sessionCount,
       avgRating: r.avgRating != null ? Number(r.avgRating) : undefined,
+      commonNotes:
+        Array.isArray(r.commonNotes) && r.commonNotes.length > 0
+          ? r.commonNotes
+          : undefined,
+      writtenSummary: r.writtenSummary ?? undefined,
     }));
   } catch (err) {
     console.error("loadCoffeeLibraryCompact error:", err);
@@ -60,7 +69,17 @@ export function formatLibraryForPrompt(library: CompactCoffee[]): string {
           : c.sessionCount > 0
             ? `${c.sessionCount} sessions`
             : "unbrewed";
-      return `- ${c.roaster} — ${c.name} | ${c.origin} ${c.process} | ${relativeRoastDate(c.latestRoastDate)} | ${usage}`;
+      const headline = `- ${c.roaster} — ${c.name} | ${c.origin} ${c.process} | ${relativeRoastDate(c.latestRoastDate)} | ${usage}`;
+      // Tasting history (only present after the weekly cron has summarised
+      // at least 2 sessions of this coffee — see /api/coffees/compact).
+      const tastingLine =
+        c.commonNotes && c.commonNotes.length > 0
+          ? `\n    Notes you taste: ${c.commonNotes.join(", ")}`
+          : "";
+      const summaryLine = c.writtenSummary
+        ? `\n    Brew memory: ${c.writtenSummary}`
+        : "";
+      return `${headline}${tastingLine}${summaryLine}`;
     })
     .join("\n");
 }

--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -494,13 +494,26 @@ function buildDiversityNote(sessions: import("../types/session").Session[]): str
   return `\nPORTFOLIO DIVERSITY — anchor methods in last ${recent.length} sessions: ${summary}. Vary deliberately unless the coffee or terrain genuinely demands the same approach.`;
 }
 
+/**
+ * Aggregated tasting history for the coffee being brewed.
+ * Populated by the weekly /api/coffees/compact cron. Both fields are
+ * optional — undefined on first brews or coffees with <2 sessions.
+ */
+export interface CoffeeHistory {
+  /** Top flavor notes the user has tasted across logged sessions. */
+  commonNotes?: string[];
+  /** 2–4 sentence AI brew memory. */
+  writtenSummary?: string;
+}
+
 export async function generateRecommendation(
   coffee: CoffeeIdentity,
   context: SessionContext,
   preferences: UserPreferences,
   pastSessions: Session[] = [],
   userRoasterPrior?: import("../roasters/priors").RoasterPrior,
-  escherTerrain?: string
+  escherTerrain?: string,
+  coffeeHistory?: CoffeeHistory,
 ): Promise<{
   recommendation: Recommendation;
   usage: { input_tokens: number; output_tokens: number };
@@ -635,6 +648,23 @@ export async function generateRecommendation(
       ? `\n${formatRoasterPriorForPrompt(roasterPrior)}`
       : "";
 
+  // Coffee tasting-history block — what the user has actually tasted vs.
+  // what the bag claims. Populated weekly by /api/coffees/compact and only
+  // present for coffees with ≥2 logged sessions.
+  const historyBlock = (() => {
+    if (!coffeeHistory) return "";
+    const lines: string[] = [
+      "\nYOUR TASTING HISTORY FOR THIS COFFEE — aggregated across your logged sessions of this exact bag. Compare against the bag's claimed tasting notes (above): when they diverge, the divergence is the signal. Use this to inform the hypothesis, not to override the bag's variety/process facts.",
+    ];
+    if (coffeeHistory.commonNotes?.length) {
+      lines.push(`- Notes you typically taste: ${coffeeHistory.commonNotes.join(", ")}`);
+    }
+    if (coffeeHistory.writtenSummary) {
+      lines.push(`- Brew memory: ${coffeeHistory.writtenSummary}`);
+    }
+    return lines.length > 1 ? lines.join("\n") : "";
+  })();
+
   // ── Knowledge layer injection ──────────────────────────────────────────
   // Three structured blocks selected per turn:
   //   1. Variety priors — what genetics tell us (WCR-grounded)
@@ -690,7 +720,7 @@ Origin: ${coffee.origin || "Unknown"}${coffee.region ? `, ${coffee.region}` : ""
 Process: ${coffee.process || "Unknown"}${coffee.fermentationStyle ? ` (${coffee.fermentationStyle})` : ""} | Roast: ${coffee.roastLevel || "Unknown"}${coffee.cuppingScore ? ` | Score: ${coffee.cuppingScore}` : ""}
 Roast date: ${coffee.roastDate ?? "unknown"}${daysOld !== null ? ` (${daysOld} days — ${freshnessNote})` : ""}
 Bag tasting notes: ${coffee.tastingNotesFromBag?.join(", ") || "none listed"}
-${roasterBlock}
+${roasterBlock}${historyBlock}
 Context:
 - Occasion: ${context.occasion}
 - Amount: ${context.amount} (${guide})


### PR DESCRIPTION
## Summary

Follow-up to #37. Now that `commonNotes` and `writtenSummary` are actually being read (and refreshed weekly), wire them into the AI so it can reason about "the bag claims X, you actually taste Y" instead of treating bag notes as ground truth.

**`/recommend`** (`src/app/api/recommend/route.ts` + `src/lib/claude/recommend.ts`)
- `generateRecommendation()` gains optional `coffeeHistory` param
- Route looks up the Coffee record by `coffeeId` (fast) with fallback to roaster+name match. Runs in parallel with existing roaster-prior and Escher-terrain lookups → zero added latency
- New "YOUR TASTING HISTORY FOR THIS COFFEE" block in the user message, right after bag notes + roaster prior. System prompt untouched → cache hit preserved.

**`/explore` + `/explore-agent`** (via `src/lib/claude/coffeeLibrary.ts`)
- `CompactCoffee` gains optional `commonNotes` + `writtenSummary`
- `loadCoffeeLibraryCompact()` fetches both
- `formatLibraryForPrompt()` emits two indented lines per coffee when present:
  ```
  Notes you taste: chocolate, citrus, ...
  Brew memory: <2-4 sentence AI summary>
  ```

For coffees without history (first brew or <2 sessions), prompt is byte-identical to pre-PR — both routes degrade gracefully.

## Test plan (per CLAUDE.md hard rule on AI behavioral changes)

- [ ] Brew-test 2-3 recommendations on coffees with established tasting history (≥2 sessions + past weekly cron). `reasoning` / `brewingLesson` should reference the "bag says X but you taste Y" tension when divergent.
- [ ] First-brew coffee (no history yet) — prompt is unchanged from pre-PR; output should not regress.
- [ ] `/explore` library-block question — "what should I brew next?" or "what does this coffee taste like to me?" — should cite your actual tasting notes when available.
- [ ] If AI starts conflating bag notes with historical notes as equally authoritative facts, the framing in `historyBlock` ("when they diverge, the divergence is the signal") may need tightening.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VcbF8sZcC7V657C9BRqw16)_