### PR TITLE
feat: navigation overlay (PR2c)

### DIFF
--- a/src/app/(light)/home/page.tsx
+++ b/src/app/(light)/home/page.tsx
@@ -1,73 +1,80 @@
+"use client";
+
+import { useState } from "react";
 import { Menu, Plus, AudioLines } from "lucide-react";
+import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
 
 /**
  * BTTS Home — Starter state (specs/home.md §11.1).
  *
- * PR2b scope: render only the Starter view of Home. Static layout, no
- * interactivity yet. Conversation Starter is hardcoded from §8.1; real
- * Haiku generation lands in PR2j. Burger, input pill, plus button, and
- * waveform render as visual scaffolding — taps do nothing.
+ * PR2b: static layout for the Starter view.
+ * PR2c: Burger becomes interactive — tap opens the Navigation Overlay
+ *       (§7). All other input-bar elements stay non-interactive until
+ *       PR2d–f wire composition, attachments, and voice.
  *
  * Layout (specs/home.md §11.0 — Hero-slot geometry):
  *   - Header (sticky-top role): pt-12 + h-11 content + pb-3 breathing
  *   - Hero slot (flex-1, flex items-center): Starter vertically centred
  *   - Input bar (sticky-bottom role): pt-3 + h-11 content + safe-area pb
- *
- * Single-screen so nothing actually scrolls — sticky semantics are
- * implicit in the flex-column geometry. When the live thread lands
- * (PR2e), the Hero slot becomes scrollable inside the same column.
  */
 export default function HomePage() {
+  const [menuOpen, setMenuOpen] = useState(false);
+
   return (
-    <main className="flex min-h-dvh flex-col">
-      {/* Header — specs/home.md §1.
-          Title is plain text (no Glass, no border, no pill). Burger is a
-          Glass pill with hairline border. Burger is not interactive in
-          PR2b; tap target intentionally inert. */}
-      <header className="flex items-center justify-between pl-5 pr-5 pt-12 pb-3">
-        <h1 className="font-inter text-[14px] font-medium text-light-foreground/60">
-          Better taste than sorry
-        </h1>
-        <div
-          aria-label="Menu"
-          className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
-        >
-          <Menu className="h-5 w-5" strokeWidth={1.5} />
-        </div>
-      </header>
+    <>
+      <main className="flex min-h-dvh flex-col">
+        {/* Header — specs/home.md §1.
+            Title is plain text (no Glass, no border, no pill). Burger
+            is a Glass pill with hairline border that opens the
+            Navigation Overlay when tapped. */}
+        <header className="flex items-center justify-between pl-5 pr-5 pt-12 pb-3">
+          <h1 className="font-inter text-[14px] font-medium text-light-foreground/60">
+            Better taste than sorry
+          </h1>
+          <button
+            type="button"
+            onClick={() => setMenuOpen(true)}
+            aria-label="Open menu"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
+          >
+            <Menu className="h-5 w-5" strokeWidth={1.5} />
+          </button>
+        </header>
 
-      {/* Hero slot — specs/home.md §11.0 + §8.1.
-          Vertically centred in the slot between Header and Input Bar.
-          Fraunces 40/600, left-aligned at pl-5 (matches Title's left
-          edge), foreground at full opacity. Hardcoded Starter from §8.1
-          until PR2j wires real Haiku generation. */}
-      <section className="flex flex-1 items-center pl-5 pr-5">
-        <p className="font-fraunces text-[40px] font-semibold leading-[1.05] tracking-[-0.01em] text-light-foreground">
-          Good morning. DAK Coffee Roasters yesterday — try Process or anything new today?
-        </p>
-      </section>
+        {/* Hero slot — specs/home.md §11.0 + §8.1.
+            Vertically centred in the slot between Header and Input Bar.
+            Fraunces 40/600, left-aligned at pl-5, foreground at full
+            opacity. Hardcoded Starter from §8.1 until PR2j wires real
+            Haiku generation. */}
+        <section className="flex flex-1 items-center pl-5 pr-5">
+          <p className="font-fraunces text-[40px] font-semibold leading-[1.05] tracking-[-0.01em] text-light-foreground">
+            Good morning. DAK Coffee Roasters yesterday — try Process or anything new today?
+          </p>
+        </section>
 
-      {/* Input bar — specs/home.md §2.1 (idle state).
-          Static visual scaffolding. Plus, pill, and waveform are not
-          interactive in PR2b. Composition states (typing, attachments,
-          voice, transcript review) land in PR2d–f. */}
-      <footer className="flex items-center gap-3 px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-3">
-        <div
-          aria-label="Attach"
-          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150"
-        >
-          <Plus className="h-5 w-5" strokeWidth={1.5} />
-        </div>
-        <div className="flex h-11 flex-1 items-center justify-between rounded-full border border-light-foreground/10 bg-light-card-default pl-5 pr-3 backdrop-blur-[14px] backdrop-saturate-150">
-          <span className="font-inter text-[15px] font-normal text-light-muted-foreground">
-            Ask anything…
-          </span>
-          <AudioLines
-            className="mr-2 h-5 w-5 text-light-foreground/60"
-            strokeWidth={1.5}
-          />
-        </div>
-      </footer>
-    </main>
+        {/* Input bar — specs/home.md §2.1 (idle state).
+            Static visual scaffolding. Plus, pill, and waveform are not
+            interactive until PR2d–f. */}
+        <footer className="flex items-center gap-3 px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-3">
+          <div
+            aria-label="Attach"
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150"
+          >
+            <Plus className="h-5 w-5" strokeWidth={1.5} />
+          </div>
+          <div className="flex h-11 flex-1 items-center justify-between rounded-full border border-light-foreground/10 bg-light-card-default pl-5 pr-3 backdrop-blur-[14px] backdrop-saturate-150">
+            <span className="font-inter text-[15px] font-normal text-light-muted-foreground">
+              Ask anything…
+            </span>
+            <AudioLines
+              className="mr-2 h-5 w-5 text-light-foreground/60"
+              strokeWidth={1.5}
+            />
+          </div>
+        </footer>
+      </main>
+
+      <NavigationOverlay open={menuOpen} onClose={() => setMenuOpen(false)} />
+    </>
   );
 }

--- a/src/components/ui/light/NavigationOverlay.tsx
+++ b/src/components/ui/light/NavigationOverlay.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { X } from "lucide-react";
+import Link from "next/link";
+
+/**
+ * BTTS Navigation Overlay (specs/home.md §7).
+ *
+ * Full-screen Glass overlay that sheets *over* the current view — the
+ * Field below stays visible through the semi-transparent surface, so
+ * navigating to and from the menu reads as one continuous room.
+ *
+ * Seven destinations (§7.2 — flat list, no hierarchy):
+ *   Home · Past Conversations · New Session · Coffee Library ·
+ *   Nearby · Café Library · Taste Profile
+ *
+ * Items without an `href` render as disabled: their target route does
+ * not yet exist. Past Conversations lands in PR2l alongside the
+ * conversation persistence schema; until then the menu item is muted
+ * and inert.
+ *
+ * Café Library currently shares the existing /cafes route with Nearby.
+ * specs/home.md §7.2 splits them by intent (geographic discovery vs.
+ * record of past visits) — that split is a later refinement.
+ *
+ * Tap on a destination both navigates and closes the overlay (§7.3),
+ * via the onClick handler firing before Next.js transitions.
+ */
+
+interface NavItem {
+  label: string;
+  href?: string;
+}
+
+const ITEMS: NavItem[] = [
+  { label: "Home", href: "/home" },
+  { label: "Past Conversations" },
+  { label: "New Session", href: "/brew/new" },
+  { label: "Coffee Library", href: "/coffees" },
+  { label: "Nearby", href: "/cafes" },
+  { label: "Café Library", href: "/cafes" },
+  { label: "Taste Profile", href: "/taste" },
+];
+
+interface NavigationOverlayProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function NavigationOverlay({ open, onClose }: NavigationOverlayProps) {
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Navigation"
+      className="fixed inset-0 z-50 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150"
+    >
+      {/* Close button — same coordinates as the Burger that opened it
+          (§7.1: "mirroring placement so thumb knows where to look"). */}
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close menu"
+        className="absolute right-5 top-12 flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
+      >
+        <X className="h-5 w-5" strokeWidth={1.5} />
+      </button>
+
+      {/* Destination list — Inter 24/500, foreground, gap-6 between items.
+          pt-24 + pl-6 per §7.1. No icons (§7.3 anti-pattern). */}
+      <nav className="flex flex-col gap-6 pl-6 pt-24">
+        {ITEMS.map((item) =>
+          item.href ? (
+            <Link
+              key={item.label}
+              href={item.href}
+              onClick={onClose}
+              className="font-inter text-[24px] font-medium text-light-foreground"
+            >
+              {item.label}
+            </Link>
+          ) : (
+            <span
+              key={item.label}
+              aria-disabled="true"
+              className="font-inter text-[24px] font-medium text-light-foreground/40"
+            >
+              {item.label}
+            </span>
+          )
+        )}
+      </nav>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

PR2c from the Home migration briefing. Burger on `/home` becomes interactive: tap opens a full-screen Glass Navigation Overlay with the seven destinations from `specs/home.md` §7.2. Tap a destination = navigate + close. Tap × = close without navigating.

- **`src/components/ui/light/NavigationOverlay.tsx`** — full-screen Glass overlay (`bg-light-card-default` + `backdrop-blur-[14px]` + `backdrop-saturate-150`). The warm Field below stays visible through the semi-transparent surface, so the menu reads as the same room rather than a new screen (§7.3). Close button at `top-12 right-5` mirrors the Burger's position. Destination list at `pt-24 pl-6`, `gap-6` between items, Inter 24/500.
- **`src/app/(light)/home/page.tsx`** — converted to a client component to host the menu open/close state. Burger is now a real `<button>` with `onClick={() => setMenuOpen(true)}`. `+`, the input pill, and the Waveform stay non-interactive (PR2d–f).

## Routing decisions

| Menu item | Route | Notes |
|---|---|---|
| Home | `/home` | This PR's own surface |
| Past Conversations | — (disabled) | No route yet — lands in PR2l with the conversation persistence schema |
| New Session | `/brew/new` | Existing Dark route |
| Coffee Library | `/coffees` | Existing Dark route |
| Nearby | `/cafes` | Existing Dark route |
| Café Library | `/cafes` | §7.2 splits Nearby (geographic discovery) vs. Café Library (record of past visits); the route split is a later refinement, so for now both link to `/cafes` |
| Taste Profile | `/taste` | Existing Dark route |

When the user taps a destination that opens a Dark route, the body bg toggles back to `#0E0B0A` automatically (no `[data-light-scope]` marker in the DOM → the `:has()` rule from #47 doesn't match).

## Out of scope (deferred to later PRs)

- Chat composition / Pre-Composition Bubble — PR2d
- Top-edge scroll fade + Agent Response styling — PR2e
- Voice / transcript review — PR2f
- `+` Sheet (Camera / Photo / Reference Coffee) — PR2g
- Reference Coffee Picker — PR2h
- Action Pills + intent classification — PR2i
- Real Haiku Conversation Starter — PR2j
- Conversation persistence + idle-window logic — PR2k
- Past Conversations view — PR2l (the disabled menu item lights up here)
- `/explore` route removal — PR2m
- Café Library / Nearby route split — separate later refinement

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Auto-deploy runs green
- [ ] On `/home`, tap Burger → full-screen Glass overlay opens with seven items
- [ ] Tap a destination (e.g. "Coffee Library") → navigates to `/coffees` (Dark) and overlay state is gone
- [ ] Past Conversations is visibly muted (40% opacity) and not tappable
- [ ] Tap × in the overlay → returns to `/home` with the warm Field intact
- [ ] No regression on existing Dark routes

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_