### PR TITLE
feat: explore agent shows reasoning when picking from user's own items

### DIFF
--- a/src/app/api/explore-agent/route.ts
+++ b/src/app/api/explore-agent/route.ts
@@ -123,6 +123,7 @@ This rule is non-negotiable. Saying "go finer to speed up" is a factual error �
 - **Brevity first.** For shopping picks: one structured block per coffee. For conversation: 3–6 sentences max.
 - **No markdown headers** (no #, ##). Use **bold** for key terms.
 - Direct, confident. Reference real people, origins, varietals by name.
+- **Show your reasoning when you compare or pick.** When the user asks you to choose between things they already have (their bags, past sessions, kit), don't just declare the winner. Briefly name each candidate and what it brings to the criterion — one short sentence each — then the pick and a one-line *why*. "Direct" means every sentence does work, not "skip the reasoning".
 - Always Niche DEGREES for grind. Metric units (g, °C, ml).
 - No emojis. No closing remarks.
 


### PR DESCRIPTION
## Summary

- `/explore`'s system prompt has explicit format guidance for **shopping picks** (fetched external products) but nothing for picking between coffees/sessions/kit the user **already owns**. Combined with "Brevity first" and "Direct, confident", the model reads it as "just declare the answer" — so when you asked which of your three Hoppenworth & Ploch bags suits a Clever Dripper, the chat named the right coffee but skipped the reasoning.
- Add a Response Style bullet: when comparing or choosing between things the user already has, briefly name each candidate and what it brings to the criterion, then the pick + one-line *why*. "Direct" means every sentence does work, not skipping the reasoning.

⚠️ **Behavioral change — not sampled before/after.** Per the CLAUDE.md hard rule, prompt edits that change output character should be validated against real outputs first. You opted to validate live on the deployed app after merge.

## Test plan

- [ ] On deployed `/explore`, re-ask "Which of my three Hoppenworth & Ploch bags is best for a Clever Dripper Brew?" — expect a short tradeoff per bag, then the pick with a one-line reason
- [ ] Try a comparison across past sessions ("which of my last 5 brews was closest to balanced?") — same shape: short reasoning per candidate, then verdict
- [ ] Try a non-comparison ("how do I bloom a natural?") — should still be the existing concise style, not bloated with extra reasoning

https://claude.ai/code/session_019fwsaVRKc21QiyLc8rdfA2

---
_Generated by [Claude Code](https://claude.ai/code/session_019fwsaVRKc21QiyLc8rdfA2)_