### PR TITLE
feat: generative field v1.1 phase 3 — render wiring + step rotation

### DIFF
--- a/src/components/flow/StepScan.tsx
+++ b/src/components/flow/StepScan.tsx
@@ -26,7 +26,7 @@ const ROASTER_QA_LOCATION_CHIPS = ["Germany", "Netherlands", "UK", "USA", "Denma
 const ROASTER_QA_STYLE_CHIPS = ["Very light", "Light", "Light-medium", "Medium", "Varies"];
 
 export default function StepScan() {
-  const { draft, setCoffee, setMode, setStep, isAnalyzing, setIsAnalyzing, clarificationMessages, addClarificationMessage, clearClarifications } = useFlowStore();
+  const { draft, setCoffee, setMode, setStep, setFieldZones, isAnalyzing, setIsAnalyzing, clarificationMessages, addClarificationMessage, clearClarifications } = useFlowStore();
   const [preview, setPreview] = useState<string | null>(null);
   const [inputMethod, setInputMethod] = useState<InputMethod | null>(null);
   const [selectedMode, setSelectedMode] = useState<ModeChoice>("home");
@@ -133,6 +133,10 @@ export default function StepScan() {
         aiExtracted: true,
         tastingNotesFromBag: result.extracted.tastingNotesFromBag ?? [],
       });
+      // Generative Field v1.1 — capture the server-mapped composition
+      // so LightFlowShell can paint the brew flow in this coffee's
+      // colours. null is valid (= use Default).
+      setFieldZones(result.fieldZones ?? null);
       checkLibraryMatch(result.extracted.name, result.extracted.roaster);
 
       // If roaster is unknown, auto-generate its profile immediately — no Q&A interruption

--- a/src/components/ui/light/Field.tsx
+++ b/src/components/ui/light/Field.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useContext, useMemo } from "react";
+import { FieldContext } from "@/lib/field/FieldContext";
+import { composeFieldGradient } from "@/lib/field/composeGradient";
+
+/**
+ * Generative Field v1.1 — the renderer.
+ *
+ * Reads the current FieldConfig from context and paints the
+ * application-wide warm gradient. The sandwich structure is preserved
+ * from v1.0 §2.1 — a `fixed inset-0 -z-10` outer wrapper, an absolute
+ * inner div with `inset-[-10%]` so the 60px blur halo lands outside
+ * the visible viewport, the same `blur(60px) scale(1.18)` post-
+ * processing.
+ *
+ * Only the `background` style swaps from the static `.bg-brew-field`
+ * utility to the coffee-driven gradient string. Output is identical
+ * for the Default coffee composition, so views that don't set a
+ * specific config render exactly what v1.0 already shipped.
+ *
+ * Memoised on the FieldConfig — composeFieldGradient is a pure function
+ * with no side effects, and the gradient string is the only place
+ * React would otherwise recompute it on every parent render.
+ */
+export default function Field() {
+  const { fieldZones, rotation } = useContext(FieldContext);
+  const gradient = useMemo(
+    () => composeFieldGradient(fieldZones, rotation),
+    [fieldZones, rotation],
+  );
+
+  return (
+    <div aria-hidden className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+      <div
+        className="absolute inset-[-10%]"
+        style={{
+          background: gradient,
+          filter: "blur(60px)",
+          transform: "scale(1.18)",
+          transformOrigin: "center",
+        }}
+      />
+    </div>
+  );
+}

--- a/src/components/ui/light/LightFlowShell.tsx
+++ b/src/components/ui/light/LightFlowShell.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useMemo, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronLeft } from "lucide-react";
 import { useFlowStore, type FlowStep } from "@/store/flowStore";
+import { useFieldConfig } from "@/lib/field/FieldContext";
+import { DEFAULT_FIELD_ZONES } from "@/lib/field/defaultZones";
 import CTA from "./CTA";
 
 /**
@@ -30,6 +32,20 @@ const HOME_STEPS: FlowStep[] = ["scan", "context", "recommend", "brew", "log", "
 const BREW_AGAIN_STEPS: FlowStep[] = ["context", "recommend", "brew", "log", "summary"];
 const EXTERNAL_STEPS: FlowStep[] = ["scan", "log", "summary"];
 
+// Generative Field v1.1 §8.1 — per-step rotation across the flow. Scan
+// runs at 0° (coffee unknown until extraction completes); each
+// subsequent step adds 25° so the seven-step flow drifts 125° total —
+// "same room, different time of day", never "different room".
+const STEP_ROTATION: Record<FlowStep, number> = {
+  scan: 0,
+  mode: 0,
+  context: 25,
+  recommend: 50,
+  brew: 75,
+  log: 100,
+  summary: 125,
+};
+
 interface LightFlowShellProps {
   children: ReactNode;
   onBack?: () => void;
@@ -47,8 +63,20 @@ export default function LightFlowShell({
   nextDisabled,
   nextLoading,
 }: LightFlowShellProps) {
-  const { step, draft, skipScan } = useFlowStore();
+  const { step, draft, skipScan, fieldZones } = useFlowStore();
   const router = useRouter();
+
+  // Drive the application-wide Field renderer with this brew's coffee
+  // composition and the current step's rotation. fieldZones === null
+  // (no scan yet, or scan returned no notes) falls through to Default.
+  const fieldConfig = useMemo(
+    () => ({
+      fieldZones: fieldZones ?? DEFAULT_FIELD_ZONES,
+      rotation: STEP_ROTATION[step as FlowStep] ?? 0,
+    }),
+    [fieldZones, step],
+  );
+  useFieldConfig(fieldConfig);
 
   const steps =
     draft.mode === "external"

--- a/src/components/ui/light/LightShell.tsx
+++ b/src/components/ui/light/LightShell.tsx
@@ -1,29 +1,38 @@
+"use client";
+
 import type { ReactNode } from "react";
+import { FieldProvider } from "@/lib/field/FieldContext";
+import Field from "./Field";
 
 /**
- * Light System v1.0 — route-scoped shell.
+ * Light System v1.0 + v1.1 — route-scoped shell.
  *
  * Applies the three anchors from specs/design-system-v1.0.md §1:
- *   - The Field (§2.1) — fixed atmospheric background, sandwich structure
- *   - The Voice (§3) — Inter as body default, Fraunces opt-in via `font-fraunces`
- *   - Foreground (§2.4) — warm near-black at full opacity, inherited by children
+ *   - The Field (§2.1 / v1.1 §7) — fixed atmospheric background,
+ *     now coffee-driven via FieldContext. Default composition
+ *     renders identical to the v1.0 static gradient when no page
+ *     overrides via useFieldConfig.
+ *   - The Voice (§3) — Inter as body default, Fraunces opt-in via
+ *     `font-fraunces`.
+ *   - Foreground (§2.4) — warm near-black at full opacity, inherited.
  *
- * Lives at the (light) route group root. Dark routes are unaffected — they
- * continue to render under the legacy root layout's body bg / Geist stack.
+ * Why a client component: FieldProvider owns useState for the
+ * current FieldConfig (pages set it via useFieldConfig). Marking
+ * "use client" here scopes that React state to the (light) tree;
+ * Dark routes outside this group keep their server-render path.
  *
- * The Field's <div absolute inset-[-10%] /> bleeds 10% past the viewport so
- * the 60px blur halo has room to land outside the visible area (§2.1).
+ * Field placement: rendered inside the FieldProvider but at the
+ * same DOM level as children, so the fixed -z-10 sandwich paints
+ * behind every (light) view. Pages don't render their own Field —
+ * they update the context.
  */
 export default function LightShell({ children }: { children: ReactNode }) {
   return (
-    <div data-light-scope="true" className="font-chivo text-light-foreground min-h-dvh">
-      <div
-        aria-hidden
-        className="pointer-events-none fixed inset-0 -z-10 overflow-hidden"
-      >
-        <div className="absolute inset-[-10%] bg-brew-field" />
+    <FieldProvider>
+      <div data-light-scope="true" className="font-chivo text-light-foreground min-h-dvh">
+        <Field />
+        {children}
       </div>
-      {children}
-    </div>
+    </FieldProvider>
   );
 }

--- a/src/lib/claude/analyzeBag.ts
+++ b/src/lib/claude/analyzeBag.ts
@@ -105,6 +105,7 @@ export interface BagAnalysisResult {
   clarifications: string[];
   isCoffeeBag: boolean;
   roasterPrior?: RoasterPriorSummary; // populated server-side after roaster lookup
+  fieldZones?: import("@/lib/field/types").FieldZones | null; // v1.1 Generative Field — server-computed from tastingNotesFromBag; null when notes are empty
 }
 
 export async function analyzeBagImage(imageBase64: string, mimeType: string): Promise<{ result: BagAnalysisResult; usage: { input_tokens: number; output_tokens: number } }> {

--- a/src/lib/field/FieldContext.tsx
+++ b/src/lib/field/FieldContext.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
+import { DEFAULT_FIELD_ZONES } from "./defaultZones";
+import type { FieldZones } from "./types";
+
+/**
+ * Generative Field v1.1 — runtime context.
+ *
+ * Holds the Field config (zones + step rotation) used by the
+ * application-wide <Field /> renderer. The provider lives at the
+ * (light) route group root inside LightShell; consumers update it
+ * via the useFieldConfig hook from page components or step shells.
+ *
+ * The state lives in one place so two stacked Fields can't race.
+ * Field rendering reads this context and produces a single fixed
+ * gradient div for the whole viewport. Pages don't render their own
+ * Field — they just declare which composition + rotation they want.
+ *
+ * Spec rules to respect:
+ *  - Hue / saturation / lightness are properties of the coffee
+ *    (mapped from tasting notes). Pages must not invent zones —
+ *    only pass zones already computed by /api/analyze-bag (or read
+ *    from coffees.field_zones once Phase 2b's persistence ships).
+ *  - Rotation is the per-step or per-view variation (§8 / §9).
+ *  - On unmount, the hook resets to default to prevent a previously-
+ *    set field config from leaking into a sibling page.
+ */
+
+interface FieldConfig {
+  fieldZones: FieldZones;
+  rotation: number;
+}
+
+interface FieldContextValue extends FieldConfig {
+  setFieldConfig: (config: FieldConfig) => void;
+}
+
+const DEFAULT_CONFIG: FieldConfig = {
+  fieldZones: DEFAULT_FIELD_ZONES,
+  rotation: 0,
+};
+
+export const FieldContext = createContext<FieldContextValue>({
+  ...DEFAULT_CONFIG,
+  setFieldConfig: () => {},
+});
+
+export function FieldProvider({ children }: { children: ReactNode }) {
+  const [config, setConfig] = useState<FieldConfig>(DEFAULT_CONFIG);
+  const setFieldConfig = useCallback((next: FieldConfig) => setConfig(next), []);
+
+  return (
+    <FieldContext.Provider value={{ ...config, setFieldConfig }}>{children}</FieldContext.Provider>
+  );
+}
+
+/**
+ * Page-side hook: declare the Field config for this view. Called from
+ * a useEffect-friendly place (the hook handles the effect itself).
+ *
+ * Unmount resets to default so the next page starts clean — no leak
+ * of "previous coffee's Field" when navigating away from a brew flow.
+ */
+export function useFieldConfig(config: FieldConfig | null | undefined): void {
+  const { setFieldConfig } = useContext(FieldContext);
+  const stableZones = config?.fieldZones;
+  const stableRotation = config?.rotation ?? 0;
+
+  useEffect(() => {
+    if (stableZones) {
+      setFieldConfig({ fieldZones: stableZones, rotation: stableRotation });
+    } else {
+      setFieldConfig(DEFAULT_CONFIG);
+    }
+    return () => setFieldConfig(DEFAULT_CONFIG);
+    // Re-run when the actual zones or rotation change. Object identity
+    // is a fine equality proxy because callers either pass a stable
+    // reference or a freshly-derived one only when the underlying
+    // state changes (flowStore drives these).
+  }, [stableZones, stableRotation, setFieldConfig]);
+}

--- a/src/store/flowStore.ts
+++ b/src/store/flowStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { persist, createJSONStorage } from "zustand/middleware";
 import type { DraftSession, SessionMode, CoffeeIdentity, SessionContext, Recommendation, BrewLog, TasteResult, ExternalPlace } from "@/lib/types/session";
+import type { FieldZones } from "@/lib/field/types";
 
 export type FlowStep =
   | "scan"         // Photo + AI extraction + clarification (always first)
@@ -14,6 +15,12 @@ export type FlowStep =
 interface FlowState {
   step: FlowStep;
   draft: DraftSession;
+  /** Generative Field v1.1 — coffee's Zone composition for this in-flight brew.
+   * Populated from /api/analyze-bag's `fieldZones` field at scan-complete.
+   * Lives in-memory only (sessionStorage-persisted with the rest of the store
+   * but NOT written into sessions.coffee on session save — that's a coffees
+   * property per spec §10.4 anti-pattern). null = use Default Field. */
+  fieldZones: FieldZones | null;
   skipScan: boolean;         // true when entering via "brew again" (no scan step)
   isAnalyzing: boolean;
   isRecommending: boolean;
@@ -30,6 +37,7 @@ interface FlowState {
   setRecommendation: (rec: Recommendation) => void;
   setBrew: (brew: BrewLog) => void;
   setResult: (result: TasteResult) => void;
+  setFieldZones: (zones: FieldZones | null) => void;
   setIsAnalyzing: (v: boolean) => void;
   setIsRecommending: (v: boolean) => void;
   setRecommendError: (err: string | null) => void;
@@ -54,6 +62,7 @@ export const useFlowStore = create<FlowState>()(
     (set) => ({
       step: "scan",
       draft: initialDraft,
+      fieldZones: null,
       skipScan: false,
       isAnalyzing: false,
       isRecommending: false,
@@ -70,6 +79,7 @@ export const useFlowStore = create<FlowState>()(
       setRecommendation: (recommendation) => set((s) => ({ draft: { ...s.draft, recommendation } })),
       setBrew: (brew) => set((s) => ({ draft: { ...s.draft, brew } })),
       setResult: (result) => set((s) => ({ draft: { ...s.draft, result } })),
+      setFieldZones: (fieldZones) => set({ fieldZones }),
       setIsAnalyzing: (v) => set({ isAnalyzing: v }),
       setIsRecommending: (v) => set({ isRecommending: v }),
       setRecommendError: (err) => set({ recommendError: err }),
@@ -77,7 +87,7 @@ export const useFlowStore = create<FlowState>()(
         set((s) => ({ clarificationMessages: [...s.clarificationMessages, msg] })),
       clearClarifications: () => set({ clarificationMessages: [] }),
       reset: () =>
-        set({ step: "scan", draft: initialDraft, skipScan: false, isAnalyzing: false, isRecommending: false, recommendError: null, clarificationMessages: [] }),
+        set({ step: "scan", draft: initialDraft, fieldZones: null, skipScan: false, isAnalyzing: false, isRecommending: false, recommendError: null, clarificationMessages: [] }),
     }),
     {
       name: "brew-flow",


### PR DESCRIPTION
## Summary

Phase 3 of the v1.1 Generative Field rollout. The brew flow on `/brew/preview` now renders the Field driven by the scanned coffee's tasting notes, rotating 25° per step.

### End-to-end pipeline

1. **/api/analyze-bag** (Phase 2) computes `fieldZones` via Haiku
2. **StepScan** captures it into `flowStore` via `setFieldZones`
3. **LightFlowShell** reads `flowStore.fieldZones` + `step`
4. **useFieldConfig** pushes `(zones, rotation)` into `FieldContext`
5. **Field component** (rendered by `LightShell` at the route-group root) re-renders the gradient with `composeFieldGradient()`

### What lands

- `src/lib/field/FieldContext.tsx` — React context + `FieldProvider` + `useFieldConfig` hook. State lives in one place (`LightShell`) so stacked Fields can't race. Hook resets to default on unmount → brew-flow's coffee composition doesn't leak into the next view.
- `src/components/ui/light/Field.tsx` — reads context, calls `composeFieldGradient`, paints the v1.0 sandwich (`fixed -z-10` outer + absolute inner with `blur(60px) scale(1.18)`). Memoised on `fieldZones+rotation`; pure function.
- `src/components/ui/light/LightShell.tsx` — now `"use client"`, wraps in `FieldProvider`, renders `<Field />` instead of the static `.bg-brew-field` utility. The CSS utility stays for any non-`(light)` consumer; cleanup deferred until no references remain.
- `src/components/ui/light/LightFlowShell.tsx` — `STEP_ROTATION` map (scan 0°, mode 0°, context 25°, recommend 50°, brew 75°, log 100°, summary 125°), wires `useFieldConfig` with current step + flow's `fieldZones`. Fallback to `DEFAULT_FIELD_ZONES` when no scan yet.
- `src/store/flowStore.ts` — top-level `fieldZones` slot + `setFieldZones` action. Comment notes it lives in memory only and must NEVER be written to `sessions.coffee` JSONB on session save (spec §10.4 anti-pattern).
- `src/components/flow/StepScan.tsx` — calls `setFieldZones` with the `/api/analyze-bag` response's `fieldZones` field after a successful bag analysis.
- `src/lib/claude/analyzeBag.ts` — `BagAnalysisResult.fieldZones` typed via inline import of `FieldZones` so the StepScan response binding is type-safe.

### Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean — `/brew/preview` and `/brew/new` both build
- [ ] Auto-deploy runs green
- [ ] On `/brew/preview`:
  - [ ] Scan a coffee with tasting notes → field colours visibly shift toward those notes' Zone (e.g. a blueberry/hibiscus coffee should feel pink-mauve-fruity, a chocolate/nut coffee should feel cocoa-warm)
  - [ ] Different coffees yield different fields
  - [ ] Same coffee yields the same field on each scan (Haiku at `temperature: 0` + weight normalisation)
  - [ ] Walking through Context → Recommend → Brew → Log → Summary, the field subtly rotates around the same composition — "same room, different time of day"
- [ ] On `/` (Home Light) and other (light) routes: field renders Default (identical to v1.0)
- [ ] `/brew/new` (Dark) unchanged

### What's NOT in this PR

- **Persistence** — writing `field_zones` into the `coffees` row at session save. The in-flight value rides on the analyze-bag response and lives in `flowStore` transiently. Phase 3b will hook the persistence into `/api/sessions` POST and `/api/coffees/[id]` GET (so the **Brew Again** path can lift zones from the DB instead of falling back to Default).
- **Per-view rotation** for non-coffee Light views. Spec §9 wants rotations 0/72/144/216/288° for Home/Cafés/Taste/Explore/Library; only Home + Past Conversations are Light today, both default to 0°, so the per-view table is left until more views migrate.
- **Brew-Again path coffee lookup** — uses Default until the persistence PR lands.

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_