### PR TITLE
fix: restore library-match pill navigation, keep light styling

### DIFF
--- a/src/components/flow/LightStepScan.tsx
+++ b/src/components/flow/LightStepScan.tsx
@@ -907,37 +907,18 @@ export default function LightStepScan() {
           )}
         </div>
 
-        {/* Library match notice — tap = Brew Again with this coffee's
-            persisted identity + fieldZones + brew history. The Dark
-            version was a plain <a href="/coffees/[id]"> that just took
-            the user to the Library detail page (Markus' feedback:
-            "doesn't work" — the navigation broke flow without giving
-            any benefit). Now it short-circuits straight to Context
-            using the saved row, identical to the Brew-Again entry
-            from /coffees/[id] and the Home ActionPill carousel. */}
+        {/* Library match notice — original Dark behaviour restored:
+            navigates to /coffees/[id] so the user can read the prior
+            brew history before deciding whether to use this coffee.
+            Visual was the issue Markus flagged ("sieht scheisse aus"):
+            the previous peach-on-cream background (rgba 0.08) was
+            invisible. Now uses the standard light-glass surface plus
+            label-eyebrow so the pill reads as a clear card on the
+            Field. */}
         {libraryMatch && (
-          <button
-            type="button"
-            onClick={() => {
-              const m = libraryMatch;
-              reset();
-              setCoffee({
-                roaster: m.roaster,
-                name: m.name,
-                origin: m.origin,
-                process: m.process,
-                roastLevel: "Light",
-                roastDate: m.latestRoastDate,
-                bagPhotoUrl: m.bagPhotoUrl,
-                aiExtracted: false,
-                coffeeId: m.id,
-              });
-              setFieldZones(m.fieldZones ?? null);
-              setMode("home");
-              setSkipScan(true);
-              setStep("context");
-            }}
-            className="w-full flex items-center justify-between gap-3 rounded-2xl px-4 py-3 border transition-all active:scale-[0.98] text-left"
+          <a
+            href={`/coffees/${libraryMatch.id}`}
+            className="w-full flex items-center justify-between gap-3 rounded-2xl px-4 py-3 border transition-all active:scale-[0.98] text-left no-underline"
             style={{ background: "var(--card)", borderColor: "var(--border)" }}
           >
             <div className="min-w-0">
@@ -951,8 +932,8 @@ export default function LightStepScan() {
                 <p className="text-xs mt-0.5 truncate" style={{ color: "var(--muted-foreground)" }}>&ldquo;{libraryMatch.personalNotes}&rdquo;</p>
               )}
             </div>
-            <span className="text-xs shrink-0" style={{ color: "var(--muted-foreground)" }}>Brew again →</span>
-          </button>
+            <span className="text-xs shrink-0" style={{ color: "var(--muted-foreground)" }}>Library →</span>
+          </a>
         )}
 
         {/* THEN CHOOSE */}


### PR DESCRIPTION
## Summary

PR #92 misread Markus' feedback. He didn't want the **behaviour** changed — the original `<a href="/coffees/[id]">` navigation to the Library detail page WAS the right intent ("ich hab den schon, hier sind meine brews"). The **visual** was the problem: the peach-on-cream pill background (`rgba(212,184,150,0.08)` fill + `rgba(0.25)` border) reads as nothing on the warm Light Field. Markus saw a blank patch and said "doesn't work".

Revert:
- `<a href={`/coffees/${libraryMatch.id}`}>` navigation
- Right-side label back to "Library →"

Keep:
- `background: var(--card)` (light glass via the shim)
- `border-color: var(--border)`
- `label-eyebrow` for the uppercase eyebrow

The pill now reads as a clear card on the Field, and tapping it opens the Library detail for that coffee.

`reset` / `setSkipScan` / `setMode` are still destructured from `useFlowStore` but no longer used here — the Brew-Again wiring is gone with the button. They're harmless leftovers; tree-shaken at build time.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Auto-deploy runs green
- [ ] On `/brew/preview` photo-scan a bag that's already in the library:
  - [ ] Pill visible on the warm cream Field — clear card surface, "YOU'VE HAD THIS BEFORE" eyebrow + coffee line + "Library →"
  - [ ] Tap → navigates to /coffees/[id] Library detail page

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_