### PR TITLE
feat: light system foundation (PR2a)

### DIFF
--- a/specs/agent-memory-tbd.md
+++ b/specs/agent-memory-tbd.md
@@ -1,0 +1,92 @@
+# BTTS Agent Memory — spec stub
+
+**Status:** Concept noted, full spec deferred to post-Home-v1.
+**Scope:** A persistent memory layer that lets the BTTS Agent learn about Markus across conversations, and (Reading 2 below) makes that memory accessible to Claude.ai strategic sessions on the same data.
+
+This file exists so the concept isn't lost. It is not a spec yet. When Home v1 ships, we open this file and design properly.
+
+---
+
+## What it is
+
+The BTTS Agent — the conversational layer that runs on Home and powers `/api/explore-agent` — currently has no persistent knowledge of Markus beyond what's passed via system prompt on each call (recent brews, library snapshot, etc.). Each conversation starts effectively cold.
+
+Agent Memory is a separate persistent layer: a curated set of facts about Markus that the agent has learned from past conversations and writes back as it learns more. The agent reads it on every call (in the system prompt) and can write to it via a dedicated tool.
+
+**Example memory items:**
+- "Markus prefers Naturals over Washed processing (mentioned 2026-05-15)"
+- "Markus uses Ode Gen 2 grinder, owns V60, Aeropress, Chemex"
+- "Markus drinks one large brew in the morning, sometimes a small after dinner"
+- "Markus actively dislikes very acidic coffees ('makes my stomach turn')"
+
+These are different from BrewLog session data (which is structured: amount, grind, time). Memory items are unstructured preference signals expressed in conversation.
+
+---
+
+## Two readings of the use case
+
+### Reading 1 — Agent Memory inside BTTS
+
+The BTTS Agent uses memory to make its responses more personalized over time. If Markus once said "I hate floral coffees", the agent doesn't recommend a Geisha six months later. If Markus mentioned switching grinders, the agent stops referring to the old one.
+
+This is internal to BTTS. The memory lives in BTTS's Postgres, the agent reads/writes it.
+
+### Reading 2 — Memory available to Claude.ai sessions
+
+This file's `agent-memory-tbd.md` content — plus the actual memory entries — is *also* useful in strategic Claude.ai project sessions like the ones where Markus designs BTTS itself. When Markus says here "remember that I dislike very acidic coffees", that should be the same knowledge the BTTS Agent has, not a separate thing.
+
+This implies a sync mechanism. Two viable paths:
+
+**Path A — Manual sync via file export.**
+BTTS has an endpoint that exports current Agent Memory as a markdown file. Markus periodically downloads it and uploads to the Claude.ai project. Project knowledge picks it up. Stable, simple, no real-time.
+
+**Path B — MCP sync.**
+BTTS exposes an MCP server that Claude.ai connects to. The server has a `read_agent_memory` tool. Strategic sessions like the current one can query in real-time. This is the same MCP server that would surface Coffee Library, Sessions, etc. (see next section / future MCP spec).
+
+Path B is much more powerful but lives in MCP-for-BTTS territory, which is its own design work.
+
+---
+
+## Open design questions (for when we actually spec this)
+
+### Memory architecture
+
+- **How does an item get written?** Agent decides ("I should remember that") with a dedicated tool, or Markus says "remember that..." explicitly, or both?
+- **How does an item get updated?** Markus changes his mind about Naturals. Is the old item edited, marked obsolete, or replaced?
+- **How does an item get deleted?** Privacy is a real concern — some Conversation content shouldn't become long-term memory. Explicit delete UI, or auto-pruning?
+- **Item structure.** Free text? Structured (category + value)? Tagged with timestamp + source-conversation-id?
+- **Confidence levels.** "Markus mentioned Naturals once" vs. "Markus has stated this consistently across five conversations" — is that distinction worth modeling?
+
+### Read integration into agent prompts
+
+- Which memory items are loaded for which agent calls? All of them every time, or relevance-filtered?
+- Token cost — at scale, memory could grow large. Pruning strategy?
+- Memory items vs. recent context — how does the agent prompt balance "what Markus said five minutes ago" with "what Markus said three months ago"?
+
+### Reading 2 — sync architecture
+
+- Manual export (Path A) or MCP (Path B)?
+- If MCP: BTTS MCP server is its own substantial design topic (see "BTTS MCP server" as next big strategic topic post-Home-v1)
+- If manual: cadence? Markus triggers it, or scheduled?
+
+### Privacy model
+
+- Does the user (Markus) see his own Agent Memory? Browse it, edit it directly?
+- Are there topics that should never become memory items? (Crisis content, health, etc.)
+- Is there a "private conversation" mode where memory writing is disabled for a session?
+
+---
+
+## Why this isn't in Home v1
+
+Home v1 ships with Conversation Persistence (§10) — threads are archived, browseable, deletable. That gives Markus the substrate from which Agent Memory will eventually be distilled.
+
+But the *Agent Memory layer itself* — the curated cross-conversation knowledge — is a different design challenge: it's about what survives distillation from raw conversation transcripts to long-term, prompt-injectable facts. That's worth doing properly, with its own iteration cycle, after Home v1 is real and the conversation archive has actual content to learn from.
+
+In the meantime: §10 archive gives us the raw material. Agent Memory v1 (when designed) reads from that.
+
+---
+
+## Reminder for future Markus
+
+You wanted this. Don't lose it. When Home v1 is in production and you have ~50 conversations archived, that's the right moment to come back to this file and design properly. Until then: file stays as a stub, marker, and reminder.

--- a/specs/design-system-v1.0.md
+++ b/specs/design-system-v1.0.md
@@ -1,0 +1,559 @@
+# BrewLog Design System v1.0
+
+**Status:** v1.0 — distilled from the Brew Context v7 iteration.
+**Scope:** Every BrewLog view from v1.0 forward. Old `docs/redesign/spec.md` (Explore chat) is superseded.
+**Migration mode:** View-by-view. Brew Detail is the first hero-view to receive this system.
+**Source of truth:** Lovable v7 export — `src/index.css`, `src/pages/Index.tsx`, `tailwind.config.ts`.
+
+---
+
+## 0. How to read this document
+
+This is a **system spec**, not a component library. It defines tokens, primitives, and rules that every BrewLog view must respect. View-specific layouts are *applications* of this system, not extensions of it.
+
+Concrete Tailwind values are embedded inline — ready for translation into `tailwind.config.ts` extensions and component classNames during the Claude Code integration step (Step B). Where a value isn't a Tailwind default (arbitrary opacity, arbitrary HSL), the exact arbitrary syntax is shown.
+
+⚠️ **Anti-pattern** boxes flag mistakes that have already been made in earlier Lovable iterations. They are non-negotiable; do not relitigate them in future views.
+
+---
+
+## 1. Visual identity
+
+BrewLog reads as a **warm, hazy, late-afternoon room**. Not a UI — a place. The gradient field is the constant ground; cards float on it as frosted glass; type is editorial, deliberate, almost printed.
+
+**Three anchors:**
+
+- **The Field** — a six-layer radial-and-linear gradient blurred to 60px and scaled past the viewport. It is *always* the background. Cards never sit on a flat color.
+- **The Glass** — every interactive surface is translucent (55–70% opacity) with `backdrop-blur` and `backdrop-saturate-150`. The Field reads *through* the surface, not behind it.
+- **The Voice** — Fraunces Semibold for the hero question on each view. Inter for everything that asks the user to act or read. Editorial serif for emotion, geometric sans for information.
+
+**Tonal range:** cream → cool mauve → warm peach → warm orange. Never cold, never neutral grey. Selected states deepen into warm taupe, not flatten into grey.
+
+**What this system is not:**
+
+- Not a card-on-white-card system. Cards are glass, not paper.
+- Not a "dark mode invertible" system. The Field *is* the system. A future dark variant would need its own Field, not a flipped palette.
+- Not emoji-friendly. Iconography is Lucide line-icons, 1.5 stroke. No filled icons, no emoji.
+
+---
+
+## 2. Color tokens
+
+### 2.1 The Field — fixed atmospheric background
+
+The Field is rendered once, fixed to the viewport, behind every view. It does not scroll with content.
+
+**Composition (rendered bottom-up, painter's algorithm):**
+
+| Layer | Definition | Role |
+|---|---|---|
+| 1 (base) | `linear-gradient(135deg, hsl(30 60% 92%) 0%, hsl(345 50% 82%) 50%, hsl(18 80% 72%) 100%)` | Cream → mauve → peach diagonal ground |
+| 2 | `radial-gradient(circle at 12% 92%, hsl(14 88% 68% / 0.8) 0%, transparent 60%)` | Bottom-left warm peach hotspot |
+| 3 | `radial-gradient(circle at 95% 45%, hsl(25 60% 88% / 0.7) 0%, transparent 50%)` | Mid-right warm cream |
+| 4 | `radial-gradient(circle at 18% 50%, hsl(330 50% 70% / 0.85) 0%, transparent 55%)` | Mid-left rose anchor |
+| 5 | `radial-gradient(circle at 55% 25%, hsl(348 75% 86% / 0.55) 0%, transparent 50%)` | Upper-mid cool mauve |
+| 6 (top) | `radial-gradient(circle at 92% 8%, hsl(30 65% 91%) 0%, transparent 60%)` | Top-right cream highlight |
+
+**Post-processing:**
+
+- `filter: blur(60px)`
+- `transform: scale(1.18)`
+- `transform-origin: center`
+
+The scale-past-viewport prevents the blur from revealing hard edges at the screen border.
+
+**Container & z-order:**
+
+- Wrapper: `pointer-events-none fixed inset-0 -z-10 overflow-hidden`
+- Inner element: `absolute inset-[-10%]` (the gradient itself, so the blurred halo has somewhere to land outside the viewport)
+
+⚠️ **Anti-pattern:** Do not re-render the Field per view, per section, or per screen. It is **one** fixed element at the app root. Per-view gradients cause flicker on navigation and break the "single room" reading. They also produced visible seams between sections during an earlier Lovable iteration.
+
+### 2.2 CTA Warmth — local gradient
+
+A second, localized gradient sits behind the primary CTA at the bottom of each view. It is *additive* to the Field, not a replacement.
+
+```
+background: radial-gradient(ellipse at 50% 100%,
+  hsl(12 88% 66% / 0.85) 0%,
+  hsl(18 82% 74% / 0.5) 35%,
+  transparent 70%);
+filter: blur(50px);
+```
+
+- Positioned `absolute inset-x-[-20%] -bottom-10 -top-16 -z-10` **relative to the CTA wrapper** (not the page)
+- Bleeds horizontally past the viewport edges (`-20%`) so the warmth feels environmental, not pasted on
+
+This layer is the visual anchor of the CTA: it warms the bottom of the screen and pulls the eye to the commit moment without the button needing a colored fill.
+
+### 2.3 Surface tokens
+
+| Token (proposed) | Value | Use |
+|---|---|---|
+| `bg-card-default` | `hsl(36 55% 96% / 0.55)` | Card default fill (warm cream, 55% opacity) |
+| `bg-card-selected` | `hsl(28 22% 84% / 0.7)` | Card pressed fill (warm taupe, 70% opacity) |
+| `shadow-card-pressed` | `inset 0 2px 4px rgba(60, 40, 30, 0.12)` | Pressed inset shadow — **warm brown, not grey** |
+| `backdrop-blur-card` | `14px` | Glass blur on all cards |
+| `backdrop-saturate-card` | `150%` | Saturation boost so the Field reads vivid through glass |
+
+### 2.4 Foreground tokens
+
+| Token | HSL | Use |
+|---|---|---|
+| `text-foreground` | `20 14% 12%` | Body, card titles, hero |
+| `text-foreground/80` | — | Icons inside cards |
+| `text-foreground/70` | — | Eyebrows |
+| `text-muted-foreground` | `20 8% 45%` | Sub-text, footnotes, captions, unit suffixes |
+| `text-foreground/15` | — | Inactive progress dots |
+
+All foreground tokens carry warm hue (20° / 8–14% saturation). They are warm near-blacks, not neutrals.
+
+⚠️ **Anti-pattern:** Do not introduce pure greys (`text-gray-500`, `text-zinc-*`, `text-slate-*`). They read cold against the Field and break the unified palette.
+
+---
+
+## 3. Typography
+
+### 3.1 Font stack
+
+- **Hero serif:** **Fraunces**, weights 400 / 500 / 600. Google Fonts variable, `opsz,wght` axis.
+- **Body sans:** **Inter**, weights 400 / 500 / 600. Google Fonts.
+
+Both loaded via a single Google Fonts `<link>` in document `<head>`. No self-hosted fonts in v1.0; revisit only if perf becomes an issue.
+
+Tailwind binding:
+
+```ts
+fontFamily: {
+  sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+  serif: ['Fraunces', 'ui-serif', 'Georgia', 'serif'],
+}
+```
+
+`body { @apply font-sans }` — Inter is the default everywhere except where `font-serif` is explicit.
+
+### 3.2 Scale
+
+| Role | Family | Size | Weight | Leading | Tracking | Tailwind |
+|---|---|---|---|---|---|---|
+| Hero question | Fraunces | 40 | 600 | 1.05 | -0.01em | `font-serif font-semibold text-[40px] leading-[1.05] tracking-[-0.01em]` |
+| Card title | Inter | 15 | 500 | tight | default | `text-[15px] font-medium leading-tight` |
+| Card sub-text | Inter | 12 | 400 | tight | default | `text-[12px] leading-tight text-muted-foreground` |
+| Eyebrow | Inter | 11 | 600 | default | 0.14em | `text-[11px] font-semibold uppercase tracking-[0.14em] text-foreground/70` |
+| Footnote | Inter | 12 | 400 | relaxed | default | `text-[12px] leading-relaxed text-muted-foreground` |
+| CTA label | Inter | 15 | 600 | default | default | `text-[15px] font-semibold` |
+| Unit suffix (in input) | Inter | 12 | 400 | tight | default | `text-[12px] text-muted-foreground` |
+
+The eyebrow style is captured in a utility:
+
+```css
+@layer utilities {
+  .label-eyebrow {
+    @apply text-[11px] font-semibold uppercase tracking-[0.14em] text-foreground/70;
+  }
+}
+```
+
+### 3.3 Rules
+
+- **Fraunces is reserved for the hero question on each view.** No serif elsewhere in v1.0. Resist the urge to "elevate" a section heading with Fraunces — the eyebrow already does that job.
+- **Card titles never wrap to three lines.** If a label is long enough to break twice in 15/500 Inter at 50% column width, shorten the label or expand the section's card height. Do not let typography break the grid.
+- **Sub-text is always `line-clamp-2`.** Three lines of sub-text in a 104px card is a smell — sub-text is shorthand, not prose.
+
+---
+
+## 4. Card primitive
+
+The Card is the load-bearing component of the system. Every selectable option in any view is a Card.
+
+### 4.1 Anatomy
+
+```
+┌─────────────────────────┐
+│                         │
+│       [Slot 1]          │   Title — always present
+│                         │
+│       [Slot 2]          │   Detail — exactly one of three forms
+│                         │
+└─────────────────────────┘
+```
+
+**Card frame:**
+
+- Fixed height **per section** — all cards in a section share height (§5). Brew Context uses `h-[104px]`. Future sections may pick a different fixed height, but within a section it's constant.
+- `rounded-3xl` (24px)
+- `px-3 py-4` (12px horizontal, 16px vertical)
+- `gap-1.5` between slots (6px)
+- `flex flex-col items-center justify-center text-center`
+- `transition-all` (covers state transitions)
+- Full-width within its grid cell (`w-full`)
+
+### 4.2 Slot 2 — three Detail forms
+
+The Card primitive supports exactly three Detail forms. **Choose one per card; never mix within a section.**
+
+**Form A — Sub-Text** (most common)
+
+Inter 12/400, muted-foreground, `line-clamp-2`, tight leading. Used for unit hints (`350 ml`), context modifiers (`Zone-1 emphasis`), or short qualifiers (`Claude picks`).
+
+**Form B — Icon**
+
+Lucide line-icon, `h-5 w-5` (20px), `strokeWidth={1.5}`, color `text-foreground/80`, rendered inside a `h-6 w-6` flex centering container. See §9 for icon rules.
+
+**Form C — Inline Input** (Custom-card variant only)
+
+A focused, transparent number input flanked by a static unit suffix. Used today only by AMOUNT's "Custom" card. When the Custom card is selected, Slot 2 swaps from Sub-Text ("enter ml") to the live Input.
+
+Input spec:
+
+- `<input type="number" inputMode="numeric">`
+- `w-14 bg-transparent text-center outline-none`
+- Spinner suppressed (`[appearance:textfield]` + webkit overrides)
+- Same typography as the card title (Inter 15/500) — the input *replaces* the title's visual weight when active
+- Static suffix label after input: Inter 12/400, muted-foreground (e.g. `ml`)
+- `onClick` on the input element calls `stopPropagation()` so editing the number doesn't bubble up and deselect the card
+- `useEffect` auto-focus + `select()` on mount
+
+⚠️ **Anti-pattern:** Two Detail forms in one card (e.g. title + icon + sub-text) is forbidden. If a card needs more information, rethink the section — not the card. The card is a fixed shape.
+
+### 4.3 States
+
+The Card has exactly two states in v1.0: **Default** and **Selected (pressed)**.
+
+There is no hover state on mobile, no ring variant, no disabled state yet. (A disabled state will be added when first needed; do not pre-emptively design it.)
+
+**Default**
+
+- Fill: `bg-[hsl(36_55%_96%_/_0.55)]`
+- `backdrop-blur-[14px] backdrop-saturate-150`
+- No border, no shadow
+
+**Selected (pressed)**
+
+- Fill: `bg-[hsl(28_22%_84%_/_0.7)]`
+- Same blur/saturate as Default
+- `scale-[0.98]` — the card visually recedes, as if physically pressed
+- `shadow-[inset_0_2px_4px_rgba(60,40,30,0.12)]` — soft inset shadow in warm brown
+
+The combination of **darker fill + scale-down + inset shadow** reads as *pressed into the surface*, not *highlighted*. This is intentional: selection should feel like commitment (a depression in the Field), not announcement (a glow).
+
+⚠️ **Anti-pattern:** Do not add a ring, outline, or border to the Selected state. An earlier ring variant (`ring-1 ring-[hsl(28_25%_72%)]`) was tested and rejected — it competes with the inset shadow and reads as *focus*, not *selection*. The ring variant has been removed from the codebase.
+
+### 4.4 Tap-to-deselect
+
+Every Card supports deselection. Tapping a Selected card returns the section to "nothing selected".
+
+- Single-select per section (radio behavior, not checkbox)
+- Tapping a different card moves selection to the new card
+- Tapping the *same* card again clears selection
+- No multi-select in v1.0 anywhere
+
+This is a deliberate departure from typical mobile radio-group patterns. The deselect affordance gives the user an out from a wrong tap without an explicit "clear" button, and it makes the section state honest: **empty is a legitimate state**, not a forced default.
+
+Pattern: `onClick={() => setX(prev => prev === id ? null : id)}`.
+
+### 4.5 Custom-input card behavior
+
+The Custom card (currently AMOUNT only) is the one sanctioned exception to "Slot 2 doesn't mutate":
+
+- Default state: Slot 2 shows Sub-Text ("enter ml")
+- Selected state: Slot 2 shows the Inline Input (Form C)
+- On deselect: input value clears (`customMl: null`)
+
+If another section needs a similar pattern in the future, it follows the same rule: Sub-Text → Input → cleared on deselect. No other Slot-2 mutations are allowed.
+
+---
+
+## 5. Section layout
+
+A Section is the unit of decision: one Eyebrow + one grid of Cards + optionally one Footnote.
+
+### 5.1 Anatomy
+
+```
+┌──────────────────────────────┐
+│ EYEBROW                      │   uppercase, tracked, muted
+│                              │
+│ ┌──────────┐ ┌──────────┐   │
+│ │  Card A  │ │  Card B  │   │   2-column grid, equal heights
+│ └──────────┘ └──────────┘   │
+│ ┌──────────┐ ┌──────────┐   │
+│ │  Card C  │ │  Card D  │   │
+│ └──────────┘ └──────────┘   │
+│                              │
+│ Footnote text (optional)     │   muted, 12/relaxed
+└──────────────────────────────┘
+```
+
+### 5.2 Grid rules
+
+- **Always 2 columns.** `grid grid-cols-2 gap-3` (12px gap, vertical = horizontal). No 1-column, no 3-column variants in v1.0.
+- **Card count must be even.** Sections with an odd number of options must either expand to the next even number (add a wildcard card like "Surprise me" / "Explore") or split into two sections. An orphan card in row N+1 is not allowed.
+- **All cards in a section share the same fixed height.** Set height once on the section, not per card. Brew Context's value is `h-[104px]`.
+
+### 5.3 Vertical spacing — the rule that broke in v6
+
+This is the rule that an earlier Lovable iteration got wrong. State it explicitly:
+
+> **Section bottom-spacing is measured from the *last visible element* of the section to the eyebrow of the next section. That distance is a constant.**
+
+"Last visible element" means:
+
+- The Footnote, **if one is rendered**
+- Otherwise, the last row of Cards
+
+The Footnote is **part of the section**, not a separate block. It does not get its own bottom margin equal to the section-spacing. The section-spacing applies once, *after* whatever the last element happens to be.
+
+**Implementation:**
+
+| Spacing | Value | Tailwind |
+|---|---|---|
+| Eyebrow → first card row | 12px | `mb-3` on eyebrow |
+| Card row → next card row | 12px | `gap-3` on grid (vertical = horizontal) |
+| Last card row → Footnote | 12px | `mt-3` on Footnote |
+| Section → next section | 40px | `space-y-10` on parent |
+
+Use `space-y-10` on the section container's parent. The Footnote sits *inside* the `<section>` with its own internal `mt-3` above. The 40px gap reads from the bottom of the Footnote — or, in sections without a Footnote, from the bottom of the last card row. Same constant either way.
+
+⚠️ **Anti-pattern:** Adding `mb-10` to the Footnote *and* `space-y-10` to the section parent produces an 80px gap below Footnote'd sections and 40px below non-Footnote sections — visibly inconsistent rhythm. **The Footnote does not own bottom space.**
+
+---
+
+## 6. Footnote system
+
+A Footnote is a single line (or short paragraph) of muted-foreground text below the card grid. Its job is to give the user *reading* — context, justification, or framing — without competing with the cards for attention.
+
+### 6.1 The three modes (plus None)
+
+Every section is in exactly one mode. **Mode is decided per-section at design time and does not change at runtime.**
+
+**Mode 1 — Educational** (always-on, static text)
+
+The Footnote is always rendered, and the text does not change based on selection. Used when the section's *concept* needs explaining, not its options. The Footnote teaches the user what the section *is*.
+
+> **Example — GOAL:** "The goal defines which method works best for THIS coffee."
+> The user needs to know *why* they're picking a goal. The text is identical regardless of which goal they pick.
+
+**Mode 2 — Reactive** (selection-driven, per-card text, hides when empty)
+
+The Footnote renders only when a card is selected. Each card maps to a unique Footnote line that justifies or annotates the choice. With nothing selected, there is no Footnote and no reserved space.
+
+> **Example — AMOUNT, BREWING APPROACH, WATER.** Each option carries its own short line:
+> *"A single cup — focused tasting, faster brew."* / *"Above SCA ceiling. Recipe will adjust accordingly."*
+
+**Mode 3 — Hybrid** (always-on, default text + per-card text)
+
+The Footnote is always rendered. With nothing selected it shows a default framing line; on selection it swaps to the selected card's specific Footnote.
+
+> **Example — OCCASION** (currently the only Hybrid section).
+> Default: *"Sets the pace and ritual of this brew."*
+> On Morning Ritual: *"A slower, deliberate pour that anchors the start of a day."*
+
+**Mode 0 — None** (trivial)
+
+The section renders no Footnote, ever. Used for sections that are self-explanatory and don't benefit from per-card annotation.
+
+> **Example — TIME, GRINDER.** The options speak for themselves; an annotation would add noise.
+
+### 6.2 Mode selection heuristic
+
+When designing a new section, pick a mode by asking:
+
+1. Does the user need to understand *what this section is for*, beyond what the eyebrow says? → **Educational** or **Hybrid**.
+2. Does each option carry meaning that's not obvious from its label? → **Reactive** or **Hybrid**.
+3. Both? → **Hybrid**.
+4. Neither? → **None**.
+
+⚠️ **Anti-pattern:** Reserving Footnote space "in case we add one later" produces inconsistent vertical rhythm. A section either has a Footnote (every render) or doesn't (never). Mode 2's "render only on selection" is a *controlled* exception: the space is genuinely absent when no card is selected — not held empty.
+
+### 6.3 Implementation
+
+A `getFootnote(section, selectedId)` helper returns either a string (render) or `null` (don't render). Every section calls it the same way:
+
+- Mode 1: helper returns the same string regardless of `selectedId`
+- Mode 2: helper returns the per-card string when `selectedId` is set, `null` when null
+- Mode 3: helper returns the default string when `selectedId` is null, per-card string when set
+- Mode 0: helper is not called
+
+Render guard: `{getFootnote(s, id) && <Footnote>{getFootnote(s, id)}</Footnote>}`.
+
+The `<Footnote>` component is a thin wrapper: `<p className="mt-3 px-1 text-[12px] leading-relaxed text-muted-foreground">`.
+
+---
+
+## 7. Page structure
+
+Every view in the system has the same skeleton.
+
+### 7.1 Anatomy
+
+```
+┌─────────────────────────────────┐
+│ ◀     • • • • •                 │   Header — back + progress dots + spacer
+│                                 │
+│ CONTEXT                         │   Hero eyebrow
+│ What's the vibe?                │   Hero question (Fraunces 40)
+│                                 │
+│ ─── Sections (see §5) ───       │   Body
+│                                 │
+│ ┌───────────────────────────┐  │
+│ │      Get my recipe        │  │   CTA — non-sticky, end-of-page
+│ └───────────────────────────┘  │
+└─────────────────────────────────┘
+```
+
+### 7.2 Container
+
+- `max-w-[430px]` (iPhone 14/15 Pro Max width — comfortable upper bound)
+- `mx-auto` centered
+- `px-5` (20px horizontal padding)
+- `relative` (so the Field can position fixed relative to viewport, not container)
+
+### 7.3 Header
+
+- Outer: `flex items-center justify-between pt-12 pb-8` (48px top clears the notch; 32px bottom)
+- Three-column: **back button (left) · progress dots (center) · spacer (right)**
+- Back button: `h-9 w-9 rounded-full text-foreground/70`, icon `ChevronLeft h-5 w-5 strokeWidth={1.75}`, container offset `-ml-2` so the visual edge of the icon aligns with content
+- Progress dots: `h-1.5 w-1.5 rounded-full` each, container `gap-2`; active dot `bg-foreground/80`, inactive `bg-foreground/15`
+- Right spacer: empty `w-9` div to keep dots centered against the back button
+
+### 7.4 Hero
+
+- `pb-10` (40px below hero before the first section)
+- Eyebrow: `label-eyebrow` utility, `mb-3 px-1`
+- Hero question: Fraunces 40/600, leading 1.05, tracking -0.01em, foreground
+
+The hero question is a single short sentence ending in a question mark. It frames the view, doesn't title it.
+
+### 7.5 CTA — non-sticky
+
+The primary CTA sits at the end of the page content. It is **not** `position: fixed` or `sticky`.
+
+- Button: `h-14 w-full rounded-full bg-foreground text-background text-[15px] font-semibold active:scale-[0.99]`
+- Wrapper: `relative pt-6 pb-[max(1.5rem,env(safe-area-inset-bottom))]`
+- The wrapper hosts the CTA Warmth Layer (§2.2) as an `absolute -z-10` sibling, scoped to the CTA position
+
+⚠️ **Anti-pattern:** Sticky-bottom CTAs were tested and rejected. They obscure the last section's Footnote and create a permanent visual weight that fights the editorial reading. The Brew Context view (and any decision-flow view modeled on it) is **a flow, not a tool**: the user scrolls through, then commits at the bottom. A sticky CTA implies "you can commit at any time" — the wrong message.
+
+---
+
+## 8. Hybrid gradient scroll
+
+The system uses exactly two background layers: a static Field and a scrolling CTA Warmth. Together they create a scroll experience where the room stays still but the warmth at the bottom *belongs to the CTA*.
+
+| Layer | Position | Scroll behavior | Job |
+|---|---|---|---|
+| Field (§2.1) | `fixed inset-0 -z-10` | Static — does not scroll | Atmospheric ground |
+| CTA Warmth (§2.2) | `absolute` inside CTA wrapper | Scrolls with the CTA | Anchors the commit moment |
+
+When the user scrolls past the CTA (on a longer view), the warmth scrolls out of view with the button. When they scroll back, the warmth returns. The Field is unchanged throughout.
+
+This is the v1.0 model. It is intentionally minimal — no parallax, no scroll-driven hue shifts, no per-section atmospheric layers. Adding more dynamic layers is allowed in future versions **only** if a specific view need justifies it.
+
+⚠️ **Anti-pattern:** Rendering the Field per-section (each section gets its own gradient block) was attempted and produced visible seams between sections plus performance drag on iOS Safari. **One fixed Field, one local CTA Warmth. Nothing else.**
+
+---
+
+## 9. Icons
+
+### 9.1 Default: Lucide
+
+Lucide line-icons are the system default. They're rendered as line icons with consistent stroke and visual weight.
+
+- Library: `lucide-react`
+- Inside cards: `h-5 w-5` (20px), `strokeWidth={1.5}`, color `text-foreground/80`
+- Inside an `h-6 w-6` flex centering container so visual center aligns with the title above
+- In the back button: `h-5 w-5`, `strokeWidth={1.75}` (slightly heavier for the smaller tappable target)
+
+### 9.2 Custom SVG pattern
+
+When Lucide doesn't have the right icon, or its closest match doesn't read clearly at card size, a custom SVG is built **to Lucide's conventions**:
+
+- `viewBox="0 0 24 24"`
+- `fill="none" stroke="currentColor"` (color inherits from parent)
+- `strokeWidth={1.5}` default, accept a prop override
+- `strokeLinecap="round" strokeLinejoin="round"`
+- Sized via parent `className` (`h-5 w-5` etc.) — **never** hard-coded `width`/`height` on the SVG element
+- `aria-hidden` on the SVG (icons in this system are always decorative)
+
+> **Current example** — `SunriseNoArrow` in the Morning Ritual card. The Lucide `Sunrise` icon includes an arrow that read as a navigation cue at card size; the custom variant strips it.
+>
+> The Morning Ritual icon itself is still iterating — its final form will land in Claude Code at integration time (Step B), not in Lovable. The *pattern* documented here (Lucide conventions, override-friendly props, sized by parent) is what governs.
+
+### 9.3 What not to use
+
+- No filled / solid icons
+- No multi-color icons
+- No emoji as icons
+- No icon fonts (Font Awesome, Material Icons, etc.)
+
+---
+
+## 10. Interaction rules
+
+A short list, because most of the interaction model is already implicit in the primitives above.
+
+1. **Single-select per section.** No multi-select anywhere in v1.0. A section has zero or one selected card.
+2. **Tap-to-deselect.** Tapping a Selected card clears the section. See §4.4.
+3. **No hover states on mobile.** The system targets the iPhone PWA first. Hover is not designed for; when desktop becomes relevant, hover treatments will be added explicitly, not inherited.
+4. **No drag, no swipe, no long-press** as primary interactions in the brew flow. Cards respond to **tap only**. (Map and list views may add swipe-to-delete etc. when those views are specified.)
+5. **`active:scale-[0.99]` on the CTA only.** Cards already animate via their state transition (`transition-all` + `scale-[0.98]` on Selected) — don't double up.
+6. **Navigation between flow steps is linear.** Back goes back, CTA goes forward, no skip-ahead. Progress dots are *informational*, not interactive.
+
+---
+
+## Appendix A — Forward-looking Tailwind config (for Step B briefing)
+
+The Claude Code integration step (Step B) will translate this spec into `tailwind.config.ts` extensions. A rough shape, for the briefing's reference — not final code:
+
+```ts
+extend: {
+  fontFamily: {
+    sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+    serif: ['Fraunces', 'ui-serif', 'Georgia', 'serif'],
+  },
+  colors: {
+    // surface tokens map to HSL custom properties so dark variants stay possible
+    'card-default': 'hsl(36 55% 96% / 0.55)',
+    'card-selected': 'hsl(28 22% 84% / 0.7)',
+  },
+  backgroundImage: {
+    'brew-field': /* full 6-layer gradient, see §2.1 */,
+    'brew-cta-warmth': /* radial, see §2.2 */,
+  },
+  boxShadow: {
+    'card-pressed': 'inset 0 2px 4px rgba(60, 40, 30, 0.12)',
+  },
+  backdropBlur: {
+    card: '14px',
+  },
+}
+```
+
+Actual translation, plus `index.css` utility wiring, lives in the Step B briefing — not here.
+
+---
+
+## Appendix B — Verified against
+
+Source files extracted from Lovable v7 export, 2026-05-11:
+
+- `src/index.css` — Field gradient, CTA Warmth gradient, `label-eyebrow` utility, all CSS-variable color tokens
+- `src/pages/Index.tsx` — Card primitive, section layout, footnote logic, page skeleton, custom-amount-input behavior
+- `tailwind.config.ts` — font stack, color HSL bindings, radius scale
+
+**Decisions made during spec authoring (not extractable from files alone):**
+
+- Selected state is **pressed-only**; the `ring` variant that exists in the Lovable codebase as dead code is rejected and not part of v1.0.
+- Footnote modes are formalized as **three modes + None**: Educational / Reactive / Hybrid + Mode 0. OCCASION stays Hybrid (does not collapse into Reactive).
+- Card Slot 2 is a **generic Detail slot** with three permitted forms (Sub-Text / Icon / Inline Input). Custom-Input is documented as a legitimate form, not a section-specific hack.
+
+**Deferred to later steps:**
+
+- Morning Ritual icon — not yet final, will be refined in Claude Code at integration time.
+- Dark mode — token names exist in CSS (`html.dark`) but their values are inherited from a generic shadcn template and are unrelated to BrewLog's identity. Treat dark mode as **not yet designed**.
+- Disabled state on cards — not encountered in Brew Context; design when first needed, not pre-emptively.
+
+---
+
+*End of v1.0.*

--- a/specs/design-system-v1.1-generative-field.md
+++ b/specs/design-system-v1.1-generative-field.md
@@ -1,0 +1,455 @@
+# BrewLog Design System v1.1 — Generative Field
+
+**Status:** v1.1 — draft. Replaces v1.0 §2.1 (The Field).
+**Scope:** The Field becomes coffee-driven across the Brew Flow + Coffee Detail Page; all other views use the v1.0 default Field with per-view rotation.
+**Relationship to v1.0:** v1.0 is frozen. v1.1 replaces only §2.1. Every other v1.0 section — typography, cards, sections, footnotes, page structure, icons, interactions — remains authoritative. Cards still float on the Field; the Field is just no longer a single fixed composition.
+**Source for data architecture:** verified against production DB and code on 2026-05-11. See Appendix B.
+
+---
+
+## 0. How to read this document
+
+This spec replaces one section of v1.0. To use it: open v1.0, skip §2.1, read everything else as-is, then apply this document for Field generation logic.
+
+Concrete Tailwind values and CSS structures are inlined where useful. The AI mapping prompt and the gradient composition algorithm are spec-level definitions — Step B will translate them into `src/lib/field/` code.
+
+⚠️ **Anti-pattern** boxes still apply across both documents.
+
+---
+
+## 1. The concept: Field as coffee signature
+
+**The Field becomes a property of the coffee.**
+
+When the user scans a Pacas from Honduras with notes `["Blueberry", "Hibiscus", "Red Grapes", "Juicy", "Elegant"]`, the Field that wraps the brew flow is **for that coffee**: floral, rose-leaning, with fruity undertones, brighter for "Juicy", more delicate for "Elegant". When the user scans a chocolatey Brazilian, the Field is cocoa-warm, lower lightness, gold-tinted.
+
+**Same coffee → same Field, every time, in every view that coffee appears.** Different coffees → genuinely different Fields. The gradient *means* something. This is the system's primary new semantic affordance compared to v1.0.
+
+**Within a single brew flow, the Field rotates per step** — same composition, slightly turned. This makes the seven-step flow feel like "same room, different time of day", not "seven different rooms".
+
+**The v1.0 default Field is itself a coffee signature** — a balanced Ethiopia-Yirgacheffe-style cup of floral + caramel + bright-citrus, expressed as roughly 0.4 Floral + 0.35 Sweet-Caramel + 0.25 Fruity-Bright. v1.1 generalises this. v1.0's specific composition becomes the "no signal available" fallback, not a special case.
+
+⚠️ **Anti-pattern:** The Field is not Goal-driven or Occasion-driven. Those are *user inputs inside the Context step* — they appear after the scan, at which point the Field is already on screen. A Field that changed when the user tapped Goal/Occasion would break v1.0 §1's "static room" anchor. The Field is set by the coffee, not by the user's choices in the flow.
+
+---
+
+## 2. The six Field Zones
+
+Every Field is composed of one or more Zones plus modifiers. A Zone is a palette specification — a hue, saturation, and lightness range plus a list of exemplar tasting notes.
+
+The Zones live within v1.0's warm envelope: hues 0–60° and 320–360°. **No cool blues, greens, or neutral greys.** The Lightness range is broadened from v1.0's 65–95% down to 25%, allowing genuinely dark warm Fields (a cocoa-bomb Brazilian Natural can be dim-warm without becoming cold). This is the one rule from v1.0 §1 that v1.1 relaxes — "never cold" stays, "never dim" goes.
+
+| Zone | Hue range | Saturation | Lightness | Character | Exemplar notes |
+|---|---|---|---|---|---|
+| **Fruity-Bright** | 0–30° (red-orange) | 60–90% | 70–90% | hell, klar, säuerlich-frisch | citrus, lemon, orange, grapefruit, mandarin, berry, blueberry, raspberry, cherry, cranberry, peach, apricot, currant, pomegranate |
+| **Fruity-Deep** | 350–360° ∪ 0–15° (deep red) | 50–75% | 50–70% | gereift, weinig, dunkel-fruchtig | dried fruit, date, raisin, fig, prune, plum, red grape, port, wine, fermented fruit, dark cherry |
+| **Floral** | 320–355° (rose-mauve-pink) | 40–70% | 70–88% | rosé, parfümiert, sanft | jasmine, rose, hibiscus, bergamot, chamomile, tea, lavender, elderflower, white flowers, floral, perfume |
+| **Nutty-Cocoa** | 20–40° (brown-amber) | 35–55% | 30–55% | warm-braun, kakao, geröstet | chocolate, cocoa, milk chocolate, dark chocolate, nut, almond, hazelnut, walnut, pecan, peanut, roasted, malt |
+| **Spice-Earth** | 25–45° (umbra, ocre, sienna) | 25–45% | 28–48% | erdig, würzig, gedeckt | cinnamon, clove, cardamom, tobacco, leather, earth, herbs, savoury, spice, woody, cedar, smoke |
+| **Sweet-Caramel** | 30–50° (honey-gold-amber) | 55–85% | 60–80% | golden, weich, gebackene Süße | caramel, honey, brown sugar, maple, vanilla, butter, toffee, syrup, molasses, custard, marzipan |
+
+**Zone overlap is intentional.** Nutty-Cocoa and Sweet-Caramel share hue range (~30–45°) but differ sharply in saturation/lightness: Nutty-Cocoa is dim and muted, Sweet-Caramel is bright and saturated. Same hue family, different perceptual weight — like dark chocolate vs. honey on the same warm axis. Same logic for Fruity-Bright vs. Fruity-Deep on the red axis.
+
+**A coffee's Field is rarely a single Zone.** Most coffees mix 2–3 Zones at varying weights. Single-Zone coffees exist but are extreme cases (a deeply roasted single-origin Brazilian might be 100% Nutty-Cocoa).
+
+---
+
+## 3. Mapping tasting notes to Zones — the AI pipeline
+
+The mapping from `tastingNotesFromBag` to a weighted Zone composition is done by a single Haiku 4.5 call, triggered once per coffee and persisted in `coffees.field_zones` (see §11). This is path **β** as agreed.
+
+### 3.1 Why AI mapping, not a closed lookup table
+
+A closed table would require maintaining ~80–150 hardcoded notes-to-zones entries and updating it every time a roaster introduces a new descriptor. In production data, tasting notes are wildly heterogeneous — German roasters write `pflaumig`, Scandinavian roasters write `lingonberry`, marketing-forward roasters write `like biting into a fresh peach on a summer afternoon`. A closed table fails open-vocabulary inputs by either dropping them silently (bad) or mis-routing them to the wrong Zone (worse).
+
+A Haiku call costs roughly $0.0001 per coffee. The call is made **once** per coffee (cached in `field_zones`) and never re-run unless tasting notes change. Cost is structurally trivial.
+
+⚠️ **Anti-pattern:** Do not call Haiku at render time. The Field gets seeded once at scan-complete and persisted. Render reads from cache. A render-time AI call would make every page navigation an API round-trip — unacceptable on iPhone PWA.
+
+### 3.2 The mapping output
+
+The Haiku call returns:
+
+```json
+{
+  "zones": [
+    { "id": "floral", "weight": 0.45 },
+    { "id": "fruity-bright", "weight": 0.30 },
+    { "id": "fruity-deep", "weight": 0.25 }
+  ],
+  "modifiers": {
+    "saturation": 5,
+    "lightness": 10
+  }
+}
+```
+
+Constraints:
+
+- `zones` array contains 1–3 entries
+- `weight` values are in [0, 1] and **sum to 1.0**
+- `modifiers.saturation` and `modifiers.lightness` are integers in [-15, +15]
+- Zone ids are exactly one of the six defined in §2
+
+The full prompt is in **Appendix A**.
+
+### 3.3 Modifiers — texture/quality descriptors
+
+Some descriptors aren't aromas — they're texture, intensity, or quality signals that should shift the Field's overall feel without changing its Zone composition. These map to the `modifiers` object, not to Zones:
+
+| Descriptor pattern | Modifier shift |
+|---|---|
+| `juicy`, `vibrant`, `lively`, `bright` | `saturation: +5 to +10` |
+| `elegant`, `delicate`, `refined` | `lightness: +5 to +10`, `saturation: -5` |
+| `clean`, `crisp`, `pristine` | `lightness: +5`, `saturation: -5` |
+| `complex`, `deep`, `intense` | no shift; signals to allow 3 zones rather than 2 |
+| `balanced`, `harmonic`, `silky` | no shift |
+| `creamy`, `velvety`, `rich` | `lightness: -5`, `saturation: +5` |
+| `dense`, `heavy`, `full-bodied` | `lightness: -10`, `saturation: +5` |
+
+Haiku is told these patterns in the prompt. It's allowed to combine multiple modifier signals (e.g. "juicy and elegant" → `saturation: +5, lightness: +8`), clamped to the [-15, +15] range.
+
+---
+
+## 4. Process modifier
+
+Process (`Washed` / `Natural` / `Honey` / `Anaerobic`) is a **secondary modifier** applied after the Zone composition is computed. It's a small global shift, not a Zone signal.
+
+| Process | Modifier shift | Rationale |
+|---|---|---|
+| `Washed` | `lightness: +5`, `saturation: +3` | Cleaner, more transparent cup → more luminous Field |
+| `Natural` | `lightness: -5`, `saturation: +3` | Deeper, more fermented texture → denser Field |
+| `Honey` | `lightness: 0`, `saturation: +5` | Middle ground with extra golden saturation |
+| `Anaerobic` | `lightness: -3`, `saturation: +8` | Fermentation-forward → more vivid, slightly deeper |
+| `null` / `Other` | no shift | Pass through |
+
+Production data check (verified 2026-05-11): the `coffees.process` column carries 4 distinct values — `Washed` (11), `Natural` (6), `Honey` (3), `null` (1). No `Anaerobic` yet (the user's library avoids it). The four-value table above covers reality plus the future-safe `Anaerobic` case.
+
+Process modifier is **additive** to the notes-derived modifier from §3.3, clamped to [-15, +15].
+
+---
+
+## 5. Variety fallback
+
+When `tastingNotesFromBag` is empty or missing (manual coffee add, scan extraction failure, low-info roaster), the system falls back to **variety-implied notes**.
+
+### 5.1 Pipeline
+
+1. Read `coffee.variety` from the session's `coffee` JSONB (or directly from `BagAnalysisResult.extracted.variety` during the scan flow).
+2. Look up the variety in `src/lib/knowledge/varieties/data.ts` via the existing `getVarietyPriorsForBag()` helper.
+3. From the variety's `cup signature` description in the knowledge file, derive implied tasting notes. **The same Haiku mapping prompt from §3 is run, but with these implied notes as input instead of bag notes.**
+
+### 5.2 Why reuse the Haiku pipeline instead of pre-baking variety→zone in the knowledge file
+
+The variety knowledge file (`coffee-experts.md` mirror + `varieties/data.ts`) describes cup signatures in prose: e.g. Geisha is "jasmine, bergamot, white peach, lemon zest, tea-like". That prose can be fed directly into the same Haiku mapping call — output is naturally a Floral-dominant composition with Fruity-Bright secondary. No separate variety→zone mapping table needed; the existing aromatic descriptions ARE the input.
+
+This means **the Zone-Mapping prompt is the only mapping layer in the system.** Tasting notes from the bag and aromatic descriptions from variety knowledge both flow through it. One pipeline, one place to debug, one place to refine.
+
+### 5.3 Variety string heterogeneity — known limitation
+
+Production data check: variety strings in `sessions.coffee.variety` are free-form, often with marketing prose (`"SL9* (locally known as 'Gesha Inca' — a rare cultivar belonging to the Ethiopian legacy group)"`). The existing `getVarietyPriorsForBag()` helper handles this with fuzzy matching. If it returns no prior, the system falls through to §6 (Default).
+
+This is the same fuzzy-match behaviour `/recommend` already uses for variety priors. No new logic needed here.
+
+---
+
+## 6. Default fallback
+
+When neither tasting notes nor a matchable variety is available:
+
+- Use the v1.0 Field composition: `0.40 Floral + 0.35 Sweet-Caramel + 0.25 Fruity-Bright`, no modifiers.
+- This is the gradient that ships in v1.0, expressed as a Zone composition.
+- It is **identical to v1.0 in rendered output**. Users with no scanned coffees see the v1.0 Field they already know.
+
+The Default is stored in code (`src/lib/field/defaultZones.ts`), not in the DB. It's a constant, not a row.
+
+---
+
+## 7. Composing the gradient from a Zone specification
+
+Given a `field_zones` JSON object, the system produces a 6-layer CSS gradient with **the same structural shape as v1.0's Field** — one linear base, five radial hotspots, blur 60px, scale 1.18. Only the colors change. The composition shape is fixed; the palette varies.
+
+### 7.1 Mapping rule (Zone composition → 6 layers)
+
+Each of the six gradient layers samples its color from the Zone composition:
+
+| Layer (from v1.0 §2.1) | Position | Color source |
+|---|---|---|
+| **1 (linear base)** | 135° diagonal across viewport | Three-stop interpolation across the top 3 weighted Zones, dim and de-saturated (lightness -10, saturation -15 from Zone baseline) |
+| **2 (bottom-left hotspot)** | `12% 92%`, radius 60% | Highest-weight Zone, picked at Zone's hue mid, saturation high end, lightness Zone mid |
+| **3 (mid-right warm)** | `95% 45%`, radius 50% | Second-weight Zone, hue mid, saturation Zone mid, lightness Zone high |
+| **4 (mid-left anchor)** | `18% 50%`, radius 55% | Third-weight Zone if 3 zones present; else echo of highest with hue rotated +10° |
+| **5 (upper-mid)** | `55% 25%`, radius 50% | Highest-weight Zone, hue mid, saturation Zone low end (more transparent), lightness Zone high |
+| **6 (top-right highlight)** | `92% 8%`, radius 60% | Lightness-max sample from highest-weight Zone — the "lit ceiling" |
+
+After layer colors are sampled, the **modifiers** (`saturation`, `lightness`) from §3.3 + §4 are applied globally — every layer's HSL is shifted by the same amount.
+
+### 7.2 Determinism
+
+The same `field_zones` object always produces the same gradient. There is **no randomness** at render time. Random sampling happens once at mapping time (Haiku), is persisted, and renders are pure functions of the persisted state.
+
+This is a critical property: two opens of the same coffee detail page show the same Field. Two devices show the same Field for the same coffee. No drift, no flicker.
+
+### 7.3 The composition algorithm lives in code
+
+The mapping rule above is the spec. The actual implementation — `composeFieldGradient(zones, modifiers, rotation): string` — belongs in `src/lib/field/composeGradient.ts` and is the deliverable of Step B. The spec defines *what* it produces; the code defines *how*.
+
+⚠️ **Anti-pattern:** Do not expose individual layer colors as user-tunable. The Field is a single semantic unit ("this coffee's signature"), not a six-knob console. Tuning happens upstream — at the Zone weights or modifiers level, never at the per-layer level.
+
+---
+
+## 8. Step rotation within the Brew Flow
+
+A single brew flow takes the user through up to seven steps (`mode → scan → context → recommend → brew → log → summary`). The Field stays the same composition throughout but **rotates subtly per step** to give a sense of progression without leaving the room.
+
+### 8.1 Mechanics
+
+- Step 1 (Mode): No coffee is scanned yet. Use Default Field, rotation 0°.
+- Step 2 (Scan): Coffee scan completes mid-step. As soon as `field_zones` is computed, the Field swaps from Default to coffee-driven, rotation 0°. The swap is **instant** at step transition, not animated mid-step.
+- Steps 3–7: Same `field_zones`, increasing rotation:
+  - Step 3 (Context): 25°
+  - Step 4 (Recommend): 50°
+  - Step 5 (Brew): 75°
+  - Step 6 (Log): 100°
+  - Step 7 (Summary): 125°
+
+125° total drift over five steps. Each per-step delta is 25°, large enough to feel like a turn, small enough to feel like the same room.
+
+### 8.2 What "rotation" actually does
+
+Rotation rotates the **position angles** of the five radial hotspots around the viewport center. The linear base layer's 135° angle also rotates by the same delta. Hues do not change. Lightness/saturation do not change. The composition stays identical — only the spatial arrangement turns.
+
+This means a 25° rotation moves the bottom-left peach hotspot slightly counter-clockwise toward the bottom edge, and so on for every other hotspot. The viewer perceives "the room turned a bit", not "different content".
+
+### 8.3 No animation between steps
+
+Step transitions are not interpolated. v1.0 says cards don't hover; v1.1 says Fields don't animate mid-screen. Each step view shows its rotation as a fixed state. The change happens during the step transition (covered by the existing page-transition behaviour), not as an explicit animation.
+
+⚠️ **Anti-pattern:** Live-interpolated rotation tied to scroll, time, or user input. This was option (iii) in the design discussion and was rejected for breaking the "static room" anchor and costing frames on iOS Safari.
+
+---
+
+## 9. Per-view rotation for non-coffee views
+
+Views that are not coffee-specific use the **Default Field** (§6) with a fixed per-view rotation, so each view has a recognisable face without each being a different room.
+
+| View | Rotation |
+|---|---|
+| Home / Diary feed | 0° |
+| Cafés (map + place detail) | 72° |
+| Taste | 144° |
+| Explore | 216° |
+| Library hub | 288° |
+
+Five views, 72° apart, evenly spaced around the full circle.
+
+**Auth views** (`/login`, `/onboarding`) and any view not in the above list: rotation 0°. The five-view fan covers the everyday navigation surfaces.
+
+**Coffee Detail Page (`/coffees/[id]`)** is **not** in this list — it's coffee-driven. The Field uses the coffee's `field_zones` at rotation 0°. Each coffee has its own face on its own detail page.
+
+**Brew Detail Page (`/brew/[id]`)** reads the session's `coffee` reference, looks up `field_zones` for that coffee, and renders at rotation 0°. Same coffee → same Field across the diary feed entry, the brew detail, and the coffee detail.
+
+---
+
+## 10. Schema: `coffees.field_zones`
+
+### 10.1 Migration
+
+Add a single JSONB column to the `coffees` table:
+
+```sql
+ALTER TABLE coffees ADD COLUMN field_zones jsonb;
+```
+
+This is the only schema change v1.1 requires. No other tables touched.
+
+### 10.2 Value shape
+
+```json
+{
+  "version": 1,
+  "zones": [
+    { "id": "floral", "weight": 0.45 },
+    { "id": "fruity-bright", "weight": 0.30 },
+    { "id": "fruity-deep", "weight": 0.25 }
+  ],
+  "modifiers": {
+    "saturation": 5,
+    "lightness": 10
+  },
+  "source": "tasting-notes",
+  "computedAt": "2026-05-11T17:00:00.000Z"
+}
+```
+
+Fields:
+
+- `version` — schema version of the value itself. `1` for v1.1. Allows future evolution without re-migration.
+- `zones` — 1–3 entries, ids from the six in §2, weights summing to 1.0.
+- `modifiers` — integers in [-15, +15] for both saturation and lightness.
+- `source` — one of `"tasting-notes"` (path §3), `"variety-implied"` (path §5), `"default"` (path §6). Useful for debugging and for indicating to the user later why the Field looks the way it does, if we ever surface that.
+- `computedAt` — ISO timestamp of when the mapping ran. Used for cache freshness if we ever want to re-run.
+
+`field_zones` is `null` when the value has not been computed yet. Rendering code interprets `null` as "use Default".
+
+### 10.3 When the value is computed
+
+Three triggers, all server-side:
+
+1. **Bag scan succeeds** (`/api/analyze-bag` returns a result with `tastingNotesFromBag.length > 0`): Haiku mapping runs immediately after extraction. Result written to `coffees.field_zones` before the response returns.
+2. **Coffee created manually** (`/api/coffees POST` with no scan): if `variety` is set, run §5 variety fallback. Otherwise leave `field_zones = null` (renders as Default).
+3. **Coffee's bag notes or variety edited**: previous `field_zones` is invalidated (set to `null`). Next read triggers re-computation (lazy regeneration) or a foreground re-mapping call (whichever Step B chooses; spec doesn't mandate).
+
+### 10.4 Invalidation rules
+
+`field_zones` is **set to `null`** when:
+
+- `coffees.common_notes` is edited (if that column ever becomes a real write path — currently it's effectively dead, see Appendix B).
+- The latest session's `coffee.tastingNotesFromBag` is replaced via re-scan.
+- `coffee.variety` is edited and tasting notes are empty.
+
+Next read after invalidation re-runs the mapping. Costs one Haiku call. Acceptable.
+
+⚠️ **Anti-pattern:** Do not store `field_zones` in `sessions.coffee` JSONB. The Field is a property of the coffee, not the session. Storing it per-session would re-run the Haiku call for every brew of the same coffee, multiply costs by session count, and create drift between two brews of the same bag (which would break the "same coffee = same Field" promise). The data lives on `coffees`, not on `sessions`.
+
+---
+
+## 11. Anti-patterns specific to v1.1
+
+Recap of new anti-patterns introduced above, in one list:
+
+1. **Field driven by Goal or Occasion** (§1). The user picks those after the Field is on screen; changing the Field mid-step breaks v1.0 §1's static-room anchor.
+2. **Haiku mapping at render time** (§3.1). Mapping is computed once per coffee, cached. Render is pure read.
+3. **Per-layer user tuning** (§7.3). The Field is one semantic unit. Tune Zone weights or modifiers, never raw layer colors.
+4. **Animated rotation** (§8.3). Rotation changes between steps, not within a step. No scroll-driven, time-driven, or input-driven rotation.
+5. **Storing `field_zones` per-session** (§10.4). It's a coffee property, not a session property.
+
+The v1.0 anti-patterns (Field re-rendered per view, ring variant on cards, sticky CTA, footnote owns bottom space, etc.) all still apply. v1.1 adds to the list, doesn't replace it.
+
+---
+
+## 12. Open items / v1.2 anchors
+
+Items deliberately deferred from v1.1, marked here so they're not forgotten:
+
+- **Roaster Prior integration.** A known clarity-biased roaster (Friedhats, April) could subtly nudge the Field toward higher Lightness / lower Saturation regardless of notes. Not in v1.1 because it adds a second signal layer to debug. Possible v1.2.
+- **Animated rotation interpolation.** Currently rotation jumps between steps. A subtle 400ms ease-out on rotation during step transition could feel right. Decide after seeing v1.1 live.
+- **User-visible Field reasoning.** Showing the user *why* their Field looks the way it does ("Floral dominant from Hibiscus, Bergamot; Fruity-Bright secondary from Blueberry") could be a delightful diary surface. Not in v1.1.
+- **Variety-derived implied notes pre-computation.** Variety data is static; the Haiku mapping for variety-implied notes could be pre-baked at build time into `varieties/data.ts`. Removes one runtime AI call. v1.2.
+- **Field on auth screens.** Currently auth views use Default rotation 0°. A roastery-warm onboarding Field could welcome the user differently. Cosmetic, low priority.
+- **Coffee-driven Field on Library list view.** The `/coffees` list shows many coffees at once — each card could carry a mini Field thumbnail derived from its `field_zones`. Performance question (rendering N gradients on one screen). v1.2 candidate.
+
+---
+
+## Appendix A — Haiku mapping prompt (full)
+
+This is the exact prompt to be sent to Haiku 4.5 in the `/api/analyze-bag` post-extraction step and in the variety-fallback path.
+
+**System:**
+
+```
+You are a perceptual aroma-to-color mapper for a specialty coffee app. Given an array of tasting notes (English or German), you return a JSON object specifying which BrewLog Field Zones the notes map to, with weights, plus optional saturation/lightness modifiers from texture descriptors. Return JSON only, no prose.
+
+Available Field Zones (id : exemplar aromas):
+- fruity-bright : citrus, lemon, orange, grapefruit, mandarin, berry, blueberry, raspberry, cherry, cranberry, peach, apricot, currant, pomegranate
+- fruity-deep : dried fruit, date, raisin, fig, prune, plum, red grape, port, wine, fermented fruit, dark cherry
+- floral : jasmine, rose, hibiscus, bergamot, chamomile, tea, lavender, elderflower, white flowers, floral, perfume
+- nutty-cocoa : chocolate, cocoa, milk chocolate, dark chocolate, nut, almond, hazelnut, walnut, pecan, peanut, roasted, malt
+- spice-earth : cinnamon, clove, cardamom, tobacco, leather, earth, herbs, savoury, spice, woody, cedar, smoke
+- sweet-caramel : caramel, honey, brown sugar, maple, vanilla, butter, toffee, syrup, molasses, custard, marzipan
+
+Texture/quality modifiers (NOT zones — adjust saturation and lightness instead):
+- juicy / vibrant / lively / bright → saturation +5 to +10
+- elegant / delicate / refined → lightness +5 to +10, saturation -5
+- clean / crisp / pristine → lightness +5, saturation -5
+- complex / deep / intense → no shift, allow 3 zones
+- balanced / harmonic / silky → no shift
+- creamy / velvety / rich → lightness -5, saturation +5
+- dense / heavy / full-bodied → lightness -10, saturation +5
+
+Rules:
+- Output 1-3 zones. Most coffees are 2-3 zones.
+- Zone weights are floats in [0, 1] summing to exactly 1.0.
+- modifier.saturation and modifier.lightness are integers in [-15, +15].
+- If a note is unfamiliar or non-aromatic (e.g. "rare", "delightful"), ignore it.
+- If ALL notes are unfamiliar, return {"zones": [], "modifiers": {"saturation": 0, "lightness": 0}}.
+  The caller will treat empty zones as "fall back to default".
+- German notes are valid input: pflaumig → prune (fruity-deep), nussig → nutty-cocoa, zitronig → citrus (fruity-bright), schokoladig → chocolate (nutty-cocoa).
+```
+
+**User:**
+
+```
+Notes: ["Blueberry", "Hibiscus", "Red Grapes", "Juicy", "Elegant"]
+```
+
+**Expected output:**
+
+```json
+{
+  "zones": [
+    {"id": "floral", "weight": 0.40},
+    {"id": "fruity-bright", "weight": 0.30},
+    {"id": "fruity-deep", "weight": 0.30}
+  ],
+  "modifiers": {
+    "saturation": 5,
+    "lightness": 10
+  }
+}
+```
+
+**Parameters:**
+
+- Model: `claude-haiku-4-5`
+- `max_tokens`: 256 (output is small structured JSON)
+- `temperature`: 0 (we want determinism per input)
+- Response parsing: via existing `parseClaudeJson()` helper with Zod schema validation
+
+A Zod schema for the response lives in Step B's code:
+
+```ts
+const FieldZonesResponseSchema = z.object({
+  zones: z.array(z.object({
+    id: z.enum(["fruity-bright", "fruity-deep", "floral", "nutty-cocoa", "spice-earth", "sweet-caramel"]),
+    weight: z.number().min(0).max(1),
+  })).max(3),
+  modifiers: z.object({
+    saturation: z.number().int().min(-15).max(15),
+    lightness: z.number().int().min(-15).max(15),
+  }),
+});
+```
+
+---
+
+## Appendix B — Verified against / open data questions
+
+### B.1 Verified on 2026-05-11
+
+- **Bag notes live in `sessions.coffee.tastingNotesFromBag`**, a flat `string[]` written by `analyzeBag.ts` and stored in the session JSONB. Coffee Detail Page reads `latestCoffee?.tastingNotesFromBag` directly (verified at `src/app/coffees/[id]/page.tsx:127`). Sample value from production: `["chocolate", "roasted nuts"]`.
+- **`BagAnalysisResult.extracted.tastingNotesFromBag`** is the in-flight equivalent during the scan API call, before persistence. Field zones can be computed from this directly without waiting for session save.
+- **`coffees.common_notes`** exists in schema (`src/lib/db/schema.ts:63`) and has a partial write path in `src/app/api/coffees/compact/route.ts:140` (aggregates `topNotes(sessions, 5)`), but is **effectively dead in production** — all 21 rows in `coffees` show `common_notes = null`. Either the aggregator is never triggered, or it returns empty. Independent bug from v1.1; flagged separately for Step B or a future cleanup.
+- **`coffees.process`** is a `text` column with four observed values in production: `Washed` (11), `Natural` (6), `Honey` (3), `null` (1). Clean enough for direct mapping without normalisation.
+- **Variety lives in `sessions.coffee.variety`** (jsonb path), not in the `coffees` table. Values are free-form strings, sometimes carrying marketing prose. The existing `getVarietyPriorsForBag()` in `src/lib/knowledge/varieties/helpers.ts` handles fuzzy matching; v1.1 reuses it.
+- **`getVarietyPriorsForBag()`** is already consumed by `recommend.ts:647`, `explore-agent`, and `explore`. v1.1 adds a fourth consumer (the variety-fallback path in §5).
+
+### B.2 Open data questions
+
+- **`common_notes` dead-field cleanup.** The column exists, has a partial write path, and is read by `helpers.ts:23`. Production data shows no rows ever populated. Decide before Step B: either fix the write path (aggregator runs on session save) or drop the column. v1.1 does not depend on it — Field zones read tasting notes from `sessions.coffee.tastingNotesFromBag`, the source of truth — but the lingering half-implementation is confusion debt.
+- **Variety extraction quality.** Production `sessions.coffee.variety` includes strings like `"SL9* (locally known as 'Gesha Inca' — a rare cultivar belonging to the Ethiopian legacy group)"`. The fuzzy matcher in `varieties/helpers.ts` is reused by v1.1, so its behaviour governs Field fallback quality. Periodic spot-check recommended; not v1.1 scope.
+- **Field rendering performance on iPhone PWA.** Six-layer blurred gradient with `backdrop-filter` is known-OK from v1.0 production. v1.1 keeps the same structural shape, so no new perf concern is expected. To be confirmed on the first integrated build.
+
+### B.3 Source files cross-checked
+
+- `src/lib/claude/analyzeBag.ts` — Zod schema for `BagAnalysisResult.extracted.tastingNotesFromBag: string[]`
+- `src/lib/db/schema.ts` — `coffees.common_notes jsonb`, `coffees.process text NOT NULL`
+- `src/lib/db/helpers.ts` — `rowToCoffee` mapping
+- `src/app/api/coffees/compact/route.ts` — only known `common_notes` write path
+- `src/app/coffees/[id]/page.tsx` — Coffee Detail Page reading `tastingNotesFromBag` from latest session
+- `src/lib/knowledge/varieties/` — variety priors module consumed by `recommend`, `explore`, `explore-agent`
+- Production DB sample: 21 coffees, 14 distinct varieties (free-form), 4 distinct processes (clean)
+
+---
+
+*End of v1.1 draft.*

--- a/specs/home.md
+++ b/specs/home.md
@@ -1,0 +1,646 @@
+# BTTS Home — view spec
+
+**Status:** draft.
+**Scope:** Defines the Home view of BTTS. Home is the conversational primary surface — the user opens BTTS into a chat with the agent. Library, brew flow, and other destinations are reached through conversation or through the Burger overlay.
+**Relationship to design system:** Builds on v1.0 (frozen) and v1.1 (draft). Introduces new primitives: Chat Surface, Pre-Composition Bubble, User Bubble, Photo Bubble, Coffee Reference Bubble, Action Pill, Attachment Sheet, Reference Coffee Picker Sheet, Navigation Overlay, Conversation Starter. These extend the system rather than replace it.
+**Wireframe source:** Figma frames received 2026-05-12, plus Dot screenshots for top-edge fade behaviour reference.
+
+⚠️ **Wireframes are structural, not visual.** Markus's Figma frames are black-on-white wireframes showing layout, hierarchy, and interaction. Final implementation uses v1.0 Light System styling: warm-cream Field background, Glass treatments on bubbles and sheets, Fraunces title, Inter body, all warm foreground tokens. Where the wireframe shows a bordered pill or rectangle, the implementation renders Glass.
+
+---
+
+## 0. The model
+
+Home is the chat. Title and Burger live in the header; the rest of the screen is conversation. Voice and type are parallel input methods — voice initiates via a Waveform tap on the right of the sticky input, type initiates by tapping into the input field. Image and Coffee Reference are attached via a `+` sheet on the left.
+
+The agent classifies each message and either responds inline with prose (optionally followed by up to three Action Pills) or issues a navigation directive that the client interprets — e.g. routing into Step 2 with a photo pre-loaded, or Step 3 with a coffee pre-selected.
+
+There is no diary feed, no card grid, no "New Brew" CTA on Home. Brew Again, Library queries, and new-coffee scans all flow through conversation.
+
+---
+
+## 1. Header
+
+Always visible, sticky-top. Sits above the Hero slot; the slot scrolls past it on scroll (see §4.4).
+
+- **Title:** "Better taste than sorry", **plain text — no Glass, no border, no pill frame**. Inter 14/500, foreground at 60% opacity. Top-left at `pt-12 pl-5`.
+- **Burger:** Icon top-right, `h-11 w-11 rounded-full` Glass treatment with hairline border. Top-right at `pt-12 pr-5`. Tap opens Navigation Overlay (§7).
+- **No back button** on Home — it is the root.
+- **No progress dots.**
+
+The Title is a soft functional anchor, not a hero element. It identifies the app for context, no more. The Hero on Home is the Conversation Starter (§8) or the live conversation thread (§4) — not the title.
+
+⚠️ **Anti-pattern:** Do not put the Title in a Glass pill, do not give it a border, do not increase the font size, do not center it. The Title sits quietly in the top-left corner. It does not compete with the Hero.
+
+⚠️ **Spec change note:** Earlier drafts of this spec called for a Glass-pill Title with Inter 18/500 as a small editorial frame. That created two competing editorial elements on Home (Title and Starter). Resolution: Title becomes plain functional text, Starter takes the full editorial weight as Hero.
+
+---
+
+## 2. Conversational input bar
+
+Sticky-bottom. The user's anchor through every state of the screen.
+
+### 2.1 Anatomy (Idle)
+
+```
+                                              
+                                              
+         [conversation thread area]           
+                                              
+                                              
+                                              
+  (+)  ┌────────────────────────────────┐    
+        │ Ask anything…              🎵 │    
+        └────────────────────────────────┘    
+```
+
+- **Outer container:** `px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-3`
+- **Left button (+):** `h-11 w-11 rounded-full` Glass, `+` icon at foreground 70%. Tap opens Attachment Sheet (§5).
+- **Gap:** ~12px between `+` and the pill
+- **Input pill:** Flex-grow, `h-11 rounded-full` Glass, padding `pl-5 pr-3`, placeholder "Ask anything…" in muted-foreground (Inter 15/400).
+- **Right icon (inside pill):** Waveform at `mr-2`, foreground 60%, `h-5 w-5`. Tap starts voice recording.
+
+### 2.2 States
+
+The input bar has these states. The bar's visual differs per state; the overall sticky-bottom position stays.
+
+| State | Left | Input area | Right |
+|---|---|---|---|
+| **Idle** | `+` | Pill with placeholder "Ask anything…" | Waveform |
+| **Typing** | `×` | Pre-Composition Bubble appears (see §3); input pill becomes a thin reference below | Send (↑) inside bubble |
+| **Photo attached** | `×` | Pre-Composition Bubble with Photo thumbnail at top | Send (↑) inside bubble |
+| **Coffee referenced** | `×` | Pre-Composition Bubble with Coffee chip at top | Send (↑) inside bubble |
+| **Recording** | `×` | Bar morphs into Recording-pill: live waveform animation across full width | (Waveform morphs to stop; tap stops + sends to transcription) |
+| **Transcript review** | `×` | Pre-Composition Bubble with transcript text (user can edit) | Send (↑) inside bubble |
+| **Thinking** | `×` (cancel response) | Empty bar with three Dots above (`mb-3`) | Spinner |
+| **Streaming** | `×` (stops TTS only — see §4.6) | Empty bar | Idle Waveform |
+
+State transitions are instant — no animations between states.
+
+### 2.3 The Cancel button (`×`) — contextual semantics
+
+The `×` replaces `+` whenever composition or response is active. Its behaviour depends on state:
+
+- **Typing / Photo attached / Coffee referenced / Transcript review:** Cancels composition. Clears text and attachment. Returns to Idle.
+- **Recording:** Cancels recording. No transcript is generated, nothing is sent. Returns to Idle.
+- **Thinking:** Cancels the agent request before response starts. Returns to Idle.
+- **Streaming:** Stops the TTS playback only. Text response continues to stream and completes. Returns to Idle when text is done.
+
+This is one button with five context-dependent behaviours. The icon stays `×`, the action varies.
+
+### 2.4 Voice: Tap-to-Start, Tap-to-Stop, Transcript Review
+
+The voice flow has three phases:
+
+**Phase 1 — Recording.** User taps Waveform in Idle. Bar morphs to Recording-pill (full-width Glass pill, live audio waveform animating left-to-right). `×` left, stop indicator right. **No audio is stored** — ElevenLabs Scribe transcribes in stream; raw audio is discarded after transcription.
+
+**Phase 2 — Stop and transcribe.** User taps the stop indicator (the right-edge morphed Waveform). Recording ends. Transcription processes (~1–2s with Scribe). During this micro-moment, the bar shows the same `×` left + a small spinner right.
+
+**Phase 3 — Transcript review.** Transcript appears in a Pre-Composition Bubble (§3) — same Bubble used by typing. User can edit the transcript if Scribe mis-heard a coffee name. Send (↑) commits. `×` left cancels (discards transcript, returns to Idle).
+
+The Transcript Review state is identical to the Typing state, just pre-populated. The same Bubble, same edit affordances, same Send. Voice does not create a separate path; it transcribes into the normal composition flow.
+
+⚠️ **Anti-pattern:** Do not auto-send transcript after Scribe completes. Voice errors on coffee names are common ("Friedhats" → "Free hats", "Geisha" → "geyser"). Transcript Review is essential for editable correction.
+
+---
+
+## 3. Pre-Composition Bubble
+
+When the user starts composing — by tapping into the input pill, attaching content via `+`, or completing voice transcription — the input area morphs into a Glass Bubble that floats above the input pill. The bubble is where composition happens; Send (↑) lives inside the bubble.
+
+### 3.1 Anatomy
+
+```
+                 ┌──────────────────────────┐
+                 │  [Attachment if present]  │
+                 │                          │
+                 │  Composed text…          │
+                 │                          │
+                 │                     ↑    │
+                 └──────────────────────────┘
+  (×)  ┌────────────────────────────────┐
+        │ Ask anything…              🎵 │
+        └────────────────────────────────┘
+```
+
+- **Bubble frame:** `rounded-2xl` Glass treatment, padding `p-3`
+- **Width:** Grows with content, `max-w-[calc(100%-64px)]` (room for `×` on the left edge)
+- **Position:** Right-aligned, `mb-2` above the input pill
+- **Send button (↑):** `h-9 w-9 rounded-full bg-[hsl(20_14%_12%)] text-[hsl(30_40%_97%)]`, in bottom-right of bubble, `m-2`
+- **Text:** Inter 15/400, foreground
+
+The input pill **stays visible** below the bubble — placeholder "Ask anything…" still shown — so the user has a continuous visual anchor. Tapping the pill again would close the bubble's keyboard but **preserves typed text and any attachment**; tapping the bubble re-opens the keyboard.
+
+### 3.2 Behaviour
+
+- Bubble appears empty when triggered by `+`-Tap with no attachment yet (rare edge case; bubble only really materialises with content)
+- Bubble grows vertically as user types more
+- Send (↑) becomes active (full opacity) only when at least one of: text present, attachment present. Disabled (foreground 30%) otherwise.
+- **Placeholder in the Bubble:** "Ask anything…" — same as the input pill. Unified placeholder regardless of attachment type.
+
+⚠️ **Decision noted:** Earlier wireframes used "Share…" as Bubble placeholder when a Photo was attached. Final choice: **"Ask anything…" everywhere**, regardless of attachment. The attachment itself signals what is being asked about; the placeholder remains neutral. (Cognitive consistency over context-specific hints.)
+
+### 3.3 Attachment display in the Bubble
+
+When a Photo or Coffee Reference is attached, it appears at the top of the Bubble:
+
+- **Photo:** Thumbnail at `h-20 w-20 rounded-xl`, top-left of bubble, with a small `×` button at top-right of thumbnail to remove
+- **Coffee Reference:** Chip with `[coffee-cup-icon] Roaster · Name`, smaller height (`h-7`), with `×` button to remove
+
+Below the attachment: the typing area. The user can compose text alongside the attachment.
+
+**Max one attachment per message.** Photo OR Coffee Reference, not both. If the user has one attached and selects another from the +-Sheet, the new attachment replaces the old (no warning prompt — silent replacement; user can tell from the changed thumbnail).
+
+---
+
+## 4. Conversation thread
+
+Where user messages and agent responses live. Renders between the header and the input bar.
+
+### 4.1 Anatomy
+
+```
+┌─────────────────────────────────┐
+│  Better taste than sorry   ☰   │   header (always visible)
+│                                 │
+│        [faded older content]    │   top edge: fade out + blur
+│                                 │
+│                  ┌────────┐    │   user content (right-aligned)
+│                  │ Photo  │    │
+│                  │        │    │
+│                  └────────┘    │
+│                  ┌────────────┐ │
+│                  │ user text  │ │
+│                  └────────────┘ │
+│                                 │
+│  Agent response prose body…     │   agent response (left-aligned, no bubble)
+│  …continues across lines…       │
+│                                 │
+│  (☕ Pill) (🔄 Pill)            │   Action Pills (§6)
+│                                 │
+│  (+)  [Ask anything…    🎵]     │   input bar
+└─────────────────────────────────┘
+```
+
+### 4.2 User content — bubble style, right-aligned
+
+User-generated content (text, attachments) renders as Glass bubbles, right-aligned, `max-w-[80%]`, `rounded-2xl px-4 py-3`. Same Glass treatment as the Pre-Composition Bubble.
+
+**Stacked bubble rule:** when a user message includes an attachment, the attachment renders as its own bubble *above* the text bubble. Two bubbles, both right-aligned, both Glass, separated by `mb-2`:
+
+- **Photo bubble:** ~280×280 image, `rounded-2xl`, Photo content fills bubble
+- **Coffee Reference bubble:** Coffee-cup-icon + Roaster (small, muted) + Name (foreground), `rounded-2xl`, content centered, `min-h-[60px]`. Optionally renders the coffee's v1.1 `field_zones` palette as a subtle background gradient when v1.1 is live.
+- **Text bubble:** Inter 15/400, the user's typed or transcribed text
+
+If both attachment and text are present, both bubbles render. If only attachment, only the attachment bubble. If only text, only the text bubble.
+
+### 4.3 Agent response — prose body, left-aligned
+
+Agent responses render as plain prose, left-aligned, full content width (`px-5`), Inter 15/400. Paragraph spacing `mb-3` between paragraphs. **No bubble around the response.**
+
+This is the key visual distinction: user speaks in bubbles, agent speaks in prose. It mirrors Dot's pattern and serves the editorial brand — BTTS writes, the user chats.
+
+### 4.4 Top-edge scroll fade
+
+When the conversation scrolls upward (older messages disappearing into the header area), the top of the thread fades to transparent and blurs slightly. Reference: Dot's behaviour, confirmed by Markus.
+
+Implementation: A `mask-image: linear-gradient(to bottom, transparent 0%, black 80px)` on the conversation container, top 80px being the fade zone. Header sits above the masked area. Optionally, a subtle backdrop-blur on the masked content as it nears the header.
+
+The fade signals "history exists, scroll up" without taking screen real estate. Older messages remain accessible by scrolling but don't visually clutter.
+
+### 4.5 Scroll behaviour
+
+- **Default position:** Latest message at bottom, conversation scrolled to bottom, input bar visible
+- **Manual scroll up:** User can scroll up to see older messages
+- **New response auto-scroll:** Auto-scroll-to-bottom on new agent message *unless* the user has manually scrolled up (preserves their position during long agent responses)
+- **Conversation persists** for the duration of the app session (see §10 for cross-session persistence)
+
+### 4.6 TTS stream parallel to text stream
+
+Agent responses stream as text in the body **and** as TTS audio through ElevenLabs synthesis simultaneously. Two streams, one response.
+
+**`×` during Streaming stops TTS only.** Text continues streaming to completion. The user can choose to:
+- Stop the audio if they're in a context where it's unwelcome (meeting, library)
+- Let both run if they want voice + text together
+
+There is no "stop everything" button. Text always completes once the agent has started responding. This is a deliberate decision: cancelling text mid-stream creates partial-state UX problems that aren't worth the rare cancel-need.
+
+⚠️ **Anti-pattern:** Do not auto-play TTS without user opt-in. TTS-on-response should be a user preference (Settings → Audio → "Read responses aloud" toggle), default off. Sound coming out of a phone unannounced is bad UX.
+
+### 4.7 Compose-while-streaming
+
+The user can tap into the input field while an agent response is still streaming. Composition is active — Pre-Composition Bubble opens, keyboard rises, typing works. **Send (↑) is disabled** until the agent response completes. Send becomes active when streaming finishes; tapping sends the queued message.
+
+This protects the natural conversation order: one exchange completes before the next begins. The user doesn't lose their next-message draft to a still-running response.
+
+---
+
+## 5. Attachment Sheet (+-Sheet)
+
+Tapping `+` in Idle opens a small bottom sheet above the input bar with three options.
+
+### 5.1 Anatomy
+
+```
+                  ┌─────────────────────────┐
+                  │  📷  Camera             │
+                  │  🖼️  Photo library      │
+                  │  ☕  Reference coffee   │
+                  └─────────────────────────┘
+  (×) [Ask anything…             🎵]
+```
+
+- **Sheet container:** `rounded-2xl` Glass treatment, padding `p-2`, positioned `mb-2` above the input bar, `max-w-[280px]` width, left-aligned (so it visually anchors to the `+` button below)
+- **Rows:** Three vertically stacked. Each row `h-10 px-3 rounded-xl flex items-center gap-3`, Inter 15/500, foreground
+- **Icons:** Lucide icons, `h-5 w-5`, foreground 80%
+  - Camera: `Camera` icon
+  - Photo library: `Image` icon
+  - Reference coffee: Coffee-cup glyph (custom or `Coffee` from Lucide)
+- **Tap-outside dismisses** the sheet without selection
+
+### 5.2 Camera option
+
+Tapping "Camera" launches the native iOS Camera (full-screen, system UI). User captures a photo. Apple's confirmation screen (Use Photo / Retake) follows. Once confirmed, returns to BTTS Home with the photo attached — Pre-Composition Bubble appears with Photo thumbnail.
+
+### 5.3 Photo library option
+
+Tapping "Photo library" launches the native iOS Photo Picker. User selects one existing image. Returns to BTTS Home with that photo attached.
+
+**Why Camera and Library are separate options:** iOS's native picker offers both inside a system action sheet. Splitting them at the BTTS Sheet level means the user goes one tap deeper into intent ("I want to take a new photo" vs. "I want to use an existing one"), but skips iOS's action sheet entirely. The result is a more direct path and a Sheet that stays in BTTS atmosphere until handoff.
+
+### 5.4 Reference coffee option
+
+Tapping "Reference coffee" opens the Reference Coffee Picker (§5.5). The +-Sheet is replaced by the Picker Sheet (transition, not nested).
+
+**Disabled state:** When the user's library is empty (no rows in `coffees`), this option is disabled. Label changes to "Reference coffee (library empty)" or similar muted treatment. The Camera and Photo library options remain enabled.
+
+### 5.5 Reference Coffee Picker — separate Sheet
+
+A larger Bottom Sheet, replaces the +-Sheet when "Reference coffee" is tapped.
+
+```
+                  ┌─────────────────────────┐
+                  │  ☕  Reference coffee   │   header row
+                  │                         │
+                  │  ┌───────────────────┐  │
+                  │  │ Search…           │  │   search pill
+                  │  └───────────────────┘  │
+                  │                         │
+                  │  Some Roaster 1         │   list rows
+                  │  Some coffee 1          │
+                  │                         │
+                  │  Some Roaster 2         │
+                  │  Some coffee 2          │
+                  │  …                      │
+                  └─────────────────────────┘
+       (Apple iOS Keyboard)
+```
+
+- **Sheet container:** `rounded-t-2xl` Glass, full-width, `min-h-[60vh]` (scrollable list)
+- **Header:** Coffee-cup-icon + "Reference coffee", `h-12 px-5 flex items-center gap-3`, Inter 17/500, hairline divider below
+- **Search pill:** `h-11 rounded-full` Glass, `mx-5 mt-3`, placeholder "Search roaster or coffee", Inter 15/400. Tap focuses, native keyboard rises.
+- **List rows:** Each row `px-5 py-3 flex flex-col`. Roaster label small/muted (Inter 13/400, foreground 60%); Coffee name larger/foreground (Inter 17/500). Tappable area is the entire row.
+- **Data source:** `/api/coffees/compact` endpoint. Lightweight library list, supports text search.
+- **Tap on a row:** Picker closes, Pre-Composition Bubble appears with Coffee Reference chip at top.
+
+⚠️ **Anti-pattern:** Don't add a search-glass icon to the search pill. The Sheet header already says "Reference coffee" and the placeholder says "Search roaster or coffee". A magnifier icon is redundant.
+
+---
+
+## 6. Action Pills
+
+Action Pills appear directly below an agent response when the response can lead to specific destinations or actions. **Max 3 pills per response.** If the agent's intent suggests more, the agent must prioritise.
+
+### 6.1 Anatomy
+
+```
+Agent response prose body…
+…ends here.
+
+(☕ Chunky Cherry)  (🔄 Brew this again)
+```
+
+- **Pill container:** Horizontal flex, `gap-2`, `mt-4` below response prose, wraps if needed (rare at max 3)
+- **Each pill:** `h-9 px-4 rounded-full` Glass treatment, Inter 13/500, foreground
+- **Icon prefix:** Small icon left of label, `h-4 w-4`, foreground 80%, `mr-1.5`
+
+### 6.2 Icon meanings — disambiguation
+
+The icon signals what type of action the pill performs. The label says what specifically.
+
+- **☕ Coffee-cup icon:** Navigation pill. Tap opens a destination (Coffee Detail Page, Library, etc.)
+- **🔄 Brew/refresh icon (custom SVG, v1.0 §9.2 conventions):** Brew Action pill. Tap starts a brew flow (e.g. Step 3 with that coffee pre-selected)
+- **📍 Map pin icon:** Navigation to map view (e.g. café result)
+- **🔗 Arrow / Link icon:** Generic navigation / external source
+
+Same coffee can appear in both icon forms in the same response — once with Coffee-cup ("☕ Chunky Cherry" → opens detail) and once with Brew ("🔄 Brew Chunky Cherry again" → starts brew). Different actions, same coffee.
+
+### 6.3 Tap behaviour
+
+Tapping a pill is a single navigation event. No confirmation, no in-between sheet. The destination loads. If the destination is a brew step (Step 2 or Step 3), the flowStore is pre-populated with the relevant coffee or photo data before navigation.
+
+⚠️ **Anti-pattern:** Do not put primary CTAs (e.g. "Brew this") as inline buttons within the response prose. Action Pills are the only action affordance on agent responses. Keeps prose readable and actions clearly grouped.
+
+---
+
+## 7. Navigation Overlay (Burger)
+
+Tap on the Burger icon top-right of header opens a full-screen overlay.
+
+### 7.1 Anatomy
+
+```
+┌─────────────────────────────────┐
+│  ✕                              │   close button, top-right
+│                                 │
+│  Library                        │
+│  Cafés                          │
+│  Taste profile                  │
+│  Match                          │
+│  Settings                       │
+│                                 │
+│                                 │
+└─────────────────────────────────┘
+```
+
+- **Overlay:** Full screen, Glass treatment, Field background (v1.0 §2.1) remains visible through the overlay
+- **Close:** `×` icon top-right, same position as the Burger was, mirroring placement so thumb knows where to look. Tap closes.
+- **Destinations:** Vertical list, `pt-24 pl-6`, gap `mb-6` between items, Inter 24/500, foreground
+- **Tap on destination:** Navigates and closes overlay simultaneously
+
+### 7.2 Destinations
+
+```
+- Home
+- Past Conversations
+- New Session
+- Coffee Library
+- Nearby
+- Café Library
+- Taste Profile
+```
+
+- **Home** — returns to the chat surface. Explicit link so deep destinations (e.g. Taste Profile) have a clear way home.
+- **Past Conversations** — archive of all previously-archived conversation threads (see §10). List view shows date + first User-Message as preview. Tap → opens that thread read-only. Swipe-to-delete on individual entries. Sits as second item in the menu because the conversation archive belongs conceptually next to Home — they share the chat surface, just at different points in time.
+- **New Session** — opens the brew flow (StepMode → Home Brew / Coffee Shop / Taste Match). Backup path for when the user prefers a structured entry over a chat command. Stays in v1 as a safety net; may be removed in later iterations once chat-driven brew commands are reliable.
+- **Coffee Library** — full library of coffee bags (search, filter, sort, detail pages)
+- **Nearby** — map view for exploring, navigating, and finding places. Was previously called "Cafés"; renamed because the view's job is geographic discovery, not the user's own café history.
+- **Café Library** — log of brews the user has had at external locations. Different from Nearby: this is the *record* of past café visits and their brews, not a discovery surface.
+- **Taste Profile** — taste profile + AI-written summary of taste evolution
+
+Flat list, no hierarchy. Seven items, one tap each.
+
+**Not in Burger:**
+- **Insights** — accessible only as chat response ("tell me something new about coffee")
+- **Match** — folded into New Session as one of three StepMode options (Home Brew / Coffee Shop / Taste Match)
+- **Settings** — BTTS is a single-user app. There is no Settings destination in v1. Equipment, grinder, and preferences are captured once via Onboarding and edited inline when relevant (rare). If a Settings-like surface becomes necessary later, it'll get its own spec.
+
+### 7.3 Visual style
+
+Same Glass treatment as cards: `bg-[hsl(36_55%_96%_/_0.55)] backdrop-blur-[14px]`. The atmospheric Field remains visible underneath. The overlay sheets *over* Home, doesn't replace it — Home is still there, just behind a sheet.
+
+⚠️ **Anti-pattern:** Don't add icons next to destination labels in the Burger. The list is short, the words are clear. Icons add noise without clarity gain. Editorial-pure: just words.
+
+---
+
+## 8. Conversation Starter — the editorial Hero of Home
+
+When the Hero slot is in Starter state (§11.1) — i.e. on the first app-open of a new day, or after an idle-reset, or whenever a live thread is absent — Home shows a short editorial sentence as its centrepiece. This is **the** Hero element of Home: the surface's voice, its writer's opening line, the thing the user reads on entering. It carries Home the way "What's the vibe?" carries Brew Context.
+
+The Starter dismisses on the first composition action (typing, attaching, starting voice). On subsequent visits within the same day where the Hero slot would otherwise show a Starter (e.g. after an idle-reset cleared a thread, see §10), the same Starter from earlier in the day is shown again — not regenerated, not dismissed. Per-day caching applies until midnight.
+
+### 8.1 Anatomy
+
+```
+┌─────────────────────────────────┐
+│ Better taste than sorry      ☰ │
+│                                 │
+│                                 │
+│                                 │
+│   Good morning.                 │
+│   DAK Coffee Roasters           │
+│   yesterday — try Process       │
+│   or anything new today?        │
+│                                 │
+│                                 │
+│                                 │
+│  (+)  [Ask anything…    🎵]    │
+└─────────────────────────────────┘
+```
+
+- **Position:** Hero-slot center. Vertically centred in the space between the Header (top, sticky) and the Input Bar (bottom, sticky). See §11 for the Hero-slot geometry definition. The Starter sits where the slot's vertical midline is — not pinned to the viewport center, but to the slot's center.
+- **Typography:** Fraunces ~40px, semibold (600), leading-tight, foreground at full opacity, left-aligned. Matches the typographic treatment of the Brew Context Hero Question ("What's the vibe?") — same scale, same family, same weight, same colour weight. Same surface posture.
+- **Text alignment:** Left-aligned within the slot, not centred per line. The block has presence on the left margin (`pl-5` matching the Title's left edge) and breathes to the right with natural ragged line breaks.
+- **Length:** Haiku-generated, 8–16 words, breaks naturally across 2–4 lines depending on content.
+- **Text content:** Haiku-generated, contextual based on user's last brew + time of day + library state.
+- **No tap target, no background, no border, no Glass treatment.** Pure typography on the Field. The Starter is reading material, not an affordance.
+
+⚠️ **Reference surface:** The Brew Context view in BrewLog (currently rendered with Field gradient + Fraunces Hero Question "What's the vibe?") is the canonical reference for the Starter's typographic treatment. When implementing Home, look at Brew Context first, then replicate the same Fraunces scale and weight for the Starter. If they diverge, Brew Context wins until Home is brought into alignment.
+
+⚠️ **Anti-pattern:** Do not render the Starter as small Inter body text. Do not centre each line. Do not put it in a Glass pill. The Starter is the largest, most editorial element on Home — bigger than the Title (Inter 14/500 at 60% opacity), bigger than any bubble, bigger than any pill. If it does not feel substantively larger than every other text element on Home, it is wrong.
+
+### 8.2 Generation logic
+
+Data sources: existing `loadUserProfile()`, `buildRecentRecipes()`, `loadCoffeeLibraryCompact()` helpers.
+
+Haiku is prompted for **one short editorial sentence**, 8–16 words, no exclamation marks (a soft question mark is fine if natural), no second sentence. Generated **once per calendar day** and cached in localStorage with a `lastStarterDate` timestamp. On the next calendar day, regenerated on the first app-open.
+
+If the user opens the app multiple times in one day, the same Starter is shown each time (until dismissed by interaction — see §8.3).
+
+### 8.3 Lifecycle within a day
+
+1. **First app-open of the day** → Starter is generated (once per calendar day, see §8.2) and rendered immediately as the Hero element of Home.
+2. **Starter stays visible** as long as no composition action occurs. Opening the Burger and closing it, navigating to another view and returning, scrolling — none of these dismiss the Starter.
+3. **First composition action dismisses the Starter:**
+   - Tap into the input pill (typing intent)
+   - Tap `+` (attachment intent)
+   - Tap Waveform (voice intent)
+
+   The Hero slot now switches from Starter state to Live-thread state (§11.2). The Starter is hidden while the thread is active.
+4. **Within-session dismissal-then-cancel** — the user taps `+` but closes the Sheet without selecting, or starts typing then taps `×`. The thread is still empty (no message sent yet), so technically the slot would have nothing to show. The Starter **does not return mid-composition cancellation**: the user already saw it and chose to act. The slot stays in the "user is between actions" state without re-pulling the Starter. The user will see the Starter again next time it qualifies (next idle-reset or next day).
+5. **30-min idle-reset, same day** — the user closes the app or leaves it idle for more than 30 min, then returns. The previous thread auto-archives (§10). The Hero slot is now empty of conversation, so today's Starter returns to the slot. Same Starter, not regenerated.
+6. **Next calendar day** — fresh Starter generated on the first app-open. The cycle restarts.
+
+So the Starter can appear multiple times within a single day: once on first open, and again after each idle-reset (each time the thread archives and the slot would otherwise be empty). It is the **same** Starter all those times. The Haiku regenerates only at calendar-day boundaries.
+
+⚠️ **Anti-pattern:** Do not regenerate the Starter mid-day. One Starter per day, period. If the slot needs filling multiple times in a day, the same text appears.
+
+⚠️ **Anti-pattern:** Do not show the Starter on top of a live thread. The slot is *either* Starter *or* thread, never both.
+
+---
+
+## 9. Intent classification — the agent's job
+
+The agent classifies every incoming message and decides between **inline response** and **navigation directive**. This logic lives in the agent prompt and tool-use, not in client code.
+
+| Intent | Trigger examples | Response shape |
+|---|---|---|
+| **Information query** | "What's the difference between Yellow and Black Honey?" | Inline prose, optional Action Pill (Coffee-cup if a specific coffee is referenced) |
+| **Brew command — specific coffee** | "Brew Chunky Cherry again", "Make the DAK one", "I want the cherry coffee" | Inline confirmation + Brew Action Pill, OR direct navigation directive to Step 3 |
+| **Brew command — open** | "What should I brew now?", "I want to brew" | Inline recommendation prose + Coffee-cup Pill (to that coffee) + Brew Action Pill (to start) |
+| **Library query** | "Show my last coffees", "What's in my library?" | Inline prose summary + up to 3 Coffee-cup Pills |
+| **Photo + brew intent** | Photo attached + "analyze and brew this" | Inline ack + navigation directive to Step 2 (photo pre-loaded) |
+| **Photo + info intent** | Photo attached + "what is this?", "tell me about this bag" | Inline analysis using `analyze_image`, optional Coffee-cup Pill if known coffee identified |
+| **Reference coffee query** | Coffee chip attached + question | Inline answer using coffee context, no Pill needed (coffee already on screen) |
+| **Navigation request** | "Show me cafés in London Soho", "Open my taste profile" | Inline confirmation + Navigation Pill |
+
+### 9.1 Ambiguity handling
+
+When the user references a coffee that matches multiple library entries ("the bourbon" with two bourbons):
+- **Default:** Ask in chat — "Which one — Red Bourbon or Yellow Bourbon?"
+- **Fallback (close match-confidence):** Render two Coffee-cup Pills, user taps to disambiguate
+
+⚠️ **Anti-pattern:** Do not default to "most recently brewed" silently when ambiguous. The user deserves a question.
+
+### 9.2 Fuzzy matching
+
+Coffee references in user input can be partial, casual, or vague ("the cherry one", "DAK Coffee Cherry", "that cherry from DAK"). The agent must fuzzy-match against the user's library before deciding intent routing. This builds on the existing `getVarietyPriorsForBag` fuzzy-match pattern but extends to coffee name + roaster matching.
+
+---
+
+## 10. Conversation persistence
+
+**Within a session:** Conversation thread persists in the database. User sends a message, navigates away via Action Pill or Burger to another view, completes a brew, returns to Home — thread is still there, exactly as left.
+
+**Across sessions — 30-minute idle window:** When the user reopens BTTS, the system checks the timestamp of the last *send* (User-Message or Agent-Response, whichever is later). If less than 30 minutes have elapsed, the existing thread is resumed in the Hero slot. If more than 30 minutes have elapsed, the thread is auto-archived and the Hero slot resets to Conversation Starter (§8) — same Starter as earlier the same day, or fresh Haiku if it's a new calendar day.
+
+**Auto-archive trigger:** Any thread that gets reset by the idle-window check is automatically saved to the Past Conversations archive, accessible via the Burger (§7.2). Empty threads — app opened, Starter seen, nothing sent — are not archived. Only threads with at least one User-Message survive.
+
+**Manual archive trigger:** None in v1. The only path into the archive is the idle-window auto-archive.
+
+**Storage:** Postgres via Drizzle. Two new tables:
+- `conversations` — id, started_at, ended_at, message_count, first_user_message (for preview in archive list)
+- `messages` — conversation_id, role (user / agent), content (text), attachments (jsonb: photo path, coffee_id), created_at
+
+Single-user app, so no `user_id` column needed. Authentication handled at app-level via existing WebAuthn passkey.
+
+**Retention:** Unlimited. Archive grows indefinitely. Manual delete is available via Past Conversations list (swipe-to-delete on individual entries; long-press for bulk select TBD if ever needed).
+
+**The "Hero slot is never empty" guarantee:**
+
+Combining §8 (Starter) and this section:
+- If a live thread exists (within 30-min idle window): Hero slot shows the conversation
+- If no live thread (fresh open, post-idle-reset, or new calendar day): Hero slot shows today's Starter
+- Within a day, after dismissal-by-interaction, the same Starter returns whenever the slot would otherwise be empty
+- Across days, the Starter regenerates once per calendar day on first open
+
+The slot is content-bearing in every state. Empty is not a state.
+
+⚠️ **Anti-pattern:** Do not show the archive UI on Home. The archive is reached only via Burger → Past Conversations. Home itself never lists or hints at past threads — that's not what Home is for. Home is current-only.
+
+---
+
+## 11. Hero-slot content states
+
+The Hero slot — the editorial middle of Home — has three content states. The slot is never empty (see §10's "Hero slot is never empty" guarantee). What it shows depends on whether a live thread exists and whether today's Starter has been generated.
+
+### 11.0 Hero-slot geometry
+
+The Hero slot is the vertical region between the sticky Header (top) and the sticky Input Bar (bottom). It is the entire space between them.
+
+- **Top edge of slot:** Bottom of the Header. Header is `pt-12` + content height (`h-11` for Burger) + ~`pb-3` breathing room — practically ends ~96px from the top of the viewport on a 390-wide iPhone.
+- **Bottom edge of slot:** Top of the Input Bar. Input Bar is `pt-3` + content height (`h-11`) + `pb-[max(1rem,env(safe-area-inset-bottom))]` — practically begins ~96px from the bottom of the viewport on a 390-wide iPhone with safe-area.
+- **Slot content vertical positioning:** When the slot is in Starter state (§11.1), the Starter text block is **vertically centred within the slot** — `flex items-center` on the slot container, so the Starter sits at the slot's vertical midline regardless of how many lines the Starter takes.
+- **Slot content horizontal positioning:** Starter text is left-aligned at `pl-5` (matching Title and Input Bar left padding); Starter content has natural right-side ragged-edge wrapping based on its content length, with no forced right margin beyond viewport-edge breathing.
+
+When the slot is in Live-thread state (§11.2), the slot becomes a scrollable container with the Conversation Thread filling it (see §4 for thread layout, which has its own top-edge fade and bottom-anchored scroll).
+
+⚠️ **Anti-pattern:** Do not pin the Starter to viewport-center (`min-h-screen flex items-center` on the full viewport). The Starter belongs to the *slot*, not the viewport. If the slot's center and the viewport's center diverge (because Header or Input Bar grow), the Starter follows the slot.
+
+### 11.1 Starter state — fresh slot
+
+The Hero slot shows today's Conversation Starter (§8). This is the state on:
+
+- First app-open of a new calendar day (Starter freshly generated)
+- Any subsequent app-open on the same day, when no live thread exists (post-idle-reset or after the previous thread was auto-archived per §10)
+
+What renders:
+- Header (Title + Burger)
+- **Conversation Starter in the Hero slot** — the daily editorial greeting from Haiku, Fraunces ~40px (see §8.1)
+- Idle input bar at bottom with "Ask anything…" placeholder
+
+The Starter is the centrepiece. It greets the user as a writer would open a letter. The user reads, then decides whether to respond by typing, speaking, or attaching.
+
+### 11.2 Live-thread state — conversation in progress
+
+The Hero slot shows the active conversation thread. This is the state once the user has sent at least one message in the current session (or has returned within the 30-min idle window with a thread still alive).
+
+What renders:
+- Header (Title + Burger)
+- **Conversation thread in the Hero slot** — user bubbles right-aligned, agent prose left-aligned, per §4
+- Idle input bar at bottom (or one of its composition states, per §2)
+
+No Starter is shown while a live thread exists. The thread *is* the editorial surface.
+
+### 11.3 Fresh-app state — no Starter context yet
+
+Edge case: the very first time the user ever opens BTTS (no library, no history), the Haiku generation has no context to draw from. The Starter for this case defaults to a static welcome line — *"Welcome to Better Taste Than Sorry."* — for one day, then the regular per-day Haiku cycle takes over once history exists.
+
+This is a sub-state of Starter state (§11.1), not a separate state. The slot still renders a Starter; the Starter's content is just a fallback string.
+
+⚠️ **Anti-pattern:** No "Welcome to BTTS" overlay modal. No onboarding carousel. No "Try saying: 'Brew the Bourbon again'" chip. The Starter (or its static fallback) is the only greeting affordance.
+
+⚠️ **Anti-pattern:** No truly empty Hero slot. If the slot would otherwise be empty (post-dismissal, post-idle-reset, post-archive), today's Starter returns. Empty middle is not a permitted state — see §10.
+
+---
+
+## 12. What's NOT in this spec
+
+Deferred to other documents or future iterations:
+
+- **Brew flow step migrations** — Step 2 (Scan), Step 3 (Context), and others each get their own view spec when migrated to Light
+- **Coffee Detail page** — destination Coffee-cup Pills navigate to. Currently Dark. Spec when migrated.
+- **Library full view** — full destination via Burger. Currently Dark. Spec when migrated.
+- **Voice playback-before-send** — Dot has this pattern (a Play button between Cancel and Send during recording-review). BTTS v1 does not — transcript review is the QA mechanism, audio is discarded
+- **Multi-image attachments** — single image only in v1
+- **Match as chat intent** — Match stays a Burger destination for v1; may migrate to chat-intent later
+- **Generative Field on Coffee Reference bubble** — when v1.1 is live, the coffee's `field_zones` can render as a mini-gradient background on the in-thread Coffee Reference bubble. Visual upgrade, not a requirement.
+- **Settings → "Read responses aloud" toggle** — implied by §4.6 but not specced here. v1 default: TTS off, user opts in
+- **TTS voice selection / customisation** — ElevenLabs has voice options; v1 picks one default
+
+---
+
+## 13. New primitives this spec introduces
+
+For Step B integration, these primitives need to be built in `src/components/ui/light/`:
+
+- **`<ChatSurface>`** — conversation thread container with top-edge fade (§4.4)
+- **`<ChatInput>`** — sticky-bottom input bar with all eight states (§2.2)
+- **`<CompositionBubble>`** — the floating Pre-Composition Bubble with Send (§3)
+- **`<UserBubble>`** — right-aligned Glass bubble for user messages in thread (§4.2)
+- **`<PhotoBubble>`** — right-aligned Glass bubble containing a photo, in-thread (§4.2)
+- **`<CoffeeReferenceBubble>`** — right-aligned Glass bubble with coffee chip, in-thread (§4.2)
+- **`<AgentResponse>`** — left-aligned prose container, no bubble (§4.3)
+- **`<ActionPill>`** — Glass pill with icon prefix, three icon variants (§6)
+- **`<AttachmentSheet>`** — three-option Bottom Sheet for `+` (§5.1)
+- **`<ReferenceCoffeePicker>`** — separate Bottom Sheet with search + list (§5.5)
+- **`<NavigationOverlay>`** — Burger full-screen overlay (§7)
+- **`<ConversationStarter>`** — daily editorial hint above input (§8)
+
+Plus the foundation primitives already specced in v1.0 (`<LightShell>`, etc.), which Home consumes.
+
+---
+
+## 14. Step B integration sequence
+
+Replaces the obsolete PR1 briefing. Realistic PR breakdown:
+
+- **PR2a — Light System foundation.** Tokens, Fraunces + Inter, `<LightShell>`, foundational primitives (Section, Footnote, PageHeader — though Home doesn't use them, they're shared system pieces). No consumer yet.
+- **PR2b — Home skeleton.** Title, Burger placeholder, empty middle, static "Ask anything…" pill (no interactivity yet). Bottom Nav removed globally. First Light surface live.
+- **PR2c — Navigation Overlay (Burger).** Full-screen overlay, destination list, navigates to existing Dark views.
+- **PR2d — Chat Input core states.** Idle / Typing / Pre-Composition Bubble / Send. No attachments, no voice yet. Connects to `/api/explore-agent` for text-only responses inline.
+- **PR2e — Top-edge scroll fade + Agent Response styling.** Thread rendering, prose-vs-bubble visual distinction, scroll behaviour.
+- **PR2f — Voice (Recording, Transcript Review).** Bar morphing, ElevenLabs Scribe integration via existing `voice/transcribe`. TTS streaming via existing `voice/synthesize`.
+- **PR2g — `+`-Sheet + Photo attachment.** Camera, Photo library, Photo bubble in Pre-Composition, Photo bubble in thread.
+- **PR2h — Reference Coffee Picker + Coffee Reference attachment.** Extract from existing `/explore` page, port to Light System.
+- **PR2i — Intent classification + Action Pills.** Agent prompt evolution, client-side directive interpretation, Pill rendering.
+- **PR2j — Conversation Starter.** `/api/greeting` endpoint, Haiku integration, daily cache logic.
+- **PR2k — Conversation persistence + idle-window logic.** Drizzle schema for `conversations` and `messages` tables, migrations, `/api/conversations` routes for create/append/archive, 30-min idle-window check on app-open, auto-archive trigger. Hero-slot decides between live thread and Starter based on this check.
+- **PR2l — Past Conversations view.** Burger destination, list view with date + first-message preview, tap-to-open read-only thread, swipe-to-delete.
+- **PR2m — `/explore` route removal.** Delete `src/app/explore/page.tsx` and related code. Final cleanup.
+
+Thirteen PRs. Each is small, deployable, reversible. PR2b can ship before any chat logic exists — Home with a placeholder pill is a valid intermediate state. Conversation Starter is one of the last UI PRs because it depends on having composition flows already working. Persistence (PR2k) lands after the chat surface is functional, before the archive view (PR2l) that consumes it.
+
+---
+
+*End of spec.*

--- a/src/app/(light)/layout.tsx
+++ b/src/app/(light)/layout.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from "react";
+import LightShell from "@/components/ui/light/LightShell";
+
+/**
+ * (light) route group layout — Light System v1.0 scope.
+ *
+ * Every page under src/app/(light)/* renders inside <LightShell>, which
+ * applies the Field background, Inter as body default, and the warm
+ * foreground token (specs/design-system-v1.0.md §1, §2.1, §2.4, §3).
+ *
+ * Dark routes outside this group keep the root layout's Geist/Instrument
+ * Serif stack — no cross-contamination.
+ */
+export default function LightRouteLayout({ children }: { children: ReactNode }) {
+  return <LightShell>{children}</LightShell>;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -151,6 +151,49 @@
   .card-scrim {
     background: linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.2) 50%, transparent 100%);
   }
+
+  /* ───────────────────────────────────────────────────────────────────────
+   * Light System v1.0 — The Field (§2.1 of specs/design-system-v1.0.md).
+   *
+   * Six-layer gradient (linear base + five radial hotspots), blurred 60px
+   * and scaled past the viewport so the blur halo lands outside.
+   *
+   * Sandwich structure required by the spec — the inner element gets this
+   * utility, the wrapper handles position/overflow:
+   *
+   *   <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+   *     <div className="absolute inset-[-10%] bg-brew-field" />
+   *   </div>
+   *
+   * CSS gradient stacking paints later layers on top, so the linear base
+   * (Layer 1) is listed LAST and the top-right cream highlight (Layer 6)
+   * is listed FIRST. This matches §2.1's "rendered bottom-up" note.
+   *
+   * One Field, application-wide. Do not re-render per view (§2.1 anti-pattern).
+   * ─────────────────────────────────────────────────────────────────────── */
+  .bg-brew-field {
+    background:
+      radial-gradient(circle at 92% 8%, hsl(30 65% 91%) 0%, transparent 60%),
+      radial-gradient(circle at 55% 25%, hsl(348 75% 86% / 0.55) 0%, transparent 50%),
+      radial-gradient(circle at 18% 50%, hsl(330 50% 70% / 0.85) 0%, transparent 55%),
+      radial-gradient(circle at 95% 45%, hsl(25 60% 88% / 0.7) 0%, transparent 50%),
+      radial-gradient(circle at 12% 92%, hsl(14 88% 68% / 0.8) 0%, transparent 60%),
+      linear-gradient(135deg, hsl(30 60% 92%) 0%, hsl(345 50% 82%) 50%, hsl(18 80% 72%) 100%);
+    filter: blur(60px);
+    transform: scale(1.18);
+    transform-origin: center;
+  }
+
+  /* Light System v1.0 §3.2 — eyebrow style.
+   * Reserved for the (light) route group; uses Inter via the font-inter family. */
+  .label-eyebrow {
+    font-family: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: hsl(20 14% 12% / 0.7);
+  }
 }
 
 /*

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Suspense } from "react";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
-import { JetBrains_Mono, Instrument_Serif } from "next/font/google";
+import { JetBrains_Mono, Instrument_Serif, Fraunces, Inter } from "next/font/google";
 import "./globals.css";
 import BottomNav from "@/components/layout/BottomNav";
 import ScrollContainer from "@/components/layout/ScrollContainer";
@@ -18,6 +18,24 @@ const instrumentSerif = Instrument_Serif({
   weight: ["400"],
   style: ["normal", "italic"],
   variable: "--font-instrument-serif",
+  display: "swap",
+});
+
+// Light System v1.0 §3.1 — Fraunces for hero questions, Inter for everything
+// else inside the (light) route group. Variables are exposed globally so the
+// (light) scope can opt in via `font-fraunces` / `font-inter` Tailwind
+// utilities. Dark-scope consumers continue to use Instrument Serif / Geist.
+const fraunces = Fraunces({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--font-fraunces",
+  display: "swap",
+});
+
+const inter = Inter({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--font-inter",
   display: "swap",
 });
 
@@ -42,7 +60,7 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable} ${jetbrainsMono.variable} ${instrumentSerif.variable}`}>
+    <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable} ${jetbrainsMono.variable} ${instrumentSerif.variable} ${fraunces.variable} ${inter.variable}`}>
       <head>
         <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
         <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />

--- a/src/components/ui/light/LightShell.tsx
+++ b/src/components/ui/light/LightShell.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+
+/**
+ * Light System v1.0 — route-scoped shell.
+ *
+ * Applies the three anchors from specs/design-system-v1.0.md §1:
+ *   - The Field (§2.1) — fixed atmospheric background, sandwich structure
+ *   - The Voice (§3) — Inter as body default, Fraunces opt-in via `font-fraunces`
+ *   - Foreground (§2.4) — warm near-black at full opacity, inherited by children
+ *
+ * Lives at the (light) route group root. Dark routes are unaffected — they
+ * continue to render under the legacy root layout's body bg / Geist stack.
+ *
+ * The Field's <div absolute inset-[-10%] /> bleeds 10% past the viewport so
+ * the 60px blur halo has room to land outside the visible area (§2.1).
+ */
+export default function LightShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="font-inter text-light-foreground min-h-dvh">
+      <div
+        aria-hidden
+        className="pointer-events-none fixed inset-0 -z-10 overflow-hidden"
+      >
+        <div className="absolute inset-[-10%] bg-brew-field" />
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -39,12 +39,27 @@ const config: Config = {
           accent: "#E8C5A8",
           edge: "rgba(255,235,220,0.08)",
         },
+        // Light System v1.0 — specs/design-system-v1.0.md §2.3, §2.4.
+        // Prefixed `light-` so they don't collide with Dark tokens or Tailwind
+        // defaults. Foreground entries use `<alpha-value>` so opacity modifiers
+        // (`text-light-foreground/70`, etc.) compile per spec §3.2.
+        light: {
+          foreground: "hsl(20 14% 12% / <alpha-value>)",
+          "muted-foreground": "hsl(20 8% 45% / <alpha-value>)",
+          "card-default": "hsl(36 55% 96% / 0.55)",
+          "card-selected": "hsl(28 22% 84% / 0.7)",
+        },
       },
       fontFamily: {
         serif: ["var(--font-instrument-serif)", "Georgia", "serif"],
         display: ["var(--font-instrument-serif)", "Georgia", "serif"],
         sans: ["var(--font-geist-sans)", "Inter", "system-ui", "sans-serif"],
         mono: ["var(--font-geist-mono)", "var(--font-jetbrains-mono)", "Fira Code", "monospace"],
+        // Light System v1.0 §3.1 — Fraunces (hero serif) + Inter (body sans).
+        // Scoped to (light) consumers via explicit `font-fraunces` / `font-inter`
+        // classes so Dark routes keep their existing typography unchanged.
+        fraunces: ["var(--font-fraunces)", "ui-serif", "Georgia", "serif"],
+        inter: ["var(--font-inter)", "ui-sans-serif", "system-ui", "sans-serif"],
       },
       borderRadius: {
         sm: "8px",
@@ -57,6 +72,12 @@ const config: Config = {
       boxShadow: {
         "glow-subtle": "0 0 60px rgba(232,197,168,0.08)",
         "glow-strong": "0 0 90px rgba(232,197,168,0.18)",
+        // Light System v1.0 §2.3, §4.3 — pressed-card inset shadow.
+        "light-card-pressed": "inset 0 2px 4px rgba(60, 40, 30, 0.12)",
+      },
+      backdropBlur: {
+        // Light System v1.0 §2.3 — glass blur on cards/sheets/overlays.
+        "light-card": "14px",
       },
       transitionTimingFunction: {
         spring: "cubic-bezier(0.32, 0.72, 0, 1)",


### PR DESCRIPTION
## Summary

PR2a from the Home migration briefing. Stands up the Light System v1.0 scope without consuming it — no new pages, no Dark migration, no Brew Context touch.

- **`specs/`** — pins the four authoritative documents (Home view, Agent Memory stub, Design System v1.0, Design System v1.1 generative field) inside the repo so future sessions and reviewers don't depend on project knowledge to read the spec.
- **`src/app/(light)/layout.tsx`** + **`src/components/ui/light/LightShell.tsx`** — route-scoped shell that applies the Field background, Inter as body default, and the warm foreground token (v1.0 §1, §2.1, §2.4, §3).
- **`src/app/globals.css`** — `.bg-brew-field` utility (v1.0 §2.1: six-layer gradient, `blur(60px)`, `scale(1.18)`) and `.label-eyebrow` (v1.0 §3.2).
- **`src/app/layout.tsx`** — Fraunces + Inter loaded via `next/font/google`, exposed as `--font-fraunces` / `--font-inter`. Dark stack (Geist, Instrument Serif, JetBrains Mono) untouched.
- **`tailwind.config.ts`** — `light.*` color tokens, `light-card-pressed` shadow, `light-card` backdropBlur, `font-fraunces` / `font-inter` families. Everything `light-` prefixed so Dark consumers stay unchanged.

The `src/components/ui/light/` folder is otherwise empty; later PRs fill it in.

## Out of scope (deferred to later PRs)

- Home page rendering — PR2b
- Navigation overlay (Burger) — PR2c
- Chat input states, voice, attachments — PR2d–g
- Conversation Starter Haiku generation — PR2j
- Brew Context migration to Light — separate later block

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Auto-deploy to Hetzner runs green
- [ ] No visual regression on existing Dark routes (`/`, `/explore`, `/coffees`, etc.) — the new font variables and Tailwind tokens are additive only
- [ ] `(light)` scope renders the warm Field when a child page eventually mounts (verified in PR2b)

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_