### PR TITLE
feat: attachment sheet + photo attachment (PR2g)

### DIFF
--- a/src/app/(light)/home/page.tsx
+++ b/src/app/(light)/home/page.tsx
@@ -28,6 +28,7 @@ import type { Session } from "@/lib/types/session";
 interface ChatMessage {
   role: "user" | "assistant";
   content: string;
+  imageUrl?: string;
 }
 
 const STARTER_TEXT =
@@ -53,18 +54,30 @@ export default function HomePage() {
 
   const showStarter = messages.length === 0 && !interacted;
 
-  const handleSend = async (text: string) => {
-    const userMsg: ChatMessage = { role: "user", content: text };
+  const handleSend = async (text: string, imageUrl?: string) => {
+    const userMsg: ChatMessage = {
+      role: "user",
+      content: text,
+      ...(imageUrl ? { imageUrl } : {}),
+    };
     const next = [...messages, userMsg];
     setMessages(next);
     setLoading(true);
     setInteracted(true);
 
     try {
+      // Strip imageUrl from the messages we ship — the agent receives
+      // the latest image via the top-level attachedImageUrl field, which
+      // it fetches+base64s once on the server side.
+      const apiMessages = next.map(({ role, content }) => ({ role, content }));
       const res = await fetch("/api/explore-agent", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ messages: next, recentSessions }),
+        body: JSON.stringify({
+          messages: apiMessages,
+          recentSessions,
+          ...(imageUrl ? { attachedImageUrl: imageUrl } : {}),
+        }),
       });
 
       if (!res.ok || !res.body) {

--- a/src/components/ui/light/AttachmentSheet.tsx
+++ b/src/components/ui/light/AttachmentSheet.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { Camera as CameraIcon, Image as ImageIcon } from "lucide-react";
+
+/**
+ * BTTS `+`-Sheet — specs/home.md §5.1.
+ *
+ * Glass bottom-sheet that floats above the input bar, anchored to the
+ * left so it visually drops out of the `+` button below. Tap-outside
+ * dismisses without selection.
+ *
+ * Two options in PR2g — Camera and Photo library. The "Reference
+ * coffee" row from §5.4 + the Reference Coffee Picker (§5.5) land in
+ * PR2h, which extracts the picker UI from the existing /explore page.
+ */
+
+interface AttachmentSheetProps {
+  onClose: () => void;
+  onPickCamera: () => void;
+  onPickLibrary: () => void;
+}
+
+export default function AttachmentSheet({
+  onClose,
+  onPickCamera,
+  onPickLibrary,
+}: AttachmentSheetProps) {
+  return (
+    <>
+      {/* Tap-outside backdrop — invisible full-screen layer. Click closes
+          the sheet without selecting anything. */}
+      <button
+        type="button"
+        aria-label="Close attachments"
+        onClick={onClose}
+        className="fixed inset-0 z-40 cursor-default"
+      />
+
+      <div className="relative z-50 mb-2 mr-auto max-w-[280px] rounded-2xl border border-light-foreground/10 bg-light-card-default p-2 backdrop-blur-[14px] backdrop-saturate-150">
+        <button
+          type="button"
+          onClick={onPickCamera}
+          className="flex h-10 w-full items-center gap-3 rounded-xl px-3 text-left"
+        >
+          <CameraIcon className="h-5 w-5 text-light-foreground/80" strokeWidth={1.5} />
+          <span className="font-inter text-[15px] font-medium text-light-foreground">
+            Camera
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={onPickLibrary}
+          className="flex h-10 w-full items-center gap-3 rounded-xl px-3 text-left"
+        >
+          <ImageIcon className="h-5 w-5 text-light-foreground/80" strokeWidth={1.5} />
+          <span className="font-inter text-[15px] font-medium text-light-foreground">
+            Photo library
+          </span>
+        </button>
+      </div>
+    </>
+  );
+}

--- a/src/components/ui/light/ChatInput.tsx
+++ b/src/components/ui/light/ChatInput.tsx
@@ -4,48 +4,69 @@ import { useRef, useState } from "react";
 import { Plus, X, AudioLines, ArrowUp, Square, Loader2 } from "lucide-react";
 import { useVoiceCapture } from "@/hooks/useVoiceCapture";
 import WaveformBars from "@/components/ui/WaveformBars";
+import AttachmentSheet from "@/components/ui/light/AttachmentSheet";
 
 /**
- * BTTS Chat Input — Idle / Typing / Voice / Loading.
+ * BTTS Chat Input — Idle / Typing / Voice / Photo-attached / Loading.
  *
- * Editor is a <div contenteditable> (PR #53) so iOS WebKit doesn't paint
- * its form input accessory bar above the keyboard.
+ * Editor is <div contenteditable> (PR #53) so iOS WebKit doesn't paint
+ * its form input accessory bar.
  *
- * Voice flow (specs/home.md §2.4):
- *   - Phase 1 — Recording. Tap the Waveform inside the idle pill. The
- *     pill morphs into a full-width Recording-pill with live audio-level
- *     bars; × on the left cancels (audio discarded), Stop on the right
- *     ends the recording and ships the audio to ElevenLabs Scribe.
- *   - Phase 2 — Transcribing. Same pill, level bars freeze, Stop is
- *     swapped for a small spinner. Lasts ~1–2 s.
- *   - Phase 3 — Transcript Review. The transcribed text is dropped
- *     straight into the contenteditable editor and focused, so the user
- *     is now in the regular Typing state with the transcript pre-filled.
- *     They can edit (fix mis-heard coffee names per the §2.4 anti-
- *     pattern) and Send (↑), or × to discard and return to Idle.
+ * Photo attachment (specs/home.md §5):
+ *   - Tap + → AttachmentSheet appears above (left-anchored). Two
+ *     options in PR2g: Camera (capture="environment") and Photo
+ *     library. The Reference Coffee option arrives in PR2h.
+ *   - After file selection the photo uploads to /api/upload and shows
+ *     as a 80×80 rounded thumbnail at the top-left of the pill, with a
+ *     small × to remove. The editor row sits below it; the pill grows
+ *     vertically to accommodate.
+ *   - Send (↑) becomes active when text OR a photo is attached
+ *     (§3.2). The photo is sent as attachedImageUrl to
+ *     /api/explore-agent so Claude sees the image natively.
  *
- * TTS output (§4.6) is deliberately deferred — it needs a default-off
- * opt-in toggle the spec lists as out of v1 (§12). When that lands, the
- * hook to wire is /api/voice/synthesize via useVoicePlayback.
+ * Voice flow (§2.4) and Loading state (§2.2) unchanged from PR2f.
  */
 
 interface ChatInputProps {
   loading: boolean;
-  onSend: (text: string) => void;
-  /** First focus / voice-start signal — Home dismisses the Starter on it. */
+  onSend: (text: string, imageUrl?: string) => void;
   onComposeStart?: () => void;
+}
+
+async function uploadPhoto(file: File): Promise<string> {
+  const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_");
+  const formData = new FormData();
+  formData.append("file", file);
+  formData.append("path", `uploads/chat-${Date.now()}-${safeName}`);
+  const res = await fetch("/api/upload", { method: "POST", body: formData });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || `Upload failed (${res.status})`);
+  }
+  const data = await res.json();
+  if (!data?.url) throw new Error("No URL returned");
+  return data.url as string;
 }
 
 export default function ChatInput({ loading, onSend, onComposeStart }: ChatInputProps) {
   const [text, setText] = useState("");
   const [voiceError, setVoiceError] = useState<string | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [attachedImageUrl, setAttachedImageUrl] = useState<string | null>(null);
+  const [uploadingImage, setUploadingImage] = useState(false);
   const editorRef = useRef<HTMLDivElement | null>(null);
+  const cameraInputRef = useRef<HTMLInputElement | null>(null);
+  const libraryInputRef = useRef<HTMLInputElement | null>(null);
   const composeStartedRef = useRef(false);
   const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const dismissError = (delay: number) => {
+  const dismissErrors = (delay: number) => {
     if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
-    errorTimerRef.current = setTimeout(() => setVoiceError(null), delay);
+    errorTimerRef.current = setTimeout(() => {
+      setVoiceError(null);
+      setUploadError(null);
+    }, delay);
   };
 
   const markComposed = () => {
@@ -62,7 +83,6 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
       if (editorRef.current) {
         editorRef.current.textContent = transcript;
         editorRef.current.focus();
-        // Cursor at end of inserted text so the user can append, not overwrite.
         try {
           const range = document.createRange();
           range.selectNodeContents(editorRef.current);
@@ -71,20 +91,23 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
           sel?.removeAllRanges();
           sel?.addRange(range);
         } catch {
-          /* ignore — selection APIs vary across iOS WebKit builds */
+          /* selection APIs vary on iOS WebKit */
         }
       }
     },
     onError: (msg) => {
       setVoiceError(msg);
-      dismissError(5000);
+      dismissErrors(5000);
     },
   });
 
   const hasText = text.trim().length > 0;
+  const hasPhoto = attachedImageUrl !== null;
+  const sendActive = hasText || hasPhoto;
   const isRecording = voice.recording;
   const isTranscribing = voice.busy && !voice.recording;
   const isVoiceActive = isRecording || isTranscribing;
+  const isCompositionActive = hasText || hasPhoto || uploadingImage;
 
   const handleInput = (e: React.FormEvent<HTMLDivElement>) => {
     setText(e.currentTarget.textContent ?? "");
@@ -100,45 +123,80 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
     document.execCommand("insertText", false, pasted);
   };
 
-  const clear = () => {
+  const handleFileSelected = async (file: File) => {
+    markComposed();
+    setUploadError(null);
+    setUploadingImage(true);
+    try {
+      const url = await uploadPhoto(file);
+      setAttachedImageUrl(url);
+    } catch (err) {
+      setUploadError(err instanceof Error ? err.message : "Upload failed");
+      dismissErrors(5000);
+    } finally {
+      setUploadingImage(false);
+    }
+  };
+
+  const clearComposition = () => {
     if (loading) return;
     if (editorRef.current) editorRef.current.textContent = "";
     setText("");
+    setAttachedImageUrl(null);
+    setUploadError(null);
     editorRef.current?.focus();
   };
 
   const send = () => {
-    if (!hasText || loading) return;
-    onSend(text.trim());
+    if (!sendActive || loading || uploadingImage) return;
+    onSend(text.trim(), attachedImageUrl ?? undefined);
     if (editorRef.current) editorRef.current.textContent = "";
     setText("");
+    setAttachedImageUrl(null);
     composeStartedRef.current = false;
     editorRef.current?.blur();
   };
 
   const startVoice = async () => {
-    if (loading || hasText) return;
+    if (loading || sendActive) return;
     setVoiceError(null);
     markComposed();
     await voice.start();
   };
 
-  const stopVoice = async () => {
-    await voice.stop();
+  const handleOpenSheet = () => {
+    if (loading || isVoiceActive) return;
+    setSheetOpen(true);
   };
 
-  const cancelVoice = () => {
-    voice.cancel();
+  const handlePickCamera = () => {
+    setSheetOpen(false);
+    cameraInputRef.current?.click();
+  };
+
+  const handlePickLibrary = () => {
+    setSheetOpen(false);
+    libraryInputRef.current?.click();
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) void handleFileSelected(file);
+    e.target.value = "";
+  };
+
+  const removePhoto = () => {
+    setAttachedImageUrl(null);
   };
 
   return (
     <footer className="flex flex-col px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-3">
-      {voiceError && (
+      {(voiceError || uploadError) && (
         <div
           role="alert"
           className="mb-2 rounded-2xl border border-light-foreground/10 bg-light-card-default px-3 py-2 font-inter text-[13px] text-light-foreground backdrop-blur-[14px] backdrop-saturate-150"
         >
-          {voiceError}
+          {voiceError ?? uploadError}
         </div>
       )}
 
@@ -159,36 +217,63 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
         </div>
       )}
 
+      {sheetOpen && (
+        <AttachmentSheet
+          onClose={() => setSheetOpen(false)}
+          onPickCamera={handlePickCamera}
+          onPickLibrary={handlePickLibrary}
+        />
+      )}
+
+      {/* Hidden file inputs trigger the native iOS Camera / Photo
+          Library experience via capture and accept attributes. */}
+      <input
+        ref={cameraInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="hidden"
+        onChange={handleInputChange}
+      />
+      <input
+        ref={libraryInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handleInputChange}
+      />
+
       <div className="flex items-end gap-3">
-        {/* Left button — × when voice is active, when text is present,
-            or while a request is in flight; otherwise + (attach). */}
+        {/* Left button: × during voice / composition / loading; + otherwise */}
         {isVoiceActive ? (
           <button
             type="button"
-            onClick={cancelVoice}
+            onClick={() => voice.cancel()}
             disabled={isTranscribing}
             aria-label="Cancel recording"
             className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150 disabled:opacity-50"
           >
             <X className="h-5 w-5" strokeWidth={1.5} />
           </button>
-        ) : hasText || loading ? (
+        ) : isCompositionActive || loading ? (
           <button
             type="button"
-            onClick={clear}
-            disabled={loading}
+            onClick={clearComposition}
+            disabled={loading || uploadingImage}
             aria-label={loading ? "Sending" : "Clear"}
             className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150 disabled:opacity-50"
           >
             <X className="h-5 w-5" strokeWidth={1.5} />
           </button>
         ) : (
-          <div
+          <button
+            type="button"
+            onClick={handleOpenSheet}
             aria-label="Attach"
             className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150"
           >
             <Plus className="h-5 w-5" strokeWidth={1.5} />
-          </div>
+          </button>
         )}
 
         {/* Middle */}
@@ -213,7 +298,7 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
             ) : (
               <button
                 type="button"
-                onClick={stopVoice}
+                onClick={() => void voice.stop()}
                 aria-label="Stop recording"
                 className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)]"
               >
@@ -222,48 +307,80 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
             )}
           </div>
         ) : (
-          <div className="flex min-h-11 flex-1 items-end gap-1 rounded-3xl border border-light-foreground/10 bg-light-card-default py-1.5 pl-5 pr-1.5 backdrop-blur-[14px] backdrop-saturate-150">
-            <div className="relative min-h-8 flex-1">
-              <div
-                ref={editorRef}
-                contentEditable
-                suppressContentEditableWarning
-                role="textbox"
-                aria-multiline="true"
-                aria-label="Message"
-                onInput={handleInput}
-                onFocus={handleFocus}
-                onPaste={handlePaste}
-                className="block min-h-8 w-full whitespace-pre-wrap break-words font-inter text-[16px] font-normal leading-[2rem] text-light-foreground focus:outline-none"
-              />
-              {!hasText && (
-                <span
-                  aria-hidden="true"
-                  className="pointer-events-none absolute left-0 top-0 font-inter text-[16px] font-normal leading-[2rem] text-light-muted-foreground"
+          <div className="flex min-h-11 flex-1 flex-col gap-2 rounded-3xl border border-light-foreground/10 bg-light-card-default py-1.5 pl-5 pr-1.5 backdrop-blur-[14px] backdrop-saturate-150">
+            {(attachedImageUrl || uploadingImage) && (
+              <div className="relative h-20 w-20">
+                {attachedImageUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={attachedImageUrl}
+                    alt="Attached"
+                    className="block h-full w-full rounded-xl object-cover"
+                  />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center rounded-xl bg-light-foreground/10">
+                    <Loader2
+                      className="h-5 w-5 animate-spin text-light-foreground/60"
+                      strokeWidth={1.5}
+                    />
+                  </div>
+                )}
+                {attachedImageUrl && (
+                  <button
+                    type="button"
+                    onClick={removePhoto}
+                    aria-label="Remove photo"
+                    className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)]"
+                  >
+                    <X className="h-3 w-3" strokeWidth={2.25} />
+                  </button>
+                )}
+              </div>
+            )}
+            <div className="flex items-end gap-1">
+              <div className="relative min-h-8 flex-1">
+                <div
+                  ref={editorRef}
+                  contentEditable
+                  suppressContentEditableWarning
+                  role="textbox"
+                  aria-multiline="true"
+                  aria-label="Message"
+                  onInput={handleInput}
+                  onFocus={handleFocus}
+                  onPaste={handlePaste}
+                  className="block min-h-8 w-full whitespace-pre-wrap break-words font-inter text-[16px] font-normal leading-[2rem] text-light-foreground focus:outline-none"
+                />
+                {!hasText && (
+                  <span
+                    aria-hidden="true"
+                    className="pointer-events-none absolute left-0 top-0 font-inter text-[16px] font-normal leading-[2rem] text-light-muted-foreground"
+                  >
+                    Ask anything…
+                  </span>
+                )}
+              </div>
+              {sendActive ? (
+                <button
+                  type="button"
+                  onClick={send}
+                  disabled={uploadingImage}
+                  aria-label="Send"
+                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)] disabled:opacity-30"
                 >
-                  Ask anything…
-                </span>
+                  <ArrowUp className="h-4 w-4" strokeWidth={2.25} />
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={startVoice}
+                  aria-label="Voice"
+                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-light-foreground/60"
+                >
+                  <AudioLines className="h-5 w-5" strokeWidth={1.5} />
+                </button>
               )}
             </div>
-            {hasText ? (
-              <button
-                type="button"
-                onClick={send}
-                aria-label="Send"
-                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)]"
-              >
-                <ArrowUp className="h-4 w-4" strokeWidth={2.25} />
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={startVoice}
-                aria-label="Voice"
-                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-light-foreground/60"
-              >
-                <AudioLines className="h-5 w-5" strokeWidth={1.5} />
-              </button>
-            )}
           </div>
         )}
       </div>

--- a/src/components/ui/light/ChatThread.tsx
+++ b/src/components/ui/light/ChatThread.tsx
@@ -5,28 +5,20 @@ import { useEffect, useRef } from "react";
 /**
  * BTTS Chat Thread — specs/home.md §4.
  *
- * Owns the scroll container so the top-edge fade (§4.4) and the
- * stick-to-bottom auto-scroll (§4.5) live together.
+ * User content as right-aligned Glass bubbles (§4.2); agent responses as
+ * left-aligned prose, no bubble (§4.3).
  *
- * §4.4 — Top-edge fade. Older messages disappear into a 80px gradient
- * mask at the top of the thread, so they read as "fading toward the
- * header" rather than getting clipped at a hard line. The header above
- * has no background, so the warm Field stays continuous.
+ * §4.2 stacked-bubble rule: when a user message includes an attachment,
+ * the attachment renders as its own bubble above the text bubble. Two
+ * bubbles, both right-aligned, both Glass, separated by mb-2.
  *
- * §4.5 — Scroll behaviour. Latest message at bottom, conversation
- * scrolled to bottom by default. Auto-scroll-to-bottom on new delta
- * UNLESS the user has manually scrolled up — in which case their
- * position is preserved so they can keep reading older content while
- * the agent's response streams in below.
- *
- * Detection: a ref tracks "stick to bottom" state. Every scroll event
- * recomputes it (50px tolerance to allow rounding). Programmatic
- * scrolls land us back at the bottom and flip the ref true again.
+ * §4.4 fade + §4.5 stick-to-bottom auto-scroll preserved from PR2e.
  */
 
-interface Message {
+export interface Message {
   role: "user" | "assistant";
   content: string;
+  imageUrl?: string;
 }
 
 interface ChatThreadProps {
@@ -38,9 +30,6 @@ export default function ChatThread({ messages, loading }: ChatThreadProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const stickToBottomRef = useRef(true);
 
-  // Latest message content reference — included as a dep so streamed
-  // deltas (which mutate the last assistant message in place) trigger
-  // a scroll attempt.
   const tailContent = messages[messages.length - 1]?.content ?? "";
 
   useEffect(() => {
@@ -66,12 +55,24 @@ export default function ChatThread({ messages, loading }: ChatThreadProps) {
         <div className="flex w-full flex-col gap-3 px-5 py-5">
           {messages.map((m, i) =>
             m.role === "user" ? (
-              <div key={i} className="flex justify-end">
-                <div className="max-w-[80%] rounded-2xl border border-light-foreground/10 bg-light-card-default px-4 py-3 backdrop-blur-[14px] backdrop-saturate-150">
-                  <p className="whitespace-pre-wrap font-inter text-[15px] font-normal text-light-foreground">
-                    {m.content}
-                  </p>
-                </div>
+              <div key={i} className="flex flex-col items-end gap-2">
+                {m.imageUrl && (
+                  <div className="max-w-[80%] overflow-hidden rounded-2xl border border-light-foreground/10 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={m.imageUrl}
+                      alt="Attached"
+                      className="block max-h-[280px] w-auto max-w-full object-cover"
+                    />
+                  </div>
+                )}
+                {m.content && (
+                  <div className="max-w-[80%] rounded-2xl border border-light-foreground/10 bg-light-card-default px-4 py-3 backdrop-blur-[14px] backdrop-saturate-150">
+                    <p className="whitespace-pre-wrap font-inter text-[15px] font-normal text-light-foreground">
+                      {m.content}
+                    </p>
+                  </div>
+                )}
               </div>
             ) : (
               m.content && (


### PR DESCRIPTION
## Summary

PR2g — `+`-Sheet with Camera + Photo library, photo attachment in the input pill, photo bubble in the thread. The Reference Coffee option (§5.4) + Picker (§5.5) land in PR2h.

### Components
- **`src/components/ui/light/AttachmentSheet.tsx`** — Glass bottom-sheet floating above the input bar, left-anchored, two rows (Camera + Photo library). Tap-outside dismisses.
- **`ChatInput.tsx`** — wires the sheet + hidden file inputs + upload. Pill switches to stacked layout when a photo is attached.
- **`ChatThread.tsx`** — renders the right-aligned Photo bubble + stacked Text bubble per §4.2.
- **`home/page.tsx`** — `ChatMessage` gains optional `imageUrl`; messages strip it before going to `/api/explore-agent`, the URL ships at the top level as `attachedImageUrl` (existing API contract).

### Flow

1. Tap `+` → sheet opens above the bar, anchored left under the button
2. Tap Camera → native iOS Camera (`capture="environment"`) — or Photo library → iOS Photo Picker
3. Upload to `/api/upload` (same pattern `/explore` uses — `FormData` with `file` + `uploads/...` path), returns `{ url }`
4. Pill shows 80×80 rounded thumbnail at top-left + a small × button to remove
5. Send (↑) activates when text OR photo present (§3.2). Voice icon hidden in that state.
6. Send → user message stamped with `imageUrl`; thread renders Photo bubble (max-h-280, right-aligned Glass) above the Text bubble (if text present)
7. Agent sees the image natively because `/api/explore-agent` fetches the URL → base64 → Claude vision content block

### Errors

Upload failures surface in the same Glass banner as voice errors, 5 s auto-dismiss.

## Out of scope

- Reference Coffee row + Picker — PR2h
- Multi-image attachments (spec §12 — v1 single image only)
- Image preview / zoom in the thread

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Auto-deploy runs green
- [ ] Tap `+` → sheet opens with Camera + Photo library
- [ ] Tap-outside dismisses sheet
- [ ] Camera → captures and uploads; thumbnail in pill
- [ ] Photo library → selects and uploads; thumbnail in pill
- [ ] Remove × → thumbnail gone, pill back to single-row
- [ ] Type text + photo attached → Send (↑) is active; send → photo bubble + text bubble in thread, response references the image
- [ ] Photo only (no text) → Send still active; thread shows photo bubble only
- [ ] Upload error (e.g. offline) → red-ish banner above bar, auto-dismisses

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_