### PR TITLE
feat: light-system fork of Brew Context behind /brew/preview

### DIFF
--- a/src/app/(light)/brew/preview/page.tsx
+++ b/src/app/(light)/brew/preview/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useFlowStore } from "@/store/flowStore";
+import StepMode from "@/components/flow/StepMode";
+import StepScan from "@/components/flow/StepScan";
+import LightStepContext from "@/components/flow/LightStepContext";
+import StepRecommend from "@/components/flow/StepRecommend";
+import StepBrew from "@/components/flow/StepBrew";
+import StepLog from "@/components/flow/StepLog";
+import StepSummary from "@/components/flow/StepSummary";
+import StepMatchResult from "@/components/flow/StepMatchResult";
+
+/**
+ * Light migration parallel route.
+ *
+ * Mirrors src/app/brew/new/page.tsx step-switch exactly, except step
+ * "context" renders <LightStepContext> instead of <StepContext>. All
+ * other steps render their Dark counterparts unchanged — this page is
+ * a deliberate Frankenstein during the view-by-view migration.
+ *
+ * The live Dark route stays at /brew/new and is the orange Plus button's
+ * destination. Switching to /brew/preview by URL is the only way to
+ * exercise the Light Context step. Cut-over (Phase 5 of the plan) will
+ * rename this directory to (light)/brew/new and delete the Dark page.
+ *
+ * NOTE: Dark step components inherit the (light) layout's Chivo body
+ * font — fine because they all set their own typography classes
+ * (font-display, font-sans, etc.), and any drift is acceptable during
+ * the migration since each Dark step is short-lived in this route.
+ */
+export default function BrewPreviewPage() {
+  const { step } = useFlowStore();
+
+  return (
+    <>
+      {step === "scan" && <StepScan />}
+      {step === "mode" && <StepMode />}
+      {step === "context" && <LightStepContext />}
+      {step === "recommend" && <StepRecommend />}
+      {step === "brew" && <StepBrew />}
+      {step === "log" && <StepLog />}
+      {step === "summary" && <StepSummary />}
+      {step === "match_result" && <StepMatchResult />}
+    </>
+  );
+}

--- a/src/components/flow/LightStepContext.tsx
+++ b/src/components/flow/LightStepContext.tsx
@@ -1,0 +1,562 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useFlowStore } from "@/store/flowStore";
+import LightFlowShell from "@/components/ui/light/LightFlowShell";
+import Hero from "@/components/ui/light/Hero";
+import Section from "@/components/ui/light/Section";
+import Footnote from "@/components/ui/light/Footnote";
+import Card, { CardTitle, CardSubText, CardIcon } from "@/components/ui/light/Card";
+import Chip from "@/components/ui/light/Chip";
+import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
+import { Brain, FlaskConical, Moon, Users, Snowflake } from "lucide-react";
+import type { Session, SessionContext } from "@/lib/types/session";
+
+/**
+ * Light System v1.0 fork of /components/flow/StepContext.tsx.
+ *
+ * Same flow logic — reads/writes the same flowStore, calls the same
+ * /api/recommend, hands off via the same `setStep("recommend")`. Only
+ * the visual layer changes: Dark surfaces (`bg-brew-surface`,
+ * `text-white`) become Light primitives (Card, Section, Footnote,
+ * Hero, CTA).
+ *
+ * Mounted ONLY by /app/(light)/brew/preview/page.tsx during migration.
+ * The Dark StepContext at /components/flow/StepContext.tsx is the live
+ * production component until the Light cut-over (Phase 5 of the plan).
+ *
+ * Spec deviations flagged for review:
+ *   - Section 3 (Time, 3 options) and Section 7 (Water, 3 options)
+ *     render as 3-column equal-width rows. Spec §5.2 mandates 2-col
+ *     grids with even card counts; the cleaner fix would be either
+ *     splitting or adding a wildcard, but both alter the data sent to
+ *     /api/recommend. Deferred — flagged in PR description.
+ *   - Section 4 (Goal, 5 options) renders 2-col with an orphan on
+ *     row 3. Same constraint as above.
+ *   - Section 6 (Brewing approach) keeps its expanding method list as
+ *     a vertical list of full-width method rows, not card-grid. The
+ *     section is fundamentally hierarchical (2-card mode toggle that
+ *     reveals a 12-option list) and doesn't fit the §5 grid pattern.
+ */
+
+async function getRecentSessions(limit: number): Promise<Session[]> {
+  const res = await fetch(`/api/sessions?limit=${limit}`);
+  if (!res.ok) return [];
+  return (await res.json()) as Session[];
+}
+
+// Sunrise icon without the upward arrow — matches the Dark version's
+// SunriseIcon byte-for-byte. The chevron read as a navigation cue at
+// card size, so the icon's arrow is stripped (Spec §9.2 custom-SVG
+// pattern, Lucide conventions).
+function SunriseIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="2 6 20 20"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      className={className}
+    >
+      <path d="M12 8v2" />
+      <path d="m4.93 10.93 1.41 1.41" />
+      <path d="M2 18h2" />
+      <path d="M20 18h2" />
+      <path d="m19.07 10.93-1.41 1.41" />
+      <path d="M22 22H2" />
+      <path d="M16 18a4 4 0 0 0-8 0" />
+    </svg>
+  );
+}
+
+const OCCASIONS = [
+  { id: "morning-ritual", label: "Morning Ritual", Icon: SunriseIcon, footnote: "A slower, deliberate pour that anchors the start of a day." },
+  { id: "focus", label: "Deep Focus", Icon: Brain, footnote: "A clean, alert cup for sustained concentration." },
+  { id: "social", label: "Social", Icon: Users, footnote: "Brewing for a guest or two — bigger batch, conversational pace." },
+  { id: "after-dinner", label: "After Dinner", Icon: Moon, footnote: "A digestive cup — lower volume, gentle finish." },
+  { id: "experiment", label: "Experiment", Icon: FlaskConical, footnote: "Push parameters — championship recipes, single-variable changes." },
+  { id: "summer-time", label: "Summer Time", Icon: Snowflake, footnote: "Iced or flash-chilled — bright, aromatic, cold-friendly." },
+];
+
+const AMOUNTS = [
+  { id: "small", label: "Small", sub: "350 ml", footnote: "A single cup — focused tasting, faster brew." },
+  { id: "big", label: "Big", sub: "520 ml", footnote: "Bigger batch for the morning — long, attentive pour." },
+  { id: "custom", label: "Custom", sub: "enter ml", footnote: null },
+  { id: "surprise", label: "Surprise me", sub: "Claude picks", footnote: "Claude picks everything freely — a 120 ml AeroPress concentrate, a 4:6 experiment, or something untried." },
+];
+
+const TIMES = [
+  { id: "quick", label: "Quick", sub: "~2 min" },
+  { id: "normal", label: "Normal", sub: "~5 min" },
+  { id: "unhurried", label: "Unhurried", sub: "7 min+" },
+];
+
+const GOALS = [
+  { id: "balanced", label: "Balanced", sub: "no taste-axis bias" },
+  { id: "high-clarity", label: "Bright / Clarity", sub: "Zone-1 emphasis" },
+  { id: "sweetness-forward", label: "Sweet", sub: "Zone-2 emphasis" },
+  { id: "body-forward", label: "Bold / Body", sub: "mouthfeel emphasis" },
+  { id: "explore", label: "Explore", sub: "wildcard / championship" },
+];
+
+const DEFAULT_GRINDERS = ["Niche Zero", "Comandante C40"];
+
+const METHODS = [
+  { id: "V60", label: "V60", sub: "Hario cone" },
+  { id: "Orea Fast", label: "Orea Fast", sub: "fast drip, max ~500 ml" },
+  { id: "Orea Apex", label: "Orea Apex", sub: "clarity & brightness" },
+  { id: "Orea Classic", label: "Orea Classic", sub: "sweetness focus" },
+  { id: "Orea Open", label: "Orea Open", sub: "open bed, max flow, max ~500 ml" },
+  { id: "Kalita Wave", label: "Kalita Wave", sub: "even bed, max ~500 ml" },
+  { id: "Origami (cone)", label: "Origami (cone)", sub: "ceramic, V60-like clarity, max ~500 ml" },
+  { id: "Origami (wave)", label: "Origami (wave)", sub: "ceramic, Kalita-like sweetness, max ~500 ml" },
+  { id: "Chemex", label: "Chemex", sub: "clean & bright, max ~600 ml" },
+  { id: "AeroPress", label: "AeroPress", sub: "max 230 ml · or concentrate" },
+  { id: "Clever Dripper", label: "Clever Dripper", sub: "immersion, max 400 ml" },
+  { id: "Moccamaster", label: "Moccamaster", sub: "batch brewer, ≥ 500 ml" },
+];
+
+const DRIP_ASSIST_COMPATIBLE = new Set<string>([
+  "V60", "Orea Fast", "Orea Apex", "Orea Classic", "Orea Open", "Kalita Wave", "Chemex",
+]);
+
+interface CoffeeMemory {
+  writtenSummary?: string;
+  whatToExplore?: string;
+}
+
+export default function LightStepContext() {
+  const { draft, setContext, setStep, setIsRecommending, setRecommendError } = useFlowStore();
+  const ctx = (draft.context || {}) as Partial<SessionContext>;
+  const [customMl, setCustomMl] = useState<string>("");
+  const [grinders, setGrinders] = useState<string[]>(DEFAULT_GRINDERS);
+  const [brewMode, setBrewMode] = useState<"ai" | "manual" | null>(null);
+  const [coffeeMemory, setCoffeeMemory] = useState<CoffeeMemory | null>(null);
+
+  useEffect(() => {
+    fetch("/api/preferences", { cache: "no-store" })
+      .then((r) => r.json())
+      .then((prefs: { grinder?: string } | null) => {
+        if (prefs?.grinder) {
+          const known = new Set([prefs.grinder, ...DEFAULT_GRINDERS]);
+          setGrinders(Array.from(known));
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    const coffeeId = draft.coffee?.coffeeId;
+    if (!coffeeId) return;
+    let cancelled = false;
+    fetch(`/api/coffees/${coffeeId}`, { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((coffee: { writtenSummary?: string; whatToExplore?: string } | null) => {
+        if (cancelled || !coffee) return;
+        if (coffee.writtenSummary || coffee.whatToExplore) {
+          setCoffeeMemory({
+            writtenSummary: coffee.writtenSummary,
+            whatToExplore: coffee.whatToExplore,
+          });
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [draft.coffee?.coffeeId]);
+
+  const updateCtx = (patch: Partial<SessionContext>) => {
+    setContext({ ...ctx, ...patch } as SessionContext);
+  };
+
+  const toggleField = <K extends keyof SessionContext>(key: K, value: SessionContext[K]) => {
+    const current = ctx[key];
+    const next = current === value ? ("" as SessionContext[K]) : value;
+    updateCtx({ [key]: next } as Partial<SessionContext>);
+  };
+
+  const isComplete = !!(
+    ctx.occasion &&
+    ctx.amount &&
+    ctx.timeAvailable &&
+    ctx.intent &&
+    (ctx.amount !== "custom" || (customMl.trim() !== "" && Number(customMl) >= 50))
+  );
+
+  const handleNext = async () => {
+    if (!isComplete) return;
+    const finalCtx: SessionContext = {
+      ...(ctx as SessionContext),
+      customWaterMl: ctx.amount === "custom" ? Number(customMl) : undefined,
+    };
+    setIsRecommending(true);
+    setRecommendError(null);
+    setStep("recommend");
+    try {
+      let pastSessions: Awaited<ReturnType<typeof getRecentSessions>> = [];
+      try {
+        pastSessions = await getRecentSessions(100);
+      } catch {}
+      const res = await fetch("/api/recommend", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ coffee: draft.coffee, context: finalCtx, pastSessions }),
+      });
+      if (!res.ok) throw new Error(`Recommendation failed (${res.status})`);
+      const recommendation = await res.json();
+      if (!recommendation.primaryMethod) throw new Error("No recommendation returned");
+      useFlowStore.getState().setRecommendation(recommendation);
+    } catch (err) {
+      setRecommendError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setIsRecommending(false);
+    }
+  };
+
+  const selectedOccasion = OCCASIONS.find((o) => o.id === ctx.occasion);
+  const selectedAmount = AMOUNTS.find((a) => a.id === ctx.amount);
+
+  return (
+    <LightFlowShell onNext={handleNext} nextDisabled={!isComplete} nextLabel="Get my recipe">
+      <Hero
+        eyebrow={`Context${draft.coffee?.name ? ` · ${draft.coffee.name}` : ""}`}
+        question={<>What&rsquo;s the vibe?</>}
+      />
+
+      {/* Brew memory — only when this coffee has prior history. */}
+      {coffeeMemory && (coffeeMemory.writtenSummary || coffeeMemory.whatToExplore) && (
+        <div className="mb-10 rounded-3xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 p-4 space-y-3">
+          {coffeeMemory.writtenSummary && (
+            <div>
+              <p className="label-eyebrow mb-1.5">Brew memory</p>
+              <p className="text-[14px] leading-relaxed text-light-foreground">
+                {coffeeMemory.writtenSummary}
+              </p>
+            </div>
+          )}
+          {coffeeMemory.whatToExplore && (
+            <div>
+              <p className="label-eyebrow mb-1.5">What to explore</p>
+              <p className="text-[14px] leading-relaxed text-light-foreground">
+                {coffeeMemory.whatToExplore}
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="space-y-10">
+        {/* Occasion — Hybrid Footnote (default + per-card). */}
+        <Section
+          eyebrow="Occasion"
+          footnote={
+            <Footnote>
+              {selectedOccasion ? selectedOccasion.footnote : "Sets the pace and ritual of this brew."}
+            </Footnote>
+          }
+        >
+          <div className="grid grid-cols-2 gap-3">
+            {OCCASIONS.map((o) => (
+              <div key={o.id} className="h-[104px]">
+                <Card
+                  selected={ctx.occasion === o.id}
+                  onClick={() => toggleField("occasion", o.id)}
+                  ariaLabel={o.label}
+                >
+                  <CardTitle>{o.label}</CardTitle>
+                  <CardIcon>
+                    <o.Icon className="h-5 w-5" strokeWidth={1.5} />
+                  </CardIcon>
+                </Card>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        {/* Amount — Reactive Footnote + Form-C input when "custom" selected. */}
+        <Section
+          eyebrow="How much?"
+          footnote={
+            selectedAmount?.footnote ? <Footnote>{selectedAmount.footnote}</Footnote> : null
+          }
+        >
+          <div className="grid grid-cols-2 gap-3">
+            {AMOUNTS.map((a) => {
+              const selected = ctx.amount === a.id;
+              return (
+                <div key={a.id} className="h-[104px]">
+                  <Card
+                    selected={selected}
+                    onClick={() => toggleField("amount", a.id)}
+                    ariaLabel={a.label}
+                  >
+                    <CardTitle>{a.label}</CardTitle>
+                    {a.id === "custom" && selected ? (
+                      <div
+                        className="flex items-baseline gap-1"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <input
+                          type="number"
+                          inputMode="numeric"
+                          min={50}
+                          max={900}
+                          value={customMl}
+                          onChange={(e) => setCustomMl(e.target.value)}
+                          placeholder="220"
+                          autoFocus
+                          className="w-14 bg-transparent text-center text-[15px] font-medium text-light-foreground outline-none [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                        />
+                        <span className="text-[12px] text-light-muted-foreground">ml</span>
+                      </div>
+                    ) : (
+                      <CardSubText>{a.sub}</CardSubText>
+                    )}
+                  </Card>
+                </div>
+              );
+            })}
+          </div>
+        </Section>
+
+        {/* Time — 3 options, equal-width row. */}
+        <Section eyebrow="Time available?">
+          <div className="grid grid-cols-3 gap-3">
+            {TIMES.map((t) => (
+              <div key={t.id} className="h-[88px]">
+                <Card
+                  selected={ctx.timeAvailable === t.id}
+                  onClick={() => toggleField("timeAvailable", t.id)}
+                  ariaLabel={t.label}
+                >
+                  <CardTitle>{t.label}</CardTitle>
+                  <CardSubText>{t.sub}</CardSubText>
+                </Card>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        {/* Goal — 5 options in 2-col, orphan on row 3. Educational Footnote. */}
+        <Section
+          eyebrow="Goal"
+          footnote={
+            <Footnote>
+              Your taste direction for this brew. Method selection is driven by science — every brewer in your equipment is eligible; the goal sharpens which is best for THIS coffee.
+            </Footnote>
+          }
+        >
+          <div className="grid grid-cols-2 gap-3">
+            {GOALS.map((g) => (
+              <div key={g.id} className="h-[88px]">
+                <Card
+                  selected={ctx.intent === g.id}
+                  onClick={() => toggleField("intent", g.id)}
+                  ariaLabel={g.label}
+                >
+                  <CardTitle>{g.label}</CardTitle>
+                  <CardSubText>{g.sub}</CardSubText>
+                </Card>
+              </div>
+            ))}
+          </div>
+        </Section>
+
+        {/* Grinder — Chips (compact, not card-grid). */}
+        <Section
+          eyebrow="Grinder"
+          footnote={
+            ctx.grinder ? (
+              <Footnote>
+                {ctx.grinder.toLowerCase().includes("niche")
+                  ? "Recipe will use Niche° values."
+                  : "Recipe will use click values."}
+              </Footnote>
+            ) : null
+          }
+        >
+          <div className="flex flex-wrap gap-2">
+            {grinders.map((g) => (
+              <Chip
+                key={g}
+                selected={ctx.grinder === g}
+                onClick={() => updateCtx({ grinder: ctx.grinder === g ? "" : g })}
+              >
+                {g}
+              </Chip>
+            ))}
+          </div>
+        </Section>
+
+        {/* Brewing approach — 2-card mode toggle + expanding method list. */}
+        <Section
+          eyebrow="Brewing approach"
+          footnote={
+            brewMode === "manual" && ctx.preferredMethod ? (
+              <Footnote>
+                {ctx.preferredMethod}
+                {ctx.dripAssist &&
+                ctx.preferredMethod !== "V60" &&
+                DRIP_ASSIST_COMPATIBLE.has(ctx.preferredMethod)
+                  ? " + Drip Assist"
+                  : ""}{" "}
+                locked in — Claude will dial in the full recipe for it.
+              </Footnote>
+            ) : brewMode === "manual" ? (
+              <Footnote>Tap a method to lock it in.</Footnote>
+            ) : brewMode === "ai" ? (
+              <Footnote>Claude picks the best method for this coffee &amp; context — and explains why.</Footnote>
+            ) : (
+              <Footnote>Pick a method below, or let Claude decide.</Footnote>
+            )
+          }
+        >
+          <div className="grid grid-cols-2 gap-3">
+            <div className="h-[88px]">
+              <Card
+                selected={brewMode === "ai"}
+                onClick={() => {
+                  setBrewMode("ai");
+                  setContext({ ...ctx, preferredMethod: "", dripAssist: false } as SessionContext);
+                }}
+                ariaLabel="Claude picks"
+              >
+                <CardTitle>Claude picks</CardTitle>
+                <CardSubText>Best method for this coffee</CardSubText>
+              </Card>
+            </div>
+            <div className="h-[88px]">
+              <Card
+                selected={brewMode === "manual"}
+                onClick={() => setBrewMode("manual")}
+                ariaLabel="I'll choose"
+              >
+                <CardTitle>I&rsquo;ll choose</CardTitle>
+                <CardSubText>Claude dials in the recipe</CardSubText>
+              </Card>
+            </div>
+          </div>
+
+          {/* Method list — expands when manual mode is active. */}
+          <div
+            className={`overflow-hidden transition-all duration-300 ${
+              brewMode === "manual" ? "max-h-[1100px] opacity-100 mt-3" : "max-h-0 opacity-0"
+            }`}
+          >
+            <div className="flex flex-col gap-2">
+              {METHODS.map((m) => {
+                const selected = ctx.preferredMethod === m.id;
+                return (
+                  <button
+                    key={m.id}
+                    type="button"
+                    onClick={() => {
+                      const newMethod = ctx.preferredMethod === m.id ? "" : m.id;
+                      setContext({
+                        ...ctx,
+                        preferredMethod: newMethod,
+                        dripAssist: DRIP_ASSIST_COMPATIBLE.has(newMethod) ? ctx.dripAssist : false,
+                      } as SessionContext);
+                    }}
+                    aria-pressed={selected}
+                    className={`flex items-center justify-between rounded-3xl px-4 py-3 backdrop-blur-light-card backdrop-saturate-150 transition-all ${
+                      selected
+                        ? "bg-light-card-selected scale-[0.99] shadow-light-card-pressed"
+                        : "bg-light-card-default"
+                    }`}
+                  >
+                    <div className="flex items-center gap-3">
+                      <BrewMethodIcon method={m.id} className="w-8 h-8 shrink-0 text-light-foreground" />
+                      <span className="text-[15px] font-medium text-light-foreground">{m.label}</span>
+                    </div>
+                    <span className="text-[12px] text-light-muted-foreground">{m.sub}</span>
+                  </button>
+                );
+              })}
+            </div>
+
+            {ctx.preferredMethod && DRIP_ASSIST_COMPATIBLE.has(ctx.preferredMethod) && (
+              <button
+                type="button"
+                onClick={() => updateCtx({ dripAssist: !ctx.dripAssist })}
+                aria-pressed={!!ctx.dripAssist}
+                className={`flex items-center justify-between w-full mt-2 rounded-3xl px-4 py-3 backdrop-blur-light-card backdrop-saturate-150 transition-all text-left ${
+                  ctx.dripAssist
+                    ? "bg-light-card-selected scale-[0.99] shadow-light-card-pressed"
+                    : "bg-light-card-default"
+                }`}
+              >
+                <div>
+                  <p className="text-[15px] font-medium text-light-foreground">With Drip Assist</p>
+                  <p className="text-[12px] text-light-muted-foreground mt-0.5">
+                    Hario disc — steadier pour for any pour-over
+                  </p>
+                </div>
+                <div
+                  className={`w-5 h-5 rounded-md flex items-center justify-center shrink-0 ${
+                    ctx.dripAssist ? "bg-light-foreground" : "border border-light-foreground/30"
+                  }`}
+                >
+                  {ctx.dripAssist && (
+                    <svg
+                      className="w-3.5 h-3.5 text-[hsl(36_55%_96%)]"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                      aria-hidden
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={3}
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
+                  )}
+                </div>
+              </button>
+            )}
+          </div>
+        </Section>
+
+        {/* Water — 3 options, equal-width row. Reactive Footnote. */}
+        <Section
+          eyebrow="Water"
+          footnote={
+            ctx.waterSource === "diluted" ? (
+              <Footnote>Equal parts tap and distilled water. SCA optimal range.</Footnote>
+            ) : ctx.waterSource === "tap" ? (
+              <Footnote>Above SCA ceiling. Recipe will adjust accordingly.</Footnote>
+            ) : ctx.waterSource === "championship" ? (
+              <Footnote>40–80 ppm TDS — championship water. Sharpest aromatic expression.</Footnote>
+            ) : null
+          }
+        >
+          <div className="grid grid-cols-3 gap-3">
+            {[
+              { id: "tap", label: "Tap only", sub: "~300 ppm" },
+              { id: "diluted", label: "Diluted", sub: "~150 ppm" },
+              { id: "championship", label: "Championship", sub: "50 ppm" },
+            ].map((w) => (
+              <div key={w.id} className="h-[88px]">
+                <Card
+                  selected={ctx.waterSource === w.id}
+                  onClick={() => toggleField("waterSource", w.id)}
+                  ariaLabel={w.label}
+                >
+                  <CardTitle>{w.label}</CardTitle>
+                  <CardSubText>{w.sub}</CardSubText>
+                </Card>
+              </div>
+            ))}
+          </div>
+        </Section>
+      </div>
+    </LightFlowShell>
+  );
+}

--- a/src/components/ui/light/CTA.tsx
+++ b/src/components/ui/light/CTA.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import type { ReactNode } from "react";
+import CTAWarmth from "./CTAWarmth";
+
+/**
+ * Light System v1.0 §7.5 — primary CTA (non-sticky).
+ *
+ * Button: h-14, rounded-full, anthracite fill, cream text, 15/600 label,
+ * active:scale-[0.99]. Sits at the end of page content; NOT pinned to
+ * the bottom. The spec §7.5 explicitly rejects sticky-bottom CTAs.
+ *
+ * Wrapper hosts the CTA Warmth (§2.2) as a -z-10 sibling so the warm
+ * glow scrolls with the button. Includes safe-area-inset-bottom padding
+ * so the button clears the iOS home indicator.
+ *
+ * `disabled` reduces opacity but keeps the button rendered — the section
+ * "completion" affordance is visual, not via absence (§10.5 spec).
+ */
+interface CTAProps {
+  onClick: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+  children: ReactNode;
+}
+
+export default function CTA({ onClick, disabled, loading, children }: CTAProps) {
+  return (
+    <div className="relative pt-6 pb-[max(1.5rem,env(safe-area-inset-bottom))]">
+      <CTAWarmth />
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled || loading}
+        className="h-14 w-full rounded-full bg-light-foreground text-[15px] font-semibold text-[hsl(36_55%_96%)] active:scale-[0.99] transition-transform disabled:opacity-40 disabled:active:scale-100"
+      >
+        {children}
+      </button>
+    </div>
+  );
+}

--- a/src/components/ui/light/CTAWarmth.tsx
+++ b/src/components/ui/light/CTAWarmth.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+/**
+ * Light System v1.0 §2.2 — local warmth gradient behind the CTA.
+ *
+ * Additive to the Field (§2.1), not a replacement. Sits in an absolute
+ * sibling inside the CTA wrapper, bleeds 20% past the viewport edges so
+ * the warmth feels environmental. Rendered via inline style: Tailwind
+ * does not scan src/lib for arbitrary class values, and the gradient
+ * lives in an .tsx file that's safer here than in a one-off utility
+ * (PR #40 precedent — bg-[linear-gradient(...)] in lib silently fails
+ * because content paths skip src/lib).
+ *
+ * Positioned ABSOLUTE inside a `relative` CTA wrapper (not page-level).
+ * The wrapper's relative + this layer's absolute keep the warmth glued
+ * to the CTA when the CTA scrolls (§8 hybrid gradient scroll).
+ */
+export default function CTAWarmth() {
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-x-[-20%] -bottom-10 -top-16 -z-10"
+      style={{
+        background:
+          "radial-gradient(ellipse at 50% 100%, hsl(12 88% 66% / 0.85) 0%, hsl(18 82% 74% / 0.5) 35%, transparent 70%)",
+        filter: "blur(50px)",
+      }}
+    />
+  );
+}

--- a/src/components/ui/light/Card.tsx
+++ b/src/components/ui/light/Card.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+/**
+ * Light System v1.0 §4 — Card primitive.
+ *
+ * Two states: Default and Selected (pressed).
+ *   - Default: cream glass at 55% with backdrop-blur + backdrop-saturate.
+ *   - Selected: warm taupe at 70%, scale-[0.98], warm inset shadow.
+ *
+ * The Card is `flex flex-col items-center justify-center text-center`.
+ * Children own their internal layout (Title above, Detail below). Fixed
+ * height is owned by the *section*, not the card — set `h-[104px]` on
+ * the grid container, not here, so all cards in a section share height
+ * (§5.2).
+ *
+ * Tap-to-deselect (§4.4) is the caller's responsibility — the Card
+ * doesn't manage state, it just renders the visual.
+ */
+interface CardProps {
+  selected?: boolean;
+  onClick?: () => void;
+  ariaLabel?: string;
+  className?: string;
+  children: ReactNode;
+}
+
+export default function Card({ selected, onClick, ariaLabel, className, children }: CardProps) {
+  const base =
+    "w-full h-full flex flex-col items-center justify-center text-center gap-1.5 " +
+    "rounded-3xl px-3 py-4 transition-all backdrop-blur-light-card backdrop-saturate-150";
+  const tone = selected
+    ? "bg-light-card-selected scale-[0.98] shadow-light-card-pressed"
+    : "bg-light-card-default";
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={selected}
+      aria-label={ariaLabel}
+      className={`${base} ${tone}${className ? ` ${className}` : ""}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * Card title — Inter/Chivo 15/500, foreground, leading-tight.
+ *
+ * Spec §3.2: card titles never wrap to three lines. If a label is long
+ * enough to break twice at 50% column width, shorten the label.
+ */
+export function CardTitle({ children }: { children: ReactNode }) {
+  return (
+    <p className="text-[15px] font-medium leading-tight text-light-foreground">{children}</p>
+  );
+}
+
+/**
+ * Card sub-text (Detail Form A) — Inter/Chivo 12/400, muted, line-clamp-2.
+ */
+export function CardSubText({ children }: { children: ReactNode }) {
+  return (
+    <p className="text-[12px] leading-tight text-light-muted-foreground line-clamp-2">
+      {children}
+    </p>
+  );
+}
+
+/**
+ * Card icon (Detail Form B) — Lucide line-icon sized externally, wrapped
+ * in an h-6 w-6 flex centering container so visual centre aligns with
+ * the title above (§9.1).
+ */
+export function CardIcon({ children }: { children: ReactNode }) {
+  return (
+    <div className="h-6 w-6 flex items-center justify-center text-light-foreground/80">
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/light/Chip.tsx
+++ b/src/components/ui/light/Chip.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+/**
+ * Light System — Chip variant.
+ *
+ * Not in design-system-v1.0.md (which only formalises Cards), but
+ * BrewLog has sections where the option labels are short and text-only
+ * (Grinder: "Niche Zero" / "Comandante C40"). A full Card grid would be
+ * visually heavy for two text labels. The Chip is a smaller, inline
+ * variant that follows the same Default → Selected tonal logic as the
+ * Card so they coexist cleanly within a Section.
+ *
+ * Default: same cream glass as Card.
+ * Selected: same warm taupe + inset shadow as Card, but no scale-down
+ * (chips are too small for the scale effect to read).
+ */
+interface ChipProps {
+  selected?: boolean;
+  onClick?: () => void;
+  children: ReactNode;
+}
+
+export default function Chip({ selected, onClick, children }: ChipProps) {
+  const base =
+    "inline-flex items-center px-4 py-2 rounded-full text-[13px] font-medium leading-tight " +
+    "transition-all backdrop-blur-light-card backdrop-saturate-150";
+  const tone = selected
+    ? "bg-light-card-selected text-light-foreground shadow-light-card-pressed"
+    : "bg-light-card-default text-light-foreground";
+
+  return (
+    <button type="button" onClick={onClick} aria-pressed={selected} className={`${base} ${tone}`}>
+      {children}
+    </button>
+  );
+}

--- a/src/components/ui/light/Footnote.tsx
+++ b/src/components/ui/light/Footnote.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+/**
+ * Light System v1.0 §6 — Footnote primitive.
+ *
+ * Single line (or short paragraph) of muted text below the section's
+ * cards. mt-3 internal — the Footnote does NOT own bottom space
+ * (§5.3 anti-pattern). Section spacing is applied by the parent's
+ * `space-y-10`, measured from the bottom of the Footnote.
+ *
+ * Three render modes per the spec (Educational / Reactive / Hybrid):
+ *   - Educational: caller renders <Footnote>{staticText}</Footnote>
+ *   - Reactive: caller guards with `{selected && <Footnote>...</Footnote>}`
+ *     so the Footnote is absent when nothing is selected.
+ *   - Hybrid: caller chooses default-vs-selected text inline.
+ *
+ * The component is intentionally dumb — no mode logic, no helper —
+ * because all three modes reduce to "render this line or don't".
+ */
+export default function Footnote({ children }: { children: ReactNode }) {
+  return (
+    <p className="mt-3 px-1 text-[12px] leading-relaxed text-light-muted-foreground">
+      {children}
+    </p>
+  );
+}

--- a/src/components/ui/light/Hero.tsx
+++ b/src/components/ui/light/Hero.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+/**
+ * Light System v1.0 §7.4 — Page hero (eyebrow + question).
+ *
+ * Eyebrow uses the `label-eyebrow` utility (Chivo 11/600 uppercase
+ * tracked, foreground/70). Question is Fraunces 40/600, leading 1.05,
+ * tracking -0.01em. Fraunces is reserved for the hero question on each
+ * view (§3.3) — do not use it for section headings or anywhere else.
+ *
+ * `pb-10` (40px) below hero before the first section. Container is
+ * applied by the caller; Hero is layout-agnostic.
+ */
+interface HeroProps {
+  eyebrow: ReactNode;
+  question: ReactNode;
+}
+
+export default function Hero({ eyebrow, question }: HeroProps) {
+  return (
+    <div className="pb-10">
+      <p className="label-eyebrow mb-3 px-1">{eyebrow}</p>
+      <h1 className="font-fraunces font-semibold text-[40px] leading-[1.05] tracking-[-0.01em] text-light-foreground px-1">
+        {question}
+      </h1>
+    </div>
+  );
+}

--- a/src/components/ui/light/LightFlowShell.tsx
+++ b/src/components/ui/light/LightFlowShell.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import { ChevronLeft } from "lucide-react";
+import { useFlowStore, type FlowStep } from "@/store/flowStore";
+import CTA from "./CTA";
+
+/**
+ * Light System v1.0 §7 — page skeleton for the brew flow.
+ *
+ * Header (§7.3): back button (left), progress dots (centre), spacer
+ * (right). Active dot = foreground/80; inactive = foreground/15.
+ *
+ * Body: caller renders <Hero>, <Section>s, etc. inside this Shell. The
+ * Shell does not provide the hero — different flow steps frame their
+ * own questions.
+ *
+ * CTA (§7.5): non-sticky. Sits at the end of the page content, not
+ * pinned. Wrapped in our <CTA> primitive which carries the CTA Warmth.
+ *
+ * Container is `max-w-[430px] mx-auto px-5`. The Field is already
+ * applied by the (light) route group's <LightShell>.
+ *
+ * Step sequence mirrors the Dark FlowShell — Light migration is
+ * view-by-view, the step machinery is shared.
+ */
+
+const HOME_STEPS: FlowStep[] = ["scan", "context", "recommend", "brew", "log", "summary"];
+const BREW_AGAIN_STEPS: FlowStep[] = ["context", "recommend", "brew", "log", "summary"];
+const EXTERNAL_STEPS: FlowStep[] = ["scan", "log", "summary"];
+const MATCH_STEPS: FlowStep[] = ["scan", "match_result"];
+
+interface LightFlowShellProps {
+  children: ReactNode;
+  onBack?: () => void;
+  onNext?: () => void;
+  nextLabel?: string;
+  nextDisabled?: boolean;
+  nextLoading?: boolean;
+}
+
+export default function LightFlowShell({
+  children,
+  onBack,
+  onNext,
+  nextLabel = "Next",
+  nextDisabled,
+  nextLoading,
+}: LightFlowShellProps) {
+  const { step, draft, skipScan } = useFlowStore();
+  const router = useRouter();
+
+  const steps =
+    draft.mode === "match"
+      ? MATCH_STEPS
+      : draft.mode === "external"
+        ? EXTERNAL_STEPS
+        : skipScan
+          ? BREW_AGAIN_STEPS
+          : HOME_STEPS;
+
+  const currentIndex = steps.indexOf(step as FlowStep);
+
+  const handleBack = () => {
+    if (onBack) {
+      onBack();
+      return;
+    }
+    if (skipScan && step === "context") {
+      router.push("/");
+      return;
+    }
+    if (currentIndex > 0) {
+      useFlowStore.getState().setStep(steps[currentIndex - 1]);
+    } else {
+      router.push("/");
+    }
+  };
+
+  return (
+    <div className="relative mx-auto max-w-[430px] px-5">
+      {/* Header (§7.3) */}
+      <div
+        className="flex items-center justify-between"
+        style={{ paddingTop: "calc(env(safe-area-inset-top) + 3rem)", paddingBottom: "2rem" }}
+      >
+        <button
+          type="button"
+          onClick={handleBack}
+          aria-label="Back"
+          className="h-9 w-9 -ml-2 rounded-full flex items-center justify-center text-light-foreground/70 active:scale-95 transition-transform"
+        >
+          <ChevronLeft className="h-5 w-5" strokeWidth={1.75} />
+        </button>
+        {currentIndex >= 0 ? (
+          <div className="flex items-center gap-2" aria-label={`Step ${currentIndex + 1} of ${steps.length}`}>
+            {steps.map((_, i) => (
+              <span
+                key={i}
+                className={`h-1.5 w-1.5 rounded-full ${
+                  i === currentIndex ? "bg-light-foreground/80" : "bg-light-foreground/15"
+                }`}
+              />
+            ))}
+          </div>
+        ) : (
+          <div />
+        )}
+        <div className="w-9" />
+      </div>
+
+      {/* Body */}
+      {children}
+
+      {/* Non-sticky CTA — sits in flow at end of content */}
+      {onNext && (
+        <CTA onClick={onNext} disabled={nextDisabled} loading={nextLoading}>
+          {nextLoading ? "…" : nextLabel}
+        </CTA>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/light/Section.tsx
+++ b/src/components/ui/light/Section.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+/**
+ * Light System v1.0 §5 — Section primitive.
+ *
+ * Anatomy: Eyebrow → grid/row of cards → optional Footnote. The Footnote
+ * is *part of the section* (§5.3); it does not own its own bottom space.
+ * Parent uses `space-y-10` to separate Sections (40px gap from the last
+ * visible element of one Section to the next eyebrow).
+ *
+ * The Section component renders eyebrow + children. Callers wrap their
+ * cards/chips in their own layout container (e.g. `grid grid-cols-2
+ * gap-3`) — the Section doesn't impose a grid because v1.0 has both
+ * card grids and chip rows.
+ *
+ * Footnote, when supplied, renders mt-3 below children — inside the
+ * Section, so it sits in the rhythm.
+ */
+interface SectionProps {
+  eyebrow: string;
+  footnote?: ReactNode;
+  children: ReactNode;
+}
+
+export default function Section({ eyebrow, footnote, children }: SectionProps) {
+  return (
+    <section>
+      <p className="label-eyebrow mb-3 px-1">{eyebrow}</p>
+      {children}
+      {footnote}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

First phase of the Dark → Light brew-flow migration (per `/root/.claude/plans/was-denkst-du-kriegen-golden-dusk.md`).

- Adds 8 Light primitives (`Card` + `CardTitle`/`CardSubText`/`CardIcon`, `Section`, `Footnote`, `Hero`, `CTA` + `CTAWarmth`, `Chip`, `LightFlowShell`) under `src/components/ui/light/`. All wired to the v1.0 spec (`specs/design-system-v1.0.md` §4–§7).
- Forks `StepContext.tsx` into `LightStepContext.tsx`. Same flowStore reads/writes, same `/api/recommend` POST, same handoff to step "recommend" — only the visual layer changes.
- Mounts the fork at `/brew/preview` via `src/app/(light)/brew/preview/page.tsx`. Step switcher mirrors `/brew/new` except `step === "context"` renders `LightStepContext`. All other steps render their Dark counterparts during the migration.

The live Dark `/brew/new` is **completely unchanged** — the orange Plus button still lands there, the morning brew flow is the same.

## How to test

1. Auto-deploy lands on Hetzner (no manual step).
2. Start a brew from the orange Plus button → `/brew/new` → progress to step Context normally.
3. Manually navigate the URL bar from `/brew/new` to `/brew/preview` (same flow state continues — flowStore is in sessionStorage).
4. Verify on the Light Context page:
   - [ ] Hero eyebrow shows `CONTEXT · <your coffee name>` (or just `CONTEXT` when entering without a coffee).
   - [ ] Hero question reads "What's the vibe?" in Fraunces.
   - [ ] Field gradient is the warm cream/peach atmosphere — no Dark surfaces inside the Context page.
   - [ ] Cards select with a warm taupe fill + slight scale-down + inset shadow. No coloured rings.
   - [ ] Tapping a selected card deselects it (single-select per section, tap-to-clear).
   - [ ] AMOUNT → "Custom" card swaps the sub-text for an inline number input + "ml" suffix. Tapping the input doesn't bubble to deselect the card.
   - [ ] Brewing approach: "I'll choose" expands the 12-method list; selecting a Drip-Assist-compatible method shows the toggle row below.
   - [ ] Footnotes appear/disappear per Section. Grinder, Water, Amount footnotes only render when selection drives them.
   - [ ] CTA "Get my recipe" is non-sticky (sits at end of content), disabled until all required fields are filled, advances to step Recommend on tap.
5. Navigate back into Dark steps from `/brew/preview` (e.g. back to Mode/Scan) — they will render Dark inside the Light field. Acceptable Frankenstein during migration.

## Known spec deviations (flagged for discussion)

These match the existing Dark UX; fixing them changes data sent to `/api/recommend`, so I deferred:

- **Time** (3 options) renders as a 3-column equal-width row. Spec §5.2 says 2-col grid with even card count.
- **Water** (3 options) — same.
- **Goal** (5 options) renders 2-col with an orphan on row 3. Spec wants even count or a split.
- **Brew memory** block (top), **method list** (expanding list under Brewing approach), and **Drip Assist toggle row** — none are formalised in the spec; they reproduce the Dark structure with Light tokens.

Two cleanup options for later: add a wildcard 4th/6th card to even out the count, or split into sub-sections. Both are non-trivial UX decisions, not for this PR.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean — `/brew/preview` registered, 5.73 kB
- [ ] Auto-deploy runs green
- [ ] Manual test on iPhone PWA per the steps above
- [ ] `/brew/new` (Dark) still loads the original Dark Context unchanged

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_