### PR TITLE
refactor: Chivo font + anthracite foreground + darker borders

### DIFF
--- a/src/app/(light)/home/page.tsx
+++ b/src/app/(light)/home/page.tsx
@@ -333,14 +333,14 @@ export default function HomePage() {
     <>
       <main className="flex h-dvh flex-col">
         <header className="flex shrink-0 items-center justify-between pl-5 pr-5 pt-12 pb-3">
-          <h1 className="font-inter text-[14px] font-medium text-light-foreground/60">
+          <h1 className="font-chivo text-[14px] font-medium text-light-foreground/60">
             Better taste than sorry
           </h1>
           <button
             type="button"
             onClick={() => setMenuOpen(true)}
             aria-label="Open menu"
-            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
           >
             <Menu className="h-5 w-5" strokeWidth={1.5} />
           </button>

--- a/src/app/(light)/past-conversations/[id]/page.tsx
+++ b/src/app/(light)/past-conversations/[id]/page.tsx
@@ -94,18 +94,18 @@ export default function PastConversationDetailPage() {
             type="button"
             onClick={() => router.push("/past-conversations")}
             aria-label="Back"
-            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
           >
             <ChevronLeft className="h-5 w-5" strokeWidth={1.5} />
           </button>
-          <h1 className="font-inter text-[14px] font-medium text-light-foreground/60">
+          <h1 className="font-chivo text-[14px] font-medium text-light-foreground/60">
             {data ? formatDate(data.conversation.lastMessageAt) : "Conversation"}
           </h1>
           <button
             type="button"
             onClick={() => setMenuOpen(true)}
             aria-label="Open menu"
-            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
           >
             <Menu className="h-5 w-5" strokeWidth={1.5} />
           </button>
@@ -114,11 +114,11 @@ export default function PastConversationDetailPage() {
         <section className="flex-1 min-h-0">
           {loading ? (
             <div className="flex h-full items-center px-5">
-              <p className="font-inter text-[15px] text-light-muted-foreground">Loading…</p>
+              <p className="font-chivo text-[15px] text-light-muted-foreground">Loading…</p>
             </div>
           ) : error ? (
             <div className="flex h-full items-center px-5">
-              <p className="font-inter text-[15px] text-light-muted-foreground">{error}</p>
+              <p className="font-chivo text-[15px] text-light-muted-foreground">{error}</p>
             </div>
           ) : (
             <ChatThread messages={messages} loading={false} />

--- a/src/app/(light)/past-conversations/page.tsx
+++ b/src/app/(light)/past-conversations/page.tsx
@@ -68,14 +68,14 @@ export default function PastConversationsPage() {
     <>
       <main className="flex h-dvh flex-col">
         <header className="flex shrink-0 items-center justify-between pl-5 pr-5 pt-12 pb-3">
-          <h1 className="font-inter text-[14px] font-medium text-light-foreground/60">
+          <h1 className="font-chivo text-[14px] font-medium text-light-foreground/60">
             Past conversations
           </h1>
           <button
             type="button"
             onClick={() => setMenuOpen(true)}
             aria-label="Open menu"
-            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
           >
             <Menu className="h-5 w-5" strokeWidth={1.5} />
           </button>
@@ -83,9 +83,9 @@ export default function PastConversationsPage() {
 
         <section className="flex-1 min-h-0 overflow-y-auto px-5 py-5">
           {loading ? (
-            <p className="font-inter text-[15px] text-light-muted-foreground">Loading…</p>
+            <p className="font-chivo text-[15px] text-light-muted-foreground">Loading…</p>
           ) : rows.length === 0 ? (
-            <p className="font-inter text-[15px] text-light-muted-foreground">
+            <p className="font-chivo text-[15px] text-light-muted-foreground">
               No archived conversations yet. Send a message on Home, leave the app idle for 30
               minutes, and it lands here.
             </p>
@@ -96,13 +96,13 @@ export default function PastConversationsPage() {
                   <div className="flex items-stretch gap-2">
                     <Link
                       href={`/past-conversations/${row.id}`}
-                      className="flex flex-1 items-center gap-3 rounded-2xl border border-light-foreground/10 bg-light-card-default px-4 py-3 backdrop-blur-[14px] backdrop-saturate-150"
+                      className="flex flex-1 items-center gap-3 rounded-2xl border border-light-foreground/25 bg-light-card-default px-4 py-3 backdrop-blur-[14px] backdrop-saturate-150"
                     >
                       <div className="flex min-w-0 flex-1 flex-col">
-                        <span className="font-inter text-[12px] font-normal text-light-muted-foreground">
+                        <span className="font-chivo text-[12px] font-normal text-light-muted-foreground">
                           {formatDate(row.lastMessageAt)} · {row.messageCount} turns
                         </span>
-                        <span className="line-clamp-2 break-words font-inter text-[15px] font-medium text-light-foreground">
+                        <span className="line-clamp-2 break-words font-chivo text-[15px] font-medium text-light-foreground">
                           {row.firstUserMessage || "(empty thread)"}
                         </span>
                       </div>
@@ -115,7 +115,7 @@ export default function PastConversationsPage() {
                       type="button"
                       onClick={() => void handleDelete(row.id)}
                       aria-label="Delete conversation"
-                      className="flex h-11 w-11 shrink-0 items-center justify-center self-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150"
+                      className="flex h-11 w-11 shrink-0 items-center justify-center self-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150"
                     >
                       <Trash2 className="h-4 w-4" strokeWidth={1.5} />
                     </button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -202,15 +202,16 @@
     transform-origin: center;
   }
 
-  /* Light System v1.0 §3.2 — eyebrow style.
-   * Reserved for the (light) route group; uses Inter via the font-inter family. */
+  /* Light System §3.2 — eyebrow style.
+   * Reserved for the (light) route group; uses Chivo via the font-chivo
+   * family. Anthracite-foreground revision: neutral dark text at 70%. */
   .label-eyebrow {
-    font-family: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
+    font-family: var(--font-chivo), ui-sans-serif, system-ui, sans-serif;
     font-size: 11px;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.14em;
-    color: hsl(20 14% 12% / 0.7);
+    color: hsl(0 0% 14% / 0.7);
   }
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Suspense } from "react";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
-import { JetBrains_Mono, Instrument_Serif, Fraunces, Inter } from "next/font/google";
+import { JetBrains_Mono, Instrument_Serif, Fraunces, Chivo } from "next/font/google";
 import "./globals.css";
 import BottomNav from "@/components/layout/BottomNav";
 import ScrollContainer from "@/components/layout/ScrollContainer";
@@ -21,10 +21,11 @@ const instrumentSerif = Instrument_Serif({
   display: "swap",
 });
 
-// Light System v1.0 §3.1 — Fraunces for hero questions, Inter for everything
-// else inside the (light) route group. Variables are exposed globally so the
-// (light) scope can opt in via `font-fraunces` / `font-inter` Tailwind
-// utilities. Dark-scope consumers continue to use Instrument Serif / Geist.
+// Light System §3.1 (anthracite revision) — Fraunces for hero questions,
+// Chivo for body text inside the (light) route group. Variables are
+// exposed globally so the (light) scope can opt in via `font-fraunces`
+// / `font-chivo` Tailwind utilities. Dark-scope consumers continue to
+// use Instrument Serif / Geist.
 const fraunces = Fraunces({
   subsets: ["latin"],
   weight: ["400", "500", "600"],
@@ -32,10 +33,10 @@ const fraunces = Fraunces({
   display: "swap",
 });
 
-const inter = Inter({
+const chivo = Chivo({
   subsets: ["latin"],
   weight: ["400", "500", "600"],
-  variable: "--font-inter",
+  variable: "--font-chivo",
   display: "swap",
 });
 
@@ -60,7 +61,7 @@ export const viewport: Viewport = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable} ${jetbrainsMono.variable} ${instrumentSerif.variable} ${fraunces.variable} ${inter.variable}`}>
+    <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable} ${jetbrainsMono.variable} ${instrumentSerif.variable} ${fraunces.variable} ${chivo.variable}`}>
       <head>
         <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
         <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />

--- a/src/components/ui/light/ActionPill.tsx
+++ b/src/components/ui/light/ActionPill.tsx
@@ -128,7 +128,7 @@ export default function ActionPill({ action }: { action: NavAction }) {
       type="button"
       onClick={() => void handleClick()}
       title={action.reason}
-      className="flex h-9 shrink-0 items-center gap-1.5 rounded-full border border-light-foreground/10 bg-light-card-default px-4 font-inter text-[13px] font-medium text-light-foreground backdrop-blur-[14px] backdrop-saturate-150"
+      className="flex h-9 shrink-0 items-center gap-1.5 rounded-full border border-light-foreground/25 bg-light-card-default px-4 font-chivo text-[13px] font-medium text-light-foreground backdrop-blur-[14px] backdrop-saturate-150"
     >
       <ActionPillIcon destination={action.destination} />
       {action.label}

--- a/src/components/ui/light/AttachmentSheet.tsx
+++ b/src/components/ui/light/AttachmentSheet.tsx
@@ -40,14 +40,14 @@ export default function AttachmentSheet({
         className="fixed inset-0 z-40 cursor-default"
       />
 
-      <div className="relative z-50 mb-2 mr-auto max-w-[280px] rounded-2xl border border-light-foreground/10 bg-light-card-default p-2 backdrop-blur-[14px] backdrop-saturate-150">
+      <div className="relative z-50 mb-2 mr-auto max-w-[280px] rounded-2xl border border-light-foreground/25 bg-light-card-default p-2 backdrop-blur-[14px] backdrop-saturate-150">
         <button
           type="button"
           onClick={onPickPhoto}
           className="flex h-10 w-full items-center gap-3 rounded-xl px-3 text-left"
         >
           <ImageIcon className="h-5 w-5 text-light-foreground/80" strokeWidth={1.5} />
-          <span className="font-inter text-[15px] font-medium text-light-foreground">
+          <span className="font-chivo text-[15px] font-medium text-light-foreground">
             Photo
           </span>
         </button>
@@ -58,7 +58,7 @@ export default function AttachmentSheet({
           className="flex h-10 w-full items-center gap-3 rounded-xl px-3 text-left disabled:opacity-40"
         >
           <CoffeeIcon className="h-5 w-5 text-light-foreground/80" strokeWidth={1.5} />
-          <span className="font-inter text-[15px] font-medium text-light-foreground">
+          <span className="font-chivo text-[15px] font-medium text-light-foreground">
             {coffeeLibraryEmpty ? "Reference coffee (library empty)" : "Reference coffee"}
           </span>
         </button>

--- a/src/components/ui/light/ChatInput.tsx
+++ b/src/components/ui/light/ChatInput.tsx
@@ -232,7 +232,7 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
         {(voiceError || uploadError) && (
           <div
             role="alert"
-            className="mb-2 rounded-2xl border border-light-foreground/10 bg-light-card-default px-3 py-2 font-inter text-[13px] text-light-foreground backdrop-blur-[14px] backdrop-saturate-150"
+            className="mb-2 rounded-2xl border border-light-foreground/25 bg-light-card-default px-3 py-2 font-chivo text-[13px] text-light-foreground backdrop-blur-[14px] backdrop-saturate-150"
           >
             {voiceError ?? uploadError}
           </div>
@@ -279,7 +279,7 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
               onClick={() => voice.cancel()}
               disabled={isTranscribing}
               aria-label="Cancel recording"
-              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150 disabled:opacity-50"
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150 disabled:opacity-50"
             >
               <X className="h-5 w-5" strokeWidth={1.5} />
             </button>
@@ -289,7 +289,7 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
               onClick={clearComposition}
               disabled={loading || uploadingImage}
               aria-label={loading ? "Sending" : "Clear"}
-              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150 disabled:opacity-50"
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150 disabled:opacity-50"
             >
               <X className="h-5 w-5" strokeWidth={1.5} />
             </button>
@@ -298,16 +298,16 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
               type="button"
               onClick={openSheet}
               aria-label="Attach"
-              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150"
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150"
             >
               <Plus className="h-5 w-5" strokeWidth={1.5} />
             </button>
           )}
 
           {loading ? (
-            <div className="h-11 flex-1 rounded-full border border-light-foreground/10 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150" />
+            <div className="h-11 flex-1 rounded-full border border-light-foreground/25 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150" />
           ) : isVoiceActive ? (
-            <div className="flex h-11 flex-1 items-center gap-2 rounded-full border border-light-foreground/10 bg-light-card-default pl-5 pr-1.5 backdrop-blur-[14px] backdrop-saturate-150">
+            <div className="flex h-11 flex-1 items-center gap-2 rounded-full border border-light-foreground/25 bg-light-card-default pl-5 pr-1.5 backdrop-blur-[14px] backdrop-saturate-150">
               <WaveformBars
                 getLevel={voice.getLevel}
                 color="hsl(20 14% 12%)"
@@ -334,7 +334,7 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
               )}
             </div>
           ) : (
-            <div className="flex min-h-11 flex-1 flex-col gap-2 rounded-3xl border border-light-foreground/10 bg-light-card-default py-1.5 pl-5 pr-1.5 backdrop-blur-[14px] backdrop-saturate-150">
+            <div className="flex min-h-11 flex-1 flex-col gap-2 rounded-3xl border border-light-foreground/25 bg-light-card-default py-1.5 pl-5 pr-1.5 backdrop-blur-[14px] backdrop-saturate-150">
               {(attachedImageUrl || uploadingImage) && (
                 <div className="relative h-20 w-20">
                   {attachedImageUrl ? (
@@ -365,16 +365,16 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
                 </div>
               )}
               {attachedCoffee && (
-                <div className="flex max-w-full items-start gap-2 rounded-xl border border-light-foreground/10 bg-light-card-default px-2.5 py-1.5">
+                <div className="flex max-w-full items-start gap-2 rounded-xl border border-light-foreground/25 bg-light-card-default px-2.5 py-1.5">
                   <CoffeeIcon
                     className="mt-0.5 h-3.5 w-3.5 shrink-0 text-light-foreground/80"
                     strokeWidth={1.5}
                   />
                   <div className="flex min-w-0 flex-1 flex-col">
-                    <span className="line-clamp-1 break-words font-inter text-[11px] font-normal text-light-muted-foreground">
+                    <span className="line-clamp-1 break-words font-chivo text-[11px] font-normal text-light-muted-foreground">
                       {attachedCoffee.roaster}
                     </span>
-                    <span className="line-clamp-2 break-words font-inter text-[13px] font-medium text-light-foreground">
+                    <span className="line-clamp-2 break-words font-chivo text-[13px] font-medium text-light-foreground">
                       {attachedCoffee.name}
                     </span>
                   </div>
@@ -400,12 +400,12 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
                     onInput={handleInput}
                     onFocus={handleFocus}
                     onPaste={handlePaste}
-                    className="block min-h-8 w-full whitespace-pre-wrap break-words font-inter text-[16px] font-normal leading-[2rem] text-light-foreground focus:outline-none"
+                    className="block min-h-8 w-full whitespace-pre-wrap break-words font-chivo text-[16px] font-normal leading-[2rem] text-light-foreground focus:outline-none"
                   />
                   {!hasText && (
                     <span
                       aria-hidden="true"
-                      className="pointer-events-none absolute left-0 top-0 font-inter text-[16px] font-normal leading-[2rem] text-light-muted-foreground"
+                      className="pointer-events-none absolute left-0 top-0 font-chivo text-[16px] font-normal leading-[2rem] text-light-muted-foreground"
                     >
                       Ask anything…
                     </span>

--- a/src/components/ui/light/ChatThread.tsx
+++ b/src/components/ui/light/ChatThread.tsx
@@ -123,7 +123,7 @@ export default function ChatThread({ messages, loading }: ChatThreadProps) {
             m.role === "user" ? (
               <div key={i} className="flex flex-col items-end gap-2">
                 {m.imageUrl && (
-                  <div className="max-w-[80%] overflow-hidden rounded-2xl border border-light-foreground/10 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150">
+                  <div className="max-w-[80%] overflow-hidden rounded-2xl border border-light-foreground/25 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={m.imageUrl}
@@ -133,21 +133,21 @@ export default function ChatThread({ messages, loading }: ChatThreadProps) {
                   </div>
                 )}
                 {m.coffeeRef && (
-                  <div className="flex max-w-[80%] items-start gap-3 rounded-2xl border border-light-foreground/10 bg-light-card-default px-4 py-3 backdrop-blur-[14px] backdrop-saturate-150">
+                  <div className="flex max-w-[80%] items-start gap-3 rounded-2xl border border-light-foreground/25 bg-light-card-default px-4 py-3 backdrop-blur-[14px] backdrop-saturate-150">
                     <CoffeeIcon className="mt-0.5 h-5 w-5 shrink-0 text-light-foreground/80" strokeWidth={1.5} />
                     <div className="flex min-w-0 flex-1 flex-col">
-                      <span className="line-clamp-2 break-words font-inter text-[13px] font-normal text-light-muted-foreground">
+                      <span className="line-clamp-2 break-words font-chivo text-[13px] font-normal text-light-muted-foreground">
                         {m.coffeeRef.roaster}
                       </span>
-                      <span className="break-words font-inter text-[15px] font-medium text-light-foreground">
+                      <span className="break-words font-chivo text-[15px] font-medium text-light-foreground">
                         {m.coffeeRef.name}
                       </span>
                     </div>
                   </div>
                 )}
                 {m.content && (
-                  <div className="max-w-[80%] rounded-2xl border border-light-foreground/10 bg-light-card-default px-4 py-3 backdrop-blur-[14px] backdrop-saturate-150">
-                    <p className="whitespace-pre-wrap font-inter text-[15px] font-normal text-light-foreground">
+                  <div className="max-w-[80%] rounded-2xl bg-light-card-default px-4 py-3 backdrop-blur-[14px] backdrop-saturate-150">
+                    <p className="whitespace-pre-wrap font-chivo text-[15px] font-normal text-light-foreground">
                       {m.content}
                     </p>
                   </div>
@@ -160,7 +160,7 @@ export default function ChatThread({ messages, loading }: ChatThreadProps) {
                     m.content.split(/\n\n+/).map((para, j) => (
                       <p
                         key={j}
-                        className="whitespace-pre-wrap font-inter text-[15px] font-normal leading-[1.5] text-light-foreground"
+                        className="whitespace-pre-wrap font-chivo text-[15px] font-normal leading-[1.5] text-light-foreground"
                       >
                         {renderInlineMarkdown(para)}
                       </p>

--- a/src/components/ui/light/LightShell.tsx
+++ b/src/components/ui/light/LightShell.tsx
@@ -16,7 +16,7 @@ import type { ReactNode } from "react";
  */
 export default function LightShell({ children }: { children: ReactNode }) {
   return (
-    <div data-light-scope="true" className="font-inter text-light-foreground min-h-dvh">
+    <div data-light-scope="true" className="font-chivo text-light-foreground min-h-dvh">
       <div
         aria-hidden
         className="pointer-events-none fixed inset-0 -z-10 overflow-hidden"

--- a/src/components/ui/light/NavigationOverlay.tsx
+++ b/src/components/ui/light/NavigationOverlay.tsx
@@ -63,7 +63,7 @@ export default function NavigationOverlay({ open, onClose }: NavigationOverlayPr
         type="button"
         onClick={onClose}
         aria-label="Close menu"
-        className="absolute right-5 top-12 flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/10 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
+        className="absolute right-5 top-12 flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
       >
         <X className="h-5 w-5" strokeWidth={1.5} />
       </button>
@@ -77,7 +77,7 @@ export default function NavigationOverlay({ open, onClose }: NavigationOverlayPr
               key={item.label}
               href={item.href}
               onClick={onClose}
-              className="font-inter text-[24px] font-medium text-light-foreground"
+              className="font-chivo text-[24px] font-medium text-light-foreground"
             >
               {item.label}
             </Link>
@@ -85,7 +85,7 @@ export default function NavigationOverlay({ open, onClose }: NavigationOverlayPr
             <span
               key={item.label}
               aria-disabled="true"
-              className="font-inter text-[24px] font-medium text-light-foreground/40"
+              className="font-chivo text-[24px] font-medium text-light-foreground/40"
             >
               {item.label}
             </span>

--- a/src/components/ui/light/ReferenceCoffeePicker.tsx
+++ b/src/components/ui/light/ReferenceCoffeePicker.tsx
@@ -63,14 +63,14 @@ export default function ReferenceCoffeePicker({
         className="fixed inset-0 z-50 cursor-default bg-light-foreground/10 backdrop-blur-[2px]"
       />
 
-      <div className="fixed inset-x-0 bottom-0 z-[60] flex max-h-[80vh] min-h-[60vh] flex-col rounded-t-2xl border border-light-foreground/10 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150">
+      <div className="fixed inset-x-0 bottom-0 z-[60] flex max-h-[80vh] min-h-[60vh] flex-col rounded-t-2xl border border-light-foreground/25 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150">
         <div className="mt-2 self-center">
           <span className="block h-1 w-10 rounded-full bg-light-foreground/30" />
         </div>
 
-        <div className="flex h-12 shrink-0 items-center gap-3 border-b border-light-foreground/10 px-5">
+        <div className="flex h-12 shrink-0 items-center gap-3 border-b border-light-foreground/25 px-5">
           <CoffeeIcon className="h-5 w-5 text-light-foreground/80" strokeWidth={1.5} />
-          <p className="font-inter text-[17px] font-medium text-light-foreground">
+          <p className="font-chivo text-[17px] font-medium text-light-foreground">
             Reference coffee
           </p>
         </div>
@@ -82,14 +82,14 @@ export default function ReferenceCoffeePicker({
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search roaster or coffee"
-            className="block h-11 w-full rounded-full border-0 bg-light-card-default px-5 font-inter text-[15px] font-normal text-light-foreground placeholder:text-light-muted-foreground focus:border-transparent focus:outline-none focus:ring-0 focus:ring-offset-0"
+            className="block h-11 w-full rounded-full border-0 bg-light-card-default px-5 font-chivo text-[15px] font-normal text-light-foreground placeholder:text-light-muted-foreground focus:border-transparent focus:outline-none focus:ring-0 focus:ring-offset-0"
             style={{ background: "hsl(36 55% 96% / 0.45)" }}
           />
         </div>
 
         <div className="flex-1 overflow-y-auto px-5 py-3 pb-[max(1rem,env(safe-area-inset-bottom))]">
           {filtered.length === 0 ? (
-            <p className="py-6 text-center font-inter text-[13px] text-light-muted-foreground">
+            <p className="py-6 text-center font-chivo text-[13px] text-light-muted-foreground">
               No matching coffees
             </p>
           ) : (
@@ -101,10 +101,10 @@ export default function ReferenceCoffeePicker({
                     onClick={() => onSelect(c)}
                     className="flex w-full flex-col gap-0.5 px-0 py-3 text-left"
                   >
-                    <span className="font-inter text-[13px] font-normal text-light-muted-foreground">
+                    <span className="font-chivo text-[13px] font-normal text-light-muted-foreground">
                       {c.roaster}
                     </span>
-                    <span className="font-inter text-[17px] font-medium text-light-foreground">
+                    <span className="font-chivo text-[17px] font-medium text-light-foreground">
                       {c.name}
                     </span>
                   </button>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -39,13 +39,17 @@ const config: Config = {
           accent: "#E8C5A8",
           edge: "rgba(255,235,220,0.08)",
         },
-        // Light System v1.0 — specs/design-system-v1.0.md §2.3, §2.4.
-        // Prefixed `light-` so they don't collide with Dark tokens or Tailwind
-        // defaults. Foreground entries use `<alpha-value>` so opacity modifiers
-        // (`text-light-foreground/70`, etc.) compile per spec §3.2.
+        // Light System tokens — neutral-anthracite revision.
+        // Background (Field gradient + Glass pills) stays warm cream from
+        // v1.0 §2.1 / §2.3. Foreground text shifts from the warm brown
+        // `hsl(20 14% 12%)` to a neutral anthracite for sharper reading.
+        // Borders use the same anthracite at higher opacity so the
+        // interactive-surface outlines (Chat input pill, Action Pills,
+        // Burger, +, Send, Coffee chip) are clearly defined against the
+        // cream Glass.
         light: {
-          foreground: "hsl(20 14% 12% / <alpha-value>)",
-          "muted-foreground": "hsl(20 8% 45% / <alpha-value>)",
+          foreground: "hsl(0 0% 14% / <alpha-value>)",
+          "muted-foreground": "hsl(0 0% 40% / <alpha-value>)",
           "card-default": "hsl(36 55% 96% / 0.55)",
           "card-selected": "hsl(28 22% 84% / 0.7)",
         },
@@ -55,11 +59,11 @@ const config: Config = {
         display: ["var(--font-instrument-serif)", "Georgia", "serif"],
         sans: ["var(--font-geist-sans)", "Inter", "system-ui", "sans-serif"],
         mono: ["var(--font-geist-mono)", "var(--font-jetbrains-mono)", "Fira Code", "monospace"],
-        // Light System v1.0 §3.1 — Fraunces (hero serif) + Inter (body sans).
-        // Scoped to (light) consumers via explicit `font-fraunces` / `font-inter`
+        // Light System — Fraunces (hero serif) + Chivo (body sans).
+        // Scoped to (light) consumers via explicit `font-fraunces` / `font-chivo`
         // classes so Dark routes keep their existing typography unchanged.
         fraunces: ["var(--font-fraunces)", "ui-serif", "Georgia", "serif"],
-        inter: ["var(--font-inter)", "ui-sans-serif", "system-ui", "sans-serif"],
+        chivo: ["var(--font-chivo)", "ui-sans-serif", "system-ui", "sans-serif"],
       },
       borderRadius: {
         sm: "8px",


### PR DESCRIPTION
## Summary

User feedback on Light System aesthetics. Cream Field background stays — only typography, foreground tone, and outline weights change.

### 1. Chivo replaces Inter

- `next/font/google` swaps `Inter` for `Chivo`
- `--font-inter` → `--font-chivo`, Tailwind family `inter` → `chivo`
- All `font-inter` consumers updated: ChatInput, ChatThread, NavigationOverlay, AttachmentSheet, ReferenceCoffeePicker, ActionPill, home, past-conversations pages, LightShell, `.label-eyebrow`

### 2. Anthracite foreground

- `light.foreground` from `hsl(20 14% 12%)` (warm brown) → `hsl(0 0% 14%)` (neutral anthracite)
- `light.muted-foreground` from `hsl(20 8% 45%)` → `hsl(0 0% 40%)`
- Field gradient stays warm cream — only text colour shifts
- Side effect: filled buttons that use `bg-light-foreground` (Send ↑, coffee chip ×, photo thumbnail ×) shift from warm-brown fills to anthracite fills; inner cream icon unchanged

### 3. Darker outlines on interactive surfaces

`border-light-foreground/10` → `border-light-foreground/25` across:
- Burger (header)
- `+` / `×` cancel buttons
- Voice & Send buttons
- Pre-Comp pill, voice recording pill, empty loading pill
- AttachmentSheet container
- In-pill coffee chip, photo thumbnail × button
- In-thread photo bubble, coffee reference bubble
- Action Pills (under agent responses)
- Past Conversations list rows + delete buttons
- ReferenceCoffeePicker container + back/menu pills

### 4. User text bubble: no outline, surface only

"Bei der Sprach-Bubble vom Text, den ich abgeschickt habe, keine outline, nur Fläche." → removed the border on the user text bubble in `ChatThread`. Photo and coffee-reference bubbles keep their outline since they need visible edges to define their content.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Auto-deploy runs green
- [ ] All body text on `/home` and `/past-conversations` renders in Chivo (geometric sans), heavier feel than Inter
- [ ] Text and icon colours read as anthracite-on-cream, not warm-brown-on-cream
- [ ] Pills (Chat input, +, Burger, Action Pills, Coffee chip, etc.) have a clearly visible dark outline
- [ ] User text bubble in the thread has no outline; just the cream Glass surface
- [ ] No regression on Dark routes

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_