### PR TITLE
fix: light scan &quot;you&#39;ve had this&quot; pill triggers brew again

### DIFF
--- a/src/components/flow/LightStepScan.tsx
+++ b/src/components/flow/LightStepScan.tsx
@@ -56,7 +56,7 @@ const ROASTER_QA_LOCATION_CHIPS = ["Germany", "Netherlands", "UK", "USA", "Denma
 const ROASTER_QA_STYLE_CHIPS = ["Very light", "Light", "Light-medium", "Medium", "Varies"];
 
 export default function LightStepScan() {
-  const { draft, setCoffee, setMode, setStep, setFieldZones, isAnalyzing, setIsAnalyzing, clarificationMessages, addClarificationMessage, clearClarifications } = useFlowStore();
+  const { draft, setCoffee, setMode, setStep, setSkipScan, setFieldZones, isAnalyzing, setIsAnalyzing, clarificationMessages, addClarificationMessage, clearClarifications, reset } = useFlowStore();
   const [preview, setPreview] = useState<string | null>(null);
   const [inputMethod, setInputMethod] = useState<InputMethod | null>(null);
   const [selectedMode, setSelectedMode] = useState<ModeChoice | null>(null);
@@ -907,15 +907,41 @@ export default function LightStepScan() {
           )}
         </div>
 
-        {/* Library match notice */}
+        {/* Library match notice — tap = Brew Again with this coffee's
+            persisted identity + fieldZones + brew history. The Dark
+            version was a plain <a href="/coffees/[id]"> that just took
+            the user to the Library detail page (Markus' feedback:
+            "doesn't work" — the navigation broke flow without giving
+            any benefit). Now it short-circuits straight to Context
+            using the saved row, identical to the Brew-Again entry
+            from /coffees/[id] and the Home ActionPill carousel. */}
         {libraryMatch && (
-          <a
-            href={`/coffees/${libraryMatch.id}`}
-            className="flex items-center justify-between gap-3 rounded-2xl px-4 py-3 border transition-all active:scale-[0.98]"
-            style={{ background: "rgba(212,184,150,0.08)", borderColor: "rgba(212,184,150,0.25)" }}
+          <button
+            type="button"
+            onClick={() => {
+              const m = libraryMatch;
+              reset();
+              setCoffee({
+                roaster: m.roaster,
+                name: m.name,
+                origin: m.origin,
+                process: m.process,
+                roastLevel: "Light",
+                roastDate: m.latestRoastDate,
+                bagPhotoUrl: m.bagPhotoUrl,
+                aiExtracted: false,
+                coffeeId: m.id,
+              });
+              setFieldZones(m.fieldZones ?? null);
+              setMode("home");
+              setSkipScan(true);
+              setStep("context");
+            }}
+            className="w-full flex items-center justify-between gap-3 rounded-2xl px-4 py-3 border transition-all active:scale-[0.98] text-left"
+            style={{ background: "var(--card)", borderColor: "var(--border)" }}
           >
             <div className="min-w-0">
-              <p className="text-xs uppercase tracking-widest mb-0.5" style={{ color: "var(--primary)" }}>You&apos;ve had this before</p>
+              <p className="label-eyebrow mb-0.5">You&apos;ve had this before</p>
               <p className="text-sm truncate" style={{ color: "var(--foreground)" }}>
                 {libraryMatch.name}
                 {libraryMatch.avgRating != null ? ` · ${libraryMatch.avgRating.toFixed(1)}★` : ""}
@@ -925,8 +951,8 @@ export default function LightStepScan() {
                 <p className="text-xs mt-0.5 truncate" style={{ color: "var(--muted-foreground)" }}>&ldquo;{libraryMatch.personalNotes}&rdquo;</p>
               )}
             </div>
-            <span className="text-xs shrink-0" style={{ color: "var(--muted-foreground)" }}>Library →</span>
-          </a>
+            <span className="text-xs shrink-0" style={{ color: "var(--muted-foreground)" }}>Brew again →</span>
+          </button>
         )}
 
         {/* THEN CHOOSE */}


### PR DESCRIPTION
## Summary

The "You've had this before" pill at the bottom of the Light scan screen was a plain `<a href="/coffees/[id]">`; tapping it took the user out of the brew flow to the Library detail page. Markus' feedback: "doesn't work" — the navigation broke flow without giving any benefit, since they're mid-brew and don't want to detour through the Library.

Replace with the established **Brew-Again pattern** (same as `/coffees/[id]` "Brew this" button and the Home ActionPill carousel):

```ts
reset();
setCoffee({ ...identity from libraryMatch });
setFieldZones(libraryMatch.fieldZones ?? null);
setMode("home");
setSkipScan(true);
setStep("context");
```

The scan in progress is discarded — the user already has this coffee in the library with its fresh-enough roast date, photo, and computed Field. They short-circuit straight to Brew Context, with the v1.1 Field repainting in this coffee's colours via the persisted `field_zones`.

Right-side action label flipped from "Library →" to **"Brew again →"** to match the new behaviour. Tag stays styled as a light glass pill; uses `label-eyebrow` for the eyebrow now instead of the inline-styled uppercase text.

`setSkipScan` + `reset` destructured from `useFlowStore` for the new action.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean — `/brew/preview` 28.3 kB
- [ ] Auto-deploy runs green
- [ ] On `/brew/preview` photo-scan a bag that's already in the library:
  - [ ] Pill renders: "You've had this before · Pacas from Honduras · 4.0★ · 3 brews"
  - [ ] Tap → Context step opens immediately (no Library detour)
  - [ ] Coffee shows the library version's identity, the Field paints in that coffee's colours
  - [ ] Continuing through Context → Recommend etc. works as a Brew Again flow
- [ ] Coffee NOT in library → pill doesn't render
- [ ] `/brew/new` (Dark) unchanged

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_