### PR TITLE
feat: coffee library light migration

### DIFF
--- a/src/app/(light)/coffees/[id]/page.tsx
+++ b/src/app/(light)/coffees/[id]/page.tsx
@@ -4,8 +4,8 @@ import { useParams, useRouter } from "next/navigation";
 import type { Coffee } from "@/lib/types/coffee";
 import type { Session, CoffeeIdentity } from "@/lib/types/session";
 import SessionCard from "@/components/session/SessionCard";
-import StarRating from "@/components/ui/StarRating";
-import CoffeeBeanGlow from "@/components/ui/CoffeeBeanGlow";
+import StarRating from "@/components/ui/light/StarRating";
+import CoffeeBeanGlow from "@/components/ui/light/CoffeeBeanGlow";
 import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
 import { useFlowStore } from "@/store/flowStore";
 
@@ -100,9 +100,9 @@ export default function CoffeeDetailPage() {
 
   if (loading) {
     return (
-      <div className="min-h-svh bg-brew-bg flex flex-col">
+      <div className="min-h-svh bg-transparent flex flex-col">
         <div className="px-5 pb-4" style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.5rem)" }}>
-          <button onClick={() => router.push("/coffees")} className="text-brew-muted text-sm">← Library</button>
+          <button onClick={() => router.push("/coffees")} className="text-light-muted-foreground text-sm">← Library</button>
         </div>
         <div className="flex-1 flex items-center justify-center">
           <CoffeeBeanGlow size={64} />
@@ -113,9 +113,9 @@ export default function CoffeeDetailPage() {
 
   if (!coffee) {
     return (
-      <div className="min-h-svh bg-brew-bg flex flex-col items-center justify-center gap-4">
-        <p className="text-brew-muted">Coffee not found</p>
-        <button onClick={() => router.push("/coffees")} className="text-white underline">Back to library</button>
+      <div className="min-h-svh bg-transparent flex flex-col items-center justify-center gap-4">
+        <p className="text-light-muted-foreground">Coffee not found</p>
+        <button onClick={() => router.push("/coffees")} className="text-light-foreground underline">Back to library</button>
       </div>
     );
   }
@@ -158,7 +158,7 @@ export default function CoffeeDetailPage() {
   };
 
   return (
-    <div className="min-h-svh bg-brew-bg flex flex-col">
+    <div className="min-h-svh bg-transparent flex flex-col">
       {/* Hero */}
       <div className="relative">
         {coffee.bagPhotoUrl ? (
@@ -168,8 +168,8 @@ export default function CoffeeDetailPage() {
             <div className="absolute inset-0 card-scrim" />
           </div>
         ) : (
-          <div className="h-40 bg-brew-surface flex items-center justify-center">
-            <svg className="w-12 h-12 text-brew-muted opacity-20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.5">
+          <div className="h-40 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 flex items-center justify-center">
+            <svg className="w-12 h-12 text-light-muted-foreground opacity-20" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.5">
               <path strokeLinecap="round" strokeLinejoin="round" d="M9.75 3.104v5.714a2.25 2.25 0 01-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 014.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15M14.25 3.104c.251.023.501.05.75.082M19.8 15a3.75 3.75 0 01-3.75 3.75H7.95A3.75 3.75 0 014.2 15m15.6 0H4.2m15.6 0H4.2" />
             </svg>
           </div>
@@ -178,7 +178,7 @@ export default function CoffeeDetailPage() {
         {/* Back button */}
         <button
           onClick={() => router.push("/coffees")}
-          className="absolute left-4 w-10 h-10 rounded-full bg-black/50 backdrop-blur-sm flex items-center justify-center text-white"
+          className="absolute left-4 w-10 h-10 rounded-full bg-light-card-default/85 backdrop-blur-light-card backdrop-blur-sm flex items-center justify-center text-light-foreground"
           style={{ top: "calc(env(safe-area-inset-top) + 1rem)" }}
         >
           <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -189,12 +189,12 @@ export default function CoffeeDetailPage() {
         {/* Title overlay */}
         <div className={`${coffee.bagPhotoUrl ? "absolute bottom-0 left-0 right-0" : ""} p-5`}>
           {coffee.process && (
-            <p className="text-white/50 text-xs tracking-widest uppercase mb-1">{coffee.process}</p>
+            <p className="text-light-foreground/50 text-xs tracking-widest uppercase mb-1">{coffee.process}</p>
           )}
-          <h1 className="font-display text-3xl text-white">{coffee.name}</h1>
-          <p className="text-white/60 text-sm mt-1">{coffee.roaster}{origin ? ` · ${origin}` : ""}</p>
+          <h1 className="font-fraunces text-3xl text-light-foreground">{coffee.name}</h1>
+          <p className="text-light-foreground/60 text-sm mt-1">{coffee.roaster}{origin ? ` · ${origin}` : ""}</p>
           {roastDate && (
-            <p className="text-white/40 text-xs mt-0.5">
+            <p className="text-light-foreground/40 text-xs mt-0.5">
               Roasted {new Date(roastDate).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })}
             </p>
           )}
@@ -202,24 +202,24 @@ export default function CoffeeDetailPage() {
       </div>
 
       {/* Stats row */}
-      <div className="px-5 py-4 flex items-center gap-6 border-b border-brew-border">
+      <div className="px-5 py-4 flex items-center gap-6 border-b border-light-foreground/15">
         <div className="text-center">
-          <p className="font-mono-num text-2xl text-white font-medium">{coffee.sessionCount}</p>
-          <p className="text-brew-muted text-xs uppercase tracking-widest mt-0.5">Brew{coffee.sessionCount !== 1 ? "s" : ""}</p>
+          <p className="font-mono-num text-2xl text-light-foreground font-medium">{coffee.sessionCount}</p>
+          <p className="text-light-muted-foreground text-xs uppercase tracking-widest mt-0.5">Brew{coffee.sessionCount !== 1 ? "s" : ""}</p>
         </div>
         {coffee.avgRating != null && coffee.avgRating > 0 && (
           <div className="flex flex-col items-center">
             <StarRating value={coffee.avgRating} readonly size="sm" />
-            <p className="text-brew-muted text-xs uppercase tracking-widest mt-1">Avg Rating</p>
+            <p className="text-light-muted-foreground text-xs uppercase tracking-widest mt-1">Avg Rating</p>
           </div>
         )}
         {coffee.bestMethod && (
           <div className="flex flex-col items-center">
             <div className="flex items-center gap-1.5">
               <BrewMethodIcon method={coffee.bestMethod} className="w-5 h-5" />
-              <p className="text-white text-sm font-medium">{coffee.bestMethod}</p>
+              <p className="text-light-foreground text-sm font-medium">{coffee.bestMethod}</p>
             </div>
-            <p className="text-brew-muted text-xs uppercase tracking-widest mt-0.5">Best Method</p>
+            <p className="text-light-muted-foreground text-xs uppercase tracking-widest mt-0.5">Best Method</p>
           </div>
         )}
       </div>
@@ -229,7 +229,7 @@ export default function CoffeeDetailPage() {
         <button
           type="button"
           onClick={brewThis}
-          className="w-full py-3.5 rounded-2xl text-sm font-medium bg-brew-accent text-brew-accent-fg active:scale-[0.98] transition-transform"
+          className="w-full py-3.5 rounded-2xl text-sm font-medium bg-light-foreground text-[hsl(36_55%_96%)] active:scale-[0.98] transition-transform"
         >
           Brew this
         </button>
@@ -257,8 +257,8 @@ export default function CoffeeDetailPage() {
           }}
           className={`w-full py-3 rounded-2xl text-sm flex items-center justify-center gap-2 border transition-transform active:scale-[0.98] ${
             coffee.inRotation
-              ? "bg-brew-accent/10 border-brew-accent/40 text-brew-accent"
-              : "bg-brew-surface border-brew-border text-brew-muted"
+              ? "bg-light-foreground/10 border-light-foreground/40 text-light-foreground"
+              : "bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border-light-foreground/15 text-light-muted-foreground"
           }`}
         >
           <svg className="w-4 h-4" viewBox="0 0 24 24" fill={coffee.inRotation ? "currentColor" : "none"} stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
@@ -270,8 +270,8 @@ export default function CoffeeDetailPage() {
 
       {/* Coffee scan details */}
       {(roastDate || variety || roastLevel || region || tastingNotes.length > 0 || commonNotes.length > 0) && (
-        <div className="px-5 py-4 border-b border-brew-border space-y-2">
-          <p className="text-brew-muted text-xs uppercase tracking-widest mb-3">Coffee Details</p>
+        <div className="px-5 py-4 border-b border-light-foreground/15 space-y-2">
+          <p className="text-light-muted-foreground text-xs uppercase tracking-widest mb-3">Coffee Details</p>
           {variety && <DetailRow label="Variety" value={variety} />}
           {roastLevel && <DetailRow label="Roast" value={roastLevel} />}
           {region && <DetailRow label="Region" value={region} />}
@@ -283,10 +283,10 @@ export default function CoffeeDetailPage() {
           )}
           {tastingNotes.length > 0 && (
             <div className="flex items-baseline gap-3 pt-0.5">
-              <span className="text-brew-muted text-sm shrink-0 w-24">Bag notes</span>
+              <span className="text-light-muted-foreground text-sm shrink-0 w-24">Bag notes</span>
               <div className="flex flex-wrap gap-1.5">
                 {tastingNotes.map(note => (
-                  <span key={note} className="text-xs capitalize px-2 py-0.5 rounded-full border border-brew-border text-white/60">
+                  <span key={note} className="text-xs capitalize px-2 py-0.5 rounded-full border border-light-foreground/15 text-light-foreground/60">
                     {note}
                   </span>
                 ))}
@@ -295,10 +295,10 @@ export default function CoffeeDetailPage() {
           )}
           {commonNotes.length > 0 && (
             <div className="flex items-baseline gap-3 pt-0.5">
-              <span className="text-brew-muted text-sm shrink-0 w-24">You taste</span>
+              <span className="text-light-muted-foreground text-sm shrink-0 w-24">You taste</span>
               <div className="flex flex-wrap gap-1.5">
                 {commonNotes.map(note => (
-                  <span key={note} className="text-xs capitalize px-2 py-0.5 rounded-full bg-white/10 text-white/80">
+                  <span key={note} className="text-xs capitalize px-2 py-0.5 rounded-full bg-light-foreground/8 text-light-foreground/80">
                     {note}
                   </span>
                 ))}
@@ -310,18 +310,18 @@ export default function CoffeeDetailPage() {
 
       {/* Roaster info */}
       {(roasterInfo || roasterGenerating) && (
-        <div className="px-5 py-4 border-b border-brew-border">
-          <p className="text-brew-muted text-xs uppercase tracking-widest mb-2">Roaster</p>
+        <div className="px-5 py-4 border-b border-light-foreground/15">
+          <p className="text-light-muted-foreground text-xs uppercase tracking-widest mb-2">Roaster</p>
           {roasterGenerating ? (
-            <p className="text-brew-muted text-sm italic">Researching roaster…</p>
+            <p className="text-light-muted-foreground text-sm italic">Researching roaster…</p>
           ) : roasterInfo ? (
             <>
               {roasterInfo.region && (
-                <p className="text-brew-muted text-xs mb-1.5">{roasterInfo.region}</p>
+                <p className="text-light-muted-foreground text-xs mb-1.5">{roasterInfo.region}</p>
               )}
-              <p className="text-white/80 text-sm leading-relaxed">{roasterInfo.styleSummary}</p>
+              <p className="text-light-foreground/80 text-sm leading-relaxed">{roasterInfo.styleSummary}</p>
               {roasterInfo.notes && (
-                <p className="text-white/40 text-xs mt-2 leading-relaxed">{roasterInfo.notes}</p>
+                <p className="text-light-foreground/40 text-xs mt-2 leading-relaxed">{roasterInfo.notes}</p>
               )}
             </>
           ) : null}
@@ -329,9 +329,9 @@ export default function CoffeeDetailPage() {
       )}
 
       {/* Personal notes */}
-      <div className="px-5 py-4 border-b border-brew-border">
+      <div className="px-5 py-4 border-b border-light-foreground/15">
         <div className="flex items-center justify-between mb-2">
-          <p className="text-brew-muted text-xs uppercase tracking-widest">Your Notes</p>
+          <p className="text-light-muted-foreground text-xs uppercase tracking-widest">Your Notes</p>
           {!editingNotes && (
             <button
               onClick={() => {
@@ -339,7 +339,7 @@ export default function CoffeeDetailPage() {
                 setEditingNotes(true);
                 setTimeout(() => notesRef.current?.focus(), 50);
               }}
-              className="text-brew-muted text-xs hover:text-white transition-colors"
+              className="text-light-muted-foreground text-xs hover:text-light-foreground transition-colors"
             >
               {coffee.personalNotes ? "Edit" : "+ Add"}
             </button>
@@ -353,7 +353,7 @@ export default function CoffeeDetailPage() {
               onChange={e => setNotesDraft(e.target.value)}
               placeholder="Would you buy this again? Anything worth remembering…"
               rows={4}
-              className="w-full bg-brew-surface border border-brew-border rounded-2xl px-4 py-3 text-white text-sm resize-none placeholder:text-brew-muted focus:outline-none focus:border-white/30"
+              className="w-full bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-2xl px-4 py-3 text-light-foreground text-sm resize-none placeholder:text-light-muted-foreground focus:outline-none focus:border-white/30"
             />
             <div className="flex gap-2">
               <button
@@ -372,32 +372,32 @@ export default function CoffeeDetailPage() {
                     setNotesSaving(false);
                   }
                 }}
-                className="flex-1 py-2.5 rounded-2xl text-sm font-medium bg-brew-accent/20 text-brew-accent border border-brew-accent/30 disabled:opacity-50"
+                className="flex-1 py-2.5 rounded-2xl text-sm font-medium bg-light-foreground/20 text-light-foreground border border-light-foreground/30 disabled:opacity-50"
               >
                 {notesSaving ? "Saving…" : "Save"}
               </button>
               <button
                 onClick={() => setEditingNotes(false)}
-                className="flex-1 py-2.5 rounded-2xl text-sm border border-brew-border text-brew-muted"
+                className="flex-1 py-2.5 rounded-2xl text-sm border border-light-foreground/15 text-light-muted-foreground"
               >
                 Cancel
               </button>
             </div>
           </div>
         ) : coffee.personalNotes ? (
-          <p className="text-white/80 text-sm leading-relaxed whitespace-pre-wrap">{coffee.personalNotes}</p>
+          <p className="text-light-foreground/80 text-sm leading-relaxed whitespace-pre-wrap">{coffee.personalNotes}</p>
         ) : (
-          <p className="text-brew-muted text-sm italic">No notes yet.</p>
+          <p className="text-light-muted-foreground text-sm italic">No notes yet.</p>
         )}
       </div>
 
       {/* Brew memory */}
       {coffee.writtenSummary && (
-        <div className="px-5 py-4 border-b border-brew-border">
-          <p className="text-brew-muted text-xs uppercase tracking-widest mb-2">Brew memory</p>
-          <p className="text-white/80 text-sm leading-relaxed">{coffee.writtenSummary}</p>
+        <div className="px-5 py-4 border-b border-light-foreground/15">
+          <p className="text-light-muted-foreground text-xs uppercase tracking-widest mb-2">Brew memory</p>
+          <p className="text-light-foreground/80 text-sm leading-relaxed">{coffee.writtenSummary}</p>
           {coffee.lastSummarizedAt && (
-            <p className="text-white/20 text-xs mt-2">
+            <p className="text-light-foreground/20 text-xs mt-2">
               Updated {new Date(coffee.lastSummarizedAt).toLocaleDateString("en", { month: "short", day: "numeric", year: "numeric" })}
             </p>
           )}
@@ -406,17 +406,17 @@ export default function CoffeeDetailPage() {
 
       {/* What to explore */}
       {coffee.whatToExplore && (
-        <div className="px-5 py-4 border-b border-brew-border">
-          <p className="text-brew-muted text-xs uppercase tracking-widest mb-2">What to explore</p>
-          <p className="text-white/80 text-sm leading-relaxed">{coffee.whatToExplore}</p>
+        <div className="px-5 py-4 border-b border-light-foreground/15">
+          <p className="text-light-muted-foreground text-xs uppercase tracking-widest mb-2">What to explore</p>
+          <p className="text-light-foreground/80 text-sm leading-relaxed">{coffee.whatToExplore}</p>
         </div>
       )}
 
       {/* Sessions */}
       <div className="px-5 py-5 flex flex-col gap-4 pb-safe pb-8">
-        <p className="text-brew-muted text-xs uppercase tracking-widest">All Brews</p>
+        <p className="text-light-muted-foreground text-xs uppercase tracking-widest">All Brews</p>
         {sessions.length === 0 ? (
-          <p className="text-brew-muted text-sm">No sessions found.</p>
+          <p className="text-light-muted-foreground text-sm">No sessions found.</p>
         ) : (
           sessions.map(s => (
             <SessionCard
@@ -434,8 +434,8 @@ export default function CoffeeDetailPage() {
 function DetailRow({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex items-baseline justify-between gap-4">
-      <span className="text-brew-muted text-sm shrink-0">{label}</span>
-      <span className="text-white/80 text-sm text-right">{value}</span>
+      <span className="text-light-muted-foreground text-sm shrink-0">{label}</span>
+      <span className="text-light-foreground/80 text-sm text-right">{value}</span>
     </div>
   );
 }

--- a/src/app/(light)/coffees/page.tsx
+++ b/src/app/(light)/coffees/page.tsx
@@ -4,7 +4,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import type { Coffee } from "@/lib/types/coffee";
 import type { CoffeeIdentity } from "@/lib/types/session";
-import StarRating from "@/components/ui/StarRating";
+import StarRating from "@/components/ui/light/StarRating";
 import { useFlowStore } from "@/store/flowStore";
 
 type Filter = "recent" | "favorites" | "roaster";
@@ -95,24 +95,24 @@ export default function CoffeesPage() {
   ];
 
   return (
-    <div className="min-h-full bg-brew-bg flex flex-col pb-8">
+    <div className="min-h-full bg-transparent flex flex-col pb-8">
 
       {/* Header */}
       <div className="px-5 pb-4" style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.25rem)" }}>
-        <Link href="/library" className="flex items-center gap-1 text-brew-muted text-sm mb-3 w-fit">
+        <Link href="/library" className="flex items-center gap-1 text-light-muted-foreground text-sm mb-3 w-fit">
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
           </svg>
           Library
         </Link>
-        <h1 className="font-display text-3xl text-white leading-none">Coffee Library</h1>
+        <h1 className="font-fraunces text-3xl text-light-foreground leading-none">Coffee Library</h1>
         {loading ? (
-          <div className="h-4 w-48 bg-brew-surface rounded-full animate-pulse mt-2" />
+          <div className="h-4 w-48 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 rounded-full animate-pulse mt-2" />
         ) : !error && coffees.length > 0 ? (
-          <p className="text-brew-muted text-sm mt-1.5">
-            <span className="text-white">{sessionTotal.toLocaleString()}</span> sessions ·{" "}
-            <span className="text-white">{coffees.length.toLocaleString()}</span> coffees ·{" "}
-            <span className="text-white">{roasterCount.toLocaleString()}</span> roasters
+          <p className="text-light-muted-foreground text-sm mt-1.5">
+            <span className="text-light-foreground">{sessionTotal.toLocaleString()}</span> sessions ·{" "}
+            <span className="text-light-foreground">{coffees.length.toLocaleString()}</span> coffees ·{" "}
+            <span className="text-light-foreground">{roasterCount.toLocaleString()}</span> roasters
           </p>
         ) : null}
       </div>
@@ -121,7 +121,7 @@ export default function CoffeesPage() {
       {!loading && !error && coffees.length > 0 && (
         <div className="px-5 mb-3">
           <div className="flex items-center gap-2 px-1 py-2">
-            <svg className="w-4 h-4 text-brew-muted shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+            <svg className="w-4 h-4 text-light-muted-foreground shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
             </svg>
             <input
@@ -129,11 +129,11 @@ export default function CoffeesPage() {
               value={search}
               onChange={e => setSearch(e.target.value)}
               placeholder="Search coffees..."
-              className="flex-1 bg-transparent text-white placeholder:text-brew-muted outline-none border-0 appearance-none"
+              className="flex-1 bg-transparent text-light-foreground placeholder:text-light-muted-foreground outline-none border-0 appearance-none"
               style={{ fontSize: "16px", WebkitAppearance: "none", boxShadow: "none" }}
             />
             {search && (
-              <button onClick={() => setSearch("")} className="text-brew-muted">
+              <button onClick={() => setSearch("")} className="text-light-muted-foreground">
                 <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                 </svg>
@@ -153,8 +153,8 @@ export default function CoffeesPage() {
               onClick={() => setFilter(f.id)}
               className={`px-4 py-1.5 rounded-full text-xs font-medium transition-all ${
                 filter === f.id
-                  ? "bg-brew-accent text-brew-accent-fg"
-                  : "bg-brew-surface border border-brew-border text-brew-muted"
+                  ? "bg-light-foreground text-[hsl(36_55%_96%)]"
+                  : "bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 text-light-muted-foreground"
               }`}
             >
               {f.label}
@@ -168,26 +168,26 @@ export default function CoffeesPage() {
         {loading ? (
           <div className="flex flex-col gap-3">
             {[1, 2, 3, 4, 5].map(i => (
-              <div key={i} className="h-20 rounded-2xl bg-brew-surface animate-pulse" />
+              <div key={i} className="h-20 rounded-2xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 animate-pulse" />
             ))}
           </div>
         ) : error ? (
           <div className="flex flex-col items-center justify-center h-[60vh] text-center gap-4">
-            <p className="font-display text-xl text-white">Couldn&apos;t load your library</p>
-            <p className="text-brew-muted text-sm">Check your connection and try again.</p>
-            <button onClick={() => setRetryCount(c => c + 1)} className="text-brew-accent text-sm underline">Retry</button>
+            <p className="font-fraunces text-xl text-light-foreground">Couldn&apos;t load your library</p>
+            <p className="text-light-muted-foreground text-sm">Check your connection and try again.</p>
+            <button onClick={() => setRetryCount(c => c + 1)} className="text-light-foreground text-sm underline">Retry</button>
           </div>
         ) : coffees.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-[60vh] text-center gap-4">
-            <svg className="w-12 h-12 text-brew-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.5">
+            <svg className="w-12 h-12 text-light-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="1.5">
               <path strokeLinecap="round" strokeLinejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />
             </svg>
-            <p className="font-display text-xl text-white">No coffees yet</p>
-            <p className="text-brew-muted text-sm">Coffees you scan will appear here.</p>
+            <p className="font-fraunces text-xl text-light-foreground">No coffees yet</p>
+            <p className="text-light-muted-foreground text-sm">Coffees you scan will appear here.</p>
           </div>
         ) : filteredCoffees.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-40 text-center gap-2">
-            <p className="text-brew-muted text-sm">No results for &ldquo;{search}&rdquo;</p>
+            <p className="text-light-muted-foreground text-sm">No results for &ldquo;{search}&rdquo;</p>
           </div>
         ) : (
           <div className="flex flex-col gap-2">
@@ -196,7 +196,7 @@ export default function CoffeesPage() {
               return (
                 <div
                   key={coffee.id}
-                  className="flex items-center gap-3 bg-brew-surface border border-brew-border rounded-2xl p-3 w-full"
+                  className="flex items-center gap-3 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-2xl p-3 w-full"
                 >
                   {/* Tap target — opens detail page */}
                   <button
@@ -205,34 +205,34 @@ export default function CoffeesPage() {
                     className="flex items-center gap-3 flex-1 min-w-0 text-left active:opacity-80 transition-opacity"
                   >
                     {/* Thumbnail */}
-                    <div className="relative w-14 h-14 rounded-xl overflow-hidden bg-brew-elevated shrink-0">
+                    <div className="relative w-14 h-14 rounded-xl overflow-hidden bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 shrink-0">
                       {coffee.bagPhotoUrl ? (
                         // eslint-disable-next-line @next/next/no-img-element
                         <img src={coffee.bagPhotoUrl} alt={coffee.name} className="w-full h-full object-cover" />
                       ) : (
                         <div className="w-full h-full flex items-center justify-center">
-                          <svg className="w-6 h-6 text-brew-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                          <svg className="w-6 h-6 text-light-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                             <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636" />
                           </svg>
                         </div>
                       )}
                       {/* Session count badge */}
-                      <div className="absolute top-0.5 right-0.5 bg-black/70 rounded-full w-4 h-4 flex items-center justify-center">
-                        <span className="text-white font-mono-num" style={{ fontSize: "8px" }}>{coffee.sessionCount}</span>
+                      <div className="absolute top-0.5 right-0.5 bg-light-foreground rounded-full w-4 h-4 flex items-center justify-center">
+                        <span className="text-[hsl(36_55%_96%)] font-mono-num" style={{ fontSize: "8px" }}>{coffee.sessionCount}</span>
                       </div>
                     </div>
 
                     {/* Text */}
                     <div className="flex-1 min-w-0">
                       {coffee.roaster && (
-                        <p className="text-brew-muted text-xs truncate mb-0.5">{coffee.roaster}</p>
+                        <p className="text-light-muted-foreground text-xs truncate mb-0.5">{coffee.roaster}</p>
                       )}
-                      <p className="text-white text-sm font-medium leading-snug truncate">{coffee.name}</p>
+                      <p className="text-light-foreground text-sm font-medium leading-snug truncate">{coffee.name}</p>
                       {sub && (
-                        <p className="text-brew-muted text-xs truncate mt-0.5">{sub}</p>
+                        <p className="text-light-muted-foreground text-xs truncate mt-0.5">{sub}</p>
                       )}
                       {coffee.latestRoastDate && (
-                        <p className="text-brew-muted text-xs truncate mt-0.5">
+                        <p className="text-light-muted-foreground text-xs truncate mt-0.5">
                           Roasted {new Date(coffee.latestRoastDate).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })}
                         </p>
                       )}
@@ -249,7 +249,7 @@ export default function CoffeesPage() {
                     type="button"
                     onClick={() => brewThis(coffee)}
                     aria-label={`Brew ${coffee.name}`}
-                    className="shrink-0 px-3 py-2 rounded-full text-xs font-medium bg-brew-accent text-brew-accent-fg active:scale-95 transition-transform"
+                    className="shrink-0 px-3 py-2 rounded-full text-xs font-medium bg-light-foreground text-[hsl(36_55%_96%)] active:scale-95 transition-transform"
                   >
                     Brew
                   </button>


### PR DESCRIPTION
## Summary

Pull the Coffee Library + Coffee Detail under the `(light)` route group. Both surfaces are high-traffic — daily checks of the bag list, brew-again from detail, rotation toggling — and the Dark canvas next to the Light home was inconsistent.

`git mv src/app/coffees → src/app/(light)/coffees`. Routes resolve identically (Next.js route groups are URL-invisible) — every existing href to `/coffees` or `/coffees/[id]` keeps working. The `(light)` layout wraps both pages in `LightShell` so Field background, Chivo body font, anthracite foreground, and the brew-method-icon CSS inversion all kick in automatically.

### Surface mapping (sed-driven for ~80 brew-* token refs)

| Dark | Light |
|---|---|
| `bg-brew-bg` | `bg-transparent` |
| `bg-brew-surface` / `bg-brew-elevated` | `bg-light-card-default + backdrop-blur` |
| `text-brew-muted` | `text-light-muted-foreground` |
| `text-brew-accent` | `text-light-foreground` (no peach in Light) |
| `bg-brew-accent` | `bg-light-foreground` (anthracite) |
| `text-brew-accent-fg` | `text-[hsl(36_55%_96%)]` (cream) |
| `border-brew-border` | `border-light-foreground/15` |
| `text-white` | `text-light-foreground` |
| `font-display` | `font-fraunces` |
| `label-mono` | `label-eyebrow` |
| `bg-black/70` (count badge) | `bg-light-foreground` + cream text |
| `bg-black/50` (back btn) | `bg-light-card-default + backdrop-blur` |
| `bg-white/10` | `bg-light-foreground/8` |

### Component swaps

- `@/components/ui/StarRating` → `@/components/ui/light/StarRating`
- `@/components/ui/CoffeeBeanGlow` → `@/components/ui/light/CoffeeBeanGlow`

### Manual nuance

The session-count badge on each list row needed an explicit text swap to cream — `bg-light-foreground` (anthracite) badge with foreground text would have been invisible.

The In Rotation toggle from PR #97 now reads as soft anthracite tint instead of warm peach (selected: `bg-light-foreground/10 border-light-foreground/40 text-light-foreground`).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx next build` clean — `/coffees` 5.1 kB, `/coffees/[id]` 7.75 kB
- [ ] Auto-deploy runs green
- [ ] On `/coffees`:
  - [ ] Warm cream Field background (not solid black)
  - [ ] "Coffee Library" Fraunces heading
  - [ ] Stats row: bold anthracite numbers, muted labels
  - [ ] Search bar + filter chips (Recent / Favorites / Roaster) light glass
  - [ ] Each coffee row: glass card with thumbnail + meta + Brew CTA in anthracite-on-cream
  - [ ] Tap row → /coffees/[id]; tap Brew → Brew Again flow into Light Context
- [ ] On `/coffees/[id]`:
  - [ ] Bag photo hero card scrim still readable, Fraunces title legible
  - [ ] Brew this + In Rotation toggle land on light glass
  - [ ] Coffee Details / Tasting Notes / Roaster Profile / Personal Notes / Brew Memory cards all light glass
  - [ ] Sessions list reads cleanly

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_