### PR TITLE
feat: reference coffee picker + action pills + haiku starter (PR2h+i+j)

### DIFF
--- a/src/app/(light)/home/page.tsx
+++ b/src/app/(light)/home/page.tsx
@@ -3,46 +3,56 @@
 import { useEffect, useState } from "react";
 import { Menu } from "lucide-react";
 import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
-import ChatInput from "@/components/ui/light/ChatInput";
-import ChatThread from "@/components/ui/light/ChatThread";
+import ChatInput, { type SendPayload } from "@/components/ui/light/ChatInput";
+import ChatThread, { type Message } from "@/components/ui/light/ChatThread";
 import type { Session } from "@/lib/types/session";
+import type { NavAction } from "@/app/api/explore-agent/route";
 
 /**
- * BTTS Home (specs/home.md §0, §11).
+ * BTTS Home (specs/home.md §0, §8, §11).
  *
- * PR2b: static Starter view.
- * PR2c: Burger opens the Navigation Overlay.
- * PR2d: chat input wired to /api/explore-agent. Send / receive / stream.
- *       The Hero slot switches from Starter (§11.1) to Live-thread (§11.2)
- *       once the user starts composing or has sent at least one message.
+ * State derives the Hero-slot content:
+ *   - showStarter — the daily editorial Haiku (§8) when no thread
+ *     exists and the user hasn't started composing.
+ *   - otherwise — the live conversation thread.
  *
- * Out of PR2d scope (deferred):
- *   - Voice / transcript review (PR2f)
- *   - Attachment + Reference Coffee (PR2g, PR2h)
- *   - Action Pills (PR2i)
- *   - Real Haiku Starter (PR2j)
- *   - Persistence / 30-min idle reset (PR2k)
- *   - Past Conversations view (PR2l)
+ * Starter (§8.2):
+ *   - One Haiku call per calendar day, cached in localStorage under
+ *     `brewlog.starter.<YYYY-MM-DD>`.
+ *   - On mount we check today's cache; if missing, fetch from
+ *     /api/greeting and store. Failures fall back to the hardcoded
+ *     welcome line.
+ *
+ * Compose flow now passes a SendPayload (text + optional photo URL +
+ * optional coffee reference). The coffee reference is folded into the
+ * last user message as an inline `[Coffee: roaster · name]` tag (same
+ * pattern /explore uses) so /api/explore-agent surfaces it without
+ * needing a new field.
+ *
+ * Action Pills (§6): the SSE `done` event carries a `actions` array;
+ * we attach it to the last assistant message so ChatThread can render
+ * the pills under the response.
  */
 
-interface ChatMessage {
-  role: "user" | "assistant";
-  content: string;
-  imageUrl?: string;
-}
+const FALLBACK_STARTER = "Welcome to Better Taste Than Sorry.";
 
-const STARTER_TEXT =
-  "Good morning. DAK Coffee Roasters yesterday — try Process or anything new today?";
+function todayKey(): string {
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = String(now.getMonth() + 1).padStart(2, "0");
+  const d = String(now.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
 
 export default function HomePage() {
   const [menuOpen, setMenuOpen] = useState(false);
-  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [messages, setMessages] = useState<Message[]>([]);
   const [recentSessions, setRecentSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(false);
   const [interacted, setInteracted] = useState(false);
+  const [starter, setStarter] = useState<string>(FALLBACK_STARTER);
 
-  // Fetch recent sessions once so /api/explore-agent has the personal
-  // recipe context. Same shape as /explore consumes.
+  // Recent sessions for the agent's personal-context block.
   useEffect(() => {
     fetch("/api/sessions?limit=5", { cache: "no-store" })
       .then((r) => (r.ok ? r.json() : []))
@@ -52,13 +62,48 @@ export default function HomePage() {
       .catch(() => {});
   }, []);
 
+  // Daily Starter — read cache, fetch if today's slot is empty.
+  useEffect(() => {
+    const key = `brewlog.starter.${todayKey()}`;
+    try {
+      const cached = window.localStorage.getItem(key);
+      if (cached) {
+        setStarter(cached);
+        return;
+      }
+    } catch {
+      /* private mode etc. — fall through to fetch */
+    }
+
+    fetch("/api/greeting", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: { text?: string } | null) => {
+        const text = data?.text?.trim();
+        if (!text) return;
+        setStarter(text);
+        try {
+          window.localStorage.setItem(key, text);
+        } catch {
+          /* ignore quota / private-mode errors */
+        }
+      })
+      .catch(() => {
+        /* keep fallback */
+      });
+  }, []);
+
   const showStarter = messages.length === 0 && !interacted;
 
-  const handleSend = async (text: string, imageUrl?: string) => {
-    const userMsg: ChatMessage = {
+  const handleSend = async ({ text, imageUrl, coffeeRef }: SendPayload) => {
+    const userMsg: Message = {
       role: "user",
       content: text,
       ...(imageUrl ? { imageUrl } : {}),
+      ...(coffeeRef ? { coffeeRef } : {}),
     };
     const next = [...messages, userMsg];
     setMessages(next);
@@ -66,10 +111,20 @@ export default function HomePage() {
     setInteracted(true);
 
     try {
-      // Strip imageUrl from the messages we ship — the agent receives
-      // the latest image via the top-level attachedImageUrl field, which
-      // it fetches+base64s once on the server side.
-      const apiMessages = next.map(({ role, content }) => ({ role, content }));
+      // Inline the coffee reference into the last user turn — same
+      // pattern /explore uses so /api/explore-agent picks it up
+      // without a new API field.
+      const apiMessages = next.map((m, idx) => {
+        if (idx === next.length - 1 && coffeeRef) {
+          const tag = `[Coffee: ${coffeeRef.roaster} ${coffeeRef.name}]`;
+          return {
+            role: m.role,
+            content: m.content ? `${tag}\n${m.content}` : tag,
+          };
+        }
+        return { role: m.role, content: m.content };
+      });
+
       const res = await fetch("/api/explore-agent", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -88,7 +143,6 @@ export default function HomePage() {
         return;
       }
 
-      // Seed an empty assistant entry that delta events progressively fill.
       setMessages((prev) => [...prev, { role: "assistant", content: "" }]);
 
       const reader = res.body.getReader();
@@ -100,7 +154,6 @@ export default function HomePage() {
         if (done) break;
         carry += decoder.decode(value, { stream: true });
 
-        // SSE frames are "event: NAME\ndata: JSON\n\n".
         let idx;
         while ((idx = carry.indexOf("\n\n")) !== -1) {
           const block = carry.slice(0, idx);
@@ -128,11 +181,9 @@ export default function HomePage() {
                 });
               }
             } catch {
-              /* malformed event — skip */
+              /* malformed — skip */
             }
           } else if (event === "retract") {
-            // Agent started speaking, then decided to call a tool — drop
-            // whatever it streamed before the tool call.
             setMessages((prev) => {
               const copy = prev.slice();
               const lastIdx = copy.length - 1;
@@ -142,9 +193,24 @@ export default function HomePage() {
               }
               return copy;
             });
+          } else if (event === "done") {
+            try {
+              const payload = JSON.parse(data) as { actions?: NavAction[] };
+              if (payload.actions && payload.actions.length > 0) {
+                setMessages((prev) => {
+                  const copy = prev.slice();
+                  const lastIdx = copy.length - 1;
+                  const last = copy[lastIdx];
+                  if (last?.role === "assistant") {
+                    copy[lastIdx] = { ...last, actions: payload.actions };
+                  }
+                  return copy;
+                });
+              }
+            } catch {
+              /* skip */
+            }
           }
-          // status / done events ignored in PR2d — status messages and
-          // navigation actions land in PR2i with the Action Pills work.
         }
       }
     } catch {
@@ -174,14 +240,11 @@ export default function HomePage() {
           </button>
         </header>
 
-        {/* Hero slot — §11.0. flex-1 + min-h-0 hold the height; ChatThread
-            owns its own scrollable container (§4.4 fade + §4.5 stick-
-            to-bottom auto-scroll). */}
         <section className="flex-1 min-h-0">
           {showStarter ? (
             <div className="flex h-full items-center px-5">
               <p className="font-fraunces text-[40px] font-semibold leading-[1.05] tracking-[-0.01em] text-light-foreground">
-                {STARTER_TEXT}
+                {starter}
               </p>
             </div>
           ) : (

--- a/src/app/api/greeting/route.ts
+++ b/src/app/api/greeting/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { requireAuth } from "@/lib/auth/requireAuth";
+import { loadCoffeeLibraryCompact } from "@/lib/claude/coffeeLibrary";
+import { db } from "@/lib/db/client";
+import { sessions } from "@/lib/db/schema";
+import { desc } from "drizzle-orm";
+import { rowToSession } from "@/lib/db/helpers";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+/**
+ * BTTS Conversation Starter (specs/home.md §8) — daily editorial Haiku.
+ *
+ * Generates a single 8–16 word sentence based on the user's recent
+ * brew context: roaster they brewed yesterday, library snapshot, time
+ * of day. One call per calendar day; the client caches the result in
+ * localStorage keyed by date and only re-fetches at midnight.
+ *
+ * Returns `{ text }` on success. Errors surface as 500; the client
+ * keeps the previous day's cached text rather than rendering nothing.
+ */
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+const SYSTEM_PROMPT = `You are writing the opening line of a personal coffee app each morning. One short editorial sentence — 8 to 16 words. Direct, warm, specific. You speak to the user as a writer would open a letter, not as a chatbot.
+
+RULES
+- Exactly one sentence. A trailing question mark is fine when natural; never an exclamation mark.
+- 8 to 16 words.
+- Reference one concrete signal from the context if it's there — a specific roaster from yesterday's brew, a coffee they haven't touched in a while, the time of day — and turn it into an invitation, not a report.
+- If the user has no recent brews and an empty library, fall back to a quiet welcome.
+- No emojis, no markdown, no second sentence, no preamble like "Here's your greeting:".
+
+EXAMPLES (style only — do not copy)
+- Good morning. DAK Coffee Roasters yesterday — try Process or anything new today?
+- Quiet afternoon. The Friedhats Wush Wush hasn't moved in a week.
+- Evening already — the Pacas you brewed at lunch is calling for a second round.
+
+Return the sentence only.`;
+
+interface RequestBody {
+  // Reserved for future client-side overrides (timezone, etc.). For now
+  // we use the server clock + Europe/Berlin assumption mirrored from
+  // CLAUDE.md.
+}
+
+export async function POST(req: NextRequest) {
+  const authError = await requireAuth(req);
+  if (authError) return authError;
+
+  try {
+    // Body is currently unused but parse defensively in case of stray
+    // payloads, so a malformed body doesn't 400 here.
+    await req.json().catch(() => ({} as RequestBody));
+
+    const [library, recentRows] = await Promise.all([
+      loadCoffeeLibraryCompact(30).catch(() => []),
+      db
+        .select()
+        .from(sessions)
+        .orderBy(desc(sessions.createdAtMs))
+        .limit(5)
+        .catch(() => []),
+    ]);
+    const recentSessions = (recentRows as unknown[]).map((row) =>
+      rowToSession(row as Parameters<typeof rowToSession>[0])
+    );
+
+    const hour = new Date().getHours();
+    const timeOfDay =
+      hour < 5 ? "late-night"
+      : hour < 11 ? "morning"
+      : hour < 14 ? "midday"
+      : hour < 18 ? "afternoon"
+      : hour < 22 ? "evening"
+      : "late-night";
+
+    const recentLines = recentSessions
+      .slice(0, 3)
+      .map((s) => {
+        const roaster = s.coffee?.roaster?.trim() ?? "";
+        const name = s.coffee?.name?.trim() ?? "";
+        const star = s.result?.rating ? `${s.result.rating}★` : "";
+        return `- ${roaster} ${name} ${star}`.trim();
+      })
+      .filter(Boolean);
+
+    const libraryLines = library.slice(0, 8).map((c) => `- ${c.roaster} ${c.name}`.trim());
+
+    const userBlock = [
+      `Time of day: ${timeOfDay} (hour ${hour}, local time)`,
+      recentLines.length > 0
+        ? `Recent brews:\n${recentLines.join("\n")}`
+        : "Recent brews: none in the last few days.",
+      libraryLines.length > 0
+        ? `Library snapshot:\n${libraryLines.join("\n")}`
+        : "Library snapshot: empty.",
+    ].join("\n\n");
+
+    const completion = await client.messages.create({
+      model: "claude-haiku-4-5",
+      max_tokens: 80,
+      temperature: 0.7,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: "user", content: userBlock }],
+    });
+
+    const textBlock = completion.content.find((b) => b.type === "text");
+    const text = (textBlock && "text" in textBlock ? textBlock.text : "").trim();
+
+    if (!text) {
+      return NextResponse.json({ error: "empty response" }, { status: 500 });
+    }
+
+    return NextResponse.json({ text });
+  } catch (err) {
+    console.error("greeting error:", err);
+    return NextResponse.json({ error: "generation failed" }, { status: 500 });
+  }
+}

--- a/src/components/ui/light/ActionPill.tsx
+++ b/src/components/ui/light/ActionPill.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Coffee, MapPin, User, Crosshair, Globe, BookOpen } from "lucide-react";
+import type { NavAction } from "@/app/api/explore-agent/route";
+
+/**
+ * BTTS Action Pill — specs/home.md §6.
+ *
+ * Glass pill rendered under an agent response when the agent emits a
+ * suggest_navigation call. Max 3 per response (§6.0 — agent prioritises
+ * if more would apply).
+ *
+ * Icon prefix signals action type (§6.2):
+ *   - Coffee-cup: navigation to a coffee detail / library
+ *   - Map-pin: navigation to a map / café view
+ *   - Crosshair: Match flow
+ *   - User: Taste profile
+ *   - Globe: generic navigation
+ *
+ * Tap is a single navigation event — no confirmation sheet (§6.3).
+ * If the destination is a brew step that needs pre-population, that's
+ * flowStore work and will land alongside PR2g/h follow-ups for the
+ * brew-flow Light migration.
+ */
+
+function destinationToPath(action: NavAction): string {
+  switch (action.destination) {
+    case "coffee_library":
+      return "/coffees";
+    case "coffee_detail":
+      return action.id ? `/coffees/${action.id}` : "/coffees";
+    case "cafe_map":
+      return "/cafes";
+    case "cafe_detail":
+      return action.id ? `/cafes/place/${encodeURIComponent(action.id)}` : "/cafes";
+    case "taste_profile":
+      return "/taste";
+    case "match":
+      return "/match";
+    case "home":
+      return "/home";
+    default:
+      return "/home";
+  }
+}
+
+function ActionPillIcon({ destination }: { destination: NavAction["destination"] }) {
+  const cls = "h-4 w-4 text-light-foreground/80";
+  switch (destination) {
+    case "coffee_library":
+      return <BookOpen className={cls} strokeWidth={1.5} />;
+    case "coffee_detail":
+      return <Coffee className={cls} strokeWidth={1.5} />;
+    case "cafe_map":
+    case "cafe_detail":
+      return <MapPin className={cls} strokeWidth={1.5} />;
+    case "taste_profile":
+      return <User className={cls} strokeWidth={1.5} />;
+    case "match":
+      return <Crosshair className={cls} strokeWidth={1.5} />;
+    default:
+      return <Globe className={cls} strokeWidth={1.5} />;
+  }
+}
+
+export default function ActionPill({ action }: { action: NavAction }) {
+  const router = useRouter();
+  return (
+    <button
+      type="button"
+      onClick={() => router.push(destinationToPath(action))}
+      title={action.reason}
+      className="flex h-9 shrink-0 items-center gap-1.5 rounded-full border border-light-foreground/10 bg-light-card-default px-4 font-inter text-[13px] font-medium text-light-foreground backdrop-blur-[14px] backdrop-saturate-150"
+    >
+      <ActionPillIcon destination={action.destination} />
+      {action.label}
+    </button>
+  );
+}

--- a/src/components/ui/light/AttachmentSheet.tsx
+++ b/src/components/ui/light/AttachmentSheet.tsx
@@ -1,34 +1,38 @@
 "use client";
 
-import { Camera as CameraIcon, Image as ImageIcon } from "lucide-react";
+import { Image as ImageIcon, Coffee as CoffeeIcon } from "lucide-react";
 
 /**
- * BTTS `+`-Sheet — specs/home.md §5.1.
+ * BTTS `+`-Sheet — specs/home.md §5.1 (post-PR2g revision).
  *
- * Glass bottom-sheet that floats above the input bar, anchored to the
- * left so it visually drops out of the `+` button below. Tap-outside
- * dismisses without selection.
+ * Original spec had three options (Camera, Photo library, Reference
+ * coffee). On iOS WebKit `<input type="file" accept="image/*">` always
+ * shows the system action sheet when there's no `capture` attribute —
+ * so splitting Camera and Photo library at our level produced a double
+ * sheet (ours then iOS's). Collapsed to a single "Photo" entry that
+ * defers to the iOS picker for source choice (camera vs. library vs.
+ * files), and a "Reference coffee" entry that opens the BTTS picker
+ * (§5.5).
  *
- * Two options in PR2g — Camera and Photo library. The "Reference
- * coffee" row from §5.4 + the Reference Coffee Picker (§5.5) land in
- * PR2h, which extracts the picker UI from the existing /explore page.
+ * Reference coffee is disabled when the user's library is empty
+ * (§5.4).
  */
 
 interface AttachmentSheetProps {
   onClose: () => void;
-  onPickCamera: () => void;
-  onPickLibrary: () => void;
+  onPickPhoto: () => void;
+  onPickCoffee: () => void;
+  coffeeLibraryEmpty?: boolean;
 }
 
 export default function AttachmentSheet({
   onClose,
-  onPickCamera,
-  onPickLibrary,
+  onPickPhoto,
+  onPickCoffee,
+  coffeeLibraryEmpty = false,
 }: AttachmentSheetProps) {
   return (
     <>
-      {/* Tap-outside backdrop — invisible full-screen layer. Click closes
-          the sheet without selecting anything. */}
       <button
         type="button"
         aria-label="Close attachments"
@@ -39,22 +43,23 @@ export default function AttachmentSheet({
       <div className="relative z-50 mb-2 mr-auto max-w-[280px] rounded-2xl border border-light-foreground/10 bg-light-card-default p-2 backdrop-blur-[14px] backdrop-saturate-150">
         <button
           type="button"
-          onClick={onPickCamera}
-          className="flex h-10 w-full items-center gap-3 rounded-xl px-3 text-left"
-        >
-          <CameraIcon className="h-5 w-5 text-light-foreground/80" strokeWidth={1.5} />
-          <span className="font-inter text-[15px] font-medium text-light-foreground">
-            Camera
-          </span>
-        </button>
-        <button
-          type="button"
-          onClick={onPickLibrary}
+          onClick={onPickPhoto}
           className="flex h-10 w-full items-center gap-3 rounded-xl px-3 text-left"
         >
           <ImageIcon className="h-5 w-5 text-light-foreground/80" strokeWidth={1.5} />
           <span className="font-inter text-[15px] font-medium text-light-foreground">
-            Photo library
+            Photo
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={onPickCoffee}
+          disabled={coffeeLibraryEmpty}
+          className="flex h-10 w-full items-center gap-3 rounded-xl px-3 text-left disabled:opacity-40"
+        >
+          <CoffeeIcon className="h-5 w-5 text-light-foreground/80" strokeWidth={1.5} />
+          <span className="font-inter text-[15px] font-medium text-light-foreground">
+            {coffeeLibraryEmpty ? "Reference coffee (library empty)" : "Reference coffee"}
           </span>
         </button>
       </div>

--- a/src/components/ui/light/ChatInput.tsx
+++ b/src/components/ui/light/ChatInput.tsx
@@ -1,35 +1,43 @@
 "use client";
 
-import { useRef, useState } from "react";
-import { Plus, X, AudioLines, ArrowUp, Square, Loader2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { Plus, X, AudioLines, ArrowUp, Square, Loader2, Coffee as CoffeeIcon } from "lucide-react";
 import { useVoiceCapture } from "@/hooks/useVoiceCapture";
 import WaveformBars from "@/components/ui/WaveformBars";
 import AttachmentSheet from "@/components/ui/light/AttachmentSheet";
+import ReferenceCoffeePicker, { type CompactCoffee } from "@/components/ui/light/ReferenceCoffeePicker";
 
 /**
- * BTTS Chat Input — Idle / Typing / Voice / Photo-attached / Loading.
+ * BTTS Chat Input — Idle / Typing / Voice / Photo / Coffee / Loading.
  *
- * Editor is <div contenteditable> (PR #53) so iOS WebKit doesn't paint
- * its form input accessory bar.
+ * Editor is <div contenteditable> so the iOS Safari/WebKit form input
+ * accessory bar doesn't attach. On Firefox iOS the bar is a known
+ * platform limitation; suppressed when installed as a Safari PWA.
  *
- * Photo attachment (specs/home.md §5):
- *   - Tap + → AttachmentSheet appears above (left-anchored). Two
- *     options in PR2g: Camera (capture="environment") and Photo
- *     library. The Reference Coffee option arrives in PR2h.
- *   - After file selection the photo uploads to /api/upload and shows
- *     as a 80×80 rounded thumbnail at the top-left of the pill, with a
- *     small × to remove. The editor row sits below it; the pill grows
- *     vertically to accommodate.
- *   - Send (↑) becomes active when text OR a photo is attached
- *     (§3.2). The photo is sent as attachedImageUrl to
- *     /api/explore-agent so Claude sees the image natively.
+ * Attachments (specs/home.md §5):
+ *   - + → AttachmentSheet (Photo + Reference coffee). Camera/Library
+ *     split was collapsed into a single "Photo" entry because iOS
+ *     WebKit always shows its own action sheet for non-capture file
+ *     inputs (post-PR2g revision).
+ *   - Photo → iOS picker → /api/upload → 80x80 thumbnail at top-left
+ *     of pill, × to remove.
+ *   - Reference coffee → ReferenceCoffeePicker bottom sheet → tap row
+ *     → 28px coffee chip at top-left of pill, × to remove.
+ *   - Max one attachment per message (§3.3). Selecting a new one
+ *     replaces the previous silently.
  *
- * Voice flow (§2.4) and Loading state (§2.2) unchanged from PR2f.
+ * Voice flow (§2.4) unchanged from PR2f.
  */
+
+export interface SendPayload {
+  text: string;
+  imageUrl?: string;
+  coffeeRef?: CompactCoffee;
+}
 
 interface ChatInputProps {
   loading: boolean;
-  onSend: (text: string, imageUrl?: string) => void;
+  onSend: (payload: SendPayload) => void;
   onComposeStart?: () => void;
 }
 
@@ -53,13 +61,31 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
   const [voiceError, setVoiceError] = useState<string | null>(null);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [sheetOpen, setSheetOpen] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
   const [attachedImageUrl, setAttachedImageUrl] = useState<string | null>(null);
+  const [attachedCoffee, setAttachedCoffee] = useState<CompactCoffee | null>(null);
   const [uploadingImage, setUploadingImage] = useState(false);
+  const [coffeeList, setCoffeeList] = useState<CompactCoffee[]>([]);
   const editorRef = useRef<HTMLDivElement | null>(null);
-  const cameraInputRef = useRef<HTMLInputElement | null>(null);
-  const libraryInputRef = useRef<HTMLInputElement | null>(null);
+  const photoInputRef = useRef<HTMLInputElement | null>(null);
   const composeStartedRef = useRef(false);
   const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Compact coffee list for the picker — fetched once on mount.
+  useEffect(() => {
+    fetch("/api/coffees", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data: { id: string; roaster: string; name: string }[]) => {
+        if (Array.isArray(data)) {
+          setCoffeeList(
+            data
+              .filter((c) => c?.id && c?.name && c?.roaster)
+              .map((c) => ({ id: c.id, roaster: c.roaster, name: c.name }))
+          );
+        }
+      })
+      .catch(() => {});
+  }, []);
 
   const dismissErrors = (delay: number) => {
     if (errorTimerRef.current) clearTimeout(errorTimerRef.current);
@@ -91,7 +117,7 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
           sel?.removeAllRanges();
           sel?.addRange(range);
         } catch {
-          /* selection APIs vary on iOS WebKit */
+          /* selection APIs vary across iOS WebKit */
         }
       }
     },
@@ -103,11 +129,12 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
 
   const hasText = text.trim().length > 0;
   const hasPhoto = attachedImageUrl !== null;
-  const sendActive = hasText || hasPhoto;
+  const hasCoffee = attachedCoffee !== null;
+  const sendActive = hasText || hasPhoto || hasCoffee;
   const isRecording = voice.recording;
   const isTranscribing = voice.busy && !voice.recording;
   const isVoiceActive = isRecording || isTranscribing;
-  const isCompositionActive = hasText || hasPhoto || uploadingImage;
+  const isCompositionActive = hasText || hasPhoto || hasCoffee || uploadingImage;
 
   const handleInput = (e: React.FormEvent<HTMLDivElement>) => {
     setText(e.currentTarget.textContent ?? "");
@@ -127,6 +154,7 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
     markComposed();
     setUploadError(null);
     setUploadingImage(true);
+    setAttachedCoffee(null); // §3.3 — one attachment at a time
     try {
       const url = await uploadPhoto(file);
       setAttachedImageUrl(url);
@@ -143,16 +171,22 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
     if (editorRef.current) editorRef.current.textContent = "";
     setText("");
     setAttachedImageUrl(null);
+    setAttachedCoffee(null);
     setUploadError(null);
     editorRef.current?.focus();
   };
 
   const send = () => {
     if (!sendActive || loading || uploadingImage) return;
-    onSend(text.trim(), attachedImageUrl ?? undefined);
+    onSend({
+      text: text.trim(),
+      ...(attachedImageUrl ? { imageUrl: attachedImageUrl } : {}),
+      ...(attachedCoffee ? { coffeeRef: attachedCoffee } : {}),
+    });
     if (editorRef.current) editorRef.current.textContent = "";
     setText("");
     setAttachedImageUrl(null);
+    setAttachedCoffee(null);
     composeStartedRef.current = false;
     editorRef.current?.blur();
   };
@@ -164,19 +198,26 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
     await voice.start();
   };
 
-  const handleOpenSheet = () => {
+  const openSheet = () => {
     if (loading || isVoiceActive) return;
     setSheetOpen(true);
   };
 
-  const handlePickCamera = () => {
+  const handlePickPhoto = () => {
     setSheetOpen(false);
-    cameraInputRef.current?.click();
+    photoInputRef.current?.click();
   };
 
-  const handlePickLibrary = () => {
+  const handlePickCoffeeRef = () => {
     setSheetOpen(false);
-    libraryInputRef.current?.click();
+    setPickerOpen(true);
+  };
+
+  const handleCoffeeSelected = (coffee: CompactCoffee) => {
+    markComposed();
+    setAttachedImageUrl(null); // §3.3 — one attachment at a time
+    setAttachedCoffee(coffee);
+    setPickerOpen(false);
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -185,205 +226,219 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
     e.target.value = "";
   };
 
-  const removePhoto = () => {
-    setAttachedImageUrl(null);
-  };
-
   return (
-    <footer className="flex flex-col px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-3">
-      {(voiceError || uploadError) && (
-        <div
-          role="alert"
-          className="mb-2 rounded-2xl border border-light-foreground/10 bg-light-card-default px-3 py-2 font-inter text-[13px] text-light-foreground backdrop-blur-[14px] backdrop-saturate-150"
-        >
-          {voiceError ?? uploadError}
-        </div>
-      )}
-
-      {loading && (
-        <div className="mb-3 flex items-center gap-2 pl-14" aria-label="Thinking">
-          <span
-            className="h-2 w-2 animate-pulse rounded-full bg-light-foreground/60"
-            style={{ animationDuration: "1200ms" }}
-          />
-          <span
-            className="h-2 w-2 animate-pulse rounded-full bg-light-foreground/60"
-            style={{ animationDuration: "1200ms", animationDelay: "150ms" }}
-          />
-          <span
-            className="h-2 w-2 animate-pulse rounded-full bg-light-foreground/60"
-            style={{ animationDuration: "1200ms", animationDelay: "300ms" }}
-          />
-        </div>
-      )}
-
-      {sheetOpen && (
-        <AttachmentSheet
-          onClose={() => setSheetOpen(false)}
-          onPickCamera={handlePickCamera}
-          onPickLibrary={handlePickLibrary}
-        />
-      )}
-
-      {/* Hidden file inputs trigger the native iOS Camera / Photo
-          Library experience via capture and accept attributes. */}
-      <input
-        ref={cameraInputRef}
-        type="file"
-        accept="image/*"
-        capture="environment"
-        className="hidden"
-        onChange={handleInputChange}
-      />
-      <input
-        ref={libraryInputRef}
-        type="file"
-        accept="image/*"
-        className="hidden"
-        onChange={handleInputChange}
-      />
-
-      <div className="flex items-end gap-3">
-        {/* Left button: × during voice / composition / loading; + otherwise */}
-        {isVoiceActive ? (
-          <button
-            type="button"
-            onClick={() => voice.cancel()}
-            disabled={isTranscribing}
-            aria-label="Cancel recording"
-            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150 disabled:opacity-50"
+    <>
+      <footer className="flex flex-col px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-3">
+        {(voiceError || uploadError) && (
+          <div
+            role="alert"
+            className="mb-2 rounded-2xl border border-light-foreground/10 bg-light-card-default px-3 py-2 font-inter text-[13px] text-light-foreground backdrop-blur-[14px] backdrop-saturate-150"
           >
-            <X className="h-5 w-5" strokeWidth={1.5} />
-          </button>
-        ) : isCompositionActive || loading ? (
-          <button
-            type="button"
-            onClick={clearComposition}
-            disabled={loading || uploadingImage}
-            aria-label={loading ? "Sending" : "Clear"}
-            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150 disabled:opacity-50"
-          >
-            <X className="h-5 w-5" strokeWidth={1.5} />
-          </button>
-        ) : (
-          <button
-            type="button"
-            onClick={handleOpenSheet}
-            aria-label="Attach"
-            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150"
-          >
-            <Plus className="h-5 w-5" strokeWidth={1.5} />
-          </button>
+            {voiceError ?? uploadError}
+          </div>
         )}
 
-        {/* Middle */}
-        {loading ? (
-          <div className="h-11 flex-1 rounded-full border border-light-foreground/10 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150" />
-        ) : isVoiceActive ? (
-          <div className="flex h-11 flex-1 items-center gap-2 rounded-full border border-light-foreground/10 bg-light-card-default pl-5 pr-1.5 backdrop-blur-[14px] backdrop-saturate-150">
-            <WaveformBars
-              getLevel={voice.getLevel}
-              color="hsl(20 14% 12%)"
-              height={20}
-              bars={28}
-              className="flex-1"
+        {loading && (
+          <div className="mb-3 flex items-center gap-2 pl-14" aria-label="Thinking">
+            <span
+              className="h-2 w-2 animate-pulse rounded-full bg-light-foreground/60"
+              style={{ animationDuration: "1200ms" }}
             />
-            {isTranscribing ? (
-              <div
-                aria-label="Transcribing"
-                className="flex h-8 w-8 shrink-0 items-center justify-center text-light-foreground/60"
-              >
-                <Loader2 className="h-5 w-5 animate-spin" strokeWidth={1.5} />
-              </div>
-            ) : (
-              <button
-                type="button"
-                onClick={() => void voice.stop()}
-                aria-label="Stop recording"
-                className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)]"
-              >
-                <Square className="h-3.5 w-3.5 fill-current" strokeWidth={0} />
-              </button>
-            )}
+            <span
+              className="h-2 w-2 animate-pulse rounded-full bg-light-foreground/60"
+              style={{ animationDuration: "1200ms", animationDelay: "150ms" }}
+            />
+            <span
+              className="h-2 w-2 animate-pulse rounded-full bg-light-foreground/60"
+              style={{ animationDuration: "1200ms", animationDelay: "300ms" }}
+            />
           </div>
-        ) : (
-          <div className="flex min-h-11 flex-1 flex-col gap-2 rounded-3xl border border-light-foreground/10 bg-light-card-default py-1.5 pl-5 pr-1.5 backdrop-blur-[14px] backdrop-saturate-150">
-            {(attachedImageUrl || uploadingImage) && (
-              <div className="relative h-20 w-20">
-                {attachedImageUrl ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img
-                    src={attachedImageUrl}
-                    alt="Attached"
-                    className="block h-full w-full rounded-xl object-cover"
-                  />
-                ) : (
-                  <div className="flex h-full w-full items-center justify-center rounded-xl bg-light-foreground/10">
-                    <Loader2
-                      className="h-5 w-5 animate-spin text-light-foreground/60"
-                      strokeWidth={1.5}
-                    />
-                  </div>
-                )}
-                {attachedImageUrl && (
-                  <button
-                    type="button"
-                    onClick={removePhoto}
-                    aria-label="Remove photo"
-                    className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)]"
-                  >
-                    <X className="h-3 w-3" strokeWidth={2.25} />
-                  </button>
-                )}
-              </div>
-            )}
-            <div className="flex items-end gap-1">
-              <div className="relative min-h-8 flex-1">
+        )}
+
+        {sheetOpen && (
+          <AttachmentSheet
+            onClose={() => setSheetOpen(false)}
+            onPickPhoto={handlePickPhoto}
+            onPickCoffee={handlePickCoffeeRef}
+            coffeeLibraryEmpty={coffeeList.length === 0}
+          />
+        )}
+
+        <input
+          ref={photoInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={handleInputChange}
+        />
+
+        <div className="flex items-end gap-3">
+          {isVoiceActive ? (
+            <button
+              type="button"
+              onClick={() => voice.cancel()}
+              disabled={isTranscribing}
+              aria-label="Cancel recording"
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150 disabled:opacity-50"
+            >
+              <X className="h-5 w-5" strokeWidth={1.5} />
+            </button>
+          ) : isCompositionActive || loading ? (
+            <button
+              type="button"
+              onClick={clearComposition}
+              disabled={loading || uploadingImage}
+              aria-label={loading ? "Sending" : "Clear"}
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150 disabled:opacity-50"
+            >
+              <X className="h-5 w-5" strokeWidth={1.5} />
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={openSheet}
+              aria-label="Attach"
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150"
+            >
+              <Plus className="h-5 w-5" strokeWidth={1.5} />
+            </button>
+          )}
+
+          {loading ? (
+            <div className="h-11 flex-1 rounded-full border border-light-foreground/10 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150" />
+          ) : isVoiceActive ? (
+            <div className="flex h-11 flex-1 items-center gap-2 rounded-full border border-light-foreground/10 bg-light-card-default pl-5 pr-1.5 backdrop-blur-[14px] backdrop-saturate-150">
+              <WaveformBars
+                getLevel={voice.getLevel}
+                color="hsl(20 14% 12%)"
+                height={20}
+                bars={28}
+                className="flex-1"
+              />
+              {isTranscribing ? (
                 <div
-                  ref={editorRef}
-                  contentEditable
-                  suppressContentEditableWarning
-                  role="textbox"
-                  aria-multiline="true"
-                  aria-label="Message"
-                  onInput={handleInput}
-                  onFocus={handleFocus}
-                  onPaste={handlePaste}
-                  className="block min-h-8 w-full whitespace-pre-wrap break-words font-inter text-[16px] font-normal leading-[2rem] text-light-foreground focus:outline-none"
-                />
-                {!hasText && (
-                  <span
-                    aria-hidden="true"
-                    className="pointer-events-none absolute left-0 top-0 font-inter text-[16px] font-normal leading-[2rem] text-light-muted-foreground"
-                  >
-                    Ask anything…
-                  </span>
-                )}
-              </div>
-              {sendActive ? (
-                <button
-                  type="button"
-                  onClick={send}
-                  disabled={uploadingImage}
-                  aria-label="Send"
-                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)] disabled:opacity-30"
+                  aria-label="Transcribing"
+                  className="flex h-8 w-8 shrink-0 items-center justify-center text-light-foreground/60"
                 >
-                  <ArrowUp className="h-4 w-4" strokeWidth={2.25} />
-                </button>
+                  <Loader2 className="h-5 w-5 animate-spin" strokeWidth={1.5} />
+                </div>
               ) : (
                 <button
                   type="button"
-                  onClick={startVoice}
-                  aria-label="Voice"
-                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-light-foreground/60"
+                  onClick={() => void voice.stop()}
+                  aria-label="Stop recording"
+                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)]"
                 >
-                  <AudioLines className="h-5 w-5" strokeWidth={1.5} />
+                  <Square className="h-3.5 w-3.5 fill-current" strokeWidth={0} />
                 </button>
               )}
             </div>
-          </div>
-        )}
-      </div>
-    </footer>
+          ) : (
+            <div className="flex min-h-11 flex-1 flex-col gap-2 rounded-3xl border border-light-foreground/10 bg-light-card-default py-1.5 pl-5 pr-1.5 backdrop-blur-[14px] backdrop-saturate-150">
+              {(attachedImageUrl || uploadingImage) && (
+                <div className="relative h-20 w-20">
+                  {attachedImageUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={attachedImageUrl}
+                      alt="Attached"
+                      className="block h-full w-full rounded-xl object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center rounded-xl bg-light-foreground/10">
+                      <Loader2
+                        className="h-5 w-5 animate-spin text-light-foreground/60"
+                        strokeWidth={1.5}
+                      />
+                    </div>
+                  )}
+                  {attachedImageUrl && (
+                    <button
+                      type="button"
+                      onClick={() => setAttachedImageUrl(null)}
+                      aria-label="Remove photo"
+                      className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)]"
+                    >
+                      <X className="h-3 w-3" strokeWidth={2.25} />
+                    </button>
+                  )}
+                </div>
+              )}
+              {attachedCoffee && (
+                <div className="flex h-7 w-fit max-w-full items-center gap-1.5 rounded-full border border-light-foreground/10 bg-light-card-default px-2 pr-1">
+                  <CoffeeIcon
+                    className="h-3.5 w-3.5 shrink-0 text-light-foreground/80"
+                    strokeWidth={1.5}
+                  />
+                  <span className="truncate font-inter text-[12px] font-medium text-light-foreground">
+                    {attachedCoffee.roaster} · {attachedCoffee.name}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setAttachedCoffee(null)}
+                    aria-label="Remove coffee reference"
+                    className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)]"
+                  >
+                    <X className="h-3 w-3" strokeWidth={2.25} />
+                  </button>
+                </div>
+              )}
+              <div className="flex items-end gap-1">
+                <div className="relative min-h-8 flex-1">
+                  <div
+                    ref={editorRef}
+                    contentEditable
+                    suppressContentEditableWarning
+                    role="textbox"
+                    aria-multiline="true"
+                    aria-label="Message"
+                    onInput={handleInput}
+                    onFocus={handleFocus}
+                    onPaste={handlePaste}
+                    className="block min-h-8 w-full whitespace-pre-wrap break-words font-inter text-[16px] font-normal leading-[2rem] text-light-foreground focus:outline-none"
+                  />
+                  {!hasText && (
+                    <span
+                      aria-hidden="true"
+                      className="pointer-events-none absolute left-0 top-0 font-inter text-[16px] font-normal leading-[2rem] text-light-muted-foreground"
+                    >
+                      Ask anything…
+                    </span>
+                  )}
+                </div>
+                {sendActive ? (
+                  <button
+                    type="button"
+                    onClick={send}
+                    disabled={uploadingImage}
+                    aria-label="Send"
+                    className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)] disabled:opacity-30"
+                  >
+                    <ArrowUp className="h-4 w-4" strokeWidth={2.25} />
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={startVoice}
+                    aria-label="Voice"
+                    className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-light-foreground/60"
+                  >
+                    <AudioLines className="h-5 w-5" strokeWidth={1.5} />
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </footer>
+
+      {pickerOpen && (
+        <ReferenceCoffeePicker
+          coffees={coffeeList}
+          onSelect={handleCoffeeSelected}
+          onClose={() => setPickerOpen(false)}
+        />
+      )}
+    </>
   );
 }

--- a/src/components/ui/light/ChatThread.tsx
+++ b/src/components/ui/light/ChatThread.tsx
@@ -1,29 +1,34 @@
 "use client";
 
 import { useEffect, useRef, type ReactNode } from "react";
+import { Coffee as CoffeeIcon } from "lucide-react";
+import type { NavAction } from "@/app/api/explore-agent/route";
+import ActionPill from "@/components/ui/light/ActionPill";
 
 /**
- * BTTS Chat Thread — specs/home.md §4.
+ * BTTS Chat Thread — specs/home.md §4 + §6.
  *
- * User content as right-aligned Glass bubbles (§4.2); agent responses as
- * left-aligned prose, no bubble (§4.3). Stacked-bubble rule when the
- * user message includes an attachment (photo bubble above text bubble).
+ * Visual distinction (the spec's "user chats, BTTS writes" anchor):
+ *   - User content: right-aligned Glass bubble(s). When a message has
+ *     a photo or coffee reference, those render as their own bubble
+ *     above the text bubble (§4.2 stacked-bubble rule).
+ *   - Agent content: left-aligned prose, no bubble. Inline Markdown
+ *     bold + italic parsed so /api/explore-agent's `**Roaster — Name**`
+ *     renders as actual bold.
+ *
+ * Below an agent response, up to three Action Pills (§6) render in a
+ * horizontal flex row when the agent emitted suggest_navigation calls.
  *
  * §4.4 top-edge fade + §4.5 stick-to-bottom auto-scroll preserved from
  * PR2e.
- *
- * Inline Markdown: the agent prose is rendered through a tiny
- * Markdown-to-React parser so `**bold**` and `*italic*` from the
- * /api/explore-agent response don't leak through as literal asterisks.
- * Anything beyond inline bold/italic (lists, headers, code blocks)
- * stays as plain text for now — add cases here as they show up in
- * real responses.
  */
 
 export interface Message {
   role: "user" | "assistant";
   content: string;
   imageUrl?: string;
+  coffeeRef?: { id: string; roaster: string; name: string };
+  actions?: NavAction[];
 }
 
 interface ChatThreadProps {
@@ -31,28 +36,10 @@ interface ChatThreadProps {
   loading: boolean;
 }
 
-/**
- * Render a string with inline Markdown emphasis. Supports `**bold**`
- * and `*italic*` (and their underscore variants). Anything else flows
- * through as plain text — `whitespace-pre-wrap` on the `<p>` preserves
- * single newlines.
- *
- * Strategy: scan left-to-right; longer delimiters (`**` / `__`) before
- * shorter (`*` / `_`) so bold isn't misread as two adjacent italics.
- */
 function renderInlineMarkdown(text: string): ReactNode[] {
   const nodes: ReactNode[] = [];
   let i = 0;
   let key = 0;
-
-  const matchDelim = (delim: string): number => {
-    if (text.startsWith(delim, i)) {
-      const end = text.indexOf(delim, i + delim.length);
-      if (end > i + delim.length) return end;
-    }
-    return -1;
-  };
-
   let buffer = "";
   const flush = () => {
     if (buffer) {
@@ -62,27 +49,21 @@ function renderInlineMarkdown(text: string): ReactNode[] {
   };
 
   while (i < text.length) {
-    const boldEnd =
-      matchDelim("**") !== -1
-        ? matchDelim("**")
-        : matchDelim("__") !== -1
-        ? matchDelim("__")
-        : -1;
     const boldDelim = text.startsWith("**", i) ? "**" : text.startsWith("__", i) ? "__" : null;
-
-    if (boldDelim && boldEnd !== -1) {
-      flush();
-      nodes.push(
-        <strong key={key++} className="font-semibold text-light-foreground">
-          {text.slice(i + 2, boldEnd)}
-        </strong>
-      );
-      i = boldEnd + 2;
-      continue;
+    if (boldDelim) {
+      const end = text.indexOf(boldDelim, i + 2);
+      if (end > i + 2) {
+        flush();
+        nodes.push(
+          <strong key={key++} className="font-semibold text-light-foreground">
+            {text.slice(i + 2, end)}
+          </strong>
+        );
+        i = end + 2;
+        continue;
+      }
     }
 
-    // Italic — single * or _ . Require non-space on both sides so URLs
-    // and word_with_underscores don't trip it.
     if (text[i] === "*" || text[i] === "_") {
       const delim = text[i];
       const end = text.indexOf(delim, i + 1);
@@ -151,6 +132,19 @@ export default function ChatThread({ messages, loading }: ChatThreadProps) {
                     />
                   </div>
                 )}
+                {m.coffeeRef && (
+                  <div className="flex max-w-[80%] items-center gap-3 rounded-2xl border border-light-foreground/10 bg-light-card-default px-4 py-3 backdrop-blur-[14px] backdrop-saturate-150">
+                    <CoffeeIcon className="h-5 w-5 shrink-0 text-light-foreground/80" strokeWidth={1.5} />
+                    <div className="flex min-w-0 flex-col">
+                      <span className="truncate font-inter text-[13px] font-normal text-light-muted-foreground">
+                        {m.coffeeRef.roaster}
+                      </span>
+                      <span className="truncate font-inter text-[15px] font-medium text-light-foreground">
+                        {m.coffeeRef.name}
+                      </span>
+                    </div>
+                  </div>
+                )}
                 {m.content && (
                   <div className="max-w-[80%] rounded-2xl border border-light-foreground/10 bg-light-card-default px-4 py-3 backdrop-blur-[14px] backdrop-saturate-150">
                     <p className="whitespace-pre-wrap font-inter text-[15px] font-normal text-light-foreground">
@@ -160,16 +154,24 @@ export default function ChatThread({ messages, loading }: ChatThreadProps) {
                 )}
               </div>
             ) : (
-              m.content && (
+              (m.content || (m.actions && m.actions.length > 0)) && (
                 <div key={i} className="space-y-3">
-                  {m.content.split(/\n\n+/).map((para, j) => (
-                    <p
-                      key={j}
-                      className="whitespace-pre-wrap font-inter text-[15px] font-normal leading-[1.5] text-light-foreground"
-                    >
-                      {renderInlineMarkdown(para)}
-                    </p>
-                  ))}
+                  {m.content &&
+                    m.content.split(/\n\n+/).map((para, j) => (
+                      <p
+                        key={j}
+                        className="whitespace-pre-wrap font-inter text-[15px] font-normal leading-[1.5] text-light-foreground"
+                      >
+                        {renderInlineMarkdown(para)}
+                      </p>
+                    ))}
+                  {m.actions && m.actions.length > 0 && (
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      {m.actions.slice(0, 3).map((a, j) => (
+                        <ActionPill key={j} action={a} />
+                      ))}
+                    </div>
+                  )}
                 </div>
               )
             )

--- a/src/components/ui/light/ReferenceCoffeePicker.tsx
+++ b/src/components/ui/light/ReferenceCoffeePicker.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Coffee as CoffeeIcon } from "lucide-react";
+
+/**
+ * BTTS Reference Coffee Picker — specs/home.md §5.5.
+ *
+ * Bottom sheet that replaces the +-Sheet when "Reference coffee" is
+ * tapped. Glass container, full-width, ≥ 60% viewport tall, scrollable
+ * coffee list, search pill at the top, header row.
+ *
+ * Data: parent passes the compact coffee list (id / roaster / name)
+ * already fetched on mount. Filtering happens client-side — list is
+ * small (max 50 displayed).
+ *
+ * Tap on a row → onSelect(coffee) (parent closes the picker and
+ * stashes the reference). Tap-outside / drag-handle closes without
+ * selection.
+ */
+
+export interface CompactCoffee {
+  id: string;
+  roaster: string;
+  name: string;
+}
+
+interface ReferenceCoffeePickerProps {
+  coffees: CompactCoffee[];
+  onSelect: (coffee: CompactCoffee) => void;
+  onClose: () => void;
+}
+
+export default function ReferenceCoffeePicker({
+  coffees,
+  onSelect,
+  onClose,
+}: ReferenceCoffeePickerProps) {
+  const [query, setQuery] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const list = q
+      ? coffees.filter(
+          (c) =>
+            c.name.toLowerCase().includes(q) || c.roaster.toLowerCase().includes(q)
+        )
+      : coffees;
+    return list.slice(0, 50);
+  }, [coffees, query]);
+
+  return (
+    <>
+      <button
+        type="button"
+        aria-label="Close picker"
+        onClick={onClose}
+        className="fixed inset-0 z-50 cursor-default bg-light-foreground/10 backdrop-blur-[2px]"
+      />
+
+      <div className="fixed inset-x-0 bottom-0 z-[60] flex max-h-[80vh] min-h-[60vh] flex-col rounded-t-2xl border border-light-foreground/10 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150">
+        <div className="mt-2 self-center">
+          <span className="block h-1 w-10 rounded-full bg-light-foreground/30" />
+        </div>
+
+        <div className="flex h-12 shrink-0 items-center gap-3 border-b border-light-foreground/10 px-5">
+          <CoffeeIcon className="h-5 w-5 text-light-foreground/80" strokeWidth={1.5} />
+          <p className="font-inter text-[17px] font-medium text-light-foreground">
+            Reference coffee
+          </p>
+        </div>
+
+        <div className="mx-5 mt-3 shrink-0">
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search roaster or coffee"
+            className="block h-11 w-full rounded-full border-0 bg-light-card-default px-5 font-inter text-[15px] font-normal text-light-foreground placeholder:text-light-muted-foreground focus:border-transparent focus:outline-none focus:ring-0 focus:ring-offset-0"
+            style={{ background: "hsl(36 55% 96% / 0.45)" }}
+          />
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-3 pb-[max(1rem,env(safe-area-inset-bottom))]">
+          {filtered.length === 0 ? (
+            <p className="py-6 text-center font-inter text-[13px] text-light-muted-foreground">
+              No matching coffees
+            </p>
+          ) : (
+            <ul className="flex flex-col">
+              {filtered.map((c) => (
+                <li key={c.id}>
+                  <button
+                    type="button"
+                    onClick={() => onSelect(c)}
+                    className="flex w-full flex-col gap-0.5 px-0 py-3 text-left"
+                  >
+                    <span className="font-inter text-[13px] font-normal text-light-muted-foreground">
+                      {c.roaster}
+                    </span>
+                    <span className="font-inter text-[17px] font-medium text-light-foreground">
+                      {c.name}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Three PRs batched into one per user request — reference coffee picker, action pills, and a real Haiku starter. Also folds in the iOS double-sheet fix for photo attachments.

### PR2g revision — single "Photo" entry in `+`-Sheet
Splitting Camera and Photo library on our side produced a double sheet because iOS WebKit always shows its own action sheet for `<input type="file">` without `capture`. Collapsed to one "Photo" entry that defers to the iOS picker. "Reference coffee" stays as the second row; disabled when the user's library is empty (§5.4).

### PR2h — Reference Coffee Picker (§5.5)
- **`src/components/ui/light/ReferenceCoffeePicker.tsx`** — bottom-sheet Glass surface, ≥60 vh, full-width, with header row + search pill + scrollable coffee list (max 50 results).
- ChatInput fetches `/api/coffees` once on mount; tapping "Reference coffee" opens the picker, tapping a row stashes the coffee and closes the picker.
- Inline 28 px chip in the pill (coffee-cup icon + `Roaster · Name` + × to remove). Same stacking pattern as the photo thumbnail. Spec §3.3 "max one attachment per message" enforced — selecting a coffee clears an attached photo and vice versa.
- Send packs the coffee ref into the message; home/page.tsx injects it into the last user turn as an inline `[Coffee: roaster name]` tag, same pattern `/explore` uses, so `/api/explore-agent` sees it without a new API field.
- ChatThread renders the user-side coffee bubble — own Glass bubble above the text bubble per §4.2 stacked rule.

### PR2i — Action Pills (§6)
- **`src/components/ui/light/ActionPill.tsx`** — Glass pill with icon prefix per destination type (BookOpen / Coffee / MapPin / User / Crosshair / Globe).
- `Message` gains optional `actions: NavAction[]`. Home parses the SSE `done` event and attaches the actions array to the last assistant message.
- ChatThread renders up to three pills in a flex-wrap row under the response. Tap → `next/router` navigation. `coffee_detail` uses the coffee's id, `cafe_detail` uses the place slug.

### PR2j — real Haiku Starter (§8)
- **`src/app/api/greeting/route.ts`** — POST endpoint, `claude-haiku-4-5`, `max_tokens: 80`, `temperature: 0.7`. Pulls last 5 sessions + compact library + a server-clock time-of-day bucket. Returns `{ text }`.
- System prompt asks for exactly one 8–16 word editorial sentence, no markdown, no preamble. Concrete signal from context turned into invitation.
- Home checks `localStorage["brewlog.starter.<YYYY-MM-DD>"]` on mount; on miss fetches `/api/greeting` and caches the result. Falls back to `"Welcome to Better Taste Than Sorry."` on error.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Auto-deploy runs green
- [ ] `+` opens a sheet with two rows (Photo, Reference coffee)
- [ ] Photo → iOS picker (camera/library/files) → upload → thumbnail in pill
- [ ] Reference coffee → bottom-sheet picker with search + coffee list → select → chip in pill
- [ ] Selecting a photo while a coffee is attached replaces it; vice versa
- [ ] Send with coffee ref → coffee bubble appears above the text bubble in the thread; agent response references the coffee
- [ ] Agent response with nav suggestions → 1–3 action pills under the prose, tap navigates
- [ ] First open today → Starter renders the real Haiku (or fallback if offline). Subsequent opens read from `localStorage` cache.

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_