### PR TITLE
fix: exclude lovable-v7/ from docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Docker build context — keep it tight.
+# Everything `COPY . .` pulls in lands inside the production image and
+# inside Next.js's build worker scan path. Add only what's verified
+# unneeded for `next build` or runtime.
+
+# Lovable v7 reference export — kept in git as a design source of
+# truth, but never bundled. Without this exclude, Next.js's build
+# worker scans lovable-v7/src/App.tsx, fails to resolve its Vite-only
+# dependencies (react-router-dom, @radix-ui/*, @tanstack/react-query)
+# and the deploy crashes with exit code 1 (deploy #183, May 2026).
+lovable-v7/
+
+# Node + build caches — re-created inside the builder stage from a
+# clean `npm ci`. Stale local artifacts must not leak in.
+node_modules/
+.next/
+out/
+
+# Local git + editor state.
+.git/
+.DS_Store
+.vscode/
+.idea/
+
+# Local env files — secrets are injected via docker-compose env_file
+# or runtime env vars, never baked into the image.
+.env
+.env.local
+.env.development
+.env.development.local
+
+# Logs.
+*.log
+npm-debug.log*


### PR DESCRIPTION
## Summary

Deploy #183 failed: `npm run build` exited with code 1 because Next.js's build worker scanned `lovable-v7/src/App.tsx` and hit unresolved imports for `react-router-dom`, `@tanstack/react-query`, and `@radix-ui/*` — Vite-only dependencies the BrewLog runtime doesn't carry.

Local `next build` is unaffected (tsconfig exclude held there), so the issue only surfaced on the Hetzner deploy. The fix is the `.dockerignore` that was missing entirely from the repo.

## What the `.dockerignore` excludes

- `lovable-v7/` — kept in git as a design reference but no longer baked into the image
- `node_modules/`, `.next/`, `out/` — caches re-created in the builder stage
- `.git/`, `.DS_Store`, `.vscode/`, `.idea/` — local + editor state
- `.env*` (except `.env.example` if it ever appears) — secrets are injected via docker-compose env_file at runtime
- `*.log`, `npm-debug.log*`

Scope kept narrow: `docs/`, `specs/`, and `scripts/` are NOT excluded in this PR. They're small and excluding them needs verification that nothing in the runtime references them — separate cleanup if you want it.

## Test plan

- [ ] Auto-deploy runs green (this is the actual test)
- [ ] `/brew/preview` shows the Lovable-matching Light Context once the new image is live
- [ ] `/brew/new` (Dark) loads unchanged

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_