### PR TITLE
feat: coffee in-rotation marker + greeting prompt signal

### DIFF
--- a/src/app/api/coffees/[id]/route.ts
+++ b/src/app/api/coffees/[id]/route.ts
@@ -18,9 +18,14 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
   }
 }
 
+// Either field is optional; PATCH must include at least one.
 const PatchSchema = z.object({
-  personalNotes: z.string().max(5000),
-});
+  personalNotes: z.string().max(5000).optional(),
+  inRotation: z.boolean().optional(),
+}).refine(
+  (v) => v.personalNotes !== undefined || v.inRotation !== undefined,
+  { message: "must provide personalNotes or inRotation" },
+);
 
 export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
   try {
@@ -31,7 +36,10 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
     }
     const rows = await db.select({ id: coffees.id }).from(coffees).where(eq(coffees.id, params.id)).limit(1);
     if (rows.length === 0) return NextResponse.json(null, { status: 404 });
-    await db.update(coffees).set({ personalNotes: parsed.data.personalNotes }).where(eq(coffees.id, params.id));
+    const updates: Record<string, unknown> = {};
+    if (parsed.data.personalNotes !== undefined) updates.personalNotes = parsed.data.personalNotes;
+    if (parsed.data.inRotation !== undefined) updates.inRotation = parsed.data.inRotation;
+    await db.update(coffees).set(updates).where(eq(coffees.id, params.id));
     return NextResponse.json({ ok: true });
   } catch (err) {
     console.error("coffee PATCH error:", err);

--- a/src/app/api/greeting/route.ts
+++ b/src/app/api/greeting/route.ts
@@ -47,6 +47,11 @@ COFFEE-HISTORY DISCIPLINE
 - "unbrewed" entries are the only ones you may describe as untouched.
 - For a brewed coffee you may invite a return ("worth revisiting", "ready for another round") — not a first try.
 
+ROTATION DISCIPLINE
+- Library lines prefixed with "★ IN ROTATION" are the user's active rotation — bags they consider current. Treat these as the primary candidates for the day's invitation.
+- If the library has ANY rotation entries, prefer one of them over a non-rotation entry, unless a recent brew makes a non-rotation reference more natural.
+- "★ IN ROTATION" is a prefix marker, not part of the coffee name — never echo it back in the sentence.
+
 EXAMPLES (style only — do not copy)
 - Good morning. DAK Coffee Roasters yesterday — try Process or anything new today?
 - Quiet afternoon. The Friedhats Wush Wush hasn't moved in a week.

--- a/src/app/coffees/[id]/page.tsx
+++ b/src/app/coffees/[id]/page.tsx
@@ -225,13 +225,46 @@ export default function CoffeeDetailPage() {
       </div>
 
       {/* Brew this — jumps straight to the brew context step with this coffee preloaded */}
-      <div className="px-5 pt-4">
+      <div className="px-5 pt-4 space-y-2">
         <button
           type="button"
           onClick={brewThis}
           className="w-full py-3.5 rounded-2xl text-sm font-medium bg-brew-accent text-brew-accent-fg active:scale-[0.98] transition-transform"
         >
           Brew this
+        </button>
+        {/* Rotation toggle — marks this bag as "currently in rotation".
+            The /api/greeting library snapshot uses this signal so the
+            daily Haiku starter prioritises rotation bags over the rest
+            of the library. Optimistic update + best-effort PATCH. */}
+        <button
+          type="button"
+          onClick={async () => {
+            if (!coffee) return;
+            const next = !coffee.inRotation;
+            setCoffee((prev) => (prev ? { ...prev, inRotation: next } : prev));
+            try {
+              const res = await fetch(`/api/coffees/${coffee.id}`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ inRotation: next }),
+              });
+              if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            } catch {
+              // Revert on failure
+              setCoffee((prev) => (prev ? { ...prev, inRotation: !next } : prev));
+            }
+          }}
+          className={`w-full py-3 rounded-2xl text-sm flex items-center justify-center gap-2 border transition-transform active:scale-[0.98] ${
+            coffee.inRotation
+              ? "bg-brew-accent/10 border-brew-accent/40 text-brew-accent"
+              : "bg-brew-surface border-brew-border text-brew-muted"
+          }`}
+        >
+          <svg className="w-4 h-4" viewBox="0 0 24 24" fill={coffee.inRotation ? "currentColor" : "none"} stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
+            <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+          </svg>
+          {coffee.inRotation ? "In rotation" : "Add to rotation"}
         </button>
       </div>
 

--- a/src/lib/claude/coffeeLibrary.ts
+++ b/src/lib/claude/coffeeLibrary.ts
@@ -16,6 +16,9 @@ export interface CompactCoffee {
   commonNotes?: string[];
   /** 2–4 sentence AI brew memory generated weekly by /api/coffees/compact. */
   writtenSummary?: string;
+  /** User-marked "currently in rotation". /api/greeting prioritises
+   * rotation bags in the library snapshot. */
+  inRotation?: boolean;
 }
 
 export async function loadCoffeeLibraryCompact(limit = 30): Promise<CompactCoffee[]> {
@@ -40,6 +43,7 @@ export async function loadCoffeeLibraryCompact(limit = 30): Promise<CompactCoffe
           ? r.commonNotes
           : undefined,
       writtenSummary: r.writtenSummary ?? undefined,
+      inRotation: r.inRotation ?? false,
     }));
   } catch (err) {
     console.error("loadCoffeeLibraryCompact error:", err);
@@ -69,7 +73,8 @@ export function formatLibraryForPrompt(library: CompactCoffee[]): string {
           : c.sessionCount > 0
             ? `${c.sessionCount} sessions`
             : "unbrewed";
-      const headline = `- ${c.roaster} — ${c.name} | ${c.origin} ${c.process} | ${relativeRoastDate(c.latestRoastDate)} | ${usage}`;
+      const rotationMark = c.inRotation ? "★ IN ROTATION | " : "";
+      const headline = `- ${rotationMark}${c.roaster} — ${c.name} | ${c.origin} ${c.process} | ${relativeRoastDate(c.latestRoastDate)} | ${usage}`;
       // Tasting history (only present after the weekly cron has summarised
       // at least 2 sessions of this coffee — see /api/coffees/compact).
       const tastingLine =

--- a/src/lib/db/helpers.ts
+++ b/src/lib/db/helpers.ts
@@ -27,6 +27,7 @@ export function rowToCoffee(r: typeof coffees.$inferSelect): Coffee {
     // JSONB column is `unknown` at the Drizzle level; trust the write
     // path (validated by FieldZonesSchema before insert) and cast.
     fieldZones: (r.fieldZones as FieldZones | null) ?? null,
+    inRotation: r.inRotation ?? false,
   };
 }
 

--- a/src/lib/db/migrations/0009_add_in_rotation.sql
+++ b/src/lib/db/migrations/0009_add_in_rotation.sql
@@ -1,0 +1,13 @@
+-- Rotation marker on coffees — Markus' /home greeting feedback:
+-- "Ich sollte auch irgendwie anmerken welche Kaffees ich in der
+-- Rotation habe." User-controlled flag, default false. The /api/
+-- greeting prompt enriches its library snapshot with this signal so
+-- the daily Haiku starter can prioritise rotation bags over the rest
+-- of the library. UI lives on /coffees/[id] (the Coffee Detail page).
+--
+-- Run on the VPS after deploy:
+--   cat src/lib/db/migrations/0009_add_in_rotation.sql \
+--     | docker compose exec -T postgres psql -U brewlog -d brewlog
+
+ALTER TABLE coffees
+  ADD COLUMN IF NOT EXISTS in_rotation boolean NOT NULL DEFAULT false;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -7,6 +7,7 @@ import {
   jsonb,
   numeric,
   serial,
+  boolean,
   doublePrecision,
   index,
   uuid,
@@ -78,6 +79,10 @@ export const coffees = pgTable("coffees", {
   // per coffee from tasting notes by Haiku; null until first mapped.
   // Shape: src/lib/field/types.ts FieldZones.
   fieldZones: jsonb("field_zones"),
+  // User-marked "currently in rotation" flag. Surfaced in the
+  // /api/greeting library snapshot so the daily Haiku starter
+  // prioritises rotation bags. Toggled from /coffees/[id].
+  inRotation: boolean("in_rotation").notNull().default(false),
 });
 
 export const preferences = pgTable("preferences", {

--- a/src/lib/types/coffee.ts
+++ b/src/lib/types/coffee.ts
@@ -24,4 +24,8 @@ export interface Coffee {
    * mapped from tasting notes; rendering falls back to Default in that
    * case. See specs/design-system-v1.1-generative-field.md §10. */
   fieldZones?: FieldZones | null;
+  /** User-marked "currently in rotation" flag. Surfaced in the
+   * /api/greeting library snapshot so the daily Haiku starter
+   * prioritises rotation bags. */
+  inRotation?: boolean;
 }


### PR DESCRIPTION
## Summary

Markus' `/home` feedback: "Ich sollte auch irgendwie anmerken welche Kaffees ich in der Rotation habe." Adds a user-controlled flag + prompt plumbing so the daily Haiku starter knows which bags are current.

### What lands

**DB**
- `migrations/0009_add_in_rotation.sql` — `ALTER TABLE coffees ADD COLUMN in_rotation boolean NOT NULL DEFAULT false;`. Idempotent. Manual `psql` run on the VPS per CLAUDE.md convention.
- Drizzle schema + `rowToCoffee` mirror the column. `Coffee` interface gains `inRotation?: boolean`.

**API**
- `/api/coffees/[id]` PATCH schema now accepts either `personalNotes` or `inRotation` (or both). Validation refines to require at least one field so an empty body still errors.

**UI**
- `/coffees/[id]` grows a second button under "Brew this": a filled-or-outlined star toggle that flips `inRotation` via optimistic PATCH. Label switches "Add to rotation" / "In rotation". Selected state uses the warm accent fill; revert-on-error keeps local state honest.

**Greeting prompt**
- `CompactCoffee` gains `inRotation?: boolean`; `loadCoffeeLibraryCompact` reads it.
- `formatLibraryForPrompt` prefixes the headline with `★ IN ROTATION |` when set:
  ```
  - ★ IN ROTATION | Roaster — Name | Origin Process | roasted Xd ago | 3.8★ over 5
  ```
- New `ROTATION DISCIPLINE` block in the system prompt: prefer rotation bags as the day's invitation; never echo `★ IN ROTATION` back in the sentence.

### Cache

Not bumped. The signal only matters when at least one bag is marked, and the cache regenerates at the next time-of-day bucket boundary (PR #96 caching). Mark a coffee now → see effect at the next bucket crossover (within hours).

## Deployment steps

1. Merge → auto-deploys to Hetzner
2. SSH to the VPS and run the migration:
   ```
   cat src/lib/db/migrations/0009_add_in_rotation.sql \
     | docker compose exec -T postgres psql -U brewlog -d brewlog
   ```

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean
- [ ] Auto-deploy runs green
- [ ] Run the SQL migration on VPS (`SELECT count(*) FROM coffees WHERE in_rotation = false;` should equal total coffees ≈ 21)
- [ ] On `/coffees/[id]`:
  - [ ] Star toggle appears under "Brew this"
  - [ ] Tap → fills in warm accent, label "In rotation", PATCH succeeds
  - [ ] Reload → state persisted
  - [ ] Tap again → empty star, "Add to rotation"
- [ ] At next time-of-day boundary, `/home` starter prefers a rotation bag if any are marked

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_