### PR TITLE
feat: add &quot;Brew this&quot; shortcut on coffee library + detail pages

### DIFF
--- a/src/app/coffees/[id]/page.tsx
+++ b/src/app/coffees/[id]/page.tsx
@@ -2,11 +2,12 @@
 import { useEffect, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import type { Coffee } from "@/lib/types/coffee";
-import type { Session } from "@/lib/types/session";
+import type { Session, CoffeeIdentity } from "@/lib/types/session";
 import SessionCard from "@/components/session/SessionCard";
 import StarRating from "@/components/ui/StarRating";
 import CoffeeBeanGlow from "@/components/ui/CoffeeBeanGlow";
 import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
+import { useFlowStore } from "@/store/flowStore";
 
 interface RoasterInfo {
   region?: string;
@@ -23,6 +24,7 @@ export default function CoffeeDetailPage() {
   const [roasterGenerating, setRoasterGenerating] = useState(false);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
+  const { reset, setCoffee: setFlowCoffee, setStep, setMode, setSkipScan } = useFlowStore();
 
   // Personal notes state
   const [editingNotes, setEditingNotes] = useState(false);
@@ -128,6 +130,29 @@ export default function CoffeeDetailPage() {
   const commonNotes = coffee.commonNotes ?? [];
   const origin = latestCoffee?.origin || coffee.origin;
 
+  const brewThis = () => {
+    // Prefer the most-recent scanned CoffeeIdentity (has variety, tasting notes,
+    // roast level). Fall back to the aggregate if the coffee somehow has no
+    // sessions yet — defaults match the user's profile (light roast).
+    const identity: CoffeeIdentity = latestCoffee ?? {
+      roaster: coffee.roaster,
+      name: coffee.name,
+      origin: coffee.origin,
+      process: coffee.process,
+      roastLevel: "Light",
+      roastDate: coffee.latestRoastDate,
+      bagPhotoUrl: coffee.bagPhotoUrl,
+      aiExtracted: false,
+      coffeeId: coffee.id,
+    };
+    reset();
+    setFlowCoffee({ ...identity, coffeeId: coffee.id });
+    setMode("home");
+    setSkipScan(true);
+    setStep("context");
+    router.push("/brew/new");
+  };
+
   return (
     <div className="min-h-svh bg-brew-bg flex flex-col">
       {/* Hero */}
@@ -193,6 +218,17 @@ export default function CoffeeDetailPage() {
             <p className="text-brew-muted text-xs uppercase tracking-widest mt-0.5">Best Method</p>
           </div>
         )}
+      </div>
+
+      {/* Brew this — jumps straight to the brew context step with this coffee preloaded */}
+      <div className="px-5 pt-4">
+        <button
+          type="button"
+          onClick={brewThis}
+          className="w-full py-3.5 rounded-2xl text-sm font-medium bg-brew-accent text-brew-accent-fg active:scale-[0.98] transition-transform"
+        >
+          Brew this
+        </button>
       </div>
 
       {/* Coffee scan details */}

--- a/src/app/coffees/page.tsx
+++ b/src/app/coffees/page.tsx
@@ -3,7 +3,9 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import type { Coffee } from "@/lib/types/coffee";
+import type { CoffeeIdentity } from "@/lib/types/session";
 import StarRating from "@/components/ui/StarRating";
+import { useFlowStore } from "@/store/flowStore";
 
 type Filter = "recent" | "favorites" | "roaster";
 
@@ -16,6 +18,30 @@ export default function CoffeesPage() {
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<Filter>("recent");
   const router = useRouter();
+  const { reset, setCoffee, setStep, setMode, setSkipScan } = useFlowStore();
+
+  const brewThis = (coffee: Coffee) => {
+    // Synthesize a CoffeeIdentity from the aggregate. roastLevel isn't stored
+    // on the Coffee row — default to "Light" (matches the user's profile).
+    // Downstream /recommend gets the rest from preferences + history.
+    const identity: CoffeeIdentity = {
+      roaster: coffee.roaster,
+      name: coffee.name,
+      origin: coffee.origin,
+      process: coffee.process,
+      roastLevel: "Light",
+      roastDate: coffee.latestRoastDate,
+      bagPhotoUrl: coffee.bagPhotoUrl,
+      aiExtracted: false,
+      coffeeId: coffee.id,
+    };
+    reset();
+    setCoffee(identity);
+    setMode("home");
+    setSkipScan(true);
+    setStep("context");
+    router.push("/brew/new");
+  };
 
   useEffect(() => {
     setLoading(true);
@@ -165,56 +191,66 @@ export default function CoffeesPage() {
             {filteredCoffees.map(coffee => {
               const sub = [coffee.origin, coffee.process].filter(Boolean).join(" · ");
               return (
-                <button
+                <div
                   key={coffee.id}
-                  type="button"
-                  onClick={() => router.push(`/coffees/${coffee.id}`)}
-                  className="flex items-center gap-3 bg-brew-surface border border-brew-border rounded-2xl p-3 text-left active:scale-[0.98] transition-transform w-full"
+                  className="flex items-center gap-3 bg-brew-surface border border-brew-border rounded-2xl p-3 w-full"
                 >
-                  {/* Thumbnail */}
-                  <div className="relative w-14 h-14 rounded-xl overflow-hidden bg-brew-elevated shrink-0">
-                    {coffee.bagPhotoUrl ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img src={coffee.bagPhotoUrl} alt={coffee.name} className="w-full h-full object-cover" />
-                    ) : (
-                      <div className="w-full h-full flex items-center justify-center">
-                        <svg className="w-6 h-6 text-brew-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636" />
-                        </svg>
+                  {/* Tap target — opens detail page */}
+                  <button
+                    type="button"
+                    onClick={() => router.push(`/coffees/${coffee.id}`)}
+                    className="flex items-center gap-3 flex-1 min-w-0 text-left active:opacity-80 transition-opacity"
+                  >
+                    {/* Thumbnail */}
+                    <div className="relative w-14 h-14 rounded-xl overflow-hidden bg-brew-elevated shrink-0">
+                      {coffee.bagPhotoUrl ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img src={coffee.bagPhotoUrl} alt={coffee.name} className="w-full h-full object-cover" />
+                      ) : (
+                        <div className="w-full h-full flex items-center justify-center">
+                          <svg className="w-6 h-6 text-brew-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636" />
+                          </svg>
+                        </div>
+                      )}
+                      {/* Session count badge */}
+                      <div className="absolute top-0.5 right-0.5 bg-black/70 rounded-full w-4 h-4 flex items-center justify-center">
+                        <span className="text-white font-mono-num" style={{ fontSize: "8px" }}>{coffee.sessionCount}</span>
                       </div>
-                    )}
-                    {/* Session count badge */}
-                    <div className="absolute top-0.5 right-0.5 bg-black/70 rounded-full w-4 h-4 flex items-center justify-center">
-                      <span className="text-white font-mono-num" style={{ fontSize: "8px" }}>{coffee.sessionCount}</span>
                     </div>
-                  </div>
 
-                  {/* Text */}
-                  <div className="flex-1 min-w-0">
-                    {coffee.roaster && (
-                      <p className="text-brew-muted text-xs truncate mb-0.5">{coffee.roaster}</p>
-                    )}
-                    <p className="text-white text-sm font-medium leading-snug truncate">{coffee.name}</p>
-                    {sub && (
-                      <p className="text-brew-muted text-xs truncate mt-0.5">{sub}</p>
-                    )}
-                    {coffee.latestRoastDate && (
-                      <p className="text-brew-muted text-xs truncate mt-0.5">
-                        Roasted {new Date(coffee.latestRoastDate).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })}
-                      </p>
-                    )}
-                    {coffee.avgRating != null && coffee.avgRating > 0 && (
-                      <div className="mt-1.5">
-                        <StarRating value={coffee.avgRating} readonly size="sm" />
-                      </div>
-                    )}
-                  </div>
+                    {/* Text */}
+                    <div className="flex-1 min-w-0">
+                      {coffee.roaster && (
+                        <p className="text-brew-muted text-xs truncate mb-0.5">{coffee.roaster}</p>
+                      )}
+                      <p className="text-white text-sm font-medium leading-snug truncate">{coffee.name}</p>
+                      {sub && (
+                        <p className="text-brew-muted text-xs truncate mt-0.5">{sub}</p>
+                      )}
+                      {coffee.latestRoastDate && (
+                        <p className="text-brew-muted text-xs truncate mt-0.5">
+                          Roasted {new Date(coffee.latestRoastDate).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })}
+                        </p>
+                      )}
+                      {coffee.avgRating != null && coffee.avgRating > 0 && (
+                        <div className="mt-1.5">
+                          <StarRating value={coffee.avgRating} readonly size="sm" />
+                        </div>
+                      )}
+                    </div>
+                  </button>
 
-                  {/* Chevron */}
-                  <svg className="w-4 h-4 text-brew-muted shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-                  </svg>
-                </button>
+                  {/* Brew this — jumps to the brew context step with this coffee preloaded */}
+                  <button
+                    type="button"
+                    onClick={() => brewThis(coffee)}
+                    aria-label={`Brew ${coffee.name}`}
+                    className="shrink-0 px-3 py-2 rounded-full text-xs font-medium bg-brew-accent text-brew-accent-fg active:scale-95 transition-transform"
+                  >
+                    Brew
+                  </button>
+                </div>
               );
             })}
           </div>


### PR DESCRIPTION
## Summary

- The coffee library and detail pages now have a one-tap shortcut into the brew flow that **skips bag-scan and jumps straight to step 3 (brew context)** with the coffee preloaded.
- **Detail page**: prominent "Brew this" button under the stats row. Uses the most recent session's full `CoffeeIdentity` (variety, tasting notes, roast level) when available; falls back to synthesizing from the aggregate.
- **Library list**: small "Brew" pill on the right of each row, replacing the chevron. The rest of the row still opens the detail page. Identity is synthesized from the aggregate; `/recommend` hydrates the rest from `coffeeId` server-side, so the synthesized fields (with `roastLevel: "Light"` matching the user's profile) are enough.

Same pattern as the home page's "Brew Again" carousel (`src/app/page.tsx:57`): `reset → setCoffee → setMode("home") → setSkipScan(true) → setStep("context") → push /brew/new`.

## Test plan

- [ ] On `/coffees`, tap the row body of any coffee → opens the detail page
- [ ] On `/coffees`, tap the "Brew" pill → lands directly on step 3 (Context), with the right coffee shown
- [ ] On a coffee detail page, tap "Brew this" → lands on step 3 with the latest scan's variety / tasting notes carried through to the recommendation
- [ ] Coffees with no `bagPhotoUrl` still display correctly in the row

https://claude.ai/code/session_019fwsaVRKc21QiyLc8rdfA2

---
_Generated by [Claude Code](https://claude.ai/code/session_019fwsaVRKc21QiyLc8rdfA2)_