### PR TITLE
fix: invert brew-method icons under [data-light-scope]

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -230,6 +230,18 @@
     outline: none;
     border-color: inherit;
   }
+
+  /* Light System — invert BrewMethodIcon assets for the warm cream Field.
+   * The /brew-icons/*.png + chemex.svg are all drawn with white strokes
+   * (designed for the Dark canvas). On Light they read as faint ghosts.
+   * `filter: brightness(0)` collapses every opaque pixel to pure black
+   * while preserving alpha, so the white-line drawings become anthracite
+   * line drawings. opacity-80 already on the <img> matches the warm
+   * foreground/80 weight elsewhere. Dark routes never carry
+   * [data-light-scope] so they keep the original white art. */
+  [data-light-scope] [data-brew-method-icon] {
+    filter: brightness(0);
+  }
 }
 
 /*

--- a/src/components/ui/BrewMethodIcon.tsx
+++ b/src/components/ui/BrewMethodIcon.tsx
@@ -17,9 +17,14 @@ export function brewIconSrc(method?: string): string {
 
 export default function BrewMethodIcon({ method, className = "w-6 h-6" }: BrewMethodIconProps) {
   return (
+    // data-brew-method-icon is the hook globals.css uses under
+    // [data-light-scope] to invert the white-stroke icon assets to
+    // anthracite for the (light) route group. Dark routes get the
+    // original white art unchanged.
     <img
       src={brewIconSrc(method)}
       alt={method ?? "Brew device"}
+      data-brew-method-icon=""
       className={`object-contain opacity-80 ${className}`}
     />
   );


### PR DESCRIPTION
## Summary

The `/brew-icons/*.png` + `chemex.svg` assets are drawn with white strokes — designed for the Dark canvas. On the warm cream Light Field they read as faint ghosts (Markus' `/brew/preview` Brewing-Approach screenshot: V60, Orea Fast/Apex/Classic/Open, Chemex, AeroPress all near-invisible).

### Fix without recutting assets

- `BrewMethodIcon`'s `<img>` gets a stable `data-brew-method-icon` attribute
- `globals.css` adds a `[data-light-scope] [data-brew-method-icon]` selector applying `filter: brightness(0)`
- `brightness(0)` collapses every opaque pixel to pure black while preserving alpha → white-line art becomes anthracite-line art
- Existing `opacity-80` on the `<img>` matches the warm `foreground/80` weight used elsewhere in the Light system

Dark routes never carry `[data-light-scope]`, so they keep the original white art — **zero Dark regression**.

Zero API change. The `text-light-foreground` classes I previously sprinkled on `<BrewMethodIcon className=...>` in Light consumers were no-ops on `<img>` (text colour doesn't apply); the attribute selector is what actually drives colour now. Those text classes are harmless leftover.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Auto-deploy runs green
- [ ] On `/brew/preview` step Context → "I'll choose": all 12 brewer icons (V60, Orea ×4, Origami ×2, Kalita, Chemex, AeroPress, Clever, Moccamaster) read as anthracite line drawings on the cream Field
- [ ] LightStepRecommend candidate row + LightStepSummary recipe line also show anthracite icons
- [ ] `/brew/new` (Dark) icons unchanged — white strokes on the dark canvas

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_