### PR TITLE
fix: sunrise icon size + add 6th goal aromatic / floral

### DIFF
--- a/src/components/flow/LightStepContext.tsx
+++ b/src/components/flow/LightStepContext.tsx
@@ -47,10 +47,17 @@ async function getRecentSessions(limit: number): Promise<Session[]> {
 }
 
 /**
- * Sunrise without the upward arrow — Lovable v7's geometric variant.
- * Path data lifted verbatim from lovable-v7/src/pages/Index.tsx so the
- * cards read identically. Replaces the earlier lucide-derived sunrise
- * which had a thicker, busier silhouette.
+ * Sunrise without the upward arrow. Spec §9.2 wants the chevron
+ * removed because at card size it reads as a navigation cue.
+ *
+ * Lovable's source variant (lovable-v7/src/pages/Index.tsx) compresses
+ * the geometry to y=7..17 of the 24×24 viewBox — only 40% of the
+ * vertical space — which renders visibly smaller than the lucide
+ * icons next to it (Brain, Moon, Users, FlaskConical) that fill the
+ * full box. Fix: keep the same artistic intent (rays + horizon + sun
+ * arc, no arrow) but use the lucide Sunrise paths sans the arrow
+ * chevron, which span the full box and visually match the other
+ * occasion icons.
  */
 function SunriseNoArrow({ className }: { className?: string }) {
   return (
@@ -64,13 +71,13 @@ function SunriseNoArrow({ className }: { className?: string }) {
       aria-hidden
       className={className}
     >
-      <path d="M4 17 L20 17" />
-      <path d="M7 17 A5 5 0 0 1 17 17" />
-      <path d="M4 12 L6 14" />
-      <path d="M7 9 L8.5 10.5" />
-      <path d="M12 7 L12 9" />
-      <path d="M17 9 L15.5 10.5" />
-      <path d="M20 12 L18 14" />
+      <path d="M12 2v8" />
+      <path d="m4.93 10.93 1.41 1.41" />
+      <path d="M2 18h2" />
+      <path d="M20 18h2" />
+      <path d="m19.07 10.93-1.41 1.41" />
+      <path d="M22 22H2" />
+      <path d="M16 18a4 4 0 0 0-8 0" />
     </svg>
   );
 }

--- a/src/components/flow/LightStepContext.tsx
+++ b/src/components/flow/LightStepContext.tsx
@@ -33,11 +33,14 @@ import type { Session, SessionContext } from "@/lib/types/session";
  *     per Markus-feedback (PR #65). Lovable's eyebrow is just
  *     "Context".
  *
- * Deferred to a separate PR (touches /api/recommend prompt):
- *   - GOAL: Lovable adds "Aromatic / Floral" and renames IDs to
- *     bright/sweet/bold. Both require prompt updates + sample-
- *     validation per CLAUDE.md hard rule. This file keeps the
- *     current 5-ID set unchanged.
+ * GOAL preserves the existing 4 ID strings (balanced/high-clarity/
+ * sweetness-forward/body-forward/explore) and adds Lovable's 6th
+ * card "Aromatic / Floral" as new id `aromatic`. Renaming the
+ * existing IDs to Lovable's bright/sweet/bold scheme would change
+ * historical-session interpretation without functional benefit, so
+ * it's been deferred indefinitely. The /api/recommend prompt grew
+ * a sixth GOAL VOCABULARY entry to accept "aromatic" — see the
+ * companion change in src/lib/claude/recommend.ts.
  */
 
 async function getRecentSessions(limit: number): Promise<Session[]> {
@@ -108,6 +111,7 @@ const GOALS = [
   { id: "high-clarity", label: "Bright / Clarity", sub: "Zone-1 emphasis" },
   { id: "sweetness-forward", label: "Sweet", sub: "Zone-2 emphasis" },
   { id: "body-forward", label: "Bold / Body", sub: "mouthfeel emphasis" },
+  { id: "aromatic", label: "Aromatic / Floral", sub: "volatile & delicate emphasis" },
   { id: "explore", label: "Explore", sub: "Wildcard" },
 ];
 
@@ -342,9 +346,11 @@ export default function LightStepContext() {
           </div>
         </Section>
 
-        {/* GOAL — current 5-ID set preserved. Educational footnote.
-            Aromatic + ID rename moved to a follow-up PR (touches the
-            /api/recommend prompt — Hard Rule validation). */}
+        {/* GOAL — 6 cards (Lovable parity). Educational footnote.
+            Existing 5 IDs are kept; Aromatic / Floral added as the
+            new id "aromatic" — recognised by the /api/recommend
+            prompt (companion change in src/lib/claude/recommend.ts).
+            ID rename to bright/sweet/bold deferred indefinitely. */}
         <Section
           eyebrow="Goal"
           footnote={

--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -75,9 +75,10 @@ GOAL VOCABULARY:
 - "high-clarity" → clarity-forward. Methods/recipes that minimize bed agitation and maximize Zone-1 expression. Ethiopian washed, Kenyan, Gesha naturally fit; the goal sharpens the choice.
 - "sweetness-forward" → longer sugar contact, gentler agitation, methods that develop body without invading Zone 3.
 - "body-forward" → body emphasis. Slightly richer ratio acceptable, longer contact, methods that build mouthfeel.
+- "aromatic" → aromatic-forward. Maximize preservation of volatile top-note compounds — jasmine, bergamot, peach, citrus zest, tea-like delicacy. Cool bloom (Hsu 2022 staged-temp), low-mineral water bias, minimal agitation, prompt drawdown. Geisha, Wush Wush, Pink Bourbon (per WCR 2024 — closer to Ethiopian landrace than Bourbon), Sidra, Ethiopian washed/natural especially appropriate. Distinct from "high-clarity" — clarity emphasises overall cup transparency; aromatic emphasises the fragile olfactory top layer specifically.
 - "explore" → wildcard-led. At least one candidate must be a method the user has not tried for this coffee, with high educational value. Championship/reference recipes (Peng, Wölfl, Kasuya, Origami Air M, Hoffmann AeroPress, AeroPress Bypass, Clever Extended, Orea Apex/Classic/Open, Turbo V60) are especially appropriate here — but they are NOT exclusive to this goal.
 
-OVERRIDE RULE: Goal beats process default. "Natural → sweetness-oriented" is a soft default that applies ONLY when goal is "balanced" or "sweetness-forward". For Natural coffee with goal="high-clarity" or "body-forward", build to the goal, not the process default.
+OVERRIDE RULE: Goal beats process default. "Natural → sweetness-oriented" is a soft default that applies ONLY when goal is "balanced" or "sweetness-forward". For Natural coffee with goal="high-clarity", "body-forward", or "aromatic", build to the goal, not the process default.
 
 OCCASION ROUTING (physical/temporal only, never taste-direction):
 - "summer-time" = iced coffee; route to Japanese Iced V60, Japanese Iced Kalita, AeroPress Iced, or Hoffmann Immersion Iced (Clever Dripper); "amount" = final drink including melted ice


### PR DESCRIPTION
**Closed — split into two PRs per CLAUDE.md hard rule on behavioural changes.**

The original bundle conflated a cosmetic icon fix with an AI-prompt change, and I cannot sample real `/api/recommend` outputs from this remote environment to validate the prompt change. Splitting:

- **Cosmetic-only** → PR #71 (`claude/sunrise-icon-fix-only`) — sunrise icon fills the full 24×24 viewBox. Safe to merge immediately.
- **AI behaviour change** → PR #72 (`claude/goal-aromatic-floral`) — 6th GOAL card "Aromatic / Floral" + `/api/recommend` prompt branch. Holds open until Markus runs the test plan on the deployed PWA.

No work lost; both commits live in the new branches.