### PR TITLE
fix: render explore chat gradients so user pill is readable

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -128,7 +128,10 @@ export default function ExplorePage() {
   };
 
   return (
-    <div className={`min-h-full flex flex-col ${activeTab === "ask" ? gradientChatBg : "bg-brew-bg"}`}>
+    <div
+      className="min-h-full flex flex-col"
+      style={activeTab === "ask" ? { background: gradientChatBg } : { background: "var(--bg-base)" }}
+    >
       {/* Header — DOT-spec: tab switcher pills only, no app icon, no title */}
       <div className="px-5 pb-3" style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.25rem)" }}>
         <div
@@ -629,8 +632,9 @@ function AskTab() {
                   // Cream speech-bubble pill — asymmetric corner on the
                   // bottom-right reads as a tail pointing toward the user.
                   <div
-                    className={`max-w-[78%] flex flex-col gap-2 ${gradientPillUser}`}
+                    className="max-w-[78%] flex flex-col gap-2"
                     style={{
+                      background: gradientPillUser,
                       borderTopLeftRadius: 22,
                       borderTopRightRadius: 22,
                       borderBottomLeftRadius: 22,

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -24,11 +24,12 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <button
         ref={ref}
         disabled={disabled || loading}
+        style={variant === "primary" ? { background: gradientButtonPrimary } : undefined}
         className={cn(
           "inline-flex items-center justify-center font-medium rounded-full transition-all duration-200 active:scale-[0.97] disabled:opacity-40 disabled:pointer-events-none select-none",
           {
-            // primary — gradient fill
-            [`${gradientButtonPrimary} text-dot-on-pill shadow-glow-subtle hover:brightness-[1.05]`]:
+            // primary — gradient fill (background applied via inline style above)
+            "text-dot-on-pill shadow-glow-subtle hover:brightness-[1.05]":
               variant === "primary",
             // secondary — glass pill
             "bg-dot-s2/60 backdrop-blur-xl border border-dot-edge text-dot-ink hover:bg-dot-s2/80":

--- a/src/lib/theme/gradients.ts
+++ b/src/lib/theme/gradients.ts
@@ -1,8 +1,9 @@
 /**
- * Named gradient class strings for the BrewLog redesign (spec §2.4).
+ * Named gradient values for the BrewLog redesign (spec §2.4).
  *
- * One source of truth — components import these instead of scattering
- * `bg-[radial-gradient(...)]` literals.
+ * One source of truth — components import these and apply them via inline
+ * `style={{ background: ... }}` so they don't depend on Tailwind's JIT
+ * scanning `src/lib` (it doesn't — `content` only covers app/components/pages).
  *
  * Reference images: docs/redesign/dot-refs/Splashscreen2_*.png +
  * LoadingScreen_*.png (chat); GradientBackground_*.png (hero).
@@ -11,30 +12,26 @@
 /**
  * Full chat-surface gradient. Two warm radial stops on the dark base.
  * Use as the wrapper background behind the message scroll area.
- *
- * Stops:
- *  - top-left peak  (warm-peak → warm-mid → base) ~55% radius
- *  - bottom-right (warm-mid at low alpha) ~70% radius
  */
 export const gradientChatBg =
-  "bg-[radial-gradient(ellipse_55%_45%_at_15%_10%,var(--bg-gradient-glow)_0%,var(--bg-gradient-warm)_35%,var(--bg-base)_75%),radial-gradient(ellipse_60%_50%_at_85%_90%,rgba(107,72,56,0.35)_0%,transparent_60%)] bg-[color:var(--bg-base)]";
+  "radial-gradient(ellipse 55% 45% at 15% 10%, var(--bg-gradient-glow) 0%, var(--bg-gradient-warm) 35%, var(--bg-base) 75%), radial-gradient(ellipse 60% 50% at 85% 90%, rgba(107,72,56,0.35) 0%, transparent 60%), var(--bg-base)";
 
 /**
  * Tighter hero gradient for the home feed hero card and Phase 4 brew
  * recommend candidates. Single warm stop, less drama than the chat bg.
  */
 export const gradientHeroSurface =
-  "bg-[radial-gradient(ellipse_70%_60%_at_30%_20%,var(--bg-gradient-warm)_0%,var(--bg-base)_70%)] bg-[color:var(--bg-base)]";
+  "radial-gradient(ellipse 70% 60% at 30% 20%, var(--bg-gradient-warm) 0%, var(--bg-base) 70%), var(--bg-base)";
 
 /**
  * Subtle warm-on-warm fill for the cream user message bubble — adds
  * dimensionality without breaking the flat-pill read.
  */
 export const gradientPillUser =
-  "bg-[linear-gradient(135deg,#F5ECE5_0%,#EBDFD2_100%)]";
+  "linear-gradient(135deg, #F5ECE5 0%, #EBDFD2 100%)";
 
 /**
  * Primary CTA fill (Phase 2/3 — Brew button, send arrow background).
  */
 export const gradientButtonPrimary =
-  "bg-[linear-gradient(135deg,#F1D2B6_0%,#E8C5A8_60%,#D4A98A_100%)]";
+  "linear-gradient(135deg, #F1D2B6 0%, #E8C5A8 60%, #D4A98A 100%)";


### PR DESCRIPTION
## Summary

- The four gradient constants in `src/lib/theme/gradients.ts` were exported as Tailwind arbitrary classes (`bg-[linear-gradient(...)]` / `bg-[radial-gradient(...)]`), but Tailwind's `content` paths only scan `app/components/pages` — so those classes were never generated.
- In `/explore`, the user message bubble therefore had no background. The warm-dark `--text-on-pill-user` text rendered directly on the chat base — basically invisible (visible in the screenshot you sent).
- Switch the constants to plain CSS background strings and apply them via inline `style` at the call sites. Same treatment for the chat radial bg, hero, and primary-button gradients so they stop silently breaking on future config drift.

## Test plan

- [ ] Open `/explore`, ask anything, and verify the user message renders inside the cream pill with the warm-dark text legible
- [ ] Verify the chat surface shows the two warm radial stops (top-left glow, bottom-right warm) again
- [ ] Verify nothing visually regressed on the assistant text or the input dock

https://claude.ai/code/session_019fwsaVRKc21QiyLc8rdfA2

---
_Generated by [Claude Code](https://claude.ai/code/session_019fwsaVRKc21QiyLc8rdfA2)_