### PR TITLE
chore: add lovable-v7/ read-only reference scaffold

### DIFF
--- a/lovable-v7/.gitignore
+++ b/lovable-v7/.gitignore
@@ -1,0 +1,22 @@
+# Lovable export hygiene — keep this folder as source files only.
+# If the export ships any of the below, they get blocked here so the
+# repo doesn't bloat. The README explains the intent.
+
+node_modules/
+.next/
+dist/
+build/
+out/
+.cache/
+.lovable/
+*.log
+.DS_Store
+
+# Lockfiles — keep one if useful, but reject pnpm/yarn duplicates.
+# Comment any of these out if you want to keep them as audit trail.
+pnpm-lock.yaml
+yarn.lock
+
+# Environment files — never commit secrets even in a reference dir.
+.env
+.env.*

--- a/lovable-v7/README.md
+++ b/lovable-v7/README.md
@@ -1,0 +1,51 @@
+# Lovable v7 — Read-Only Design Reference
+
+This directory holds an exported snapshot of the Lovable v7 BrewLog
+project. **It is a reference, not application code.** Nothing here is
+imported by the live app; the production routes live under `src/`.
+
+## What it's for
+
+`specs/design-system-v1.0.md` was distilled from Lovable v7, but the
+spec covers *primitives and tokens*, not per-view content (card labels,
+sub-text, footnote copy, exact section counts, custom inputs). When
+the Light migration of a view starts, we read the matching view here
+to pull the exact composition.
+
+Example mismatches the spec alone couldn't have surfaced (caught
+post-deploy on `/brew/preview` PR #66):
+
+- Grinder section uses **Cards** with sub-text (`° values` / `click
+  values`), not Chips.
+- Water section is **2 cards** (Tap only / Championship), not 3.
+- Amount → Custom card carries the footnote **"Set your own target in
+  millilitres."**
+
+## How to use it
+
+1. The user paste-drops the Lovable export into this folder (any
+   structure Lovable produces is fine — typically `src/pages/`,
+   `src/components/`, `src/index.css`, `tailwind.config.ts`).
+2. When migrating a Light view, read the relevant Lovable page (e.g.
+   `lovable-v7/src/pages/BrewContext.tsx`) before writing the Light
+   fork.
+3. **Do not edit files here.** If a label needs to change, change it
+   in the live `src/` component AND update `specs/` if it's a
+   system-level rule. The Lovable export stays pristine as the
+   audit trail.
+
+## Lifecycle
+
+When all Light views are migrated and the production app no longer
+references Lovable as a source of truth, this directory can be
+removed. Until then, it's the canonical "what did Lovable show?"
+answer that prevents reading screenshots and guessing.
+
+## Not in scope
+
+- `node_modules` (don't commit)
+- `.lovable/` cache files (don't commit)
+- Build artifacts (`dist/`, `.next/`, etc. — don't commit)
+
+If the Lovable export contains those, prune before committing or add
+them to `.gitignore` under this path.


### PR DESCRIPTION
## Summary

Creates `lovable-v7/` as the place to drop an exported snapshot of the Lovable v7 BrewLog project. Read-only reference; nothing here is imported by the live app.

## Why

`specs/design-system-v1.0.md` covers tokens and primitives but not per-view content (card labels, sub-text, footnote copy, custom inputs). PR #66's Light Context spike shipped several content mismatches because there was no canonical reference in the repo (Grinder as chips not cards, Water 3 cards not 2, missing Custom footnote, etc.). The Lovable preview is gated behind login → my WebFetch returns 403, so I can't read it directly.

Future Light view migrations: read the matching Lovable page from `lovable-v7/`, then write the Light fork against it. Pasted screenshots and rebuild-from-memory are out.

## What's in the PR

- `lovable-v7/README.md` — explains scope, lifecycle, "do not edit" rule
- `lovable-v7/.gitignore` — preemptively blocks `node_modules`, build artifacts, `.env*` in case the Lovable export drags them in

## Next step (after merge)

You drop the Lovable export into `lovable-v7/` (push branch, GitHub web upload, or local commit — whatever's easiest). Then I read `lovable-v7/src/pages/BrewContext.tsx` (or wherever Lovable puts it) and fix `LightStepContext.tsx` to match.

## Test plan

- [x] No application code touched — no functional risk
- [x] Auto-deploy will run but the new directory is invisible to the app

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_