### PR TITLE
feat: top-edge scroll fade + stick-to-bottom auto-scroll (PR2e)

### DIFF
--- a/src/app/(light)/home/page.tsx
+++ b/src/app/(light)/home/page.tsx
@@ -161,10 +161,10 @@ export default function HomePage() {
           </button>
         </header>
 
-        {/* Hero slot — §11.0. flex-1 + min-h-0 + overflow-y-auto so a long
-            thread scrolls inside the slot rather than pushing the input
-            bar off the viewport. PR2e refines with the top-edge fade. */}
-        <section className="flex-1 min-h-0 overflow-y-auto">
+        {/* Hero slot — §11.0. flex-1 + min-h-0 hold the height; ChatThread
+            owns its own scrollable container (§4.4 fade + §4.5 stick-
+            to-bottom auto-scroll). */}
+        <section className="flex-1 min-h-0">
           {showStarter ? (
             <div className="flex h-full items-center px-5">
               <p className="font-fraunces text-[40px] font-semibold leading-[1.05] tracking-[-0.01em] text-light-foreground">
@@ -172,9 +172,7 @@ export default function HomePage() {
               </p>
             </div>
           ) : (
-            <div className="flex min-h-full flex-col justify-end">
-              <ChatThread messages={messages} loading={loading} />
-            </div>
+            <ChatThread messages={messages} loading={loading} />
           )}
         </section>
 

--- a/src/components/ui/light/ChatThread.tsx
+++ b/src/components/ui/light/ChatThread.tsx
@@ -3,19 +3,25 @@
 import { useEffect, useRef } from "react";
 
 /**
- * BTTS Chat Thread — specs/home.md §4 (conversation thread).
+ * BTTS Chat Thread — specs/home.md §4.
  *
- * User content as right-aligned Glass bubbles (§4.2); agent responses as
- * left-aligned prose, no bubble (§4.3) — the spec's "user chats, BTTS
- * writes" anchor.
+ * Owns the scroll container so the top-edge fade (§4.4) and the
+ * stick-to-bottom auto-scroll (§4.5) live together.
  *
- * The "thinking" three-dot indicator lives in ChatInput (§2.2 — above the
- * empty bar with mb-3) so the loading signal stays anchored to the
- * input area rather than the thread tail.
+ * §4.4 — Top-edge fade. Older messages disappear into a 80px gradient
+ * mask at the top of the thread, so they read as "fading toward the
+ * header" rather than getting clipped at a hard line. The header above
+ * has no background, so the warm Field stays continuous.
  *
- * PR2e refines: top-edge fade (mask-image), manual-scroll detection,
- * proper sticky-aware scroll behaviour. For PR2d, basic auto-scroll to
- * bottom on new content is enough.
+ * §4.5 — Scroll behaviour. Latest message at bottom, conversation
+ * scrolled to bottom by default. Auto-scroll-to-bottom on new delta
+ * UNLESS the user has manually scrolled up — in which case their
+ * position is preserved so they can keep reading older content while
+ * the agent's response streams in below.
+ *
+ * Detection: a ref tracks "stick to bottom" state. Every scroll event
+ * recomputes it (50px tolerance to allow rounding). Programmatic
+ * scrolls land us back at the bottom and flip the ref true again.
  */
 
 interface Message {
@@ -29,39 +35,61 @@ interface ChatThreadProps {
 }
 
 export default function ChatThread({ messages, loading }: ChatThreadProps) {
-  const endRef = useRef<HTMLDivElement | null>(null);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const stickToBottomRef = useRef(true);
+
+  // Latest message content reference — included as a dep so streamed
+  // deltas (which mutate the last assistant message in place) trigger
+  // a scroll attempt.
+  const tailContent = messages[messages.length - 1]?.content ?? "";
 
   useEffect(() => {
-    endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
-  }, [messages, loading]);
+    if (!stickToBottomRef.current) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [messages, loading, tailContent]);
+
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget;
+    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 50;
+    stickToBottomRef.current = atBottom;
+  };
 
   return (
-    <div className="flex w-full flex-col gap-3 px-5 py-5">
-      {messages.map((m, i) =>
-        m.role === "user" ? (
-          <div key={i} className="flex justify-end">
-            <div className="max-w-[80%] rounded-2xl border border-light-foreground/10 bg-light-card-default px-4 py-3 backdrop-blur-[14px] backdrop-saturate-150">
-              <p className="whitespace-pre-wrap font-inter text-[15px] font-normal text-light-foreground">
-                {m.content}
-              </p>
-            </div>
-          </div>
-        ) : (
-          m.content && (
-            <div key={i} className="space-y-3">
-              {m.content.split(/\n\n+/).map((para, j) => (
-                <p
-                  key={j}
-                  className="whitespace-pre-wrap font-inter text-[15px] font-normal leading-[1.5] text-light-foreground"
-                >
-                  {para}
-                </p>
-              ))}
-            </div>
-          )
-        )
-      )}
-      <div ref={endRef} />
+    <div
+      ref={scrollRef}
+      onScroll={handleScroll}
+      className="h-full overflow-y-auto [-webkit-mask-image:linear-gradient(to_bottom,transparent_0,black_80px)] [mask-image:linear-gradient(to_bottom,transparent_0,black_80px)]"
+    >
+      <div className="flex min-h-full flex-col justify-end">
+        <div className="flex w-full flex-col gap-3 px-5 py-5">
+          {messages.map((m, i) =>
+            m.role === "user" ? (
+              <div key={i} className="flex justify-end">
+                <div className="max-w-[80%] rounded-2xl border border-light-foreground/10 bg-light-card-default px-4 py-3 backdrop-blur-[14px] backdrop-saturate-150">
+                  <p className="whitespace-pre-wrap font-inter text-[15px] font-normal text-light-foreground">
+                    {m.content}
+                  </p>
+                </div>
+              </div>
+            ) : (
+              m.content && (
+                <div key={i} className="space-y-3">
+                  {m.content.split(/\n\n+/).map((para, j) => (
+                    <p
+                      key={j}
+                      className="whitespace-pre-wrap font-inter text-[15px] font-normal leading-[1.5] text-light-foreground"
+                    >
+                      {para}
+                    </p>
+                  ))}
+                </div>
+              )
+            )
+          )}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

PR2e — top-edge scroll fade + smarter auto-scroll. `ChatThread` now owns the scroll container so both spec sections live in one place.

### §4.4 — Top-edge fade

Older messages fade into an 80px transparent-to-opaque CSS mask at the top of the thread, reading as "dissolving toward the header" rather than getting clipped at a hard line. The Field stays continuous because the header has no background of its own.

```css
mask-image: linear-gradient(to bottom, transparent 0, black 80px)
```

(plus the `-webkit-` prefix for Safari.)

### §4.5 — Stick-to-bottom auto-scroll

A `stickToBottomRef` tracks whether the user is currently at the bottom of the thread (50px tolerance for rounding). On every render where messages, loading, or the streaming tail changes, the thread scrolls to the bottom **only** if the ref is true. If the user has scrolled up to read older content, their position is preserved while the agent's response continues streaming below.

The `onScroll` handler recomputes the ref on every event, so going back to the bottom re-engages auto-scroll automatically.

## Structural change

`home/page.tsx` no longer applies `overflow-y-auto` to the Hero-slot section — the section is just layout now (`flex-1 min-h-0`). `ChatThread` is the scroll container. Starter rendering is unchanged.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Auto-deploy runs green
- [ ] Long conversation: scroll the thread, the top messages fade out smoothly instead of getting clipped
- [ ] Stream a response, stay at the bottom — auto-scrolls as text streams in
- [ ] Stream a response while scrolled up — position stays put, new content appears below without yanking the view
- [ ] Scroll back to the bottom mid-stream → auto-scroll re-engages

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_