### PR TITLE
refactor: inline typing pill (drop floating bubble + right-side spinner)

### DIFF
--- a/src/components/ui/light/ChatInput.tsx
+++ b/src/components/ui/light/ChatInput.tsx
@@ -1,114 +1,80 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Plus, X, AudioLines, ArrowUp, Loader2 } from "lucide-react";
+import { Plus, X, AudioLines, ArrowUp } from "lucide-react";
 
 /**
- * BTTS Chat Input — specs/home.md §2 (input bar) + §3 (Pre-Composition Bubble).
+ * BTTS Chat Input — inline pill variant.
  *
- * PR2d scope: Idle, Typing, and Loading. Composition is text-only.
+ * Departs from specs/home.md §3 (Pre-Composition Bubble). User feedback on
+ * the first PR2d test: a separate Glass bubble floating above the pill —
+ * while the pill still shows "Ask anything…" placeholder — felt
+ * counter-intuitive. The pill is now the textarea: tap → focus → type →
+ * the pill grows vertically as the text wraps. Send (↑) sits inside the
+ * pill on the right where the Waveform sat in idle, replacing it as soon
+ * as there is text.
  *
  * State machine:
- *   - Idle (!composing && !loading)         → Plus + "Ask anything…" pill + Waveform
- *   - Typing (composing && !loading)        → × + decorative pill + Pre-Comp Bubble above
- *   - Loading (loading; composing forced false during loading)
- *                                           → × + empty bar + Spinner, with three
- *                                             Dots above the bar (§2.2 mb-3)
+ *   - Empty + not loading: + (left, decorative until PR2g) | pill with
+ *     "Ask anything…" placeholder | Waveform (right, decorative until PR2f)
+ *   - HasText + not loading: × (left, clears text) | pill with text |
+ *     Send (right, ships the message)
+ *   - Loading: × (left, decorative until PR2f cancel) | empty bar |
+ *     three Dots animated above the bar (specs/home.md §2.2 mb-3)
  *
- * Textarea overrides: the project uses `@tailwindcss/forms`, which paints
- * a blue focus ring + adds 8/12px padding to every textarea. Both are
- * explicitly suppressed here (`border-0 p-0 focus:ring-0 focus:ring-offset-0
- * focus:border-transparent`) so the bubble hugs its content and the
- * focus state inherits the warm system instead of a stray Tailwind-blue.
- *
- * Send button placement: spec §3.1 specifies "in bottom-right of bubble,
- * m-2" — implemented via absolute positioning so the bubble height tracks
- * the textarea exactly rather than reserving a separate flex row.
+ * Departed from spec also: no right-side Spinner during Thinking. The
+ * three Dots above the bar already carry the loading signal; the spinner
+ * was redundant.
  */
 
 interface ChatInputProps {
   loading: boolean;
   onSend: (text: string) => void;
-  /**
-   * Fires when the user enters the Typing state for the first time. Home
-   * uses this to dismiss the daily Conversation Starter (§8.3).
-   */
+  /** Fires the first time the textarea is focused — Home dismisses the
+   *  Conversation Starter on this signal (§8.3). */
   onComposeStart?: () => void;
 }
 
 export default function ChatInput({ loading, onSend, onComposeStart }: ChatInputProps) {
-  const [composing, setComposing] = useState(false);
   const [text, setText] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const composeStartedRef = useRef(false);
 
+  // Auto-grow textarea to fit content.
   useEffect(() => {
     const ta = textareaRef.current;
     if (!ta) return;
     ta.style.height = "auto";
     ta.style.height = `${ta.scrollHeight}px`;
-  }, [text, composing]);
+  }, [text, loading]);
 
-  useEffect(() => {
-    if (composing) textareaRef.current?.focus();
-  }, [composing]);
+  const hasText = text.trim().length > 0;
 
-  useEffect(() => {
-    if (loading && composing) setComposing(false);
-  }, [loading, composing]);
-
-  const enterCompose = () => {
-    if (loading) return;
-    if (!composing) onComposeStart?.();
-    setComposing(true);
+  const handleFocus = () => {
+    if (!composeStartedRef.current) {
+      composeStartedRef.current = true;
+      onComposeStart?.();
+    }
   };
 
-  const cancel = () => {
-    setComposing(false);
+  const clear = () => {
+    if (loading) return;
     setText("");
+    textareaRef.current?.focus();
   };
 
   const send = () => {
-    const trimmed = text.trim();
-    if (!trimmed || loading) return;
-    onSend(trimmed);
+    if (!hasText || loading) return;
+    onSend(text.trim());
     setText("");
-    setComposing(false);
+    composeStartedRef.current = false;
+    textareaRef.current?.blur();
   };
-
-  const sendDisabled = !text.trim();
 
   return (
     <footer className="flex flex-col px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-3">
-      {/* Pre-Composition Bubble — §3.
-          Reserves 48px (pb-12) at the bottom for the absolute-positioned
-          Send button so the bubble height tracks the textarea cleanly. */}
-      {composing && !loading && (
-        <div className="mb-2 flex justify-end">
-          <div className="relative max-w-[calc(100%-64px)] rounded-2xl border border-light-foreground/10 bg-light-card-default p-3 pb-12 backdrop-blur-[14px] backdrop-saturate-150">
-            <textarea
-              ref={textareaRef}
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-              placeholder="Ask anything…"
-              rows={1}
-              className="block w-full resize-none border-0 bg-transparent p-0 font-inter text-[15px] font-normal leading-[1.4] text-light-foreground placeholder:text-light-muted-foreground focus:border-transparent focus:outline-none focus:ring-0 focus:ring-offset-0"
-            />
-            <button
-              type="button"
-              onClick={send}
-              disabled={sendDisabled}
-              aria-label="Send"
-              className="absolute bottom-2 right-2 flex h-9 w-9 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)] transition-opacity disabled:opacity-30"
-            >
-              <ArrowUp className="h-4 w-4" strokeWidth={2.25} />
-            </button>
-          </div>
-        </div>
-      )}
-
-      {/* Thinking dots — §2.2 "Empty bar with three Dots above (mb-3)".
-          Indented past the × column so the dots sit visually above the
-          pill area, not the cancel button. */}
+      {/* Thinking dots — §2.2 "three Dots above (mb-3)". Indented past the
+          × column so the dots sit visually above the pill area. */}
       {loading && (
         <div className="mb-3 flex items-center gap-2 pl-14" aria-label="Thinking">
           <span
@@ -126,14 +92,14 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
         </div>
       )}
 
-      {/* Input bar row */}
-      <div className="flex items-center gap-3">
-        {composing || loading ? (
+      <div className="flex items-end gap-3">
+        {/* Left button: × when text present or loading, otherwise + */}
+        {hasText || loading ? (
           <button
             type="button"
-            onClick={cancel}
+            onClick={clear}
             disabled={loading}
-            aria-label={loading ? "Sending" : "Cancel"}
+            aria-label={loading ? "Sending" : "Clear"}
             className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150 disabled:opacity-50"
           >
             <X className="h-5 w-5" strokeWidth={1.5} />
@@ -147,31 +113,40 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
           </div>
         )}
 
+        {/* Pill — empty during loading; otherwise hosts the textarea and
+            the right-edge inline icon (Waveform when empty, Send when
+            text present). items-end keeps the inline icon aligned with
+            the last line of text as the textarea grows. */}
         {loading ? (
           <div className="h-11 flex-1 rounded-full border border-light-foreground/10 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150" />
         ) : (
-          <button
-            type="button"
-            onClick={enterCompose}
-            disabled={composing}
-            className="flex h-11 flex-1 cursor-text items-center justify-between rounded-full border border-light-foreground/10 bg-light-card-default pl-5 pr-3 text-left backdrop-blur-[14px] backdrop-saturate-150 disabled:cursor-default"
-          >
-            <span className="font-inter text-[15px] font-normal text-light-muted-foreground">
-              Ask anything…
-            </span>
-            <AudioLines
-              className="mr-2 h-5 w-5 text-light-foreground/60"
-              strokeWidth={1.5}
+          <div className="flex min-h-11 flex-1 items-end gap-1 rounded-3xl border border-light-foreground/10 bg-light-card-default py-1.5 pl-5 pr-1.5 backdrop-blur-[14px] backdrop-saturate-150">
+            <textarea
+              ref={textareaRef}
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              onFocus={handleFocus}
+              placeholder="Ask anything…"
+              rows={1}
+              className="block min-h-[2rem] w-full resize-none border-0 bg-transparent p-0 font-inter text-[15px] font-normal leading-[2rem] text-light-foreground placeholder:text-light-muted-foreground focus:border-transparent focus:outline-none focus:ring-0 focus:ring-offset-0"
             />
-          </button>
-        )}
-
-        {loading && (
-          <div
-            aria-label="Sending"
-            className="flex h-11 w-11 shrink-0 items-center justify-center text-light-foreground/60"
-          >
-            <Loader2 className="h-5 w-5 animate-spin" strokeWidth={1.5} />
+            {hasText ? (
+              <button
+                type="button"
+                onClick={send}
+                aria-label="Send"
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)]"
+              >
+                <ArrowUp className="h-4 w-4" strokeWidth={2.25} />
+              </button>
+            ) : (
+              <div
+                aria-label="Voice"
+                className="flex h-8 w-8 shrink-0 items-center justify-center text-light-foreground/60"
+              >
+                <AudioLines className="h-5 w-5" strokeWidth={1.5} />
+              </div>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Two user-feedback changes to the chat input:

### 1. Inline typing pill (drops the floating Pre-Composition Bubble)

`specs/home.md` §3 specified a separate Glass bubble floating above the pill, where typing happens, with the pill still showing the `Ask anything…` placeholder as a visual anchor below. On first test that read as two competing surfaces — the placeholder pill saying `Ask anything…` while the user was already typing into a bubble felt counter-intuitive.

New behavior: tap the pill → textarea focuses inside the pill → the pill grows vertically as text wraps. Send (↑) sits inside the pill on the right where the Waveform was in idle, replacing it as soon as there is text. `items-end` alignment keeps Send and the left × anchored to the last line of text as the pill grows.

Spec deviation noted in the commit — §3 (Pre-Composition Bubble) is effectively replaced by the inline pill behavior. Downstream PRs that reference the bubble (attachment thumbnail at top of bubble §3.3, transcript review §2.4 Phase 3) will need to port to the inline-pill model in PR2f/g/h.

### 2. Spinner removed during Thinking

`specs/home.md` §2.2 puts a Spinner in the right column for the Thinking state. In practice the three pulsing Dots above the bar already carry the loading signal — the duplicate spinner on the right read as accidental UI rather than intentional. Three dots alone is enough.

## State machine (post-refactor)

| State | Left | Pill | Right (inside pill) | Above bar |
|---|---|---|---|---|
| Empty + idle | `+` | `Ask anything…` placeholder | Waveform icon | — |
| Has text | `×` (clear) | typed text, grows vertically | Send (↑) dark filled | — |
| Loading | `×` (decorative) | empty Glass pill | — | three pulsing dots, mb-3 |

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Auto-deploy runs green
- [ ] Tap "Ask anything…" → pill focuses, cursor visible, no floating bubble above
- [ ] Type → text appears INSIDE the pill, pill grows vertically as text wraps
- [ ] When text present → left button is `×`, right inside pill is dark Send circle
- [ ] Tap Send → message sent, pill shrinks back to single line, three dots appear above (no spinner on right)
- [ ] Response streams in as left-aligned prose, dots disappear once first delta arrives

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_