### PR TITLE
fix: chat input layout (textarea ring, bubble height, loading dots)

### DIFF
--- a/src/components/ui/light/ChatInput.tsx
+++ b/src/components/ui/light/ChatInput.tsx
@@ -7,20 +7,23 @@ import { Plus, X, AudioLines, ArrowUp, Loader2 } from "lucide-react";
  * BTTS Chat Input — specs/home.md §2 (input bar) + §3 (Pre-Composition Bubble).
  *
  * PR2d scope: Idle, Typing, and Loading. Composition is text-only.
- * Voice / attachments / coffee references / action pills land in later PRs.
  *
  * State machine:
  *   - Idle (!composing && !loading)         → Plus + "Ask anything…" pill + Waveform
- *   - Typing (composing && !loading)        → Cancel + decorative pill + Pre-Comp Bubble above
- *   - Loading (loading; composing forced false during loading) → Cancel + empty pill + Spinner
+ *   - Typing (composing && !loading)        → × + decorative pill + Pre-Comp Bubble above
+ *   - Loading (loading; composing forced false during loading)
+ *                                           → × + empty bar + Spinner, with three
+ *                                             Dots above the bar (§2.2 mb-3)
  *
- * Spec §3 requires the input pill to stay visible *below* the Bubble during
- * composition so the user has a continuous visual anchor; that's preserved
- * here by rendering both rows in the same footer.
+ * Textarea overrides: the project uses `@tailwindcss/forms`, which paints
+ * a blue focus ring + adds 8/12px padding to every textarea. Both are
+ * explicitly suppressed here (`border-0 p-0 focus:ring-0 focus:ring-offset-0
+ * focus:border-transparent`) so the bubble hugs its content and the
+ * focus state inherits the warm system instead of a stray Tailwind-blue.
  *
- * Cancel during loading is a UI affordance only in PR2d — the in-flight
- * fetch is not aborted yet (PR2f adds proper cancellation alongside the
- * cancel-during-recording / cancel-during-streaming distinctions).
+ * Send button placement: spec §3.1 specifies "in bottom-right of bubble,
+ * m-2" — implemented via absolute positioning so the bubble height tracks
+ * the textarea exactly rather than reserving a separate flex row.
  */
 
 interface ChatInputProps {
@@ -28,8 +31,7 @@ interface ChatInputProps {
   onSend: (text: string) => void;
   /**
    * Fires when the user enters the Typing state for the first time. Home
-   * uses this to dismiss the daily Conversation Starter (§8.3 — first
-   * composition action dismisses the Starter, even before a send).
+   * uses this to dismiss the daily Conversation Starter (§8.3).
    */
   onComposeStart?: () => void;
 }
@@ -39,7 +41,6 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
   const [text, setText] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
-  // Auto-grow the textarea to fit content, no manual rows config.
   useEffect(() => {
     const ta = textareaRef.current;
     if (!ta) return;
@@ -47,12 +48,10 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
     ta.style.height = `${ta.scrollHeight}px`;
   }, [text, composing]);
 
-  // Focus the textarea when the Bubble opens so the keyboard rises immediately.
   useEffect(() => {
     if (composing) textareaRef.current?.focus();
   }, [composing]);
 
-  // Loading wins over composing — the Bubble closes when a send is in flight.
   useEffect(() => {
     if (loading && composing) setComposing(false);
   }, [loading, composing]);
@@ -79,43 +78,55 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
   const sendDisabled = !text.trim();
 
   return (
-    <footer className="flex flex-col gap-2 px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-3">
+    <footer className="flex flex-col px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-3">
       {/* Pre-Composition Bubble — §3.
-          Right-aligned; bubble grows with content; Send (↑) sits in the
-          bubble's bottom-right per §3.1. Reserves 64px on the left for the
-          × in the bar row below to remain visually clear. */}
+          Reserves 48px (pb-12) at the bottom for the absolute-positioned
+          Send button so the bubble height tracks the textarea cleanly. */}
       {composing && !loading && (
-        <div className="flex justify-end">
-          <div className="max-w-[calc(100%-64px)] rounded-2xl border border-light-foreground/10 bg-light-card-default p-3 backdrop-blur-[14px] backdrop-saturate-150">
+        <div className="mb-2 flex justify-end">
+          <div className="relative max-w-[calc(100%-64px)] rounded-2xl border border-light-foreground/10 bg-light-card-default p-3 pb-12 backdrop-blur-[14px] backdrop-saturate-150">
             <textarea
               ref={textareaRef}
               value={text}
               onChange={(e) => setText(e.target.value)}
               placeholder="Ask anything…"
               rows={1}
-              className="block w-full resize-none bg-transparent font-inter text-[15px] font-normal leading-[1.4] text-light-foreground placeholder:text-light-muted-foreground focus:outline-none"
+              className="block w-full resize-none border-0 bg-transparent p-0 font-inter text-[15px] font-normal leading-[1.4] text-light-foreground placeholder:text-light-muted-foreground focus:border-transparent focus:outline-none focus:ring-0 focus:ring-offset-0"
             />
-            <div className="mt-2 flex justify-end">
-              <button
-                type="button"
-                onClick={send}
-                disabled={sendDisabled}
-                aria-label="Send"
-                className="flex h-9 w-9 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)] transition-opacity disabled:opacity-30"
-              >
-                <ArrowUp className="h-4 w-4" strokeWidth={2.25} />
-              </button>
-            </div>
+            <button
+              type="button"
+              onClick={send}
+              disabled={sendDisabled}
+              aria-label="Send"
+              className="absolute bottom-2 right-2 flex h-9 w-9 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)] transition-opacity disabled:opacity-30"
+            >
+              <ArrowUp className="h-4 w-4" strokeWidth={2.25} />
+            </button>
           </div>
         </div>
       )}
 
-      {/* Input bar row.
-          Left: + (idle) or × (composing/loading).
-          Middle: tappable pill (idle), decorative pill (composing), empty
-          pill (loading).
-          Right: Waveform inside the pill (idle/composing) — replaced by an
-          external spinner in loading state. */}
+      {/* Thinking dots — §2.2 "Empty bar with three Dots above (mb-3)".
+          Indented past the × column so the dots sit visually above the
+          pill area, not the cancel button. */}
+      {loading && (
+        <div className="mb-3 flex items-center gap-2 pl-14" aria-label="Thinking">
+          <span
+            className="h-2 w-2 animate-pulse rounded-full bg-light-foreground/60"
+            style={{ animationDuration: "1200ms" }}
+          />
+          <span
+            className="h-2 w-2 animate-pulse rounded-full bg-light-foreground/60"
+            style={{ animationDuration: "1200ms", animationDelay: "150ms" }}
+          />
+          <span
+            className="h-2 w-2 animate-pulse rounded-full bg-light-foreground/60"
+            style={{ animationDuration: "1200ms", animationDelay: "300ms" }}
+          />
+        </div>
+      )}
+
+      {/* Input bar row */}
       <div className="flex items-center gap-3">
         {composing || loading ? (
           <button
@@ -157,7 +168,7 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
 
         {loading && (
           <div
-            aria-label="Thinking"
+            aria-label="Sending"
             className="flex h-11 w-11 shrink-0 items-center justify-center text-light-foreground/60"
           >
             <Loader2 className="h-5 w-5 animate-spin" strokeWidth={1.5} />

--- a/src/components/ui/light/ChatThread.tsx
+++ b/src/components/ui/light/ChatThread.tsx
@@ -5,18 +5,17 @@ import { useEffect, useRef } from "react";
 /**
  * BTTS Chat Thread — specs/home.md §4 (conversation thread).
  *
- * PR2d minimum: render messages array. User content as right-aligned Glass
- * bubbles (§4.2); agent responses as left-aligned prose, no bubble (§4.3).
- * That visual distinction is the spec's "user chats, BTTS writes" anchor.
+ * User content as right-aligned Glass bubbles (§4.2); agent responses as
+ * left-aligned prose, no bubble (§4.3) — the spec's "user chats, BTTS
+ * writes" anchor.
  *
- * PR2e refines: top-edge fade (mask-image), proper sticky-aware scroll
- * behaviour with manual-scroll detection, and the streaming/done UX
- * polish. For PR2d, basic auto-scroll-to-bottom is enough so streamed
- * content stays in view.
+ * The "thinking" three-dot indicator lives in ChatInput (§2.2 — above the
+ * empty bar with mb-3) so the loading signal stays anchored to the
+ * input area rather than the thread tail.
  *
- * Three-dot indicator renders only between a sent user message and the
- * first assistant delta — once any assistant text arrives, the indicator
- * is replaced by the (still-streaming) prose.
+ * PR2e refines: top-edge fade (mask-image), manual-scroll detection,
+ * proper sticky-aware scroll behaviour. For PR2d, basic auto-scroll to
+ * bottom on new content is enough.
  */
 
 interface Message {
@@ -35,13 +34,6 @@ export default function ChatThread({ messages, loading }: ChatThreadProps) {
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
   }, [messages, loading]);
-
-  // Show the dots only when waiting for the first delta — i.e. the most
-  // recent message is the user's, OR the latest assistant message is empty.
-  const last = messages[messages.length - 1];
-  const showDots =
-    loading &&
-    (!last || last.role === "user" || (last.role === "assistant" && last.content === ""));
 
   return (
     <div className="flex w-full flex-col gap-3 px-5 py-5">
@@ -69,24 +61,6 @@ export default function ChatThread({ messages, loading }: ChatThreadProps) {
           )
         )
       )}
-
-      {showDots && (
-        <div className="flex items-center gap-1.5 pt-1" aria-label="Thinking">
-          <span
-            className="h-1.5 w-1.5 animate-pulse rounded-full bg-light-foreground/40"
-            style={{ animationDuration: "1200ms" }}
-          />
-          <span
-            className="h-1.5 w-1.5 animate-pulse rounded-full bg-light-foreground/40"
-            style={{ animationDuration: "1200ms", animationDelay: "150ms" }}
-          />
-          <span
-            className="h-1.5 w-1.5 animate-pulse rounded-full bg-light-foreground/40"
-            style={{ animationDuration: "1200ms", animationDelay: "300ms" }}
-          />
-        </div>
-      )}
-
       <div ref={endRef} />
     </div>
   );


### PR DESCRIPTION
## Summary

Three layout bugs visible on the first /home chat test, all from `@tailwindcss/forms` defaults + a misplaced loading indicator. Single fix PR.

### 1. Blue border on the textarea
`@tailwindcss/forms` paints a Tailwind-blue (`#2563eb`) focus *ring* on every textarea by default. `focus:outline-none` alone didn't override it because the plugin uses `box-shadow` rings, not CSS `outline`. Suppressed explicitly with `focus:ring-0 focus:ring-offset-0 focus:border-transparent` plus `border-0 p-0` to clear the plugin's 1px border and 8/12px padding.

### 2. Bubble far taller than the textarea content
Same plugin: the 8/12px textarea padding added ~40px to the bubble. With the overrides above, the textarea now hugs its content. Also moved Send to `absolute bottom-2 right-2` inside the bubble (spec §3.1: *"m-2 from bottom-right"*) so the bubble height tracks `scrollHeight` directly instead of reserving a separate flex row for the button.

### 3. Loading: only a wheel was visible, no three dots
The three-dot indicator lived in the thread tail at `h-1.5/w-1.5` + 40% opacity — invisible in practice. Moved it into the input bar per `specs/home.md` §2.2 (*"Empty bar with three Dots above (mb-3)"*), bumped to `h-2/w-2` at 60% opacity, indented past the × column so it sits visually above the pill area. `ChatThread` no longer renders dots — loading is signalled in one place.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Auto-deploy runs green
- [ ] Tap "Ask anything…" → Bubble opens hugging the textarea, no blue ring
- [ ] Type text → Send (↑) at bottom-right of the bubble, no extra empty space
- [ ] Send → Bubble closes, three pulsing dots appear above the empty pill, spinner on the right
- [ ] Response streams in as left-aligned prose, dots disappear once first delta arrives

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_