### PR TITLE
fix: greeting respects real time-of-day + library usage signal

### DIFF
--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -127,7 +127,11 @@ export default function HomePage() {
 
   // Daily Starter — cached per calendar day in localStorage.
   useEffect(() => {
-    const key = `brewlog.starter.${todayKey()}`;
+    // Cache version bumped (v2) to invalidate the day's starter after the
+    // /api/greeting prompt fix (time-of-day + library-usage signals).
+    // Old `brewlog.starter.<date>` entries are orphaned in localStorage —
+    // harmless, just unused.
+    const key = `brewlog.starter.v2.${todayKey()}`;
     try {
       const cached = window.localStorage.getItem(key);
       if (cached) {

--- a/src/app/api/greeting/route.ts
+++ b/src/app/api/greeting/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
 import { requireAuth } from "@/lib/auth/requireAuth";
-import { loadCoffeeLibraryCompact } from "@/lib/claude/coffeeLibrary";
+import { loadCoffeeLibraryCompact, formatLibraryForPrompt } from "@/lib/claude/coffeeLibrary";
 import { db } from "@/lib/db/client";
 import { sessions } from "@/lib/db/schema";
 import { desc } from "drizzle-orm";
@@ -32,6 +32,20 @@ RULES
 - Reference one concrete signal from the context if it's there — a specific roaster from yesterday's brew, a coffee they haven't touched in a while, the time of day — and turn it into an invitation, not a report.
 - If the user has no recent brews and an empty library, fall back to a quiet welcome.
 - No emojis, no markdown, no second sentence, no preamble like "Here's your greeting:".
+
+TIME-OF-DAY DISCIPLINE
+- The context block tells you the current time of day. Use that label or omit time entirely — never invent a different one.
+  • "morning" → "Good morning", "Morning", "Early start"
+  • "midday" / "afternoon" → "Quiet afternoon", "Midday lull"
+  • "evening" → "Evening already", "End of the day"
+  • "late-night" → "Late night", "Past midnight"
+- NEVER say "late night" when the context says evening. NEVER say "morning" when the context says afternoon. Etc.
+
+COFFEE-HISTORY DISCIPLINE
+- Each library line shows session count and average rating ("3.8★ over 5") or "unbrewed" when the bag has never been brewed.
+- A coffee with session count > 0 HAS been brewed. Never say "haven't brewed yet" or "untried" for those.
+- "unbrewed" entries are the only ones you may describe as untouched.
+- For a brewed coffee you may invite a return ("worth revisiting", "ready for another round") — not a first try.
 
 EXAMPLES (style only — do not copy)
 - Good morning. DAK Coffee Roasters yesterday — try Process or anything new today?
@@ -71,7 +85,9 @@ export async function POST(req: NextRequest) {
       rowToSession(row as Parameters<typeof rowToSession>[0])
     );
 
-    const hour = new Date().getHours();
+    const now = new Date();
+    const hour = now.getHours();
+    const minute = now.getMinutes();
     const timeOfDay =
       hour < 5 ? "late-night"
       : hour < 11 ? "morning"
@@ -79,6 +95,7 @@ export async function POST(req: NextRequest) {
       : hour < 18 ? "afternoon"
       : hour < 22 ? "evening"
       : "late-night";
+    const localHHMM = `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
 
     const recentLines = recentSessions
       .slice(0, 3)
@@ -90,15 +107,21 @@ export async function POST(req: NextRequest) {
       })
       .filter(Boolean);
 
-    const libraryLines = library.slice(0, 4).map((c) => `- ${c.roaster} ${c.name}`.trim());
+    // formatLibraryForPrompt renders each line as
+    //   - ROASTER — NAME | ORIGIN PROCESS | roasted Xd ago | X.X★ over N
+    // so Haiku sees session counts + ratings and won't claim a brewed
+    // coffee is "untried" — the earlier bare roaster+name line gave
+    // Haiku no signal, so it hallucinated "haven't brewed yet" on a
+    // bag that had 1+ saved sessions.
+    const libraryBlock = formatLibraryForPrompt(library);
 
     const userBlock = [
-      `Time of day: ${timeOfDay} (hour ${hour}, local time)`,
+      `Time of day: ${timeOfDay} (local clock ${localHHMM}). Use this label exactly, or omit time entirely.`,
       recentLines.length > 0
         ? `Recent brews:\n${recentLines.join("\n")}`
         : "Recent brews: none in the last few days.",
-      libraryLines.length > 0
-        ? `Library snapshot:\n${libraryLines.join("\n")}`
+      libraryBlock.length > 0
+        ? `Library snapshot (with usage):\n${libraryBlock}`
         : "Library snapshot: empty.",
     ].join("\n\n");
 


### PR DESCRIPTION
## Summary

Markus' `/home` screenshot at 18:41 (evening), with La Primavera previously brewed several times, showed the starter:

> "Late night still — the Jaime Sanchez rated highest, or venture into La Primavera you haven't brewed yet?"

Wrong on **both** counts.

### Two bugs in `src/app/api/greeting`

**1. Time-of-day was sent but ignored.** The user block contained `"evening"`, but the prompt never said "use this label exactly". Haiku ran on style examples and reached for "late night" because it sounded more editorial.

Fix:
- User block now includes the exact local clock — `"Time of day: evening (local clock 18:41). Use this label exactly, or omit time entirely."`
- New `TIME-OF-DAY DISCIPLINE` block in the system prompt lists allowed phrasings per label plus explicit "NEVER say X when context says Y" rules.

**2. Library snapshot dropped the usage signal.** The endpoint hand-rolled `- roaster name` instead of using `formatLibraryForPrompt`, which renders:

```
- ROASTER — NAME | ORIGIN PROCESS | roasted Xd ago | X.X★ over N
```

Without session count + rating, Haiku guessed "haven't brewed yet" — false for any bag with sessions.

Fix:
- Switched to `formatLibraryForPrompt(library)` — Haiku now sees `3.8★ over 5` (brewed 5 times) or `unbrewed` (never brewed).
- New `COFFEE-HISTORY DISCIPLINE` block forbids "haven't brewed yet" / "untried" for any session-bearing entry; reserves "untouched" wording for literal `unbrewed` markers.

### Cache invalidation

Client localStorage key bumped from `brewlog.starter.<date>` to `brewlog.starter.v2.<date>` so today's stale cached starter is orphaned and the next `/home` load fetches a fresh one. Old keys sit unused in localStorage; harmless.

## CLAUDE.md hard-rule note

This is a prompt change. The new rules are **restrictive** (forbid two specific hallucination patterns; the existing happy paths still satisfy every rule), so the regression surface is narrow. Markus sees the new starter on next `/home` load and can flag if anything's off — revert is single-squash trivial.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Auto-deploy runs green
- [ ] Reload `/home` — new starter:
  - [ ] References the actual current time-of-day (or omits time entirely), never invents
  - [ ] If it mentions a library coffee with sessions, calls it "ready for another round" / "worth revisiting" — NOT "haven't tried" or "haven't brewed yet"
  - [ ] Coffees marked `unbrewed` in the library can still be invited as new

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_