### PR TITLE
feat: brew memory card + what-to-explore on detail page and brew flow

### DIFF
--- a/src/app/api/coffees/compact/route.ts
+++ b/src/app/api/coffees/compact/route.ts
@@ -12,16 +12,16 @@ export const maxDuration = 120;
 
 const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
-const SYSTEM_PROMPT = `You are generating a personal brew memory for a specialty coffee enthusiast.
-Given all brew sessions for one coffee, write 2–4 sentences that capture:
-- overall quality impression and rating pattern
-- which method(s) worked best
-- recurring flavor notes or sensory highlights
-- any trend over time (improving, consistent, one-off)
+const SYSTEM_PROMPT = `You are generating two short paragraphs for a personal brew memory.
 
-Be direct, specific, and personal. No generic phrases. No emojis.
-Reference actual numbers (e.g. "4 of 6 brews rated 4★+").
-Metric units only.`;
+Given all brew sessions for one coffee, output exactly this JSON shape (no markdown, no commentary):
+
+{
+  "writtenSummary": "Exactly 2 sentences. Capture overall quality, which method worked best, recurring flavor notes, and trend if any. Reference actual numbers (e.g. \\"4 of 6 brews rated 4★+\\"). Direct, specific, personal. Metric units only. No emojis.",
+  "whatToExplore": "Exactly 2 sentences suggesting a specific unexplored angle for the next brew of this coffee. Could be: an untested method, a temperature shift, a different ratio, a championship recipe that fits the variety/process, or a technique to test (e.g. Hsu staged-temp, Rao spin, sieving fines). Be concrete. No emojis. No generic 'try different things'."
+}
+
+Both fields are required strings. Total response budget: ~120 words.`;
 
 function topNotes(sessionList: Session[], n = 5): string[] {
   const counts: Record<string, number> = {};
@@ -126,12 +126,37 @@ export async function POST(req: NextRequest) {
 
         const msg = await client.messages.create({
           model: "claude-haiku-4-5",
-          max_tokens: 200,
+          max_tokens: 350,
           system: SYSTEM_PROMPT,
           messages: [{ role: "user", content: userMessage }],
         });
 
-        const writtenSummary = (msg.content[0] as { type: string; text: string })?.text?.trim();
+        const rawText = (msg.content[0] as { type: string; text: string })?.text?.trim();
+        if (!rawText) {
+          errors++;
+          continue;
+        }
+
+        // Parse the structured JSON output. Be defensive — if the model
+        // emits anything that doesn't have both fields, fall back to
+        // treating the whole response as writtenSummary (preserves
+        // pre-PR behaviour for this coffee).
+        let writtenSummary: string;
+        let whatToExplore: string | null;
+        try {
+          const jsonMatch = rawText.match(/\{[\s\S]*\}/);
+          const parsed = JSON.parse(jsonMatch ? jsonMatch[0] : rawText);
+          writtenSummary = typeof parsed.writtenSummary === "string"
+            ? parsed.writtenSummary.trim()
+            : rawText;
+          whatToExplore = typeof parsed.whatToExplore === "string"
+            ? parsed.whatToExplore.trim()
+            : null;
+        } catch {
+          writtenSummary = rawText;
+          whatToExplore = null;
+        }
+
         if (!writtenSummary) {
           errors++;
           continue;
@@ -141,7 +166,7 @@ export async function POST(req: NextRequest) {
         const lastSummarizedAt = new Date().toISOString();
 
         await db.update(coffees)
-          .set({ writtenSummary, lastSummarizedAt, commonNotes })
+          .set({ writtenSummary, whatToExplore, lastSummarizedAt, commonNotes })
           .where(eq(coffees.id, coffee.id));
 
         processed++;

--- a/src/app/coffees/[id]/page.tsx
+++ b/src/app/coffees/[id]/page.tsx
@@ -331,6 +331,14 @@ export default function CoffeeDetailPage() {
         </div>
       )}
 
+      {/* What to explore */}
+      {coffee.whatToExplore && (
+        <div className="px-5 py-4 border-b border-brew-border">
+          <p className="text-brew-muted text-xs uppercase tracking-widest mb-2">What to explore</p>
+          <p className="text-white/80 text-sm leading-relaxed">{coffee.whatToExplore}</p>
+        </div>
+      )}
+
       {/* Sessions */}
       <div className="px-5 py-5 flex flex-col gap-4 pb-safe pb-8">
         <p className="text-brew-muted text-xs uppercase tracking-widest">All Brews</p>

--- a/src/components/flow/StepContext.tsx
+++ b/src/components/flow/StepContext.tsx
@@ -84,6 +84,11 @@ const DRIP_ASSIST_COMPATIBLE = new Set<string>([
   "V60", "Orea Fast", "Orea Apex", "Orea Classic", "Orea Open", "Kalita Wave", "Chemex",
 ]);
 
+interface CoffeeMemory {
+  writtenSummary?: string;
+  whatToExplore?: string;
+}
+
 export default function StepContext() {
   const { draft, setContext, setStep, setIsRecommending, setRecommendError } = useFlowStore();
   const ctx = draft.context || {} as Partial<SessionContext>;
@@ -91,6 +96,11 @@ export default function StepContext() {
   const [grinders, setGrinders] = useState<string[]>(DEFAULT_GRINDERS);
   // null = nothing selected yet (like all other sections); "ai" = Claude picks; "manual" = user picks
   const [brewMode, setBrewMode] = useState<"ai" | "manual" | null>(null);
+  // Aggregated brew memory + what-to-explore for this coffee. Populated
+  // weekly by /api/coffees/compact. Only shown when entering the flow
+  // for a previously brewed coffee (typically via "Brew Again" from
+  // home; not on a first-time bag scan).
+  const [coffeeMemory, setCoffeeMemory] = useState<CoffeeMemory | null>(null);
 
   useEffect(() => {
     fetch("/api/preferences", { cache: "no-store" })
@@ -103,6 +113,30 @@ export default function StepContext() {
       })
       .catch(() => {});
   }, []);
+
+  // Load this coffee's brew memory if it exists (i.e. the user has
+  // brewed it before and the weekly cron has summarised at least 2
+  // sessions). Silent failure — absence of memory is the common case.
+  useEffect(() => {
+    const coffeeId = draft.coffee?.coffeeId;
+    if (!coffeeId) return;
+    let cancelled = false;
+    fetch(`/api/coffees/${coffeeId}`, { cache: "no-store" })
+      .then(r => (r.ok ? r.json() : null))
+      .then((coffee: { writtenSummary?: string; whatToExplore?: string } | null) => {
+        if (cancelled || !coffee) return;
+        if (coffee.writtenSummary || coffee.whatToExplore) {
+          setCoffeeMemory({
+            writtenSummary: coffee.writtenSummary,
+            whatToExplore: coffee.whatToExplore,
+          });
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [draft.coffee?.coffeeId]);
 
   const update = (key: keyof SessionContext, value: string | number | boolean) => {
     setContext({ ...ctx, [key]: value } as SessionContext);
@@ -151,6 +185,27 @@ export default function StepContext() {
           <p className="text-brew-muted text-xs tracking-widest uppercase mb-2">Context</p>
           <h1 className="font-display text-2xl text-white">What&apos;s the vibe?</h1>
         </div>
+
+        {/* Brew memory — present only when this coffee has prior history. */}
+        {coffeeMemory && (coffeeMemory.writtenSummary || coffeeMemory.whatToExplore) && (
+          <div
+            className="rounded-2xl border p-4 flex flex-col gap-3"
+            style={{ background: "var(--card)", borderColor: "var(--border)" }}
+          >
+            {coffeeMemory.writtenSummary && (
+              <div>
+                <p className="text-brew-muted text-xs uppercase tracking-widest mb-1.5">Brew memory</p>
+                <p className="text-white/80 text-sm leading-relaxed">{coffeeMemory.writtenSummary}</p>
+              </div>
+            )}
+            {coffeeMemory.whatToExplore && (
+              <div>
+                <p className="text-brew-muted text-xs uppercase tracking-widest mb-1.5">What to explore</p>
+                <p className="text-white/80 text-sm leading-relaxed">{coffeeMemory.whatToExplore}</p>
+              </div>
+            )}
+          </div>
+        )}
 
         <Section title="Occasion">
           <div className="grid grid-cols-2 gap-2">

--- a/src/lib/db/helpers.ts
+++ b/src/lib/db/helpers.ts
@@ -21,6 +21,7 @@ export function rowToCoffee(r: typeof coffees.$inferSelect): Coffee {
     writtenSummary: r.writtenSummary ?? undefined,
     lastSummarizedAt: r.lastSummarizedAt ?? undefined,
     commonNotes: r.commonNotes ?? undefined,
+    whatToExplore: r.whatToExplore ?? undefined,
     personalNotes: r.personalNotes ?? undefined,
   };
 }

--- a/src/lib/db/migrations/0006_add_what_to_explore.sql
+++ b/src/lib/db/migrations/0006_add_what_to_explore.sql
@@ -1,0 +1,6 @@
+-- Add what_to_explore column to coffees table.
+-- Populated weekly alongside written_summary by /api/coffees/compact.
+-- Surfaces in /coffees/[id] and in StepContext (the brew-context entry step)
+-- as a 2-sentence "what to try next on this coffee" hint.
+
+ALTER TABLE coffees ADD COLUMN IF NOT EXISTS what_to_explore text;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -61,6 +61,7 @@ export const coffees = pgTable("coffees", {
   writtenSummary: text("written_summary"),
   lastSummarizedAt: text("last_summarized_at"),
   commonNotes: jsonb("common_notes").$type<string[]>(),
+  whatToExplore: text("what_to_explore"),
   personalNotes: text("personal_notes"),
 });
 

--- a/src/lib/types/coffee.ts
+++ b/src/lib/types/coffee.ts
@@ -16,5 +16,6 @@ export interface Coffee {
   writtenSummary?: string;
   lastSummarizedAt?: string;
   commonNotes?: string[];
+  whatToExplore?: string;
   personalNotes?: string; // free-text notes written by the user
 }


### PR DESCRIPTION
## Summary

Follow-up to #37 / #38. Surfaces the weekly-cron-populated coffee memory on the two UI surfaces requested:

1. **Coffee Detail page** (`/coffees/[id]`) — adds a "What to explore" section beside the existing "Brew memory".
2. **StepContext** (step 3 of a fresh brew flow; step 1 when entering via "Brew Again" from home) — new top card with 2-sentence brew memory + 2-sentence what-to-explore.

The "what to explore" content is generated alongside `writtenSummary` by the same weekly Haiku call — no extra cost, same staleness.

## Changes

**Schema**
- New nullable column `coffees.what_to_explore` (migration `0006`)
- Drizzle schema, type, and `rowToCoffee` mapper updated

**Cron rewrite (`/api/coffees/compact`)**
- System prompt now requests structured JSON `{ writtenSummary, whatToExplore }`
- Defensive parser — if JSON malformed, entire response treated as `writtenSummary` (preserves pre-PR behaviour)
- `max_tokens` 200 → 350 to fit two paragraphs

**UI**
- Coffee detail: new "What to explore" section
- StepContext: top card, hidden when this is a first-brew bag scan (no `coffeeId`) or when neither field is set

## Post-merge action

After auto-deploy, SSH to VPS and apply the migration:

```bash
cd /opt/brewlog && cat src/lib/db/migrations/0006_add_what_to_explore.sql | \
  docker compose exec -T postgres psql -U brewlog -d brewlog
```

Then optionally trigger the cron immediately to backfill existing coffees:

```bash
docker compose exec app curl -sf -X POST http://localhost:3000/api/coffees/compact \
  -H "Authorization: Bearer $CRON_SECRET"
```

## Test plan (per CLAUDE.md hard rule)

- [ ] Apply migration on VPS
- [ ] Trigger cron manually on a coffee with ≥2 sessions; confirm both `written_summary` and `what_to_explore` are populated
- [ ] Open `/coffees/[id]` for that coffee — confirm both sections render
- [ ] On home page, tap "Brew Again" for that coffee → land on StepContext → memory card visible at top, hidden after navigation away
- [ ] First-brew scan flow: card stays hidden
- [ ] If Haiku malformed JSON, the fallback kicks in and `writtenSummary` becomes literal JSON text — flag this if observed and we tighten the prompt or switch to prefilled assistant turn


---
_Generated by [Claude Code](https://claude.ai/code/session_01VcbF8sZcC7V657C9BRqw16)_