### PR TITLE
fix: breathing room under home chat pills

### DIFF
--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -361,8 +361,8 @@ export default function HomePage() {
     <>
       <main className="flex h-dvh flex-col">
         <header className="flex shrink-0 items-center justify-between pl-5 pr-5 pt-12 pb-3">
-          <h1 className="font-fraunces text-3xl leading-none text-light-foreground">
-            Better taste than sorry.
+          <h1 className="font-fraunces text-3xl leading-[1.05] text-light-foreground">
+            Better taste<br />than sorry.
           </h1>
           <button
             type="button"

--- a/src/components/ui/light/ChatInput.tsx
+++ b/src/components/ui/light/ChatInput.tsx
@@ -235,7 +235,7 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
 
   return (
     <>
-      <footer className="flex flex-col px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-3">
+      <footer className="flex flex-col px-5 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] pt-3">
         {(voiceError || uploadError) && (
           <div
             role="alert"


### PR DESCRIPTION
## Summary

Chat input footer on Home used `pb-[max(1rem,env(safe-area-inset-bottom))]`. On iPhone the safe-area inset is ~34px which is exactly the height of the home-indicator zone, so the "+" and "Ask anything" pills sat flush against the hardware grab area — Markus called it gequetscht.

Switch to `pb-[calc(env(safe-area-inset-bottom)+0.75rem)]` so the pills always sit 12px above the indicator zone regardless of device. Non-notched browsers (`env(...) = 0`) still get a 12px bottom margin, slightly tighter than before but visually fine because there's no system UI competing for the space.

## Test plan

- [ ] iPhone PWA Home: visible breathing room between the chat pills and the home-indicator line.
- [ ] Desktop browser: chat pills still anchored to the bottom of the viewport, ~12px gap.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_