### PR TITLE
feat: generative field v1.1 phase 3b — persistence + brew-again lookup

### DIFF
--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -6,6 +6,7 @@ import { db } from "@/lib/db/client";
 import { sessions, coffees } from "@/lib/db/schema";
 import { rowToSession } from "@/lib/db/helpers";
 import type { Session } from "@/lib/types/session";
+import { FieldZonesSchema } from "@/lib/field/schema";
 
 const SessionPostSchema = z.object({
   type: z.enum(["coffee", "wine"]),
@@ -61,6 +62,10 @@ const SessionPostSchema = z.object({
     craft: z.enum(["off", "solid", "exceptional"]).optional(),
     fit: z.enum(["not-my-style", "neutral", "my-kind"]).optional(),
   }).optional(),
+  // Generative Field v1.1 — top-level (NOT on coffee). Persisted to
+  // coffees.field_zones on first insert; ignored on subsequent saves
+  // so re-scans of the same bag don't drift the coffee's Field.
+  fieldZones: FieldZonesSchema.nullable().optional(),
 });
 
 export const dynamic = "force-dynamic";
@@ -106,7 +111,11 @@ export async function POST(req: NextRequest) {
     if (!parsed.success) {
       return NextResponse.json({ error: "Invalid session data", details: parsed.error.flatten() }, { status: 400 });
     }
-    const data = parsed.data as Omit<Session, "id">;
+    // Extract the top-level fieldZones (v1.1 Generative Field) before
+    // narrowing the rest to Session-shape — fieldZones is routed to
+    // the coffees table separately, not into sessions.coffee JSONB.
+    const { fieldZones: incomingFieldZones, ...sessionData } = parsed.data;
+    const data = sessionData as Omit<Session, "id">;
     const sessionId = randomUUID();
     const createdAtMs = Date.now();
     const createdAt = new Date(data.createdAt);
@@ -157,6 +166,11 @@ export async function POST(req: NextRequest) {
           ratingSum: hasRating ? String(newRating) : "0",
           ratingCount: hasRating ? 1 : 0,
           avgRating: hasRating ? String(newRating) : undefined,
+          // Generative Field v1.1 — persist the in-flight composition
+          // computed by /api/analyze-bag for this coffee. Null is fine;
+          // render falls back to Default until a future re-scan with
+          // notes succeeds.
+          fieldZones: incomingFieldZones ?? undefined,
         });
       } else {
         const sessionIds = [...(existing.sessionIds ?? []), sessionId];
@@ -166,17 +180,27 @@ export async function POST(req: NextRequest) {
         const ratingCount = prevCount + (hasRating ? 1 : 0);
         const avgRating = ratingCount > 0 ? ratingSum / ratingCount : null;
 
+        // Field zones policy: write only if the existing row has no
+        // composition yet (organic backfill — first time this coffee
+        // gets a non-null fieldZones from any session). Don't overwrite
+        // an already-computed Field; spec §10.4 says invalidation is a
+        // separate concern (re-scan path), not a save-time concern.
+        const updates: Record<string, unknown> = {
+          sessionCount: sessionIds.length,
+          sessionIds,
+          ratingSum: String(ratingSum),
+          ratingCount,
+          avgRating: avgRating != null ? String(avgRating) : null,
+          bagPhotoUrl: existing.bagPhotoUrl ?? data.coffee.bagPhotoUrl ?? null,
+          latestRoastDate: data.coffee.roastDate ?? existing.latestRoastDate,
+        };
+        if (existing.fieldZones == null && incomingFieldZones != null) {
+          updates.fieldZones = incomingFieldZones;
+        }
+
         await db
           .update(coffees)
-          .set({
-            sessionCount: sessionIds.length,
-            sessionIds,
-            ratingSum: String(ratingSum),
-            ratingCount,
-            avgRating: avgRating != null ? String(avgRating) : null,
-            bagPhotoUrl: existing.bagPhotoUrl ?? data.coffee.bagPhotoUrl ?? null,
-            latestRoastDate: data.coffee.roastDate ?? existing.latestRoastDate,
-          })
+          .set(updates)
           .where(sql`${coffees.id} = ${coffeeKey}`);
       }
     }

--- a/src/app/coffees/[id]/page.tsx
+++ b/src/app/coffees/[id]/page.tsx
@@ -24,7 +24,7 @@ export default function CoffeeDetailPage() {
   const [roasterGenerating, setRoasterGenerating] = useState(false);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
-  const { reset, setCoffee: setFlowCoffee, setStep, setMode, setSkipScan } = useFlowStore();
+  const { reset, setCoffee: setFlowCoffee, setStep, setMode, setSkipScan, setFieldZones } = useFlowStore();
 
   // Personal notes state
   const [editingNotes, setEditingNotes] = useState(false);
@@ -147,6 +147,10 @@ export default function CoffeeDetailPage() {
     };
     reset();
     setFlowCoffee({ ...identity, coffeeId: coffee.id });
+    // Generative Field v1.1 — Brew Again path: lift the persisted
+    // composition so the flow paints in this coffee's colours rather
+    // than the Default fallback.
+    setFieldZones(coffee.fieldZones ?? null);
     setMode("home");
     setSkipScan(true);
     setStep("context");

--- a/src/app/coffees/page.tsx
+++ b/src/app/coffees/page.tsx
@@ -18,7 +18,7 @@ export default function CoffeesPage() {
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<Filter>("recent");
   const router = useRouter();
-  const { reset, setCoffee, setStep, setMode, setSkipScan } = useFlowStore();
+  const { reset, setCoffee, setStep, setMode, setSkipScan, setFieldZones } = useFlowStore();
 
   const brewThis = (coffee: Coffee) => {
     // Synthesize a CoffeeIdentity from the aggregate. roastLevel isn't stored
@@ -37,6 +37,9 @@ export default function CoffeesPage() {
     };
     reset();
     setCoffee(identity);
+    // Generative Field v1.1 — lift this coffee's persisted Field
+    // composition for the Brew Again flow.
+    setFieldZones(coffee.fieldZones ?? null);
     setMode("home");
     setSkipScan(true);
     setStep("context");

--- a/src/components/flow/StepSummary.tsx
+++ b/src/components/flow/StepSummary.tsx
@@ -42,6 +42,9 @@ export default function StepSummary() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           ...draft,
+          // Top-level (not on coffee, per spec §10.4 anti-pattern).
+          // Server writes to coffees.field_zones, NOT sessions.coffee.
+          fieldZones: useFlowStore.getState().fieldZones,
           type: "coffee",
           createdAt: new Date().toISOString(),
         }),

--- a/src/components/ui/light/ActionPill.tsx
+++ b/src/components/ui/light/ActionPill.tsx
@@ -37,6 +37,9 @@ interface CoffeeRow {
   process: string;
   latestRoastDate?: string;
   bagPhotoUrl?: string;
+  // Generative Field v1.1 — present on the /api/coffees/[id] response
+  // via rowToCoffee, used for the Brew Again Field lift.
+  fieldZones?: import("@/lib/field/types").FieldZones | null;
 }
 
 function destinationToPath(action: NavAction): string {
@@ -88,7 +91,7 @@ function ActionPillIcon({ destination }: { destination: NavAction["destination"]
 
 export default function ActionPill({ action }: { action: NavAction }) {
   const router = useRouter();
-  const { reset, setCoffee, setMode, setSkipScan, setStep } = useFlowStore();
+  const { reset, setCoffee, setMode, setSkipScan, setStep, setFieldZones } = useFlowStore();
 
   const handleClick = async () => {
     if (action.destination === "brew_again" && action.id) {
@@ -112,6 +115,10 @@ export default function ActionPill({ action }: { action: NavAction }) {
             };
             reset();
             setCoffee(identity);
+            // Generative Field v1.1 — Brew Again from Home: lift the
+            // persisted Field composition. The /api/coffees/[id]
+            // response now carries fieldZones via rowToCoffee.
+            setFieldZones(row.fieldZones ?? null);
             setMode("home");
             setSkipScan(true);
             setStep("context");

--- a/src/lib/db/helpers.ts
+++ b/src/lib/db/helpers.ts
@@ -1,4 +1,5 @@
 import type { Coffee } from "@/lib/types/coffee";
+import type { FieldZones } from "@/lib/field/types";
 import type { Session } from "@/lib/types/session";
 import { coffees, sessions } from "@/lib/db/schema";
 
@@ -23,6 +24,9 @@ export function rowToCoffee(r: typeof coffees.$inferSelect): Coffee {
     commonNotes: r.commonNotes ?? undefined,
     whatToExplore: r.whatToExplore ?? undefined,
     personalNotes: r.personalNotes ?? undefined,
+    // JSONB column is `unknown` at the Drizzle level; trust the write
+    // path (validated by FieldZonesSchema before insert) and cast.
+    fieldZones: (r.fieldZones as FieldZones | null) ?? null,
   };
 }
 

--- a/src/lib/field/schema.ts
+++ b/src/lib/field/schema.ts
@@ -1,0 +1,57 @@
+/**
+ * Generative Field v1.1 — Zod validation for the persisted FieldZones shape.
+ *
+ * Used at two boundaries:
+ *   1. Inside /api/sessions POST, to validate the `fieldZones` field
+ *      coming from the client before writing it into coffees.field_zones.
+ *      Without this, a malicious or buggy client could write arbitrary
+ *      JSONB into the DB column.
+ *   2. As the runtime shape of /api/coffees/[id]'s response field —
+ *      callers downstream import the TypeScript type from types.ts and
+ *      trust the JSONB read, since we control the write path.
+ *
+ * Kept in its own file (not collapsed into types.ts) so the heavy Zod
+ * import doesn't follow `FieldZones` consumers that only want the type.
+ */
+
+import { z } from "zod";
+
+export const ZoneIdSchema = z.enum([
+  "fruity-bright",
+  "fruity-deep",
+  "floral",
+  "nutty-cocoa",
+  "spice-earth",
+  "sweet-caramel",
+]);
+
+export const FieldZonesSchema = z
+  .object({
+    version: z.literal(1),
+    zones: z
+      .array(
+        z.object({
+          id: ZoneIdSchema,
+          weight: z.number().min(0).max(1),
+        }),
+      )
+      .min(1)
+      .max(3),
+    modifiers: z.object({
+      saturation: z.number().int().min(-15).max(15),
+      lightness: z.number().int().min(-15).max(15),
+    }),
+    source: z.enum(["tasting-notes", "variety-implied", "default"]),
+    computedAt: z.string(),
+  })
+  // Allow weights summing within a small tolerance of 1.0 — Haiku is
+  // usually within 0.01 of exact and the normalisation in
+  // mapNotesToZones brings it to 1.0, but we don't want a 0.9999
+  // payload to bounce on rounding alone.
+  .refine(
+    (v) => {
+      const sum = v.zones.reduce((a, z) => a + z.weight, 0);
+      return Math.abs(sum - 1) < 0.05;
+    },
+    { message: "zone weights must sum to ~1.0" },
+  );

--- a/src/lib/types/coffee.ts
+++ b/src/lib/types/coffee.ts
@@ -1,3 +1,5 @@
+import type { FieldZones } from "@/lib/field/types";
+
 export interface Coffee {
   id: string;
   roaster: string;
@@ -18,4 +20,8 @@ export interface Coffee {
   commonNotes?: string[];
   whatToExplore?: string;
   personalNotes?: string; // free-text notes written by the user
+  /** Generative Field v1.1 composition for this coffee. `null` until
+   * mapped from tasting notes; rendering falls back to Default in that
+   * case. See specs/design-system-v1.1-generative-field.md §10. */
+  fieldZones?: FieldZones | null;
 }


### PR DESCRIPTION
## Summary

Phase 3b. Field zones now **survive a session save**: the in-flight value from `/api/analyze-bag` flows through the brew flow → gets persisted to `coffees.field_zones` at save → is lifted back into the flow when the user later picks the coffee for a Brew Again.

### What lands

**API**
- `/api/sessions POST` schema gains an optional top-level `fieldZones` (validated by `FieldZonesSchema`). On first insert of a coffees row the value is persisted. On subsequent saves it's only written if the existing row has no composition yet — **organic backfill** for pre-v1.1 coffees without overwriting an already-computed Field. Routed to `coffees.field_zones`, **never** into `sessions.coffee` JSONB (spec §10.4 anti-pattern).

**Validation**
- `src/lib/field/schema.ts` — Zod `FieldZonesSchema` with `ZoneIdSchema` enum + weight tolerance refinement (0.05 slack so a 0.9999 sum from Haiku doesn't bounce on rounding alone).

**Types + helpers**
- `Coffee` interface grows `fieldZones?: FieldZones | null`
- `rowToCoffee` maps the JSONB column (cast — JSONB is `unknown` at Drizzle level and we trust the Zod-validated write path)

**Brew Again entry points**
- `/coffees/[id]` page (Coffee Detail "Brew this")
- `/coffees` page (Library list)
- `ActionPill` (Home Brew Again carousel)

All three now call `setFieldZones(coffee.fieldZones ?? null)` before `setStep("context")`.

**Save site**
- `StepSummary` POST body spreads `draft` AND adds top-level `fieldZones` from `useFlowStore.getState().fieldZones` (the value is a flowStore-level field, not part of `DraftSession`).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean
- [ ] Auto-deploy runs green
- [ ] Scan a new coffee with tasting notes → field colours match → save the session
- [ ] Verify on the VPS: `SELECT roaster, name, field_zones FROM coffees WHERE id = '<saved coffee>';` → JSONB present with `version: 1` + zones
- [ ] From Home / Coffees library / Coffee Detail, hit "Brew this" on a coffee that has a saved field → Context step paints in those colours (not Default)
- [ ] Existing pre-v1.1 coffees: next save organically writes their field (if scan produced one)

## What's NOT in this PR

- **Variety fallback (Phase 4)** — coffees with no notes still get Default until a future scan with notes succeeds.
- **Backfill script (Phase 5)** for the ~21 existing coffees — they backfill organically on the next save (the `existing.fieldZones == null && data.fieldZones != null` path).
- **Re-scan invalidation** — re-scanning the same bag with new notes won't overwrite the existing composition. Deferred until we hit it in practice.

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_