### PR TITLE
fix: light step-log chip sizes + focus ring suppression

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -213,6 +213,23 @@
     letter-spacing: 0.14em;
     color: hsl(0 0% 14% / 0.7);
   }
+
+  /* Light System — suppress @tailwindcss/forms blue focus ring inside the
+   * (light) route group. The forms plugin applies a 2px ring-blue-500
+   * box-shadow on focus to every <input>/<textarea>/<select>; that ring
+   * is a hard visual mismatch on the warm Light field. Suppress globally
+   * for anything inside [data-light-scope] so individual components don't
+   * have to repeat focus:outline-none focus:ring-0 on every field. */
+  [data-light-scope] input:focus,
+  [data-light-scope] textarea:focus,
+  [data-light-scope] select:focus {
+    --tw-ring-color: transparent;
+    --tw-ring-shadow: 0 0 #0000;
+    --tw-ring-offset-shadow: 0 0 #0000;
+    box-shadow: none;
+    outline: none;
+    border-color: inherit;
+  }
 }
 
 /*

--- a/src/components/flow/LightStepLog.tsx
+++ b/src/components/flow/LightStepLog.tsx
@@ -199,7 +199,7 @@ export default function LightStepLog() {
             <Section eyebrow="Flow">
               <div className="flex flex-wrap gap-2">
                 {FLOW_OPTIONS.map((o) => (
-                  <Chip key={o} size="sm" selected={flow === o} onClick={() => setFlow((prev) => (prev === o ? "" : o))}>
+                  <Chip key={o} selected={flow === o} onClick={() => setFlow((prev) => (prev === o ? "" : o))}>
                     {FLOW_LABELS[o]}
                   </Chip>
                 ))}
@@ -209,7 +209,7 @@ export default function LightStepLog() {
             <Section eyebrow="Timing">
               <div className="flex flex-wrap gap-2">
                 {TIMING_OPTIONS.map((o) => (
-                  <Chip key={o} size="sm" selected={timing === o} onClick={() => setTiming((prev) => (prev === o ? "" : o))}>
+                  <Chip key={o} selected={timing === o} onClick={() => setTiming((prev) => (prev === o ? "" : o))}>
                     {TIMING_LABELS[o]}
                   </Chip>
                 ))}
@@ -237,7 +237,7 @@ export default function LightStepLog() {
             <Section eyebrow="Agitation">
               <div className="flex flex-wrap gap-2">
                 {AGITATION_OPTIONS.map((o) => (
-                  <Chip key={o} size="sm" selected={followedAgitation === o} onClick={() => setFollowedAgitation((prev) => (prev === o ? "" : o))}>
+                  <Chip key={o} selected={followedAgitation === o} onClick={() => setFollowedAgitation((prev) => (prev === o ? "" : o))}>
                     {AGITATION_LABELS[o]}
                   </Chip>
                 ))}


### PR DESCRIPTION
## Summary

Two on-device issues from Markus' `/brew/preview` test:

### 1. Chip sizes unified

Flow, Timing, and Agitation chip rows looked smaller than Acidity and The Roast. They carried Dark StepLog's `size="sm"` into the Light fork; the 1px text + 1px padding delta reads as accidental inconsistency rather than density signalling.

Drop `sm` from those four top-level rows so all **section-level** chip rows share one size. FlavorWheel-internal chips and the Sensory disclosure chips keep `sm` — those are dense pickers, not section selectors.

### 2. Blue focus ring on inputs / textarea

Tapping Notes (and any input under `[data-light-scope]`) showed a blue ring. `@tailwindcss/forms` applies a 2px `ring-blue-500` box-shadow on focus to every `<input>`/`<textarea>`; per-class `outline-none` doesn't suppress it.

Fixed at the source — `globals.css` adds a Light-scope-only rule that neutralises `--tw-ring-shadow`, `--tw-ring-offset-shadow`, and the outline on focus for `input/textarea/select` inside the `(light)` route group. The per-class focus utilities I'd added inline have been reverted. Dark routes are untouched — the new selector is gated on `[data-light-scope]`, which only `LightShell` sets.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Auto-deploy runs green
- [ ] `/brew/preview` step=log:
  - [ ] Section-level chip rows (Your Brew, Bean, Roast, Flow, Timing, Agitation, Body, Acidity, Attribution) visually match in size
  - [ ] Tapping Notes textarea — no blue ring
  - [ ] Tapping Recipe Check inputs — no blue ring
  - [ ] FlavorWheel + Sensory chips stay in the smaller density-friendly size
- [ ] `/brew/new` (Dark) inputs still show their original Dark focus styling

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_