### PR TITLE
style: home title — ExtraLight 200 + trailing period

### DIFF
--- a/src/app/(light)/home/page.tsx
+++ b/src/app/(light)/home/page.tsx
@@ -333,8 +333,8 @@ export default function HomePage() {
     <>
       <main className="flex h-dvh flex-col">
         <header className="flex shrink-0 items-center justify-between pl-5 pr-5 pt-12 pb-3">
-          <h1 className="font-chivo text-[14px] font-medium text-light-foreground/60">
-            Better taste than sorry
+          <h1 className="font-chivo text-[14px] font-extralight text-light-foreground/60">
+            Better taste than sorry.
           </h1>
           <button
             type="button"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,7 +35,7 @@ const fraunces = Fraunces({
 
 const chivo = Chivo({
   subsets: ["latin"],
-  weight: ["400", "500", "600"],
+  weight: ["200", "400", "500", "600"],
   variable: "--font-chivo",
   display: "swap",
 });


### PR DESCRIPTION
## Summary

Two-line tweak to the Home headline:

- `layout.tsx` adds weight `200` to the Chivo font loader so the ExtraLight glyph actually loads.
- `home/page.tsx` swaps `font-medium` (500) for `font-extralight` (200) on the `<h1>` and appends a period — "Better taste than sorry."

Past Conversations title kept at its current weight; user only asked about the Home headline.

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_