### PR TITLE
fix: reference coffee picker sorts by recency (latest scan first)

### DIFF
--- a/src/components/ui/light/ChatInput.tsx
+++ b/src/components/ui/light/ChatInput.tsx
@@ -72,13 +72,20 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
   const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Compact coffee list for the picker — fetched once on mount.
+  // Sorted by firstSeenAt DESC so the most-recently-scanned bag is at
+  // the top (matches the /coffees library page's default sort, and
+  // matches user expectation: "what did I just add" is what you
+  // usually want to reference).
   useEffect(() => {
     fetch("/api/coffees", { cache: "no-store" })
       .then((r) => (r.ok ? r.json() : []))
-      .then((data: { id: string; roaster: string; name: string }[]) => {
+      .then((data: { id: string; roaster: string; name: string; firstSeenAt?: string }[]) => {
         if (Array.isArray(data)) {
+          const sorted = [...data].sort((a, b) =>
+            (b.firstSeenAt || "").localeCompare(a.firstSeenAt || "")
+          );
           setCoffeeList(
-            data
+            sorted
               .filter((c) => c?.id && c?.name && c?.roaster)
               .map((c) => ({ id: c.id, roaster: c.roaster, name: c.name }))
           );


### PR DESCRIPTION
## Summary

User feedback: the Reference Coffee Picker should list the most-recently-scanned bag at the top — currently rows appear in DB-insertion order, hiding fresh bags.

Match the `/coffees` library page's existing default sort: client-side `firstSeenAt` DESC on the data fetched from `/api/coffees`, before stripping down to `{ id, roaster, name }` for the picker. `/api/coffees` itself stays unsorted for other consumers.

The three Hoppenworth & Ploch bags (last scanned) should land at the top after this.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Auto-deploy runs green
- [ ] Tap `+` → Reference coffee → top of the list is the latest scan
- [ ] Search still works (filter applies to the sorted list)

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_