### PR TITLE
feat: light step-summary (review + save commit)

### DIFF
--- a/src/app/(light)/brew/preview/page.tsx
+++ b/src/app/(light)/brew/preview/page.tsx
@@ -4,7 +4,7 @@ import { useFlowStore } from "@/store/flowStore";
 import StepScan from "@/components/flow/StepScan";
 import LightStepMode from "@/components/flow/LightStepMode";
 import LightStepContext from "@/components/flow/LightStepContext";
-import StepRecommend from "@/components/flow/StepRecommend";
+import LightStepRecommend from "@/components/flow/LightStepRecommend";
 import StepBrew from "@/components/flow/StepBrew";
 import LightStepLog from "@/components/flow/LightStepLog";
 import StepSummary from "@/components/flow/StepSummary";
@@ -35,7 +35,7 @@ export default function BrewPreviewPage() {
       {step === "scan" && <StepScan />}
       {step === "mode" && <LightStepMode />}
       {step === "context" && <LightStepContext />}
-      {step === "recommend" && <StepRecommend />}
+      {step === "recommend" && <LightStepRecommend />}
       {step === "brew" && <StepBrew />}
       {step === "log" && <LightStepLog />}
       {step === "summary" && <StepSummary />}

--- a/src/app/(light)/brew/preview/page.tsx
+++ b/src/app/(light)/brew/preview/page.tsx
@@ -7,7 +7,7 @@ import LightStepContext from "@/components/flow/LightStepContext";
 import LightStepRecommend from "@/components/flow/LightStepRecommend";
 import StepBrew from "@/components/flow/StepBrew";
 import LightStepLog from "@/components/flow/LightStepLog";
-import StepSummary from "@/components/flow/StepSummary";
+import LightStepSummary from "@/components/flow/LightStepSummary";
 
 /**
  * Light migration parallel route.
@@ -38,7 +38,7 @@ export default function BrewPreviewPage() {
       {step === "recommend" && <LightStepRecommend />}
       {step === "brew" && <StepBrew />}
       {step === "log" && <LightStepLog />}
-      {step === "summary" && <StepSummary />}
+      {step === "summary" && <LightStepSummary />}
     </>
   );
 }

--- a/src/components/flow/LightStepRecommend.tsx
+++ b/src/components/flow/LightStepRecommend.tsx
@@ -1,0 +1,411 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useFlowStore } from "@/store/flowStore";
+import LightFlowShell from "@/components/ui/light/LightFlowShell";
+import Section from "@/components/ui/light/Section";
+import Chip from "@/components/ui/light/Chip";
+import CTA from "@/components/ui/light/CTA";
+import { formatSeconds } from "@/lib/utils/formatTime";
+import CoffeeBeanGlow from "@/components/ui/CoffeeBeanGlow";
+import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
+import { getLoadingHints, COFFEE_HINTS } from "@/lib/coffeeHints";
+import { useWakeLock } from "@/hooks/useWakeLock";
+import type { RecommendationCandidate, CandidateRole, CandidateConfidence } from "@/lib/types/session";
+
+/**
+ * Light System fork of /components/flow/StepRecommend.tsx.
+ *
+ * Same recommendation data, three same view states (loading → error →
+ * loaded), same handoff to step "brew" with setBrew on commit. Only
+ * the surfaces change: glass cards replace Dark surface-brew, anthracite
+ * text replaces text-white, Chips replace tinted role pills, the CTA
+ * primitive replaces the white-on-black button.
+ *
+ * Loading + error states render bare (no LightFlowShell) — mirrors Dark's
+ * hideNav pattern. The Field still paints whatever the previous step
+ * configured because the FieldContext is route-scoped at LightShell, not
+ * inside the brew flow shell.
+ *
+ * CoffeeBeanGlow uses #E8C5A8 (peach) hardcoded — kept as-is for v1. On
+ * the warm-cream Light field it still reads as a different tone (peach
+ * over cream); revisit if it disappears visually.
+ */
+
+function shuffleSubset(arr: string[], count: number): string[] {
+  const shuffled = [...arr].sort(() => Math.random() - 0.5);
+  return shuffled.slice(0, count);
+}
+
+const ROLE_LABELS: Record<CandidateRole, string> = {
+  anchor: "Anchor",
+  adjacent: "Adjacent",
+  contrast: "Contrast",
+  "clarity-probe": "Clarity",
+  "sweetness-probe": "Sweetness",
+  "body-probe": "Body",
+  wildcard: "Wildcard",
+};
+
+const CONFIDENCE_LABELS: Record<CandidateConfidence, string> = {
+  high: "High confidence",
+  moderate: "Moderate",
+  low: "Low confidence",
+  exploratory: "Exploratory",
+};
+
+export default function LightStepRecommend() {
+  const { draft, setStep, isRecommending, recommendError, setBrew } = useFlowStore();
+  const rec = draft.recommendation;
+  const [selectedIdx, setSelectedIdx] = useState(0);
+
+  const { enableWakeLock, disableWakeLock } = useWakeLock();
+  useEffect(() => {
+    if (isRecommending) enableWakeLock();
+    else disableWakeLock();
+  }, [isRecommending, enableWakeLock, disableWakeLock]);
+
+  const [hints, setHints] = useState<string[]>(() => getLoadingHints(8));
+  const [hintIdx, setHintIdx] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/hints")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: { hints: string[] } | null) => {
+        if (cancelled) return;
+        if (data && Array.isArray(data.hints) && data.hints.length >= 8) {
+          setHints(shuffleSubset(data.hints, 8));
+        } else {
+          setHints(shuffleSubset(COFFEE_HINTS, 8));
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setHints(shuffleSubset(COFFEE_HINTS, 8));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const hintTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  useEffect(() => {
+    if (isRecommending) {
+      hintTimer.current = setInterval(() => setHintIdx((i) => (i + 1) % hints.length), 10000);
+    } else if (hintTimer.current) {
+      clearInterval(hintTimer.current);
+    }
+    return () => {
+      if (hintTimer.current) clearInterval(hintTimer.current);
+    };
+  }, [isRecommending, hints.length]);
+
+  useEffect(() => {
+    setSelectedIdx(0);
+  }, [rec?.generatedAt]);
+
+  const candidates: RecommendationCandidate[] = rec?.candidates ?? [];
+  const active = candidates[selectedIdx];
+  const activeRecipe = active?.recipe;
+  const activeMethod = active?.method;
+  const activeMethodLabel =
+    activeMethod && draft.context?.dripAssist && !/drip assist/i.test(activeMethod)
+      ? `${activeMethod} + Drip Assist`
+      : activeMethod;
+
+  const handleUse = () => {
+    if (!activeMethod || !activeRecipe) return;
+    const dripAssist = draft.context?.dripAssist ?? /drip assist/i.test(activeMethod);
+    setBrew({ methodUsed: activeMethodLabel ?? activeMethod, dripAssist, followedRecipe: true });
+    setStep("brew");
+  };
+
+  // ── Loading state ─────────────────────────────────────────────────────
+  if (isRecommending) {
+    return (
+      <div className="min-h-dvh flex flex-col items-center justify-center px-8">
+        <CoffeeBeanGlow size={72} />
+        <p className="label-eyebrow mt-8">Crafting your recipe…</p>
+        <div className="mt-12 max-w-xs mx-auto w-full text-center space-y-2 min-h-[6rem] flex flex-col items-center justify-start">
+          <p className="label-eyebrow">Did you know?</p>
+          <p
+            key={hintIdx}
+            className="text-[13px] leading-relaxed text-light-foreground/70 animate-hint-cycle"
+          >
+            {hints[hintIdx]}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Error state ────────────────────────────────────────────────────────
+  if (recommendError) {
+    return (
+      <div className="min-h-dvh flex flex-col items-center justify-center gap-4 px-8 text-center">
+        <p className="text-[14px] text-light-foreground">{recommendError}</p>
+        <button
+          type="button"
+          onClick={() => setStep("context")}
+          className="px-6 py-3 rounded-full bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 text-[14px] text-light-foreground active:scale-95 transition-transform"
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  if (!rec || !candidates.length) return null;
+
+  return (
+    <LightFlowShell>
+      <p className="label-eyebrow px-1">
+        Suggested Recipe
+        {draft.coffee?.name ? ` · ${draft.coffee.roaster ? `${draft.coffee.roaster} · ` : ""}${draft.coffee.name}` : ""}
+      </p>
+
+      {rec.reasoning && (
+        <p className="mt-3 px-1 text-[13px] leading-relaxed text-light-muted-foreground italic">
+          {rec.reasoning}
+        </p>
+      )}
+
+      {candidates.length > 1 && (
+        <div className="mt-6 flex gap-2 overflow-x-auto pb-1" style={{ scrollbarWidth: "none" }}>
+          {candidates.map((c, i) => (
+            <Chip
+              key={i}
+              size="sm"
+              selected={selectedIdx === i}
+              onClick={() => setSelectedIdx(i)}
+            >
+              {ROLE_LABELS[c.role as CandidateRole] ?? c.role}
+            </Chip>
+          ))}
+        </div>
+      )}
+
+      {active && (
+        <div className="mt-6">
+          <h1 className="font-fraunces text-[28px] leading-tight tracking-[-0.01em] text-light-foreground px-1">
+            {active.title}
+          </h1>
+          <div className="flex items-center justify-between mt-2 px-1">
+            <div className="flex items-center gap-2">
+              <BrewMethodIcon method={activeMethod} className="w-5 h-5 text-light-foreground" />
+              <p className="text-[13px] text-light-muted-foreground">{activeMethodLabel}</p>
+            </div>
+            <span
+              className={`text-[13px] shrink-0 ${
+                active.confidence === "high"
+                  ? "text-light-foreground"
+                  : "text-light-muted-foreground"
+              }`}
+            >
+              {CONFIDENCE_LABELS[active.confidence]}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {activeRecipe && (
+        <div className="mt-6 rounded-3xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 p-5 space-y-4">
+          <div className="grid grid-cols-3 gap-4 text-center">
+            <RecipeStat label="Dose" value={`${activeRecipe.doseGrams}g`} />
+            <RecipeStat label="Water" value={`${activeRecipe.waterGrams}g`} />
+            <RecipeStat label="Temp" value={`${activeRecipe.waterTempC}°C`} />
+          </div>
+          <div className="border-t border-light-foreground/10 pt-4 grid grid-cols-2 gap-4 text-center">
+            <RecipeStat label="Grind" value={activeRecipe.grindSize} />
+            <RecipeStat label="Time" value={formatSeconds(activeRecipe.targetTimeSec)} />
+          </div>
+
+          {activeRecipe.pourSequence && (
+            <div className="border-t border-light-foreground/10 pt-4">
+              <p className="label-eyebrow mb-4">Pour sequence</p>
+              <PourSequence
+                sequence={activeRecipe.pourSequence}
+                totalGrams={activeRecipe.waterGrams}
+                targetTimeSec={activeRecipe.targetTimeSec}
+                roastDate={draft.coffee?.roastDate}
+                method={activeMethod}
+                process={draft.coffee?.process}
+              />
+            </div>
+          )}
+        </div>
+      )}
+
+      {active && (
+        <div className="mt-6 rounded-3xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 p-4 space-y-3">
+          <InfoRow label="Why" value={active.whyChosen} />
+          <div className="border-t border-light-foreground/10 pt-3">
+            <InfoRow label="Hypothesis" value={active.hypothesis} />
+          </div>
+          <div className="border-t border-light-foreground/10 pt-3">
+            <InfoRow label="Predicted cup" value={active.predictedCupProfile} />
+          </div>
+          <div className="border-t border-light-foreground/10 pt-3">
+            <InfoRow label="Observe" value={active.whatToObserve} />
+          </div>
+        </div>
+      )}
+
+      <CTA onClick={handleUse}>Brew with {activeMethodLabel}</CTA>
+    </LightFlowShell>
+  );
+}
+
+// ── PourSequence ─────────────────────────────────────────────────────────
+
+function getBloomAgitation(method?: string, process?: string): string | null {
+  const m = (method ?? "").toLowerCase();
+  const isWashed = process?.toLowerCase() === "washed";
+  if (m.includes("kalita")) return "Gentle swirl only";
+  if (m.includes("orea") && (m.includes("apex") || m.includes("fast") || m.includes("wölfl"))) return "Light stir 1–2×";
+  if (m.includes("orea")) return "Gentle swirl";
+  if (m.includes("peng") || m.includes("kasuya") || m.includes("4:6")) return "Stir 3×";
+  return isWashed ? "Stir 3–5×" : "Gentle swirl";
+}
+
+function getFinalAgitation(method?: string): string | null {
+  if (!method) return "Gentle swirl";
+  const m = method.toLowerCase();
+  if (m.includes("kalita")) return null;
+  if (m.includes("orea") && !m.includes("classic")) return null;
+  return "Gentle swirl";
+}
+
+function PourSequence({
+  sequence,
+  targetTimeSec,
+  roastDate,
+  method,
+  process,
+}: {
+  sequence: string;
+  totalGrams: number;
+  targetTimeSec: number;
+  roastDate?: string;
+  method?: string;
+  process?: string;
+}) {
+  const parts = sequence.split(/\s*[–—\-]\s*/).map((s) => s.trim());
+  const isCumulative = parts.length >= 2 && parts.every((p) => /^\d+$/.test(p));
+
+  if (!isCumulative) {
+    const steps = sequence.split(/\s*[·|]\s*/).map((s) => s.trim()).filter(Boolean);
+    if (steps.length < 2) {
+      return <p className="text-[13px] leading-relaxed text-light-foreground/70">{sequence}</p>;
+    }
+    return (
+      <div className="space-y-2">
+        {steps.map((step, i) => (
+          <div key={i} className="flex items-start gap-3">
+            <div className="w-5 h-5 rounded-full border border-light-foreground/20 shrink-0 flex items-center justify-center mt-0.5">
+              <span className="font-mono-num text-[11px] text-light-muted-foreground">{i + 1}</span>
+            </div>
+            <p className="text-[14px] capitalize leading-snug text-light-foreground">{step}</p>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  const milestones = parts.map(Number);
+  const n = milestones.length;
+  const daysOld = roastDate
+    ? Math.max(0, Math.floor((Date.now() - new Date(roastDate).getTime()) / 86_400_000))
+    : null;
+  const bloomDur =
+    daysOld === null ? 45 : daysOld < 7 ? 50 : daysOld < 22 ? 45 : 30;
+  const interval = n > 1 ? (targetTimeSec - bloomDur) / (n - 1) : 0;
+  const stepTimes = milestones.map((_, i) => (i === 0 ? 0 : Math.round(bloomDur + (i - 1) * interval)));
+
+  const rows: { time: string; label: React.ReactNode; isFirst?: boolean }[] = [
+    {
+      time: "",
+      isFirst: true,
+      label: <span className="text-[13px] text-light-muted-foreground">Ready</span>,
+    },
+    ...milestones.map((grams, i) => {
+      const pourGrams = i === 0 ? grams : grams - milestones[i - 1];
+      const label = i === 0 ? "Bloom" : i === n - 1 ? "Final pour" : `Pour ${i + 1}`;
+      const agitation =
+        i === 0
+          ? getBloomAgitation(method, process)
+          : i === n - 1
+            ? getFinalAgitation(method)
+            : null;
+      return {
+        time: stepTimes[i] === 0 ? "0:00" : formatSeconds(stepTimes[i]),
+        label: (
+          <div>
+            <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+              <span className="text-[14px] font-medium text-light-foreground">{label}</span>
+              <span className="font-mono-num text-[12px] font-semibold text-light-foreground">+{pourGrams}g</span>
+              <span className="font-mono-num text-[12px] text-light-muted-foreground">→ {grams}g</span>
+            </div>
+            {agitation && (
+              <span className="text-[12px] text-light-muted-foreground block mt-0.5">{agitation}</span>
+            )}
+          </div>
+        ),
+      };
+    }),
+    {
+      time: formatSeconds(targetTimeSec),
+      label: <span className="text-[13px] text-light-muted-foreground">Drawdown complete</span>,
+    },
+  ];
+
+  return (
+    <div className="relative">
+      {rows.map((row, i) => {
+        const isLast = i === rows.length - 1;
+        return (
+          <div key={i} className="flex items-center gap-0 min-h-[44px]">
+            <div className="w-10 shrink-0 flex items-center justify-end pr-3">
+              <span className="font-mono-num text-[11px] text-light-muted-foreground leading-none whitespace-nowrap">
+                {row.time}
+              </span>
+            </div>
+            <div className="relative flex flex-col items-center w-4 shrink-0 self-stretch">
+              <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-10 w-2.5 h-2.5 rounded-full bg-light-foreground/40" />
+              {!isLast && (
+                <div className="absolute top-1/2 bottom-0 left-1/2 -translate-x-1/2 w-px bg-light-foreground/15" />
+              )}
+              {!row.isFirst && (
+                <div className="absolute top-0 bottom-1/2 left-1/2 -translate-x-1/2 w-px bg-light-foreground/15" />
+              )}
+            </div>
+            <div className="flex-1 pl-3 py-2">{row.label}</div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function RecipeStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="label-eyebrow mb-1">{label}</p>
+      <p
+        className="font-mono-num text-light-foreground font-medium"
+        style={{ fontSize: "1.25rem", lineHeight: 1.2 }}
+      >
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="space-y-1">
+      <p className="label-eyebrow">{label}</p>
+      <p className="text-[13px] leading-relaxed text-light-foreground/80">{value}</p>
+    </div>
+  );
+}

--- a/src/components/flow/LightStepSummary.tsx
+++ b/src/components/flow/LightStepSummary.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useFlowStore } from "@/store/flowStore";
+import { useRouter } from "next/navigation";
+import LightFlowShell from "@/components/ui/light/LightFlowShell";
+import Chip from "@/components/ui/light/Chip";
+import LightStarRating from "@/components/ui/light/StarRating";
+import CoffeeBeanGlow from "@/components/ui/CoffeeBeanGlow";
+import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
+
+/**
+ * Light System fork of /components/flow/StepSummary.tsx.
+ *
+ * Same logic — POST to /api/sessions with the in-flight draft + top-
+ * level fieldZones, fetch the Escher insight (terrain + adjustment)
+ * non-blocking, transition to a "Logged" success state for 1.5s, then
+ * reset + router.push("/").
+ *
+ * The save action stays inline (a custom button at page end), not the
+ * LightFlowShell's CTA prop. Reason: the flow ends here, so there is
+ * no onNext step — the button is the save commit. LightFlowShell with
+ * onNext omitted renders only the header (back + dots).
+ *
+ * Hero treatment: if the user scanned a bag photo, it's the hero
+ * imagery with a CREAM-to-transparent scrim (not the Dark card-scrim
+ * which is black-to-transparent) so the anthracite caption stays
+ * readable. Photo-less coffees fall back to a frosted-glass title
+ * card.
+ *
+ * Saved state renders without LightFlowShell — full-screen centred
+ * success display, no back button (the flow is done).
+ *
+ * Dark /components/flow/StepSummary.tsx stays untouched until cut-over.
+ */
+
+export default function LightStepSummary() {
+  const { draft, reset } = useFlowStore();
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [terrain, setTerrain] = useState<string | null>(null);
+  const [adjustment, setAdjustment] = useState<string | null>(null);
+  const [insightLoading, setInsightLoading] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!draft.result?.rating) return;
+    setInsightLoading(true);
+    fetch("/api/brew-insight", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ draft, recentSessions: [] }),
+    })
+      .then((r) => r.json())
+      .then((d) => {
+        setTerrain(d.terrain || null);
+        setAdjustment(d.adjustment || null);
+      })
+      .catch(() => {})
+      .finally(() => setInsightLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const res = await fetch("/api/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...draft,
+          fieldZones: useFlowStore.getState().fieldZones,
+          type: "coffee",
+          createdAt: new Date().toISOString(),
+        }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as {
+          error?: string;
+          details?: { fieldErrors?: Record<string, string[]>; formErrors?: string[] };
+        };
+        const fieldErrors = body.details?.fieldErrors ?? {};
+        const firstField = Object.entries(fieldErrors).find(([, msgs]) => msgs && msgs.length > 0);
+        const detailMsg = firstField
+          ? `${firstField[0]}: ${firstField[1][0]}`
+          : body.details?.formErrors?.[0];
+        const baseMsg = body.error || `Save failed (${res.status})`;
+        throw new Error(detailMsg ? `${baseMsg} — ${detailMsg}` : baseMsg);
+      }
+      setSaved(true);
+      setTimeout(() => {
+        reset();
+        router.push("/");
+      }, 1500);
+    } catch (err) {
+      console.error("Session save error:", err);
+      setSaveError(err instanceof Error ? err.message : "Failed to save — please try again");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const coffee = draft.coffee;
+  const result = draft.result;
+  const brew = draft.brew;
+  const rec = draft.recommendation;
+
+  // ── Saved success state ─────────────────────────────────────────────
+  if (saved) {
+    return (
+      <div className="min-h-dvh flex flex-col items-center justify-center gap-5 px-8">
+        <div className="relative">
+          <svg className="w-16 h-16 text-light-foreground" fill="none" viewBox="0 0 100 100" aria-hidden>
+            <path
+              d="M14,50 C14,26 26,7 50,7 C74,7 86,26 86,50 C86,74 74,93 50,93 C26,93 14,74 14,50 Z"
+              stroke="currentColor"
+              strokeWidth="6"
+              fill="none"
+            />
+            <path d="M50,7 C43,29 57,61 50,93" stroke="currentColor" strokeWidth="5" />
+          </svg>
+          <div className="absolute -bottom-1 -right-1 w-6 h-6 rounded-full bg-light-foreground flex items-center justify-center">
+            <svg
+              className="w-3.5 h-3.5 text-[hsl(36_55%_96%)]"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+            </svg>
+          </div>
+        </div>
+        <div className="text-center">
+          <p className="font-fraunces text-[32px] leading-tight text-light-foreground">Logged</p>
+          <p className="text-[13px] text-light-muted-foreground mt-1">Session saved to your diary</p>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Review + save state ─────────────────────────────────────────────
+  return (
+    <LightFlowShell>
+      {coffee?.bagPhotoUrl ? (
+        <div className="relative -mx-5 mb-6 h-64 overflow-hidden rounded-3xl">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={coffee.bagPhotoUrl}
+            alt="Coffee bag"
+            className="absolute inset-0 w-full h-full object-cover"
+          />
+          {/* Cream-to-transparent bottom scrim so the anthracite caption
+              stays readable over an arbitrary bag photo. Specifically
+              NOT the Dark card-scrim utility (which is black-to-
+              transparent and would invert the text colour expectation). */}
+          <div
+            aria-hidden
+            className="absolute inset-0 pointer-events-none"
+            style={{
+              background:
+                "linear-gradient(to top, hsl(30 60% 92% / 0.92) 0%, hsl(30 60% 92% / 0.35) 45%, transparent 80%)",
+            }}
+          />
+          <div className="absolute bottom-0 left-0 right-0 p-5">
+            <h2 className="font-fraunces text-[28px] leading-tight text-light-foreground">
+              {coffee.name || "Unknown Coffee"}
+            </h2>
+            {coffee.roaster && (
+              <p className="text-[13px] text-light-foreground/70 mt-1">{coffee.roaster}</p>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className="mb-6 rounded-3xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 px-5 py-8">
+          <h2 className="font-fraunces text-[28px] leading-tight text-light-foreground">
+            {coffee?.name || "Coffee Session"}
+          </h2>
+          {coffee?.roaster && (
+            <p className="text-[13px] text-light-muted-foreground mt-1">{coffee.roaster}</p>
+          )}
+        </div>
+      )}
+
+      <div className="space-y-5">
+        {result?.rating ? (
+          <div className="flex items-center gap-3">
+            <LightStarRating value={result.rating} readonly size="md" />
+            <span className="text-[15px] font-medium text-light-foreground">{result.rating} / 5</span>
+          </div>
+        ) : null}
+
+        {(insightLoading || terrain || adjustment) && (
+          <div className="rounded-3xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 p-4 space-y-3">
+            {insightLoading ? (
+              <div className="flex items-start gap-3">
+                <CoffeeBeanGlow size={24} className="shrink-0 mt-0.5" />
+                <p className="text-[13px] italic text-light-muted-foreground">Reading the session…</p>
+              </div>
+            ) : (
+              <>
+                {terrain && (
+                  <div className="flex items-start gap-3">
+                    <svg
+                      className="w-4 h-4 shrink-0 mt-0.5 text-light-foreground/70"
+                      fill="none"
+                      viewBox="0 0 100 100"
+                      aria-hidden
+                    >
+                      <path
+                        d="M14,50 C14,26 26,7 50,7 C74,7 86,26 86,50 C86,74 74,93 50,93 C26,93 14,74 14,50 Z"
+                        stroke="currentColor"
+                        strokeWidth="8"
+                      />
+                      <path d="M50,7 C43,29 57,61 50,93" stroke="currentColor" strokeWidth="6" />
+                    </svg>
+                    <p className="text-[14px] italic leading-relaxed text-light-foreground">{terrain}</p>
+                  </div>
+                )}
+                {adjustment && (
+                  <div
+                    className={`${terrain ? "border-t border-light-foreground/10 pt-3" : ""} flex items-start gap-3`}
+                  >
+                    <div className="w-4 h-4 shrink-0 mt-0.5 flex items-center justify-center">
+                      <div className="w-1.5 h-1.5 rounded-full bg-light-foreground/40" />
+                    </div>
+                    <p className="text-[14px] leading-relaxed text-light-foreground/80">{adjustment}</p>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+        )}
+
+        {coffee && (coffee.origin || coffee.process || coffee.roastLevel) && (
+          <div className="rounded-3xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 p-4 space-y-2">
+            {coffee.origin && (
+              <InfoRow
+                label="Origin"
+                value={[coffee.origin, coffee.region].filter(Boolean).join(" · ")}
+              />
+            )}
+            {coffee.process && <InfoRow label="Process" value={coffee.process} />}
+            {coffee.roastLevel && <InfoRow label="Roast" value={coffee.roastLevel} />}
+          </div>
+        )}
+
+        {rec && brew?.methodUsed && (
+          <div className="rounded-3xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 p-4">
+            <p className="label-eyebrow mb-2">Recipe</p>
+            <div className="flex items-center gap-2 flex-wrap">
+              <BrewMethodIcon method={brew.methodUsed} className="w-4 h-4 shrink-0 text-light-foreground" />
+              <p className="text-[14px] text-light-foreground">
+                {brew.methodUsed} · {rec.primaryRecipe.doseGrams}g / {rec.primaryRecipe.waterGrams}g ·{" "}
+                {rec.primaryRecipe.waterTempC}°C
+              </p>
+            </div>
+          </div>
+        )}
+
+        {result?.flavorNotes && result.flavorNotes.length > 0 && (
+          <div className="flex flex-wrap gap-2">
+            {result.flavorNotes.map((f) => (
+              <Chip key={f} size="sm" selected>
+                {f}
+              </Chip>
+            ))}
+          </div>
+        )}
+
+        {result?.freeNotes && (
+          <p className="text-[13px] italic leading-relaxed text-light-muted-foreground">
+            &ldquo;{result.freeNotes}&rdquo;
+          </p>
+        )}
+      </div>
+
+      <div className="pt-6 pb-[max(1.5rem,env(safe-area-inset-bottom))]">
+        {saveError && (
+          <p className="text-[13px] text-light-foreground text-center leading-snug mb-3">
+            {saveError}
+          </p>
+        )}
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={saving}
+          className="h-14 w-full rounded-full bg-light-foreground text-[15px] font-semibold text-[hsl(36_55%_96%)] active:scale-[0.99] transition-transform disabled:opacity-60 disabled:active:scale-100"
+        >
+          {saving ? "Saving…" : saveError ? "Retry" : "Save Brew"}
+        </button>
+      </div>
+    </LightFlowShell>
+  );
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4">
+      <span className="text-[13px] text-light-muted-foreground shrink-0">{label}</span>
+      <span className="text-[14px] text-light-foreground text-right">{value}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Fifth step of the Light brew-flow migration. Mounts at `/brew/preview` when `step === "summary"`. Functional parity with Dark `StepSummary` — same `/api/sessions` POST shape (top-level `fieldZones` threaded through), same `/api/brew-insight` fetch on mount, same 1.5s "Logged" success transition + `reset` + `router.push("/")`. Visual layer only.

### Two render states

| State | Layout |
|---|---|
| **Review** (default) | `LightFlowShell`-wrapped review with bag-photo hero (CREAM-to-transparent scrim, not Dark's black one — keeps anthracite caption readable over arbitrary photo), `LightStarRating` (readonly), Escher insight card (terrain + adjustment), coffee/origin/process/roast info card, recipe line with `BrewMethodIcon`, flavor `Chip`s rendered selected as read-only tags, free-text note, anthracite **"Save Brew"** CTA pinned at body end (not via `LightFlowShell.onNext` because the flow ends here — no next step). |
| **Saved** | Bare centred coffee-bean glyph + checkmark badge in anthracite-on-cream + Fraunces 32px "Logged" + muted sub-line. Auto-redirects after 1500ms. |

The "Logged" hero uses Fraunces at 32px (rather than v1.0's 24px) — only Light-flow surface where "Logged" is the headline, earns the editorial-serif moment.

### Carryovers from Dark (untouched)

- `useFlowStore.getState().fieldZones` threaded into POST body (top-level, not on coffee, per v1.1 §10.4)
- Save-error parsing (Zod `fieldErrors` + `formErrors`)
- `CoffeeBeanGlow` during insight fetch
- `BrewMethodIcon` next to recipe line

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean — `/brew/preview` at 14.8 kB
- [ ] Auto-deploy runs green
- [ ] On `/brew/preview` after a brew + log:
  - [ ] Summary screen renders with bag photo hero (if scanned) or glass title card
  - [ ] Star rating renders anthracite (readonly)
  - [ ] Escher insight loads with CoffeeBeanGlow → terrain/adjustment text
  - [ ] Info card shows Origin / Process / Roast in muted/foreground pairs
  - [ ] Flavor chips render selected (taupe) as read-only tags
  - [ ] Save Brew → "Logged" success state → auto-redirect to `/`
  - [ ] Save error → red message + "Retry" button
- [ ] `/brew/new` (Dark) unchanged

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_