### PR TITLE
feat: recency bias for greeting + brew recommendations + time context

### DIFF
--- a/src/app/api/explore-agent/route.ts
+++ b/src/app/api/explore-agent/route.ts
@@ -54,7 +54,9 @@ You're a chat agent inside BrewLog. When the user asks "what can you do?" or "ca
 - **analyze_image**: download an image URL and read it visually — extract origin, varietal, process, roaster name, tasting notes from bag photos.
 - **suggest_navigation**: propose navigating to a BrewLog feature. Call this *during your response* whenever the conversation makes one of the in-app features genuinely useful. Be selective — only when it adds clear value, not as a reflex. You can call it multiple times in one turn (e.g. map + coffee detail).
 
-**Personalized context injected each turn (you don't need a tool — it's already below):** the user's recent recipes (dose/water/grind/temp/timing), their coffee library (bags currently in rotation), their equipment & grind settings, roaster style priors for roasters they're brewing, and recent research insights.
+**Personalized context injected each turn (you don't need a tool — it's already below):** current local time + weekday, the user's recent recipes (dose/water/grind/temp/timing), the bags **currently in rotation** (last 6 — this is *not* the full library, just what's open and active right now), their equipment & grind settings, roaster style priors for roasters they're brewing, and recent research insights.
+
+When the user asks "what should I brew?" / "what should I drink today?" / similar open-ended brew commands, restrict your candidates to the bags in the Coffee Library block below — that's the active rotation. Don't pull older bags out of memory; if none of the rotation fits, say so plainly.
 
 Mention capabilities only when relevant — don't pitch them unprompted.
 
@@ -429,7 +431,12 @@ export async function POST(req: NextRequest) {
 
     const [userPrefs, library] = await Promise.all([
       loadUserProfile().catch(() => null),
-      loadCoffeeLibraryCompact(30).catch(() => []),
+      // Only the bags in active rotation. Recommendations bias toward
+      // what the user is actually brewing right now, not their full
+      // historical library. The agent can still answer questions about
+      // older bags by name; this just keeps "what should I brew?"
+      // grounded in recent stock.
+      loadCoffeeLibraryCompact(6).catch(() => []),
     ]);
 
     const profileBlock = formatProfileForPrompt(userPrefs);
@@ -438,6 +445,23 @@ export async function POST(req: NextRequest) {
       : [];
 
     const contextParts: string[] = [];
+
+    // Current time injected per-turn (not cached) so the agent can
+    // interpret "right now", "today", "this morning" reliably.
+    const now = new Date();
+    const hour = now.getHours();
+    const timeOfDay =
+      hour < 5 ? "late night"
+      : hour < 11 ? "morning"
+      : hour < 14 ? "midday"
+      : hour < 18 ? "afternoon"
+      : hour < 22 ? "evening"
+      : "late night";
+    const weekday = now.toLocaleDateString("en-US", { weekday: "long" });
+    const dateStr = now.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "numeric" });
+    contextParts.push(
+      `\n## Current time\n${weekday} ${dateStr}, ${timeOfDay} (hour ${hour}, local time).`
+    );
 
     const recipesBlock = buildRecentRecipes(recentSessions, 5);
     if (recipesBlock) {

--- a/src/app/api/greeting/route.ts
+++ b/src/app/api/greeting/route.ts
@@ -56,7 +56,10 @@ export async function POST(req: NextRequest) {
     await req.json().catch(() => ({} as RequestBody));
 
     const [library, recentRows] = await Promise.all([
-      loadCoffeeLibraryCompact(30).catch(() => []),
+      // Only the last few bags in active rotation — the Haiku biases
+      // toward what the user is brewing right now, not their full
+      // historical library.
+      loadCoffeeLibraryCompact(4).catch(() => []),
       db
         .select()
         .from(sessions)
@@ -87,7 +90,7 @@ export async function POST(req: NextRequest) {
       })
       .filter(Boolean);
 
-    const libraryLines = library.slice(0, 8).map((c) => `- ${c.roaster} ${c.name}`.trim());
+    const libraryLines = library.slice(0, 4).map((c) => `- ${c.roaster} ${c.name}`.trim());
 
     const userBlock = [
       `Time of day: ${timeOfDay} (hour ${hour}, local time)`,


### PR DESCRIPTION
## Summary

Three tightening passes on the agent context per user feedback ("nur die letzten 3–4 Kaffees im AI-Haiku, nur die letzten 4–6 für 'was soll ich brewen?'", "versteht Claude auch Uhrzeit?").

### 1. Greeting (Haiku Starter) recency
`loadCoffeeLibraryCompact(30)` → `loadCoffeeLibraryCompact(4)`, and the prompt line drops from `slice(0, 8)` to `slice(0, 4)`. The morning line is now grounded in what the user is actually brewing right now, not a long historical tail.

### 2. Explore-agent recency for "what should I brew?"
`loadCoffeeLibraryCompact(30)` → `loadCoffeeLibraryCompact(6)`. The system prompt now states explicitly:

> When the user asks "what should I brew?" / "what should I drink today?" / similar open-ended brew commands, restrict your candidates to the bags in the Coffee Library block below — that's the active rotation. Don't pull older bags out of memory; if none of the rotation fits, say so plainly.

Older bags only surface when the user names them; recommendations stay grounded in the active rotation.

### 3. Time context for the agent
Added a fresh-per-turn `## Current time` block to the dynamic context (outside the cached system prompt): weekday, date, time-of-day bucket, raw hour. Lets the agent interpret "right now", "today", "this morning" reliably instead of guessing from natural-language cues.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Auto-deploy runs green
- [ ] First open tomorrow morning → Starter references at most 3–4 recent bags
- [ ] Ask "what should I brew?" → agent suggests only from the last ~6 bags (active rotation), names one or two
- [ ] Ask "is it morning here?" → agent picks up the actual time-of-day rather than hallucinating from "good morning" wording
- [ ] Ask about a bag from 6+ weeks ago by name → agent still answers (recent-sessions block carries the context)

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_