### PR TITLE
fix: greeting prompt — strict rotation rule, close 'unless' loophole

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,7 +274,7 @@ Both migrations applied manually on the VPS — see migration NOTE above.
 **Greeting Haiku (PR #87, #96)**
 - Time-of-day discipline block in the system prompt (fixed "Late night" at 18:44).
 - Library snapshot uses `formatLibraryForPrompt` (with rotation prefix + usage signal) instead of bare roaster+name.
-- localStorage cache keyed by `brewlog.starter.v3.<date>.<bucket>` — regenerates 5× per day at tod-bucket boundaries instead of once per calendar day. Bumping the version is the canonical invalidation lever for any greeting prompt change.
+- localStorage cache keyed by `brewlog.starter.v4.<date>.<bucket>` — regenerates 5× per day at tod-bucket boundaries instead of once per calendar day. Bumping the version is the canonical invalidation lever for any greeting prompt change.
 
 **Nearby map split (PR #101)**
 - `/cafes/map` is now a dedicated route (full-screen Leaflet with dark CartoCDN tiles). `/cafes` is the tabbed Café Library list (Cafés + Coffees tasted out). `NavigationOverlay` "Nearby" → `/cafes/map`; "Café Library" → `/cafes`.

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -30,7 +30,7 @@ All seven steps migrated and cut over. `/brew/new` resolves through `(light)/bre
 ### Greeting Haiku — bug fixes
 - Time-of-day discipline added to the prompt (no more "Late night" at 18:44)
 - Library snapshot uses `formatLibraryForPrompt` (with usage signal) instead of bare roaster+name
-- localStorage cache keyed by `brewlog.starter.v3.<date>.<bucket>` — regenerates 5x per day at tod-bucket boundaries instead of once per calendar day
+- localStorage cache keyed by `brewlog.starter.v4.<date>.<bucket>` — regenerates 5x per day at tod-bucket boundaries instead of once per calendar day
 - `/api/greeting` (src/app/api/greeting/route.ts) already passes time-of-day + library snapshot + rotation prefix
 
 ### Coffee Library Light migration ✅ (PR #102)
@@ -88,7 +88,7 @@ Roughly in priority order. Numbers are Markus' tentative ranking from earlier in
 - **`min-h-full flex flex-col` does not give children definite height.** `flex-1` inside collapses to 0. Leaflet container needed `h-dvh flex flex-col` + `flex-1 min-h-0` (PR #101).
 - **The `[data-light-scope]` CSS shim** in globals.css catches inline `var(--card)` etc. for un-migrated components inside the Light tree — but NOT hardcoded hex values like `#2A241C`. Those need explicit Light tokens at the source.
 - **CSS `filter: brightness(0)` under `[data-light-scope]`** is the trick used to invert hardcoded-white SVGs (BrewMethodIcon assets, original CoffeeBeanGlow) without forking the components.
-- **localStorage starter cache.** Versioned key `brewlog.starter.v3.<date>.<bucket>`. Bumping the version is the canonical invalidation. If you change the greeting prompt, bump the cache to `v4`.
+- **localStorage starter cache.** Versioned key `brewlog.starter.v4.<date>.<bucket>`. Bumping the version is the canonical invalidation. If you change the greeting prompt, bump the cache to `v5`.
 - **Hard Rule on AI behavior changes.** Any prompt / model / schema-enum change to `/api/recommend`, `/api/greeting`, `/api/match`, etc. needs sample-before-after outputs per `CLAUDE.md`. Cannot validate from this remote env — Markus runs on the deployed PWA.
 - **Auto-deploy** is GitHub Actions → SSH → Hetzner (`.github/workflows/deploy.yml`). Direct push to `main` blocked; PR-only workflow with `enable_pr_auto_merge` (mergeMethod SQUASH).
 - **Manual migrations.** SQL files in `src/lib/db/migrations/` are NOT auto-applied. Run on VPS per CLAUDE.md: `cat src/lib/db/migrations/00XX_*.sql | docker compose exec -T postgres psql -U brewlog -d brewlog`. The Drizzle journal only tracks `0000_init`.

--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -145,14 +145,17 @@ export default function HomePage() {
 
   // Daily Starter — cached per calendar day in localStorage.
   useEffect(() => {
-    // Cache version bumped (v3) + time-of-day bucket appended so the
+    // Cache version bumped on every greeting-prompt change so stale
+    // cached lines from the previous rule don't show up next morning.
+    // v4 = strict rotation rule (no non-rotation references when
+    // rotation is non-empty). Time-of-day bucket appended so the
     // starter regenerates when the user crosses a tod boundary
     // (morning → midday → afternoon → evening → late-night). Earlier
     // bug: opening the app at 11:00 cached a "morning" line that
     // showed all day even when re-opened at 20:45. Old
-    // `brewlog.starter.v2.<date>` entries are orphaned in
+    // `brewlog.starter.v{2,3}.<date>` entries are orphaned in
     // localStorage — harmless.
-    const key = `brewlog.starter.v3.${todayKey()}.${timeBucket()}`;
+    const key = `brewlog.starter.v4.${todayKey()}.${timeBucket()}`;
     try {
       const cached = window.localStorage.getItem(key);
       if (cached) {

--- a/src/app/api/greeting/route.ts
+++ b/src/app/api/greeting/route.ts
@@ -48,8 +48,10 @@ COFFEE-HISTORY DISCIPLINE
 - For a brewed coffee you may invite a return ("worth revisiting", "ready for another round") — not a first try.
 
 ROTATION DISCIPLINE
-- Library lines prefixed with "★ IN ROTATION" are the user's active rotation — bags they consider current. Treat these as the primary candidates for the day's invitation.
-- If the library has ANY rotation entries, prefer one of them over a non-rotation entry, unless a recent brew makes a non-rotation reference more natural.
+- Library lines prefixed with "★ IN ROTATION" are the user's active rotation — the bags they currently have access to (think: they're traveling and only some bags came along).
+- If the library shows ANY "★ IN ROTATION" entries, the day's invitation MUST name a rotation entry. NEVER reference a non-rotation bag — not as the invitation, not as a recent-brew mention, not in passing. Non-rotation bags are out of reach right now; naming them is useless.
+- This holds even when a recent brew was a non-rotation bag (café visit, end-of-bag, etc.). Drop the recent-brew angle entirely and reach into the rotation for an invitation.
+- Only when the library shows ZERO rotation entries may you reference a non-rotation bag.
 - "★ IN ROTATION" is a prefix marker, not part of the coffee name — never echo it back in the sentence.
 
 EXAMPLES (style only — do not copy)


### PR DESCRIPTION
## Summary

Closes the "unless" loophole in the greeting Haiku's ROTATION DISCIPLINE block.

**Before:** *"prefer rotation, unless a recent brew makes a non-rotation reference more natural"* — which gave Haiku room to keep mentioning bags the user can't reach. Concrete failure mode: traveling to Portugal with 3 rotation bags, the greeting still invites a non-rotation bag sitting at home.

**After:** if the library shows ANY ★ IN ROTATION entries, the invitation MUST name a rotation entry. Never a non-rotation bag — not as invitation, not as recent-brew mention, not in passing. Non-rotation bags only become eligible when rotation is empty.

Also bumps the localStorage cache key `v3` → `v4` so any cached pre-rule lines from before this deploy don't show up tomorrow morning. `CLAUDE.md` + `HANDOVER.md` notes follow the version bump.

## Validation note (Hard Rule)

This is a behavioural change to `/api/greeting`. Per `CLAUDE.md`'s Hard Rule, prompt changes should be sample-verified before/after. **Cannot sample from the remote dev env** (auth + DB required) — Markus will see the first real output tomorrow morning. The change is narrow (one sentence rewritten), so the risk surface is small, but flagging openly. Roll back this commit if the greeting line looks off.

## Test plan

- [ ] Tomorrow morning's greeting names a rotation bag (verify against the star toggle on `/coffees/[id]`)
- [ ] If a recent brew was a non-rotation bag, the greeting does NOT reference it
- [ ] Toggle ALL rotation off → next greeting (next tod bucket) is allowed to reference any bag
- [ ] No cached "Late night" / "unless"-permitted line lingers — localStorage key changed to `brewlog.starter.v4.*`

https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPfkNuYMLMpkuafnQpp6iG)_