### PR TITLE
feat: brew_again action pill — jump to brew context with coffee preselected

### DIFF
--- a/src/app/api/explore-agent/route.ts
+++ b/src/app/api/explore-agent/route.ts
@@ -27,6 +27,7 @@ export interface NavAction {
   destination:
     | "coffee_library"
     | "coffee_detail"
+    | "brew_again"
     | "cafe_map"
     | "cafe_detail"
     | "taste_profile"
@@ -62,6 +63,7 @@ Mention capabilities only when relevant — don't pitch them unprompted.
 | Situation | Destination |
 |-----------|-------------|
 | You mention a specific coffee **bag** from the user's library | coffee_detail (use the coffee's id from context) |
+| The user explicitly wants to **brew a specific bag again** — "brew the Jaime Sanchez again", "make me the cherry one", "I want the DAK Bourbon" | brew_again (use the coffee's id from context) — this lands the user in Step 3 (Context) of the brew flow with the bag already selected |
 | You reference several of their coffee bags, or suggest browsing their bag collection | coffee_library |
 | You recommend visiting a specific **café, roastery, or physical place** | cafe_detail — opens the Explore Nearby map |
 | General "what's near me" or map exploration | cafe_map — opens the Explore Nearby map |
@@ -185,12 +187,12 @@ const TOOLS: Anthropic.Tool[] = [
       properties: {
         destination: {
           type: "string",
-          enum: ["coffee_library", "coffee_detail", "cafe_map", "cafe_detail", "taste_profile", "match", "home"],
-          description: "Which part of BrewLog to open. IMPORTANT: coffee_library and coffee_detail are for the user's personal collection of coffee BAGS they have purchased — NOT for cafés or physical places. Use cafe_map or cafe_detail for any physical café, roastery, or place to visit.",
+          enum: ["coffee_library", "coffee_detail", "brew_again", "cafe_map", "cafe_detail", "taste_profile", "match", "home"],
+          description: "Which part of BrewLog to open. IMPORTANT: coffee_library and coffee_detail are for the user's personal collection of coffee BAGS they have purchased — NOT for cafés or physical places. Use cafe_map or cafe_detail for any physical café, roastery, or place to visit. Use brew_again when the user explicitly wants to start a brew flow with a specific bag from their library — drops them into Step 3 (Context) with the bag pre-selected.",
         },
         label: {
           type: "string",
-          description: "Short action label shown on the button, e.g. 'View El Congo in library' or 'Open RVTC on the map'",
+          description: "Short action label shown on the button, e.g. 'View El Congo in library', 'Brew Jaime Sanchez again', or 'Open RVTC on the map'",
         },
         reason: {
           type: "string",

--- a/src/components/ui/light/ActionPill.tsx
+++ b/src/components/ui/light/ActionPill.tsx
@@ -1,28 +1,43 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { Coffee, MapPin, User, Crosshair, Globe, BookOpen } from "lucide-react";
+import { Coffee, MapPin, User, Crosshair, Globe, BookOpen, RotateCcw } from "lucide-react";
 import type { NavAction } from "@/app/api/explore-agent/route";
+import { useFlowStore } from "@/store/flowStore";
+import type { CoffeeIdentity } from "@/lib/types/session";
 
 /**
  * BTTS Action Pill — specs/home.md §6.
  *
  * Glass pill rendered under an agent response when the agent emits a
- * suggest_navigation call. Max 3 per response (§6.0 — agent prioritises
- * if more would apply).
+ * suggest_navigation call. Max 3 per response (§6.0).
  *
  * Icon prefix signals action type (§6.2):
- *   - Coffee-cup: navigation to a coffee detail / library
- *   - Map-pin: navigation to a map / café view
+ *   - BookOpen / Coffee: navigation to library or detail
+ *   - RotateCcw: Brew Action — starts a brew flow with a coffee
+ *     pre-selected; lands in Step 3 (Context). Spec §6.2 calls this
+ *     the "Brew/refresh icon".
+ *   - MapPin: navigation to a map / café view
  *   - Crosshair: Match flow
  *   - User: Taste profile
  *   - Globe: generic navigation
  *
- * Tap is a single navigation event — no confirmation sheet (§6.3).
- * If the destination is a brew step that needs pre-population, that's
- * flowStore work and will land alongside PR2g/h follow-ups for the
- * brew-flow Light migration.
+ * For brew_again specifically: tap fetches the coffee from
+ * /api/coffees/[id], synthesises a CoffeeIdentity (same shape as the
+ * /coffees library page's "Brew this" button), hydrates the
+ * flowStore, then navigates to /brew/new. The brew flow opens directly
+ * on Step 3 (Context) with the bag already selected. (§6.3)
  */
+
+interface CoffeeRow {
+  id: string;
+  roaster: string;
+  name: string;
+  origin: string;
+  process: string;
+  latestRoastDate?: string;
+  bagPhotoUrl?: string;
+}
 
 function destinationToPath(action: NavAction): string {
   switch (action.destination) {
@@ -30,6 +45,10 @@ function destinationToPath(action: NavAction): string {
       return "/coffees";
     case "coffee_detail":
       return action.id ? `/coffees/${action.id}` : "/coffees";
+    case "brew_again":
+      // brew_again is handled specially — the click handler hydrates
+      // the flow store first. Fallback path on failure.
+      return "/brew/new";
     case "cafe_map":
       return "/cafes";
     case "cafe_detail":
@@ -52,6 +71,8 @@ function ActionPillIcon({ destination }: { destination: NavAction["destination"]
       return <BookOpen className={cls} strokeWidth={1.5} />;
     case "coffee_detail":
       return <Coffee className={cls} strokeWidth={1.5} />;
+    case "brew_again":
+      return <RotateCcw className={cls} strokeWidth={1.5} />;
     case "cafe_map":
     case "cafe_detail":
       return <MapPin className={cls} strokeWidth={1.5} />;
@@ -66,10 +87,46 @@ function ActionPillIcon({ destination }: { destination: NavAction["destination"]
 
 export default function ActionPill({ action }: { action: NavAction }) {
   const router = useRouter();
+  const { reset, setCoffee, setMode, setSkipScan, setStep } = useFlowStore();
+
+  const handleClick = async () => {
+    if (action.destination === "brew_again" && action.id) {
+      // Hydrate the flow store with the coffee, then jump into Step 3.
+      // Same pattern /coffees and /coffees/[id] use for "Brew this".
+      try {
+        const res = await fetch(`/api/coffees/${action.id}`, { cache: "no-store" });
+        if (res.ok) {
+          const row = (await res.json()) as CoffeeRow | null;
+          if (row && row.id) {
+            const identity: CoffeeIdentity = {
+              roaster: row.roaster,
+              name: row.name,
+              origin: row.origin,
+              process: row.process,
+              roastLevel: "Light",
+              roastDate: row.latestRoastDate,
+              bagPhotoUrl: row.bagPhotoUrl,
+              aiExtracted: false,
+              coffeeId: row.id,
+            };
+            reset();
+            setCoffee(identity);
+            setMode("home");
+            setSkipScan(true);
+            setStep("context");
+          }
+        }
+      } catch {
+        /* fall through to plain navigation if the fetch fails */
+      }
+    }
+    router.push(destinationToPath(action));
+  };
+
   return (
     <button
       type="button"
-      onClick={() => router.push(destinationToPath(action))}
+      onClick={() => void handleClick()}
       title={action.reason}
       className="flex h-9 shrink-0 items-center gap-1.5 rounded-full border border-light-foreground/10 bg-light-card-default px-4 font-inter text-[13px] font-medium text-light-foreground backdrop-blur-[14px] backdrop-saturate-150"
     >


### PR DESCRIPTION
## Summary

User says in the chat *"I want to brew Jaime Sanchez again"* → agent classifies the intent → emits a `brew_again` `suggest_navigation` → an Action Pill with the brew/refresh icon renders under the response → tap drops the user into Step 3 (Context) of the brew flow with the bag already selected.

Spec backing: §9 "Brew command — specific coffee", §6.2 brew/refresh icon, §6.3 "If the destination is a brew step the flowStore is pre-populated with the relevant coffee or photo data before navigation."

### Changes

- **`/api/explore-agent`** — `NavAction` destination type + the tool's `input_schema` enum gain a new `"brew_again"` entry. The `suggest_navigation` system prompt grows a row spelling out when to emit it:
  > "The user explicitly wants to **brew a specific bag again** — 'brew the Jaime Sanchez again', 'make me the cherry one', 'I want the DAK Bourbon' | brew_again (use the coffee's id from context)"
- **`ActionPill`** — recognises `brew_again`, renders the `RotateCcw` icon (the spec's "brew/refresh icon"). On tap:
  1. Fetches `/api/coffees/[id]`
  2. Synthesises a `CoffeeIdentity` (same shape `/coffees` and `/coffees/[id]` already use for their existing "Brew this" buttons)
  3. Hydrates the flowStore: `reset → setCoffee → setMode("home") → setSkipScan(true) → setStep("context")`
  4. `router.push("/brew/new")` — opens directly on Step 3
  
  Pure-navigation fallback if the fetch fails (lands on `/brew/new` Step 1).

`/recommend` re-hydrates the full coffee row from `coffeeId` server-side, so the synthesised identity carries enough.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Auto-deploy runs green
- [ ] On `/home`, ask "Brew Jaime Sanchez again" → agent response includes a pill with the rotate-arrow icon and the label
- [ ] Tap the pill → lands on `/brew/new` directly on the Context step with Jaime Sanchez selected (no scan step shown)
- [ ] Generic "what should I brew?" still triggers existing `coffee_detail` / `coffee_library` pills (not brew_again, since intent is exploratory not committed)

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_