### PR TITLE
fix: nearby actually opens the map — wire cafemap into /cafes

### DIFF
--- a/src/app/cafes/page.tsx
+++ b/src/app/cafes/page.tsx
@@ -2,11 +2,16 @@
 import { useEffect, useState, useMemo, type ReactNode } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
+import dynamic from "next/dynamic";
 import type { CafeSummary } from "@/lib/types/cafes";
 import type { Session, CoffeeIdentity } from "@/lib/types/session";
 import StarRating from "@/components/ui/StarRating";
 
-type Tab = "cafes" | "coffees";
+// CafeMap pulls in Leaflet which assumes a browser `window` — lazy-
+// load client-side only so the SSR render doesn't crash.
+const CafeMap = dynamic(() => import("@/components/cafes/CafeMap"), { ssr: false });
+
+type Tab = "map" | "cafes" | "coffees";
 
 function formatRelativeDate(ms: number): string {
   const diff = Date.now() - ms;
@@ -60,8 +65,11 @@ function deriveCafeCoffees(sessions: Session[]): CafeCoffee[] {
 
 export default function CafesPage() {
   const searchParams = useSearchParams();
-  const initialTab = searchParams.get("tab") === "coffees" ? "coffees" : "cafes";
+  const tabParam = searchParams.get("tab");
+  const initialTab: Tab =
+    tabParam === "map" ? "map" : tabParam === "coffees" ? "coffees" : "cafes";
   const [activeTab, setActiveTab] = useState<Tab>(initialTab);
+  const router = useRouter();
 
   const [cafes, setCafes] = useState<CafeSummary[]>([]);
   const [cafesLoading, setCafesLoading] = useState(true);
@@ -69,8 +77,6 @@ export default function CafesPage() {
   const [externalSessions, setExternalSessions] = useState<Session[]>([]);
   const [sessionsLoading, setSessionsLoading] = useState(false);
   const [sessionsFetched, setSessionsFetched] = useState(false);
-
-  const router = useRouter();
 
   useEffect(() => {
     fetch("/api/cafes", { cache: "no-store" })
@@ -95,6 +101,7 @@ export default function CafesPage() {
   const totalVisits = cafes.reduce((sum: number, cafe: CafeSummary) => sum + cafe.visits, 0);
 
   const tabs: { id: Tab; label: string }[] = [
+    { id: "map", label: "Map" },
     { id: "cafes", label: "Cafés" },
     { id: "coffees", label: "Coffees" },
   ];
@@ -139,6 +146,12 @@ export default function CafesPage() {
       </div>
 
       <div className="flex-1 px-5">
+        {activeTab === "map" && (
+          <CafeMap
+            cafes={cafes}
+            onSelect={(cafe) => router.push(`/cafes/place/${encodeURIComponent(cafe.name)}`)}
+          />
+        )}
         {activeTab === "cafes" && (
           <CafesTab cafes={cafes} loading={cafesLoading} onSelect={cafe => router.push(`/cafes/place/${encodeURIComponent(cafe.name)}`)} />
         )}

--- a/src/components/ui/light/NavigationOverlay.tsx
+++ b/src/components/ui/light/NavigationOverlay.tsx
@@ -37,8 +37,8 @@ const ITEMS: NavItem[] = [
   { label: "Past Conversations", href: "/past-conversations" },
   { label: "New Session", href: "/brew/new" },
   { label: "Coffee Library", href: "/coffees" },
-  { label: "Nearby", href: "/cafes" },
-  { label: "Café Library", href: "/cafes" },
+  { label: "Nearby", href: "/cafes?tab=map" },
+  { label: "Café Library", href: "/cafes?tab=cafes" },
   { label: "Taste Profile", href: "/taste" },
 ];
 


### PR DESCRIPTION
## Summary

Markus' `/home` "Nearby" link routed to `/cafes`, which rendered a tabbed list view (Cafés + Coffees) — **no map anywhere**. The `CafeMap` component (290+ lines: Leaflet + Nominatim geocoding + "near me" filtering, originally the centrepiece of Nearby) had become **orphaned** during earlier refactors. WTF moment confirmed.

### Fix

Wire `CafeMap` back in as a third tab on `/cafes`:

- Tab type widened to `"map" | "cafes" | "coffees"` (Map first)
- `tabParam` parser accepts `?tab=map`, `?tab=cafes`, `?tab=coffees`
- `CafeMap` imported via `next/dynamic` with `ssr: false` so Leaflet's `window`-bound code never runs server-side (would crash the build)
- Map tab renders `<CafeMap cafes={cafes} onSelect={navigate to /cafes/place/[name]} />` — same selection target as the cafés list

`NavigationOverlay` disambiguates the two cafe entry points:
- **"Nearby"** → `/cafes?tab=map` (Markus' expectation)
- **"Café Library"** → `/cafes?tab=cafes` (the saved-list intent)

Both still hit the same route; the query param picks the initial tab. No new pages, no Light-migration scope creep — `/cafes` stays Dark until its own migration round.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean — `/cafes` 4.28 kB
- [ ] Auto-deploy runs green
- [ ] Tap "Nearby" in `/home` burger → `/cafes?tab=map` → Map renders with Leaflet markers
- [ ] Tap "Café Library" in `/home` burger → `/cafes?tab=cafes` → existing list
- [ ] Manual `/cafes` (no query) → defaults to Cafés tab (original behaviour)
- [ ] Tap a marker on the map → routes to `/cafes/place/[name]`
- [ ] Switch tabs Map ↔ Cafés ↔ Coffees → all three render correctly

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_