### PR TITLE
fix: nearby gets its own /cafes/map route — map renders + no tabs

### DIFF
--- a/src/app/cafes/map/page.tsx
+++ b/src/app/cafes/map/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import dynamic from "next/dynamic";
+import type { CafeSummary } from "@/lib/types/cafes";
+
+// Leaflet needs `window`; lazy-load client-side only so SSR doesn't
+// crash.
+const CafeMap = dynamic(() => import("@/components/cafes/CafeMap"), { ssr: false });
+
+/**
+ * Nearby — full-screen map view. Markus' /cafes feedback: "Nearby
+ * ohne Café und Coffee. Nur Map." Lives under /cafes/map; the
+ * navigation overlay's "Nearby" link routes here. Café Library
+ * (the saved-list + tasted-coffees tabs) stays on /cafes.
+ *
+ * The map needs a definitively sized container — the previous
+ * Map-as-tab inside /cafes had `min-h-full` upstream which didn't
+ * propagate, and the Leaflet container collapsed to 0 height
+ * (visible only as the attribution edge in Markus' screenshot).
+ * Here we anchor with `h-dvh flex flex-col` so the inner Map fills
+ * the entire remaining viewport.
+ */
+export default function CafesMapPage() {
+  const router = useRouter();
+  const [cafes, setCafes] = useState<CafeSummary[]>([]);
+
+  useEffect(() => {
+    fetch("/api/cafes", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data: CafeSummary[]) => setCafes(Array.isArray(data) ? data : []))
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div className="h-dvh flex flex-col bg-brew-bg overflow-hidden">
+      <header
+        className="shrink-0 px-5 pb-3 flex items-center justify-between"
+        style={{ paddingTop: "calc(env(safe-area-inset-top) + 1rem)" }}
+      >
+        <Link href="/library" className="flex items-center gap-1 text-brew-muted text-sm">
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5} aria-hidden>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+          </svg>
+          Library
+        </Link>
+        <h1 className="font-display text-lg text-white">Nearby</h1>
+        <Link href="/cafes" className="text-brew-muted text-xs">
+          List →
+        </Link>
+      </header>
+
+      <div className="flex-1 min-h-0">
+        <CafeMap
+          cafes={cafes}
+          onSelect={(cafe) => router.push(`/cafes/place/${encodeURIComponent(cafe.name)}`)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/cafes/page.tsx
+++ b/src/app/cafes/page.tsx
@@ -2,16 +2,11 @@
 import { useEffect, useState, useMemo, type ReactNode } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import dynamic from "next/dynamic";
 import type { CafeSummary } from "@/lib/types/cafes";
 import type { Session, CoffeeIdentity } from "@/lib/types/session";
 import StarRating from "@/components/ui/StarRating";
 
-// CafeMap pulls in Leaflet which assumes a browser `window` — lazy-
-// load client-side only so the SSR render doesn't crash.
-const CafeMap = dynamic(() => import("@/components/cafes/CafeMap"), { ssr: false });
-
-type Tab = "map" | "cafes" | "coffees";
+type Tab = "cafes" | "coffees";
 
 function formatRelativeDate(ms: number): string {
   const diff = Date.now() - ms;
@@ -65,9 +60,7 @@ function deriveCafeCoffees(sessions: Session[]): CafeCoffee[] {
 
 export default function CafesPage() {
   const searchParams = useSearchParams();
-  const tabParam = searchParams.get("tab");
-  const initialTab: Tab =
-    tabParam === "map" ? "map" : tabParam === "coffees" ? "coffees" : "cafes";
+  const initialTab: Tab = searchParams.get("tab") === "coffees" ? "coffees" : "cafes";
   const [activeTab, setActiveTab] = useState<Tab>(initialTab);
   const router = useRouter();
 
@@ -101,7 +94,6 @@ export default function CafesPage() {
   const totalVisits = cafes.reduce((sum: number, cafe: CafeSummary) => sum + cafe.visits, 0);
 
   const tabs: { id: Tab; label: string }[] = [
-    { id: "map", label: "Map" },
     { id: "cafes", label: "Cafés" },
     { id: "coffees", label: "Coffees" },
   ];
@@ -146,12 +138,6 @@ export default function CafesPage() {
       </div>
 
       <div className="flex-1 px-5">
-        {activeTab === "map" && (
-          <CafeMap
-            cafes={cafes}
-            onSelect={(cafe) => router.push(`/cafes/place/${encodeURIComponent(cafe.name)}`)}
-          />
-        )}
         {activeTab === "cafes" && (
           <CafesTab cafes={cafes} loading={cafesLoading} onSelect={cafe => router.push(`/cafes/place/${encodeURIComponent(cafe.name)}`)} />
         )}

--- a/src/components/ui/light/NavigationOverlay.tsx
+++ b/src/components/ui/light/NavigationOverlay.tsx
@@ -37,8 +37,8 @@ const ITEMS: NavItem[] = [
   { label: "Past Conversations", href: "/past-conversations" },
   { label: "New Session", href: "/brew/new" },
   { label: "Coffee Library", href: "/coffees" },
-  { label: "Nearby", href: "/cafes?tab=map" },
-  { label: "Café Library", href: "/cafes?tab=cafes" },
+  { label: "Nearby", href: "/cafes/map" },
+  { label: "Café Library", href: "/cafes" },
   { label: "Taste Profile", href: "/taste" },
 ];
 


### PR DESCRIPTION
## Summary

Markus' Café Library screenshot: tapped "Nearby", landed on the tabbed page with Map / Cafés / Coffees, Map tab active — and the **map area was black**. Two real bugs in one screen:

1. **Map didn't render.** Container collapsed to 0 height. `/cafes` uses `min-h-full flex flex-col`, and `min-height` doesn't give flex children a definite size to share — `flex-1` on the tab-content wrapper resolved to 0. Only Leaflet's attribution overlay was visible at the very top, floating beside the "Coffees" tab.
2. **Tabs shouldn't be there for the Nearby intent.** "Nearby" = "where can I go right now" = full-screen map. Mixing it with the saved-cafés library + coffees-tasted-at-cafés list muddied the UX.

### Fix

Split the route:

- **`src/app/cafes/map/page.tsx`** — full-screen Nearby map. Anchored with `h-dvh flex flex-col`, header is `shrink-0`, map wrapper is `flex-1 min-h-0` so Leaflet gets a positively-sized container. Compact header (`Library ← Nearby List →`) so the page is map-first.
- **`/cafes`** — reverted to the original tab structure (Cafés + Coffees only). Map tab removed; the Map import is gone from this page entirely.
- **`NavigationOverlay`**:
  - `"Nearby"` → `/cafes/map` (full-screen map)
  - `"Café Library"` → `/cafes` (the tabbed list)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean — `/cafes/map` 1.81 kB, `/cafes` 3.48 kB (down from yesterday's 4.28)
- [ ] Auto-deploy runs green
- [ ] Tap "Nearby" in the home burger → `/cafes/map` → full-screen Leaflet map with dark Carto tiles, locate-me prompt, markers when GPS resolves
- [ ] Tap "Café Library" → `/cafes` → tabs Cafés / Coffees, no map
- [ ] On `/cafes/map`, "List →" link routes to `/cafes`

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_