### PR TITLE
docs: document brew-this shortcut, explore reasoning rule, tailwind/lib trap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,6 +224,7 @@ lib/
 - **Immersion timer precision** — per-step durations sum exactly to `targetTimeSec`; no absolute timestamps
 - **Background-safe timer** — `CircularTimer` uses `Date.now()` anchor; snaps via `visibilitychange` on iOS
 - **Step-change alerts** — 2-tone Web Audio cue (880 Hz → 660 Hz) on each auto-advanced step; `navigator.vibrate(80)` on Android
+- **"Brew this" entry shortcut (May 2026)** — both `/coffees` (library list) and `/coffees/[id]` (detail) expose a one-tap button that jumps straight to step 3 (Context) with the coffee preloaded. Same `reset → setCoffee → setMode("home") → setSkipScan(true) → setStep("context") → push /brew/new` pattern as the home page's "Brew Again" carousel. Detail page uses the latest scanned `CoffeeIdentity` from sessions; library list synthesizes from the aggregate (roastLevel defaults to "Light"). `/recommend` re-hydrates the full coffee row from `coffeeId` server-side, so synthesized identities are sufficient.
 
 **Data & persistence**
 - Session save: Zod validation → Postgres JSONB (null-safe)
@@ -246,6 +247,7 @@ lib/
   - **Roaster priors block** — up to 5 unique roasters from recent sessions hydrated via `getRoasterPrior()` so it can reference Friedhats' clarity bias, April's minimal-agitation rule, etc.
   - **BrewLog feature awareness** — system prompt now knows about Match, Taste, Cafés and points the user at them when relevant
   - **Self-aware capabilities (May 2026 follow-up)** — `## Your Capabilities` block in `src/app/api/explore-agent/route.ts` lists every tool the agent has (`search_places`, `fetch_page`, `analyze_image`, `suggest_navigation`) plus voice in/out (ElevenLabs Scribe STT + TTS). When the user asks "what can you do?" the chat answers from the list instead of hallucinating.
+  - **Reasoning on internal picks (May 2026)** — Response Style now includes "Show your reasoning when you compare or pick": when the user asks the chat to choose between things they already own (their bags, past sessions, kit), it must briefly name each candidate and what it brings to the criterion before declaring the pick. Prevents the failure mode where "Direct, confident" + "Brevity first" collapsed to a one-line declaration with no explanation.
 - **Place search — English DB + diacritic-tolerant fold (May 2026)** — `places.city` is stored in English/ASCII (Cologne, Munich, Dusseldorf, Vienna, Prague, Bucharest, Lisbon, …). Both the `/explore` chat (`searchPlaces`) and the `/cafes` map (`/api/places` GET) accept any spelling: a `fold()` helper in `src/app/api/explore-agent/route.ts` strips diacritics and collapses German digraphs (`ue→u`, `oe→o`, `ae→a`, `ß→ss`) on both query and DB rows in memory, so "Düsseldorf" / "Dusseldorf" / "Duesseldorf" all match the same row. The chat's system prompt instructs it to translate any German city name (Köln→Cologne, München→Munich) before searching. Map search additionally splits the query on whitespace and ANDs tokens, so "Kolo Berlin" finds Kolo in Berlin.
 - Weekly deep-research cron (Ofelia)
 - Knowledge base: insights, hints, news, questions
@@ -315,7 +317,8 @@ Cause for this rule: claimed "~33 cafés in the places table" based on counting 
 
 ### Code
 - **TypeScript strict** — no `any`, no `@ts-ignore` without comment
-- **Tailwind only** — no inline styles except `safe-area-inset-*`
+- **Tailwind only** — no inline styles except `safe-area-inset-*` (and the gradient exception below)
+- **Tailwind only scans `src/{app,components,pages}`** — `tailwind.config.ts` `content` paths do NOT include `src/lib/**`. Utility class strings that live solely in lib (including arbitrary values like `bg-[linear-gradient(...)]`) are silently never generated; the styles vanish at runtime with no error. If you need a shared visual constant in lib, export it as a raw CSS value and apply via inline `style={{ background: ... }}` at the call site — see `src/lib/theme/gradients.ts`. PR #40 fixed a regression where the /explore user-message cream pill never rendered because of this trap.
 - **No external UI libraries** — every component is bespoke
 - **Refs over state** for values that don't need to trigger renders (timers, wake lock, callbacks)
 - `useCallback` deps must be accurate — don't omit to silence linter


### PR DESCRIPTION
## Summary

Three additions to `CLAUDE.md` documenting what shipped this session:

- **Core brew flow** → the "Brew this" entry shortcut on `/coffees` and `/coffees/[id]`, with the `reset → setCoffee → setStep("context")` pattern it reuses from the home page's "Brew Again" carousel.
- **AI features** → the new Response Style rule that makes `/explore-agent` show its reasoning when picking between things the user already owns, instead of declaring a one-line verdict.
- **Conventions → Code** → Tailwind only scans `src/{app,components,pages}`. Utility-class strings that live solely in `src/lib/**` (including arbitrary values like `bg-[linear-gradient(...)]`) are silently never generated. Use raw CSS values + inline `style` for shared visual constants in lib; see `src/lib/theme/gradients.ts`. PR #40 fixed exactly this regression for the /explore user-message cream pill.

Docs-only — no code or behavior change.

## Test plan

- [ ] Read the diff in `CLAUDE.md` — three new bullets, each in the right section, no other edits

https://claude.ai/code/session_019fwsaVRKc21QiyLc8rdfA2

---
_Generated by [Claude Code](https://claude.ai/code/session_019fwsaVRKc21QiyLc8rdfA2)_