### PR TITLE
fix: scroll to top on every brew-flow step change

### DIFF
--- a/src/components/ui/light/LightFlowShell.tsx
+++ b/src/components/ui/light/LightFlowShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronLeft } from "lucide-react";
 import { useFlowStore, type FlowStep } from "@/store/flowStore";
@@ -77,6 +77,16 @@ export default function LightFlowShell({
     [fieldZones, step],
   );
   useFieldConfig(fieldConfig);
+
+  // Reset scroll to the top on every step transition. Without this,
+  // tapping Continue from a long Scan screen lands the user
+  // mid-Context with the eyebrow off-screen. Each step is a fresh
+  // page in the user's mental model — they should always see the
+  // Hero first. `instant` avoids the smooth animation that would
+  // jar the field rotation transition.
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "instant" });
+  }, [step]);
 
   const steps =
     draft.mode === "external"


### PR DESCRIPTION
## Summary

Long-standing UX irritation: tapping Continue from a long Scan screen lands the user **mid-Context** with the eyebrow off-screen. Every step is a fresh page in the user's mental model — they should always see the Hero first.

`LightFlowShell` now runs `window.scrollTo({ top: 0, behavior: "instant" })` in a `useEffect` on `step` change. Instant (no smooth animation) so it doesn't fight the field rotation transition (step rotation jumps 25° per step per spec §8.3).

Applies to every step that mounts inside `LightFlowShell` — Context, Recommend, Brew, Log, Summary all benefit. (Scan + Mode don't trigger the effect on their own since `step` was already "scan" when the user landed, but the effect is harmless there.)

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Auto-deploy runs green
- [ ] On `/brew/preview`:
  - [ ] Photo scan + scroll down to fill in the Identified card → Continue → Context appears with "Context · X" eyebrow at top, not mid-scroll
  - [ ] Context → Recommend → Brew → Log → Summary: every transition starts with the page header visible
  - [ ] Back button respects history scroll? Browser back will restore previous scroll naturally; the effect only fires on FORWARD step transitions because `step` changes via setStep
- [ ] `/brew/new` (Dark) unchanged — uses its own FlowShell

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_