### PR TITLE
fix: consistent fraunces 30px headlines across light pages

### DIFF
--- a/src/app/(light)/coffees/page.tsx
+++ b/src/app/(light)/coffees/page.tsx
@@ -101,13 +101,13 @@ export default function CoffeesPage() {
 
       {/* Header */}
       <div className="px-5 pb-4" style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.25rem)" }}>
-        <div className="flex items-start justify-between mb-2">
-          <h1 className="font-fraunces text-3xl text-light-foreground leading-none">Coffee Library</h1>
+        <div className="flex items-center justify-between mb-2">
+          <h1 className="font-fraunces text-3xl leading-none text-light-foreground">Coffee Library</h1>
           <button
             type="button"
             onClick={() => setMenuOpen(true)}
             aria-label="Open menu"
-            className="h-10 w-10 -mr-2 rounded-full bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 flex items-center justify-center text-light-foreground active:scale-95 transition-transform"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150 active:scale-95 transition-transform"
           >
             <Menu className="h-5 w-5" strokeWidth={1.5} />
           </button>

--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -361,7 +361,7 @@ export default function HomePage() {
     <>
       <main className="flex h-dvh flex-col">
         <header className="flex shrink-0 items-center justify-between pl-5 pr-5 pt-12 pb-3">
-          <h1 className="font-chivo text-[14px] font-extralight text-light-foreground">
+          <h1 className="font-fraunces text-3xl leading-none text-light-foreground">
             Better taste than sorry.
           </h1>
           <button

--- a/src/app/(light)/past-conversations/page.tsx
+++ b/src/app/(light)/past-conversations/page.tsx
@@ -68,7 +68,7 @@ export default function PastConversationsPage() {
     <>
       <main className="flex h-dvh flex-col">
         <header className="flex shrink-0 items-center justify-between pl-5 pr-5 pt-12 pb-3">
-          <h1 className="font-chivo text-[14px] font-medium text-light-foreground/60">
+          <h1 className="font-fraunces text-3xl leading-none text-light-foreground">
             Past conversations
           </h1>
           <button


### PR DESCRIPTION
## Summary

Three Light pages had three different headline treatments. Now they all share one.

- **Home**: `Better taste than sorry.` — was Chivo 14px extralight (looked off — Chivo is the content font), now Fraunces 30px.
- **Past Conversations**: `Past conversations` — was Chivo 14px medium grey, now Fraunces 30px.
- **Coffee Library**: was already Fraunces 30px but the menu button was `h-10` on `items-start` and used a different border style. Normalised to `h-11` + `items-center` + the same bordered glass pill the other two surfaces use.

Headline tier (per Markus' design call):
- **Normal page headline** — Fraunces 30px, vertically centred with the burger button.
- **Highlight tier** (Brew Flow Hero, Welcome Haiku on Home) — Fraunces 40px. Unchanged.

Dark surfaces (cafes / taste / library / brew detail) deliberately untouched — they get the same pattern when they migrate to Light.

## Test plan

- [ ] Home: header shows "Better taste than sorry." in Fraunces 30px, vertically centred next to the burger; Welcome Haiku below stays at 40px.
- [ ] Past Conversations: header shows "Past conversations" in Fraunces 30px.
- [ ] Coffee Library: header unchanged at a glance, but menu button now matches the bordered glass pill on the other two surfaces.
- [ ] Burger button vertically centred with the headline on all three pages.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_