### PR TITLE
fix: sensory disclosure chips also use default size

### DIFF
--- a/src/components/flow/LightStepLog.tsx
+++ b/src/components/flow/LightStepLog.tsx
@@ -464,7 +464,7 @@ function SensoryRow({
       <p className="label-eyebrow px-1">{label}</p>
       <div className="flex flex-wrap gap-2">
         {options.map((o) => (
-          <Chip key={o.id} size="sm" selected={value === o.id} onClick={() => onChange(value === o.id ? "" : o.id)}>
+          <Chip key={o.id} selected={value === o.id} onClick={() => onChange(value === o.id ? "" : o.id)}>
             {o.label}
           </Chip>
         ))}
@@ -486,10 +486,10 @@ function SensoryToggle({
     <div className="flex items-center justify-between">
       <span className="text-[14px] text-light-foreground/80">{label}</span>
       <div className="flex gap-2">
-        <Chip size="sm" selected={value === true} onClick={() => onChange(value === true ? null : true)}>
+        <Chip selected={value === true} onClick={() => onChange(value === true ? null : true)}>
           Yes
         </Chip>
-        <Chip size="sm" selected={value === false} onClick={() => onChange(value === false ? null : false)}>
+        <Chip selected={value === false} onClick={() => onChange(value === false ? null : false)}>
           No
         </Chip>
       </div>


### PR DESCRIPTION
## Summary

Even inside the Sensory disclosure, chip rows should match the rest of the page. Drop `size="sm"` from `SensoryRow` chips (Sweetness, Clarity, Bitterness, Finish) and the `SensoryToggle` Yes/No pair. Now everything from Your Brew down to the Sensory toggles renders at one chip size.

FlavorWheel-internal chips still keep `sm` — those rows show 10+ subcategory chips at once and density genuinely helps.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Auto-deploy runs green
- [ ] `/brew/preview` step=log → expand Sensory detail disclosure → Sweetness / Clarity / Bitterness / Finish chips visually match Body / Acidity above
- [ ] Yes / No toggles (Improved while cooling, Matched intention) match the same size

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_