### PR TITLE
fix: line break in home headline after 'taste'

### DIFF
--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -361,8 +361,8 @@ export default function HomePage() {
     <>
       <main className="flex h-dvh flex-col">
         <header className="flex shrink-0 items-center justify-between pl-5 pr-5 pt-12 pb-3">
-          <h1 className="font-fraunces text-3xl leading-none text-light-foreground">
-            Better taste than sorry.
+          <h1 className="font-fraunces text-3xl leading-[1.05] text-light-foreground">
+            Better taste<br />than sorry.
           </h1>
           <button
             type="button"


### PR DESCRIPTION
## Summary

Force a line break after "taste" so the home headline reads on two lines:

```
Better taste
than sorry.
```

Leading bumped from `none` to `1.05` so the two lines breathe instead of touching.

## Test plan

- [ ] Home: headline shows "Better taste" on line 1, "than sorry." on line 2.
- [ ] Burger button still vertically centred with the (now taller) headline block.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_