### PR TITLE
feat: add aromatic / floral as 6th goal in light step-context

### DIFF
--- a/src/components/flow/LightStepContext.tsx
+++ b/src/components/flow/LightStepContext.tsx
@@ -33,11 +33,14 @@ import type { Session, SessionContext } from "@/lib/types/session";
  *     per Markus-feedback (PR #65). Lovable's eyebrow is just
  *     "Context".
  *
- * Deferred to a separate PR (touches /api/recommend prompt):
- *   - GOAL: Lovable adds "Aromatic / Floral" and renames IDs to
- *     bright/sweet/bold. Both require prompt updates + sample-
- *     validation per CLAUDE.md hard rule. This file keeps the
- *     current 5-ID set unchanged.
+ * GOAL preserves the existing 4 ID strings (balanced/high-clarity/
+ * sweetness-forward/body-forward/explore) and adds Lovable's 6th
+ * card "Aromatic / Floral" as new id `aromatic`. Renaming the
+ * existing IDs to Lovable's bright/sweet/bold scheme would change
+ * historical-session interpretation without functional benefit, so
+ * it's been deferred indefinitely. The /api/recommend prompt grew
+ * a sixth GOAL VOCABULARY entry to accept "aromatic" — see the
+ * companion change in src/lib/claude/recommend.ts.
  */
 
 async function getRecentSessions(limit: number): Promise<Session[]> {
@@ -101,6 +104,7 @@ const GOALS = [
   { id: "high-clarity", label: "Bright / Clarity", sub: "Zone-1 emphasis" },
   { id: "sweetness-forward", label: "Sweet", sub: "Zone-2 emphasis" },
   { id: "body-forward", label: "Bold / Body", sub: "mouthfeel emphasis" },
+  { id: "aromatic", label: "Aromatic / Floral", sub: "volatile & delicate emphasis" },
   { id: "explore", label: "Explore", sub: "Wildcard" },
 ];
 
@@ -335,9 +339,11 @@ export default function LightStepContext() {
           </div>
         </Section>
 
-        {/* GOAL — current 5-ID set preserved. Educational footnote.
-            Aromatic + ID rename moved to a follow-up PR (touches the
-            /api/recommend prompt — Hard Rule validation). */}
+        {/* GOAL — 6 cards (Lovable parity). Educational footnote.
+            Existing 5 IDs are kept; Aromatic / Floral added as the
+            new id "aromatic" — recognised by the /api/recommend
+            prompt (companion change in src/lib/claude/recommend.ts).
+            ID rename to bright/sweet/bold deferred indefinitely. */}
         <Section
           eyebrow="Goal"
           footnote={

--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -75,9 +75,10 @@ GOAL VOCABULARY:
 - "high-clarity" → clarity-forward. Methods/recipes that minimize bed agitation and maximize Zone-1 expression. Ethiopian washed, Kenyan, Gesha naturally fit; the goal sharpens the choice.
 - "sweetness-forward" → longer sugar contact, gentler agitation, methods that develop body without invading Zone 3.
 - "body-forward" → body emphasis. Slightly richer ratio acceptable, longer contact, methods that build mouthfeel.
+- "aromatic" → aromatic-forward. Maximize preservation of volatile top-note compounds — jasmine, bergamot, peach, citrus zest, tea-like delicacy. Cool bloom (Hsu 2022 staged-temp), low-mineral water bias, minimal agitation, prompt drawdown. Geisha, Wush Wush, Pink Bourbon (per WCR 2024 — closer to Ethiopian landrace than Bourbon), Sidra, Ethiopian washed/natural especially appropriate. Distinct from "high-clarity" — clarity emphasises overall cup transparency; aromatic emphasises the fragile olfactory top layer specifically.
 - "explore" → wildcard-led. At least one candidate must be a method the user has not tried for this coffee, with high educational value. Championship/reference recipes (Peng, Wölfl, Kasuya, Origami Air M, Hoffmann AeroPress, AeroPress Bypass, Clever Extended, Orea Apex/Classic/Open, Turbo V60) are especially appropriate here — but they are NOT exclusive to this goal.
 
-OVERRIDE RULE: Goal beats process default. "Natural → sweetness-oriented" is a soft default that applies ONLY when goal is "balanced" or "sweetness-forward". For Natural coffee with goal="high-clarity" or "body-forward", build to the goal, not the process default.
+OVERRIDE RULE: Goal beats process default. "Natural → sweetness-oriented" is a soft default that applies ONLY when goal is "balanced" or "sweetness-forward". For Natural coffee with goal="high-clarity", "body-forward", or "aromatic", build to the goal, not the process default.
 
 OCCASION ROUTING (physical/temporal only, never taste-direction):
 - "summer-time" = iced coffee; route to Japanese Iced V60, Japanese Iced Kalita, AeroPress Iced, or Hoffmann Immersion Iced (Clever Dripper); "amount" = final drink including melted ice


### PR DESCRIPTION
## Summary

Adds Lovable v7's 6th GOAL card — "Aromatic / Floral" — with a companion branch in the `/api/recommend` prompt. Final layout matches Lovable's 3-row × 2-col grid exactly (no orphan card).

### What changes

- `src/components/flow/LightStepContext.tsx` — 6th card `{ id: "aromatic", label: "Aromatic / Floral", sub: "volatile & delicate emphasis" }`
- `src/lib/claude/recommend.ts` — new "aromatic" entry in GOAL VOCABULARY between body-forward and explore. Definition: maximize volatile top-note preservation (jasmine, bergamot, peach, citrus zest), cool bloom (Hsu 2022 staged-temp), low-mineral water bias, minimal agitation, prompt drawdown. Cites Geisha / Wush Wush / Pink Bourbon (per WCR 2024) / Sidra / Ethiopian washed-natural as fits — same coffees the knowledge-layer varieties module already flags as intense aromatics.
- `recommend.ts` — OVERRIDE RULE updated so `aromatic` joins `high-clarity` / `body-forward` in beating the "Natural → sweetness" process default.

Existing IDs (`balanced` / `high-clarity` / `sweetness-forward` / `body-forward` / `explore`) are **not** renamed — historical sessions keep their meaning, no migration needed. The Lovable bright/sweet/bold rename remains deferred indefinitely (cosmetic only, no functional benefit worth the validation cost).

## ⚠️ Validation gate — DO NOT merge until tested

CLAUDE.md's hard rule on AI behaviour changes requires sample-validation before shipping. **I cannot sample from this remote environment** — no Anthropic credentials, no DB access. The prompt change is structured to be additive only (new branch fires only when `intent === "aromatic"`; old sessions never set it; existing 5 branches untouched), but the rule is explicit and recent. Markus runs this on the deployed PWA before merge.

### Test plan — Markus on PWA

1. **Existing GOAL options unchanged**
   - [ ] Brew with goal "Bright / Clarity" → recipes should be the same character as before this PR (clarity-forward, low agitation, Ethiopian/Kenyan/Gesha vibes).
   - [ ] Brew with goal "Bold / Body" → same as before (body emphasis, longer contact).
   - [ ] Brew with goal "Balanced" → unchanged.
2. **Aromatic / Floral is the new behaviour**
   - [ ] Brew with goal "Aromatic / Floral" on a delicate coffee (Geisha, Wush Wush, Pink Bourbon, Ethiopian washed). Recipes should lean toward: cool bloom (Hsu 2022 staged-temp ~70°C bloom → 95°C), championship/low-mineral water, minimal agitation, prompt drawdown.
   - [ ] Brew with goal "Aromatic / Floral" on a Natural — the override rule should kick in: build to aromatic, not the natural-sweetness default.
   - [ ] Compare against goal "Bright / Clarity" on the same coffee: aromatic should emphasise volatile top notes (jasmine/bergamot/peach), clarity should emphasise overall cup transparency.

Once those pass, merge this. If anything is off, revert is trivial — single squash-commit.

## Test plan (local)

- [x] `npx tsc --noEmit` clean
- [ ] Markus runs the brew tests above

This is the AI-behaviour half of the original PR #70.

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_