### PR TITLE
feat: generative field v1.1 phase 2 — haiku mapping + db column

### DIFF
--- a/src/app/api/analyze-bag/route.ts
+++ b/src/app/api/analyze-bag/route.ts
@@ -5,6 +5,7 @@ import { getRoasterPrior, canonicalRoasterSlug } from "@/lib/roasters/priors";
 import { db } from "@/lib/db/client";
 import { roasters } from "@/lib/db/schema";
 import type { RoasterPrior } from "@/lib/roasters/priors";
+import { mapNotesToZones } from "@/lib/field/mapNotesToZones";
 
 export const dynamic = "force-dynamic";
 
@@ -22,6 +23,13 @@ export async function POST(req: NextRequest) {
     const mimeType = file.type || "image/jpeg";
 
     const { result } = await analyzeBagImage(base64, mimeType);
+
+    // Field-zone mapping runs in parallel with the roaster-prior lookup —
+    // both are sequential add-ons to the bag extraction, neither blocks
+    // the other. mapNotesToZones swallows errors and returns null, so a
+    // Haiku outage doesn't fail the scan; clients fall back to Default.
+    const notes = result.extracted.tastingNotesFromBag ?? [];
+    const fieldZonesPromise = notes.length > 0 ? mapNotesToZones(notes) : Promise.resolve(null);
 
     // Roaster prior lookup: user-saved Firestore record takes priority over built-in list.
     // Fallback priors carry no real signal and are omitted to avoid noise.
@@ -67,7 +75,8 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    return NextResponse.json({ ...result, roasterPrior });
+    const fieldZones = await fieldZonesPromise;
+    return NextResponse.json({ ...result, roasterPrior, fieldZones });
   } catch (err) {
     console.error("analyze-bag error:", err);
     return NextResponse.json({ error: "Analysis failed" }, { status: 500 });

--- a/src/lib/db/migrations/0008_add_field_zones.sql
+++ b/src/lib/db/migrations/0008_add_field_zones.sql
@@ -1,0 +1,22 @@
+-- Generative Field v1.1 — add field_zones JSONB to coffees.
+--
+-- Stores a coffee's perceptual Field composition (see specs/design-
+-- system-v1.1-generative-field.md §10). Computed once per coffee by
+-- Haiku from tasting notes, persisted here, read at render time.
+--
+-- Value shape:
+--   {
+--     "version": 1,
+--     "zones": [{ "id": "floral", "weight": 0.45 }, ...],   // 1–3 entries
+--     "modifiers": { "saturation": 5, "lightness": 10 },
+--     "source": "tasting-notes" | "variety-implied" | "default",
+--     "computedAt": "2026-05-16T17:00:00.000Z"
+--   }
+--
+-- `null` means "not computed yet — render Default Field".
+--
+-- Run on the VPS after deploy:
+--   cat src/lib/db/migrations/0008_add_field_zones.sql \
+--     | docker compose exec -T postgres psql -U brewlog -d brewlog
+
+ALTER TABLE coffees ADD COLUMN IF NOT EXISTS field_zones jsonb;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -73,6 +73,11 @@ export const coffees = pgTable("coffees", {
   commonNotes: jsonb("common_notes").$type<string[]>(),
   whatToExplore: text("what_to_explore"),
   personalNotes: text("personal_notes"),
+  // Generative Field v1.1 — perceptual Field composition for this coffee
+  // (see specs/design-system-v1.1-generative-field.md §10). Computed once
+  // per coffee from tasting notes by Haiku; null until first mapped.
+  // Shape: src/lib/field/types.ts FieldZones.
+  fieldZones: jsonb("field_zones"),
 });
 
 export const preferences = pgTable("preferences", {

--- a/src/lib/field/mapNotesToZones.ts
+++ b/src/lib/field/mapNotesToZones.ts
@@ -1,0 +1,136 @@
+/**
+ * Generative Field v1.1 — Haiku tasting-notes → Field Zone mapping.
+ *
+ * Single Anthropic call that perceptually maps a list of tasting notes
+ * (English or German) to a weighted Zone composition + optional
+ * saturation/lightness modifiers. See spec §3 + Appendix A for the
+ * full prompt and rationale.
+ *
+ * Per-coffee call cost is roughly $0.0001 (Haiku, short structured
+ * output). Mapping runs **once per coffee** and is persisted in
+ * coffees.field_zones — never at render time. The "single mapping
+ * layer in the system" guarantee comes from both the tasting-notes
+ * path and the variety-implied path feeding through this helper
+ * (spec §5.2).
+ *
+ * Temperature 0 + the strict Zod schema make this deterministic-ish
+ * — Haiku still has some variance at temp=0, but the schema either
+ * accepts a valid output or we return null and the caller falls back
+ * to DEFAULT_FIELD_ZONES.
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import { parseClaudeJson, z } from "../claude/parseJson";
+import type { FieldZones, FieldZonesSource } from "./types";
+
+const client = new Anthropic({
+  apiKey: process.env.ANTHROPIC_API_KEY,
+  timeout: 30_000,
+});
+
+const FieldZonesResponseSchema = z.object({
+  zones: z
+    .array(
+      z.object({
+        id: z.enum([
+          "fruity-bright",
+          "fruity-deep",
+          "floral",
+          "nutty-cocoa",
+          "spice-earth",
+          "sweet-caramel",
+        ]),
+        weight: z.number().min(0).max(1),
+      }),
+    )
+    .max(3),
+  modifiers: z.object({
+    saturation: z.number().int().min(-15).max(15),
+    lightness: z.number().int().min(-15).max(15),
+  }),
+});
+
+const SYSTEM_PROMPT = `You are a perceptual aroma-to-color mapper for a specialty coffee app. Given an array of tasting notes (English or German), you return a JSON object specifying which BrewLog Field Zones the notes map to, with weights, plus optional saturation/lightness modifiers from texture descriptors. Return JSON only, no prose.
+
+Available Field Zones (id : exemplar aromas):
+- fruity-bright : citrus, lemon, orange, grapefruit, mandarin, berry, blueberry, raspberry, cherry, cranberry, peach, apricot, currant, pomegranate
+- fruity-deep : dried fruit, date, raisin, fig, prune, plum, red grape, port, wine, fermented fruit, dark cherry
+- floral : jasmine, rose, hibiscus, bergamot, chamomile, tea, lavender, elderflower, white flowers, floral, perfume
+- nutty-cocoa : chocolate, cocoa, milk chocolate, dark chocolate, nut, almond, hazelnut, walnut, pecan, peanut, roasted, malt
+- spice-earth : cinnamon, clove, cardamom, tobacco, leather, earth, herbs, savoury, spice, woody, cedar, smoke
+- sweet-caramel : caramel, honey, brown sugar, maple, vanilla, butter, toffee, syrup, molasses, custard, marzipan
+
+Texture/quality modifiers (NOT zones — adjust saturation and lightness instead):
+- juicy / vibrant / lively / bright → saturation +5 to +10
+- elegant / delicate / refined → lightness +5 to +10, saturation -5
+- clean / crisp / pristine → lightness +5, saturation -5
+- complex / deep / intense → no shift, allow 3 zones
+- balanced / harmonic / silky → no shift
+- creamy / velvety / rich → lightness -5, saturation +5
+- dense / heavy / full-bodied → lightness -10, saturation +5
+
+Rules:
+- Output 1-3 zones. Most coffees are 2-3 zones.
+- Zone weights are floats in [0, 1] summing to exactly 1.0.
+- modifier.saturation and modifier.lightness are integers in [-15, +15].
+- If a note is unfamiliar or non-aromatic (e.g. "rare", "delightful"), ignore it.
+- If ALL notes are unfamiliar, return {"zones": [], "modifiers": {"saturation": 0, "lightness": 0}}.
+  The caller will treat empty zones as "fall back to default".
+- German notes are valid input: pflaumig → prune (fruity-deep), nussig → nutty-cocoa, zitronig → citrus (fruity-bright), schokoladig → chocolate (nutty-cocoa).`;
+
+/**
+ * Run the mapping on a list of notes and return a FieldZones object,
+ * or null if the model returned no usable zones (caller should fall
+ * back to DEFAULT_FIELD_ZONES). Errors are swallowed and surface as
+ * null — Field rendering must never block a brew flow on an AI call.
+ *
+ * `source` describes the origin path so debug tools can later show
+ * "this Field came from tasting notes" vs "from variety implication".
+ */
+export async function mapNotesToZones(
+  notes: string[],
+  source: FieldZonesSource = "tasting-notes",
+): Promise<FieldZones | null> {
+  if (!notes || notes.length === 0) return null;
+
+  try {
+    const response = await client.messages.create({
+      model: "claude-haiku-4-5",
+      max_tokens: 256,
+      temperature: 0,
+      system: SYSTEM_PROMPT,
+      messages: [
+        {
+          role: "user",
+          content: `Notes: ${JSON.stringify(notes)}`,
+        },
+      ],
+    });
+
+    const block = response.content[0];
+    if (!block || block.type !== "text") return null;
+
+    const parsed = parseClaudeJson(block.text, FieldZonesResponseSchema);
+    if (!parsed || parsed.zones.length === 0) return null;
+
+    // Normalise weights to exactly 1.0 — Haiku is usually within 0.01
+    // but the algorithm sorts and composes assuming weights are a real
+    // probability distribution.
+    const totalWeight = parsed.zones.reduce((sum, z) => sum + z.weight, 0);
+    const zones =
+      totalWeight > 0
+        ? parsed.zones.map((z) => ({ id: z.id, weight: z.weight / totalWeight }))
+        : parsed.zones;
+
+    return {
+      version: 1,
+      zones,
+      modifiers: parsed.modifiers,
+      source,
+      computedAt: new Date().toISOString(),
+    };
+  } catch (err) {
+    console.error("mapNotesToZones error:", err);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the v1.1 Generative Field rollout. `/api/analyze-bag` now returns a computed `FieldZones` alongside the existing extraction result. Phase 3 will swap render consumers to read it.

### What lands

**DB**
- `migrations/0008_add_field_zones.sql` — adds `coffees.field_zones jsonb`. Idempotent (`IF NOT EXISTS`); re-runnable.
- Drizzle schema mirrors the column (`fieldZones`).
- Per CLAUDE.md, this migration is **applied manually on the VPS** after deploy — header comment in the SQL file has the one-liner.

**Code**
- `src/lib/field/mapNotesToZones.ts` — Haiku helper. Full Appendix A system prompt verbatim (English + German exemplar aromas + texture modifiers), `temperature: 0`, `max_tokens: 256`, Zod-validated response, weight normalisation post-parse so Haiku's slight drift (sum ≈ 0.99) doesn't break the composition algorithm. Swallows errors → returns `null`; Field rendering must never block a brew flow on an AI call.
- `/api/analyze-bag` — Haiku mapping kicked off **in parallel** with the existing roaster-prior lookup; awaited just before the response. `fieldZones` flows out in the JSON payload alongside `roasterPrior`. Empty / missing tasting-notes path returns `null` (= "use Default").

### Cost

~$0.0001 per bag scan with non-empty notes. Trivial.

### What's intentionally NOT in this PR

Persistence — writing `field_zones` into the `coffees` row at session save. The in-flight value rides on the `/api/analyze-bag` response and lives transiently in `flowStore.draft` until Phase 3's render wiring lands. Persistence is mechanical and will follow in a focused Phase 2b PR.

### Deployment steps

1. Merge → auto-deploys to Hetzner
2. SSH to the VPS and run the migration once:
   ```
   cat src/lib/db/migrations/0008_add_field_zones.sql \
     | docker compose exec -T postgres psql -U brewlog -d brewlog
   ```

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean — `/api/analyze-bag` still registered
- [ ] Auto-deploy runs green
- [ ] Run the SQL migration on the VPS (`SELECT field_zones FROM coffees LIMIT 1;` should return `NULL`)
- [ ] Scan a bag → response should include a `fieldZones` block when tasting notes were extracted
- [ ] Scan a bag with no tasting notes → response has `fieldZones: null` (= Default)
- [ ] Phase 3 will exercise the value end-to-end

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_