### PR TITLE
fix: render light field on /home (body-bg painting order)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -96,6 +96,24 @@
     font-family: var(--font-geist-sans), system-ui, sans-serif;
     overscroll-behavior: none;
   }
+
+  /* Light System v1.0 hybrid-repo override.
+   *
+   * The root layout sets body bg = #0E0B0A so every Dark route renders on
+   * the canonical dark canvas. v1.0 §2.1 puts the warm Field at z-index
+   * -10 — but in CSS painting order, body's bg paints in step 3 of the
+   * root stacking context, ON TOP of -z-10 children. The dark body
+   * therefore covers the Field on (light) routes.
+   *
+   * Fix: when a LightShell is mounted, drop body bg to transparent so
+   * the -z-10 Field is visible. Dark routes have no [data-light-scope]
+   * marker, so the rule does not match and their bg stays #0E0B0A.
+   *
+   * `:has()` is supported in Safari 15.4+ / iOS 15.4+ — the iPhone PWA
+   * target sits well above that. */
+  body:has([data-light-scope="true"]) {
+    background-color: transparent;
+  }
 }
 
 @layer utilities {

--- a/src/components/ui/light/LightShell.tsx
+++ b/src/components/ui/light/LightShell.tsx
@@ -16,7 +16,7 @@ import type { ReactNode } from "react";
  */
 export default function LightShell({ children }: { children: ReactNode }) {
   return (
-    <div className="font-inter text-light-foreground min-h-dvh">
+    <div data-light-scope="true" className="font-inter text-light-foreground min-h-dvh">
       <div
         aria-hidden
         className="pointer-events-none fixed inset-0 -z-10 overflow-hidden"


### PR DESCRIPTION
## Summary

Fix on top of PR2a (#44) + PR2b (#45). `/home` rendered with the dark BrewLog body bg leaking through instead of the warm cream Field — only Glass pills were visible.

**Root cause:** `globals.css` sets `body { background-color: #0E0B0A }` so every Dark route gets the canonical canvas. In CSS painting order, body bg paints in step 3 of the root stacking context, on top of any `-z-10` child. Light System v1.0 §2.1's `-z-10` Field sandwich therefore got hidden by the dark body.

**Fix:** mark `<LightShell>` with `data-light-scope="true"` and add a targeted CSS rule:

```css
body:has([data-light-scope="true"]) {
  background-color: transparent;
}
```

Light routes drop body bg → Field shows. Dark routes never mount the marker → their bg stays `#0E0B0A`. `:has()` is in Safari 15.4+ / iOS 15.4+ — well within the iPhone PWA target.

(PR #46 was the same fix on the old branch but had merge conflicts from the squash-merged PR2a/2b history. This PR is the same fix on a clean branch off `main`.)

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_