### PR TITLE
fix: cache greeting per time-of-day bucket, not per calendar day

### DIFF
--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -52,6 +52,24 @@ function todayKey(): string {
   return `${y}-${m}-${d}`;
 }
 
+/**
+ * Bucket the current hour into the same time-of-day labels the
+ * /api/greeting prompt uses (morning / midday / afternoon / evening /
+ * late-night). The Starter cache key includes this bucket so a
+ * starter generated at 11:30 doesn't keep saying "Quiet afternoon"
+ * when the user re-opens at 20:45 — Markus' bug. Five regenerations
+ * per active day max; ~$0.0005 in Haiku cost, structurally trivial.
+ */
+function timeBucket(): string {
+  const hour = new Date().getHours();
+  if (hour < 5) return "late-night";
+  if (hour < 11) return "morning";
+  if (hour < 14) return "midday";
+  if (hour < 18) return "afternoon";
+  if (hour < 22) return "evening";
+  return "late-night";
+}
+
 interface ActiveConversationResponse {
   conversation: {
     id: string;
@@ -127,11 +145,14 @@ export default function HomePage() {
 
   // Daily Starter — cached per calendar day in localStorage.
   useEffect(() => {
-    // Cache version bumped (v2) to invalidate the day's starter after the
-    // /api/greeting prompt fix (time-of-day + library-usage signals).
-    // Old `brewlog.starter.<date>` entries are orphaned in localStorage —
-    // harmless, just unused.
-    const key = `brewlog.starter.v2.${todayKey()}`;
+    // Cache version bumped (v3) + time-of-day bucket appended so the
+    // starter regenerates when the user crosses a tod boundary
+    // (morning → midday → afternoon → evening → late-night). Earlier
+    // bug: opening the app at 11:00 cached a "morning" line that
+    // showed all day even when re-opened at 20:45. Old
+    // `brewlog.starter.v2.<date>` entries are orphaned in
+    // localStorage — harmless.
+    const key = `brewlog.starter.v3.${todayKey()}.${timeBucket()}`;
     try {
       const cached = window.localStorage.getItem(key);
       if (cached) {


### PR DESCRIPTION
## Summary

Markus' `/home` at 20:44 still showed "Quiet afternoon. The El Congo from RVTC earned a perfect score — ready to revisit?" — even though PR #87 had fixed the `/api/greeting` prompt to respect the supplied time-of-day.

Why: the localStorage cache key was `brewlog.starter.v2.<YYYY-MM-DD>` — keyed on the calendar day only. Markus opened the app earlier today during the actual afternoon, the starter was generated correctly THEN, and cached for the whole day. Re-opening at 20:45 served the stale afternoon line; the prompt fix had no chance to fire because the client never re-requested.

### Fix

Derive a time-of-day bucket on the client using the same boundaries the server prompt uses:

| Hour | Bucket |
|---|---|
| <5 | late-night |
| <11 | morning |
| <14 | midday |
| <18 | afternoon |
| <22 | evening |
| ≥22 | late-night |

Include it in the cache key:

```
brewlog.starter.v3.<YYYY-MM-DD>.<bucket>
```

Crossing a tod boundary triggers one fresh `/api/greeting` call. Five regenerations per active day max → ~$0.0005 in Haiku cost, structurally trivial.

Cache version bumped v2 → v3 so today's stale "afternoon" entry is orphaned. Next `/home` load fetches a fresh evening-bucketed starter.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Auto-deploy runs green
- [ ] Open `/home` at 20:45 → starter references "evening" or omits time entirely, never "afternoon"
- [ ] If the page is re-opened in the same bucket within a day, the same starter is served (cache hit)
- [ ] Crossing midnight or a bucket boundary triggers a regeneration

## What's NOT in this PR

Markus' second ask — explicit "in rotation" markers for coffees — is a feature, not a bug fix. New DB column + library UI toggle + greeting prompt enrichment. Bigger scope; flag for a separate PR after sign-off on the cache fix.

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_