### PR TITLE
feat: chat input wired to /api/explore-agent (PR2d)

### DIFF
--- a/src/app/(light)/home/page.tsx
+++ b/src/app/(light)/home/page.tsx
@@ -1,33 +1,153 @@
 "use client";
 
-import { useState } from "react";
-import { Menu, Plus, AudioLines } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Menu } from "lucide-react";
 import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
+import ChatInput from "@/components/ui/light/ChatInput";
+import ChatThread from "@/components/ui/light/ChatThread";
+import type { Session } from "@/lib/types/session";
 
 /**
- * BTTS Home — Starter state (specs/home.md §11.1).
+ * BTTS Home (specs/home.md §0, §11).
  *
- * PR2b: static layout for the Starter view.
- * PR2c: Burger becomes interactive — tap opens the Navigation Overlay
- *       (§7). All other input-bar elements stay non-interactive until
- *       PR2d–f wire composition, attachments, and voice.
+ * PR2b: static Starter view.
+ * PR2c: Burger opens the Navigation Overlay.
+ * PR2d: chat input wired to /api/explore-agent. Send / receive / stream.
+ *       The Hero slot switches from Starter (§11.1) to Live-thread (§11.2)
+ *       once the user starts composing or has sent at least one message.
  *
- * Layout (specs/home.md §11.0 — Hero-slot geometry):
- *   - Header (sticky-top role): pt-12 + h-11 content + pb-3 breathing
- *   - Hero slot (flex-1, flex items-center): Starter vertically centred
- *   - Input bar (sticky-bottom role): pt-3 + h-11 content + safe-area pb
+ * Out of PR2d scope (deferred):
+ *   - Voice / transcript review (PR2f)
+ *   - Attachment + Reference Coffee (PR2g, PR2h)
+ *   - Action Pills (PR2i)
+ *   - Real Haiku Starter (PR2j)
+ *   - Persistence / 30-min idle reset (PR2k)
+ *   - Past Conversations view (PR2l)
  */
+
+interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+const STARTER_TEXT =
+  "Good morning. DAK Coffee Roasters yesterday — try Process or anything new today?";
+
 export default function HomePage() {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [recentSessions, setRecentSessions] = useState<Session[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [interacted, setInteracted] = useState(false);
+
+  // Fetch recent sessions once so /api/explore-agent has the personal
+  // recipe context. Same shape as /explore consumes.
+  useEffect(() => {
+    fetch("/api/sessions?limit=5", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data: Session[]) => {
+        if (Array.isArray(data)) setRecentSessions(data);
+      })
+      .catch(() => {});
+  }, []);
+
+  const showStarter = messages.length === 0 && !interacted;
+
+  const handleSend = async (text: string) => {
+    const userMsg: ChatMessage = { role: "user", content: text };
+    const next = [...messages, userMsg];
+    setMessages(next);
+    setLoading(true);
+    setInteracted(true);
+
+    try {
+      const res = await fetch("/api/explore-agent", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ messages: next, recentSessions }),
+      });
+
+      if (!res.ok || !res.body) {
+        setMessages((prev) => [
+          ...prev,
+          { role: "assistant", content: "Sorry, I couldn't get a response. Try again." },
+        ]);
+        return;
+      }
+
+      // Seed an empty assistant entry that delta events progressively fill.
+      setMessages((prev) => [...prev, { role: "assistant", content: "" }]);
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let carry = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        carry += decoder.decode(value, { stream: true });
+
+        // SSE frames are "event: NAME\ndata: JSON\n\n".
+        let idx;
+        while ((idx = carry.indexOf("\n\n")) !== -1) {
+          const block = carry.slice(0, idx);
+          carry = carry.slice(idx + 2);
+
+          let event = "message";
+          let data = "";
+          for (const line of block.split("\n")) {
+            if (line.startsWith("event: ")) event = line.slice(7);
+            else if (line.startsWith("data: ")) data += line.slice(6);
+          }
+
+          if (event === "delta") {
+            try {
+              const payload = JSON.parse(data) as { text?: string };
+              if (payload.text) {
+                setMessages((prev) => {
+                  const copy = prev.slice();
+                  const lastIdx = copy.length - 1;
+                  const last = copy[lastIdx];
+                  if (last?.role === "assistant") {
+                    copy[lastIdx] = { ...last, content: last.content + payload.text };
+                  }
+                  return copy;
+                });
+              }
+            } catch {
+              /* malformed event — skip */
+            }
+          } else if (event === "retract") {
+            // Agent started speaking, then decided to call a tool — drop
+            // whatever it streamed before the tool call.
+            setMessages((prev) => {
+              const copy = prev.slice();
+              const lastIdx = copy.length - 1;
+              const last = copy[lastIdx];
+              if (last?.role === "assistant") {
+                copy[lastIdx] = { ...last, content: "" };
+              }
+              return copy;
+            });
+          }
+          // status / done events ignored in PR2d — status messages and
+          // navigation actions land in PR2i with the Action Pills work.
+        }
+      }
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        { role: "assistant", content: "Couldn't reach BTTS. Check your connection." },
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
     <>
-      <main className="flex min-h-dvh flex-col">
-        {/* Header — specs/home.md §1.
-            Title is plain text (no Glass, no border, no pill). Burger
-            is a Glass pill with hairline border that opens the
-            Navigation Overlay when tapped. */}
-        <header className="flex items-center justify-between pl-5 pr-5 pt-12 pb-3">
+      <main className="flex h-dvh flex-col">
+        <header className="flex shrink-0 items-center justify-between pl-5 pr-5 pt-12 pb-3">
           <h1 className="font-inter text-[14px] font-medium text-light-foreground/60">
             Better taste than sorry
           </h1>
@@ -41,37 +161,28 @@ export default function HomePage() {
           </button>
         </header>
 
-        {/* Hero slot — specs/home.md §11.0 + §8.1.
-            Vertically centred in the slot between Header and Input Bar.
-            Fraunces 40/600, left-aligned at pl-5, foreground at full
-            opacity. Hardcoded Starter from §8.1 until PR2j wires real
-            Haiku generation. */}
-        <section className="flex flex-1 items-center pl-5 pr-5">
-          <p className="font-fraunces text-[40px] font-semibold leading-[1.05] tracking-[-0.01em] text-light-foreground">
-            Good morning. DAK Coffee Roasters yesterday — try Process or anything new today?
-          </p>
+        {/* Hero slot — §11.0. flex-1 + min-h-0 + overflow-y-auto so a long
+            thread scrolls inside the slot rather than pushing the input
+            bar off the viewport. PR2e refines with the top-edge fade. */}
+        <section className="flex-1 min-h-0 overflow-y-auto">
+          {showStarter ? (
+            <div className="flex h-full items-center px-5">
+              <p className="font-fraunces text-[40px] font-semibold leading-[1.05] tracking-[-0.01em] text-light-foreground">
+                {STARTER_TEXT}
+              </p>
+            </div>
+          ) : (
+            <div className="flex min-h-full flex-col justify-end">
+              <ChatThread messages={messages} loading={loading} />
+            </div>
+          )}
         </section>
 
-        {/* Input bar — specs/home.md §2.1 (idle state).
-            Static visual scaffolding. Plus, pill, and waveform are not
-            interactive until PR2d–f. */}
-        <footer className="flex items-center gap-3 px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-3">
-          <div
-            aria-label="Attach"
-            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150"
-          >
-            <Plus className="h-5 w-5" strokeWidth={1.5} />
-          </div>
-          <div className="flex h-11 flex-1 items-center justify-between rounded-full border border-light-foreground/10 bg-light-card-default pl-5 pr-3 backdrop-blur-[14px] backdrop-saturate-150">
-            <span className="font-inter text-[15px] font-normal text-light-muted-foreground">
-              Ask anything…
-            </span>
-            <AudioLines
-              className="mr-2 h-5 w-5 text-light-foreground/60"
-              strokeWidth={1.5}
-            />
-          </div>
-        </footer>
+        <ChatInput
+          loading={loading}
+          onSend={handleSend}
+          onComposeStart={() => setInteracted(true)}
+        />
       </main>
 
       <NavigationOverlay open={menuOpen} onClose={() => setMenuOpen(false)} />

--- a/src/components/ui/light/ChatInput.tsx
+++ b/src/components/ui/light/ChatInput.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Plus, X, AudioLines, ArrowUp, Loader2 } from "lucide-react";
+
+/**
+ * BTTS Chat Input — specs/home.md §2 (input bar) + §3 (Pre-Composition Bubble).
+ *
+ * PR2d scope: Idle, Typing, and Loading. Composition is text-only.
+ * Voice / attachments / coffee references / action pills land in later PRs.
+ *
+ * State machine:
+ *   - Idle (!composing && !loading)         → Plus + "Ask anything…" pill + Waveform
+ *   - Typing (composing && !loading)        → Cancel + decorative pill + Pre-Comp Bubble above
+ *   - Loading (loading; composing forced false during loading) → Cancel + empty pill + Spinner
+ *
+ * Spec §3 requires the input pill to stay visible *below* the Bubble during
+ * composition so the user has a continuous visual anchor; that's preserved
+ * here by rendering both rows in the same footer.
+ *
+ * Cancel during loading is a UI affordance only in PR2d — the in-flight
+ * fetch is not aborted yet (PR2f adds proper cancellation alongside the
+ * cancel-during-recording / cancel-during-streaming distinctions).
+ */
+
+interface ChatInputProps {
+  loading: boolean;
+  onSend: (text: string) => void;
+  /**
+   * Fires when the user enters the Typing state for the first time. Home
+   * uses this to dismiss the daily Conversation Starter (§8.3 — first
+   * composition action dismisses the Starter, even before a send).
+   */
+  onComposeStart?: () => void;
+}
+
+export default function ChatInput({ loading, onSend, onComposeStart }: ChatInputProps) {
+  const [composing, setComposing] = useState(false);
+  const [text, setText] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // Auto-grow the textarea to fit content, no manual rows config.
+  useEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    ta.style.height = "auto";
+    ta.style.height = `${ta.scrollHeight}px`;
+  }, [text, composing]);
+
+  // Focus the textarea when the Bubble opens so the keyboard rises immediately.
+  useEffect(() => {
+    if (composing) textareaRef.current?.focus();
+  }, [composing]);
+
+  // Loading wins over composing — the Bubble closes when a send is in flight.
+  useEffect(() => {
+    if (loading && composing) setComposing(false);
+  }, [loading, composing]);
+
+  const enterCompose = () => {
+    if (loading) return;
+    if (!composing) onComposeStart?.();
+    setComposing(true);
+  };
+
+  const cancel = () => {
+    setComposing(false);
+    setText("");
+  };
+
+  const send = () => {
+    const trimmed = text.trim();
+    if (!trimmed || loading) return;
+    onSend(trimmed);
+    setText("");
+    setComposing(false);
+  };
+
+  const sendDisabled = !text.trim();
+
+  return (
+    <footer className="flex flex-col gap-2 px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-3">
+      {/* Pre-Composition Bubble — §3.
+          Right-aligned; bubble grows with content; Send (↑) sits in the
+          bubble's bottom-right per §3.1. Reserves 64px on the left for the
+          × in the bar row below to remain visually clear. */}
+      {composing && !loading && (
+        <div className="flex justify-end">
+          <div className="max-w-[calc(100%-64px)] rounded-2xl border border-light-foreground/10 bg-light-card-default p-3 backdrop-blur-[14px] backdrop-saturate-150">
+            <textarea
+              ref={textareaRef}
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              placeholder="Ask anything…"
+              rows={1}
+              className="block w-full resize-none bg-transparent font-inter text-[15px] font-normal leading-[1.4] text-light-foreground placeholder:text-light-muted-foreground focus:outline-none"
+            />
+            <div className="mt-2 flex justify-end">
+              <button
+                type="button"
+                onClick={send}
+                disabled={sendDisabled}
+                aria-label="Send"
+                className="flex h-9 w-9 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)] transition-opacity disabled:opacity-30"
+              >
+                <ArrowUp className="h-4 w-4" strokeWidth={2.25} />
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Input bar row.
+          Left: + (idle) or × (composing/loading).
+          Middle: tappable pill (idle), decorative pill (composing), empty
+          pill (loading).
+          Right: Waveform inside the pill (idle/composing) — replaced by an
+          external spinner in loading state. */}
+      <div className="flex items-center gap-3">
+        {composing || loading ? (
+          <button
+            type="button"
+            onClick={cancel}
+            disabled={loading}
+            aria-label={loading ? "Sending" : "Cancel"}
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150 disabled:opacity-50"
+          >
+            <X className="h-5 w-5" strokeWidth={1.5} />
+          </button>
+        ) : (
+          <div
+            aria-label="Attach"
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150"
+          >
+            <Plus className="h-5 w-5" strokeWidth={1.5} />
+          </div>
+        )}
+
+        {loading ? (
+          <div className="h-11 flex-1 rounded-full border border-light-foreground/10 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150" />
+        ) : (
+          <button
+            type="button"
+            onClick={enterCompose}
+            disabled={composing}
+            className="flex h-11 flex-1 cursor-text items-center justify-between rounded-full border border-light-foreground/10 bg-light-card-default pl-5 pr-3 text-left backdrop-blur-[14px] backdrop-saturate-150 disabled:cursor-default"
+          >
+            <span className="font-inter text-[15px] font-normal text-light-muted-foreground">
+              Ask anything…
+            </span>
+            <AudioLines
+              className="mr-2 h-5 w-5 text-light-foreground/60"
+              strokeWidth={1.5}
+            />
+          </button>
+        )}
+
+        {loading && (
+          <div
+            aria-label="Thinking"
+            className="flex h-11 w-11 shrink-0 items-center justify-center text-light-foreground/60"
+          >
+            <Loader2 className="h-5 w-5 animate-spin" strokeWidth={1.5} />
+          </div>
+        )}
+      </div>
+    </footer>
+  );
+}

--- a/src/components/ui/light/ChatThread.tsx
+++ b/src/components/ui/light/ChatThread.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * BTTS Chat Thread — specs/home.md §4 (conversation thread).
+ *
+ * PR2d minimum: render messages array. User content as right-aligned Glass
+ * bubbles (§4.2); agent responses as left-aligned prose, no bubble (§4.3).
+ * That visual distinction is the spec's "user chats, BTTS writes" anchor.
+ *
+ * PR2e refines: top-edge fade (mask-image), proper sticky-aware scroll
+ * behaviour with manual-scroll detection, and the streaming/done UX
+ * polish. For PR2d, basic auto-scroll-to-bottom is enough so streamed
+ * content stays in view.
+ *
+ * Three-dot indicator renders only between a sent user message and the
+ * first assistant delta — once any assistant text arrives, the indicator
+ * is replaced by the (still-streaming) prose.
+ */
+
+interface Message {
+  role: "user" | "assistant";
+  content: string;
+}
+
+interface ChatThreadProps {
+  messages: Message[];
+  loading: boolean;
+}
+
+export default function ChatThread({ messages, loading }: ChatThreadProps) {
+  const endRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [messages, loading]);
+
+  // Show the dots only when waiting for the first delta — i.e. the most
+  // recent message is the user's, OR the latest assistant message is empty.
+  const last = messages[messages.length - 1];
+  const showDots =
+    loading &&
+    (!last || last.role === "user" || (last.role === "assistant" && last.content === ""));
+
+  return (
+    <div className="flex w-full flex-col gap-3 px-5 py-5">
+      {messages.map((m, i) =>
+        m.role === "user" ? (
+          <div key={i} className="flex justify-end">
+            <div className="max-w-[80%] rounded-2xl border border-light-foreground/10 bg-light-card-default px-4 py-3 backdrop-blur-[14px] backdrop-saturate-150">
+              <p className="whitespace-pre-wrap font-inter text-[15px] font-normal text-light-foreground">
+                {m.content}
+              </p>
+            </div>
+          </div>
+        ) : (
+          m.content && (
+            <div key={i} className="space-y-3">
+              {m.content.split(/\n\n+/).map((para, j) => (
+                <p
+                  key={j}
+                  className="whitespace-pre-wrap font-inter text-[15px] font-normal leading-[1.5] text-light-foreground"
+                >
+                  {para}
+                </p>
+              ))}
+            </div>
+          )
+        )
+      )}
+
+      {showDots && (
+        <div className="flex items-center gap-1.5 pt-1" aria-label="Thinking">
+          <span
+            className="h-1.5 w-1.5 animate-pulse rounded-full bg-light-foreground/40"
+            style={{ animationDuration: "1200ms" }}
+          />
+          <span
+            className="h-1.5 w-1.5 animate-pulse rounded-full bg-light-foreground/40"
+            style={{ animationDuration: "1200ms", animationDelay: "150ms" }}
+          />
+          <span
+            className="h-1.5 w-1.5 animate-pulse rounded-full bg-light-foreground/40"
+            style={{ animationDuration: "1200ms", animationDelay: "300ms" }}
+          />
+        </div>
+      )}
+
+      <div ref={endRef} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

PR2d from the Home migration briefing. First functional chat surface on `/home`. Tap the pill → Pre-Composition Bubble opens; type → bubble grows; Send (↑) ships the message to `/api/explore-agent` and streams the response inline.

- **`src/components/ui/light/ChatInput.tsx`** — full state machine for Idle / Typing / Loading. Pre-Composition Bubble (§3) with auto-grow textarea and an inverted Send button (`bg-light-foreground` + cream icon). Cancel `×` replaces `+` during composing/loading. Input pill stays visible *below* the bubble per §3 so the user has a continuous visual anchor.
- **`src/components/ui/light/ChatThread.tsx`** — user content as right-aligned Glass bubbles (§4.2); agent responses as left-aligned prose with no bubble (§4.3) — the spec's "user chats, BTTS writes" anchor. Three-dot indicator while waiting for the first delta. Basic auto-scroll-to-bottom.
- **`src/app/(light)/home/page.tsx`** — orchestrates: messages array, recentSessions fetch on mount, SSE consumption (`delta` + `retract` handled). Hero slot switches from Conversation Starter to live thread on first compose action (§8.3 + §11.2). Layout changes to `h-dvh` with the section as `flex-1 min-h-0 overflow-y-auto` so long threads scroll inside the slot rather than pushing the input bar off the viewport.

## Out of scope (deferred)

- Voice / transcript review — PR2f
- Attachment + Reference Coffee Picker — PR2g / PR2h
- Action Pills + intent classification + nav directives — PR2i (the SSE `status` and `done` events are received but ignored in this PR)
- Real Haiku Starter — PR2j (still hardcoded)
- Persistence + 30-min idle-window logic — PR2k
- Past Conversations view — PR2l
- Compose-while-streaming send queue (§4.7)
- Cancel mid-stream (× is decorative during loading; proper abort lands in PR2f)
- Top-edge scroll fade + sticky header polish — PR2e

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Auto-deploy runs green
- [ ] On `/home`, tap "Ask anything…" → Pre-Composition Bubble opens with focused textarea
- [ ] Type "what should I brew today?" → Send becomes active
- [ ] Tap ↑ → user message appears as right-aligned Glass bubble; three dots show; agent response streams in as left-aligned prose
- [ ] Send a follow-up message → conversation accumulates
- [ ] Tap × in compose state → bubble closes, text cleared, returns to Idle
- [ ] Open Burger from a thread state → menu still works, returning closes the menu and the thread is intact
- [ ] No regression on existing Dark routes

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_