### PR TITLE
style: step-context eyebrow shows the coffee name

### DIFF
--- a/src/components/flow/StepContext.tsx
+++ b/src/components/flow/StepContext.tsx
@@ -182,7 +182,9 @@ export default function StepContext() {
     <FlowShell onNext={handleNext} nextDisabled={!isComplete} nextLabel="Get My Recipe">
       <div className="px-5 py-4 flex flex-col gap-8">
         <div>
-          <p className="text-brew-muted text-xs tracking-widest uppercase mb-2">Context</p>
+          <p className="text-brew-muted text-xs tracking-widest uppercase mb-2">
+            Context{draft.coffee?.name ? ` · ${draft.coffee.name}` : ""}
+          </p>
           <h1 className="font-display text-2xl text-white">What&apos;s the vibe?</h1>
         </div>
 


### PR DESCRIPTION
## Summary

The Brew Context step's eyebrow currently reads "CONTEXT" — no signal which bag the user is about to brew. User feedback: append the coffee name so the eyebrow reads e.g. `CONTEXT · LA PRIMAVERA`.

Source: `flowStore.draft.coffee.name`. Falls back to plain "CONTEXT" when no coffee is set (rare — brew-from-scratch without a scan or brew-again path).

One-line change, purely presentational. Lands in the existing Dark `StepContext` so it's available immediately on `/brew/new`; the upcoming Light migration carries the same pattern into `<Hero eyebrow=...>`.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Auto-deploy runs green
- [ ] Brew a coffee from `/coffees/[id]` via "Brew this" → context eyebrow reads `CONTEXT · <coffee name>`
- [ ] Brew via the orange `+` from scratch (scan flow) → after Scan, Context eyebrow reads `CONTEXT · <extracted name>`

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_