### PR TITLE
fix: swap textarea for contenteditable to hide iOS form accessory bar

### DIFF
--- a/src/components/ui/light/ChatInput.tsx
+++ b/src/components/ui/light/ChatInput.tsx
@@ -1,54 +1,45 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { Plus, X, AudioLines, ArrowUp } from "lucide-react";
 
 /**
- * BTTS Chat Input — inline pill variant.
+ * BTTS Chat Input — contenteditable inline pill.
  *
- * Departs from specs/home.md §3 (Pre-Composition Bubble). User feedback on
- * the first PR2d test: a separate Glass bubble floating above the pill —
- * while the pill still shows "Ask anything…" placeholder — felt
- * counter-intuitive. The pill is now the textarea: tap → focus → type →
- * the pill grows vertically as the text wraps. Send (↑) sits inside the
- * pill on the right where the Waveform sat in idle, replacing it as soon
- * as there is text.
+ * iOS Safari paints a form input accessory bar (prev/next arrows + Done
+ * checkmark) above the keyboard whenever a <textarea> or <input> is
+ * focused. There is no web-standard API to suppress it. The canonical
+ * workaround — used by every modern chat app on the mobile web — is to
+ * back the editor with a <div contenteditable="true"> instead.
  *
- * State machine:
- *   - Empty + not loading: + (left, decorative until PR2g) | pill with
- *     "Ask anything…" placeholder | Waveform (right, decorative until PR2f)
- *   - HasText + not loading: × (left, clears text) | pill with text |
- *     Send (right, ships the message)
- *   - Loading: × (left, decorative until PR2f cancel) | empty bar |
- *     three Dots animated above the bar (specs/home.md §2.2 mb-3)
+ * Side benefit: the contenteditable div auto-grows with its content
+ * natively, so the scrollHeight tracking we needed for the textarea is
+ * gone.
  *
- * Departed from spec also: no right-side Spinner during Thinking. The
- * three Dots above the bar already carry the loading signal; the spinner
- * was redundant.
+ * State machine unchanged from PR2d:
+ *   - Empty + idle: + (left) | pill ("Ask anything…" placeholder) +
+ *                   Waveform inside pill
+ *   - HasText:      × (left, clear) | pill with text | Send inside pill
+ *   - Loading:      × (decorative) | empty bar | three Dots above
  */
 
 interface ChatInputProps {
   loading: boolean;
   onSend: (text: string) => void;
-  /** Fires the first time the textarea is focused — Home dismisses the
-   *  Conversation Starter on this signal (§8.3). */
+  /** First focus signal — Home dismisses the Conversation Starter on it. */
   onComposeStart?: () => void;
 }
 
 export default function ChatInput({ loading, onSend, onComposeStart }: ChatInputProps) {
   const [text, setText] = useState("");
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const editorRef = useRef<HTMLDivElement | null>(null);
   const composeStartedRef = useRef(false);
 
-  // Auto-grow textarea to fit content.
-  useEffect(() => {
-    const ta = textareaRef.current;
-    if (!ta) return;
-    ta.style.height = "auto";
-    ta.style.height = `${ta.scrollHeight}px`;
-  }, [text, loading]);
-
   const hasText = text.trim().length > 0;
+
+  const handleInput = (e: React.FormEvent<HTMLDivElement>) => {
+    setText(e.currentTarget.textContent ?? "");
+  };
 
   const handleFocus = () => {
     if (!composeStartedRef.current) {
@@ -57,24 +48,31 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
     }
   };
 
+  // Keep input plain-text — strip HTML formatting on paste.
+  const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const pasted = e.clipboardData.getData("text/plain");
+    document.execCommand("insertText", false, pasted);
+  };
+
   const clear = () => {
     if (loading) return;
+    if (editorRef.current) editorRef.current.textContent = "";
     setText("");
-    textareaRef.current?.focus();
+    editorRef.current?.focus();
   };
 
   const send = () => {
     if (!hasText || loading) return;
     onSend(text.trim());
+    if (editorRef.current) editorRef.current.textContent = "";
     setText("");
     composeStartedRef.current = false;
-    textareaRef.current?.blur();
+    editorRef.current?.blur();
   };
 
   return (
     <footer className="flex flex-col px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-3">
-      {/* Thinking dots — §2.2 "three Dots above (mb-3)". Indented past the
-          × column so the dots sit visually above the pill area. */}
       {loading && (
         <div className="mb-3 flex items-center gap-2 pl-14" aria-label="Thinking">
           <span
@@ -93,7 +91,6 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
       )}
 
       <div className="flex items-end gap-3">
-        {/* Left button: × when text present or loading, otherwise + */}
         {hasText || loading ? (
           <button
             type="button"
@@ -113,23 +110,32 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
           </div>
         )}
 
-        {/* Pill — empty during loading; otherwise hosts the textarea and
-            the right-edge inline icon (Waveform when empty, Send when
-            text present). items-end keeps the inline icon aligned with
-            the last line of text as the textarea grows. */}
         {loading ? (
           <div className="h-11 flex-1 rounded-full border border-light-foreground/10 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150" />
         ) : (
           <div className="flex min-h-11 flex-1 items-end gap-1 rounded-3xl border border-light-foreground/10 bg-light-card-default py-1.5 pl-5 pr-1.5 backdrop-blur-[14px] backdrop-saturate-150">
-            <textarea
-              ref={textareaRef}
-              value={text}
-              onChange={(e) => setText(e.target.value)}
-              onFocus={handleFocus}
-              placeholder="Ask anything…"
-              rows={1}
-              className="block min-h-[2rem] w-full resize-none border-0 bg-transparent p-0 font-inter text-[15px] font-normal leading-[2rem] text-light-foreground placeholder:text-light-muted-foreground focus:border-transparent focus:outline-none focus:ring-0 focus:ring-offset-0"
-            />
+            <div className="relative min-h-8 flex-1">
+              <div
+                ref={editorRef}
+                contentEditable
+                suppressContentEditableWarning
+                role="textbox"
+                aria-multiline="true"
+                aria-label="Message"
+                onInput={handleInput}
+                onFocus={handleFocus}
+                onPaste={handlePaste}
+                className="block min-h-8 w-full whitespace-pre-wrap break-words font-inter text-[16px] font-normal leading-[2rem] text-light-foreground focus:outline-none"
+              />
+              {!hasText && (
+                <span
+                  aria-hidden="true"
+                  className="pointer-events-none absolute left-0 top-0 font-inter text-[16px] font-normal leading-[2rem] text-light-muted-foreground"
+                >
+                  Ask anything…
+                </span>
+              )}
+            </div>
             {hasText ? (
               <button
                 type="button"


### PR DESCRIPTION
## Summary

iOS Safari paints a form input accessory bar (prev/next arrows + a Done checkmark) above the keyboard whenever a `<textarea>` or `<input>` gets focus. There's no web-standard API to suppress it. Every modern chat app on mobile web (WhatsApp Web, Slack, Discord, etc.) backs their composer with a `<div contenteditable="true">` instead — the bar does not attach to it.

Swap the textarea for a contenteditable div. Same React state (`text`), same callbacks (`onSend`, `onComposeStart`), same visual layout — only the editor element changes. Plain-text paste handler keeps copy/paste safe (no HTML formatting injected).

Side benefit: the contenteditable div auto-grows with its content natively, so the `scrollHeight`-tracking `useEffect` for the textarea is gone.

Placeholder is rendered as an absolutely-positioned span that hides as soon as text appears, rather than relying on the `:empty` pseudo-class (contenteditable cannot reliably be `:empty` cross-browser — browsers insert `<br>` and similar on cleanup).

## Note on iOS edge cases

If the form bar still appears in some configuration, installing the site as a PWA (Add to Home Screen → open from home screen icon) hides it definitively in current iOS versions.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Auto-deploy runs green
- [ ] Tap "Ask anything…" → keyboard rises with **no** prev/next/Done bar between keyboard and pill
- [ ] Type "Ah, ä" → text appears in the pill (German diacritics work)
- [ ] Multi-line typing grows the pill vertically
- [ ] Paste rich text from another app → only plain text appears
- [ ] Clear (×), Send (↑), and conversation flow still work as in PR2d

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_