### PR TITLE
feat: voice input — record → transcribe → review (PR2f)

### DIFF
--- a/src/components/ui/light/ChatInput.tsx
+++ b/src/components/ui/light/ChatInput.tsx
@@ -1,54 +1,99 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { Plus, X, AudioLines, ArrowUp } from "lucide-react";
+import { Plus, X, AudioLines, ArrowUp, Square, Loader2 } from "lucide-react";
+import { useVoiceCapture } from "@/hooks/useVoiceCapture";
+import WaveformBars from "@/components/ui/WaveformBars";
 
 /**
- * BTTS Chat Input — contenteditable inline pill.
+ * BTTS Chat Input — Idle / Typing / Voice / Loading.
  *
- * iOS Safari paints a form input accessory bar (prev/next arrows + Done
- * checkmark) above the keyboard whenever a <textarea> or <input> is
- * focused. There is no web-standard API to suppress it. The canonical
- * workaround — used by every modern chat app on the mobile web — is to
- * back the editor with a <div contenteditable="true"> instead.
+ * Editor is a <div contenteditable> (PR #53) so iOS WebKit doesn't paint
+ * its form input accessory bar above the keyboard.
  *
- * Side benefit: the contenteditable div auto-grows with its content
- * natively, so the scrollHeight tracking we needed for the textarea is
- * gone.
+ * Voice flow (specs/home.md §2.4):
+ *   - Phase 1 — Recording. Tap the Waveform inside the idle pill. The
+ *     pill morphs into a full-width Recording-pill with live audio-level
+ *     bars; × on the left cancels (audio discarded), Stop on the right
+ *     ends the recording and ships the audio to ElevenLabs Scribe.
+ *   - Phase 2 — Transcribing. Same pill, level bars freeze, Stop is
+ *     swapped for a small spinner. Lasts ~1–2 s.
+ *   - Phase 3 — Transcript Review. The transcribed text is dropped
+ *     straight into the contenteditable editor and focused, so the user
+ *     is now in the regular Typing state with the transcript pre-filled.
+ *     They can edit (fix mis-heard coffee names per the §2.4 anti-
+ *     pattern) and Send (↑), or × to discard and return to Idle.
  *
- * State machine unchanged from PR2d:
- *   - Empty + idle: + (left) | pill ("Ask anything…" placeholder) +
- *                   Waveform inside pill
- *   - HasText:      × (left, clear) | pill with text | Send inside pill
- *   - Loading:      × (decorative) | empty bar | three Dots above
+ * TTS output (§4.6) is deliberately deferred — it needs a default-off
+ * opt-in toggle the spec lists as out of v1 (§12). When that lands, the
+ * hook to wire is /api/voice/synthesize via useVoicePlayback.
  */
 
 interface ChatInputProps {
   loading: boolean;
   onSend: (text: string) => void;
-  /** First focus signal — Home dismisses the Conversation Starter on it. */
+  /** First focus / voice-start signal — Home dismisses the Starter on it. */
   onComposeStart?: () => void;
 }
 
 export default function ChatInput({ loading, onSend, onComposeStart }: ChatInputProps) {
   const [text, setText] = useState("");
+  const [voiceError, setVoiceError] = useState<string | null>(null);
   const editorRef = useRef<HTMLDivElement | null>(null);
   const composeStartedRef = useRef(false);
+  const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const hasText = text.trim().length > 0;
-
-  const handleInput = (e: React.FormEvent<HTMLDivElement>) => {
-    setText(e.currentTarget.textContent ?? "");
+  const dismissError = (delay: number) => {
+    if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
+    errorTimerRef.current = setTimeout(() => setVoiceError(null), delay);
   };
 
-  const handleFocus = () => {
+  const markComposed = () => {
     if (!composeStartedRef.current) {
       composeStartedRef.current = true;
       onComposeStart?.();
     }
   };
 
-  // Keep input plain-text — strip HTML formatting on paste.
+  const voice = useVoiceCapture({
+    onTranscript: (transcript) => {
+      markComposed();
+      setText(transcript);
+      if (editorRef.current) {
+        editorRef.current.textContent = transcript;
+        editorRef.current.focus();
+        // Cursor at end of inserted text so the user can append, not overwrite.
+        try {
+          const range = document.createRange();
+          range.selectNodeContents(editorRef.current);
+          range.collapse(false);
+          const sel = window.getSelection();
+          sel?.removeAllRanges();
+          sel?.addRange(range);
+        } catch {
+          /* ignore — selection APIs vary across iOS WebKit builds */
+        }
+      }
+    },
+    onError: (msg) => {
+      setVoiceError(msg);
+      dismissError(5000);
+    },
+  });
+
+  const hasText = text.trim().length > 0;
+  const isRecording = voice.recording;
+  const isTranscribing = voice.busy && !voice.recording;
+  const isVoiceActive = isRecording || isTranscribing;
+
+  const handleInput = (e: React.FormEvent<HTMLDivElement>) => {
+    setText(e.currentTarget.textContent ?? "");
+  };
+
+  const handleFocus = () => {
+    markComposed();
+  };
+
   const handlePaste = (e: React.ClipboardEvent<HTMLDivElement>) => {
     e.preventDefault();
     const pasted = e.clipboardData.getData("text/plain");
@@ -71,8 +116,32 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
     editorRef.current?.blur();
   };
 
+  const startVoice = async () => {
+    if (loading || hasText) return;
+    setVoiceError(null);
+    markComposed();
+    await voice.start();
+  };
+
+  const stopVoice = async () => {
+    await voice.stop();
+  };
+
+  const cancelVoice = () => {
+    voice.cancel();
+  };
+
   return (
     <footer className="flex flex-col px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-3">
+      {voiceError && (
+        <div
+          role="alert"
+          className="mb-2 rounded-2xl border border-light-foreground/10 bg-light-card-default px-3 py-2 font-inter text-[13px] text-light-foreground backdrop-blur-[14px] backdrop-saturate-150"
+        >
+          {voiceError}
+        </div>
+      )}
+
       {loading && (
         <div className="mb-3 flex items-center gap-2 pl-14" aria-label="Thinking">
           <span
@@ -91,7 +160,19 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
       )}
 
       <div className="flex items-end gap-3">
-        {hasText || loading ? (
+        {/* Left button — × when voice is active, when text is present,
+            or while a request is in flight; otherwise + (attach). */}
+        {isVoiceActive ? (
+          <button
+            type="button"
+            onClick={cancelVoice}
+            disabled={isTranscribing}
+            aria-label="Cancel recording"
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150 disabled:opacity-50"
+          >
+            <X className="h-5 w-5" strokeWidth={1.5} />
+          </button>
+        ) : hasText || loading ? (
           <button
             type="button"
             onClick={clear}
@@ -110,8 +191,36 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
           </div>
         )}
 
+        {/* Middle */}
         {loading ? (
           <div className="h-11 flex-1 rounded-full border border-light-foreground/10 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150" />
+        ) : isVoiceActive ? (
+          <div className="flex h-11 flex-1 items-center gap-2 rounded-full border border-light-foreground/10 bg-light-card-default pl-5 pr-1.5 backdrop-blur-[14px] backdrop-saturate-150">
+            <WaveformBars
+              getLevel={voice.getLevel}
+              color="hsl(20 14% 12%)"
+              height={20}
+              bars={28}
+              className="flex-1"
+            />
+            {isTranscribing ? (
+              <div
+                aria-label="Transcribing"
+                className="flex h-8 w-8 shrink-0 items-center justify-center text-light-foreground/60"
+              >
+                <Loader2 className="h-5 w-5 animate-spin" strokeWidth={1.5} />
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={stopVoice}
+                aria-label="Stop recording"
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)]"
+              >
+                <Square className="h-3.5 w-3.5 fill-current" strokeWidth={0} />
+              </button>
+            )}
+          </div>
         ) : (
           <div className="flex min-h-11 flex-1 items-end gap-1 rounded-3xl border border-light-foreground/10 bg-light-card-default py-1.5 pl-5 pr-1.5 backdrop-blur-[14px] backdrop-saturate-150">
             <div className="relative min-h-8 flex-1">
@@ -146,12 +255,14 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
                 <ArrowUp className="h-4 w-4" strokeWidth={2.25} />
               </button>
             ) : (
-              <div
+              <button
+                type="button"
+                onClick={startVoice}
                 aria-label="Voice"
-                className="flex h-8 w-8 shrink-0 items-center justify-center text-light-foreground/60"
+                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-light-foreground/60"
               >
                 <AudioLines className="h-5 w-5" strokeWidth={1.5} />
-              </div>
+              </button>
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary

PR2f — voice input wired into the chat. All three phases of `specs/home.md` §2.4:

### Phase 1 — Recording
Tap the Waveform inside the idle pill → mic starts. Pill morphs into a full-width Recording-pill with live audio-level bars (`WaveformBars` driven by AnalyserNode via the existing `useVoiceCapture` hook). × on the left cancels and discards the audio. Stop (square button) on the right ends the recording and ships the audio to ElevenLabs Scribe via `/api/voice/transcribe`.

### Phase 2 — Transcribing
Level bars freeze when the mic stops; Stop swaps for a small spinner. ~1–2 s.

### Phase 3 — Transcript Review
The transcribed text drops straight into the contenteditable editor, focused with the cursor placed at the end so the user can append. They are now in the regular Typing state with the transcript pre-filled — they can edit (fix mis-heard coffee names per the §2.4 anti-pattern) and Send (↑), or × to discard and return to Idle.

## Error surfacing

Mic-permission / browser-support / "didn't catch that" failures from the hook render as a small Glass banner above the input bar that auto-dismisses after 5 s.

## Other change

The Waveform icon inside the idle pill is now a real `<button>` instead of a decorative `<div>`, since it now has a tap action.

## Deferred

TTS output (§4.6) is out of this PR. Spec §12 lists it as v1-deferred: needs an opt-in toggle, default off. When it lands the hook to wire is `useVoicePlayback` against `/api/voice/synthesize`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Auto-deploy runs green
- [ ] Tap Waveform → mic permission prompt (first time) → recording pill with live bars
- [ ] Tap Stop → bars freeze, spinner spins ~1–2 s
- [ ] Transcript appears in the editor, cursor at end, keyboard up
- [ ] Edit/Send works, response streams as before
- [ ] Tap × during recording → discards audio, returns to idle
- [ ] Deny mic permission → red-ish error banner appears, auto-dismisses

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_