### PR TITLE
fix: url scan recognizes known roasters + visual cleanup

### DIFF
--- a/src/app/api/analyze-url/route.ts
+++ b/src/app/api/analyze-url/route.ts
@@ -1,7 +1,12 @@
 import { NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
+import { eq, sql } from "drizzle-orm";
 import { parseClaudeJson, z } from "@/lib/claude/parseJson";
 import { assertSafeHttpsUrl } from "@/lib/utils/safeFetch";
+import { getRoasterPrior, canonicalRoasterSlug } from "@/lib/roasters/priors";
+import { db } from "@/lib/db/client";
+import { roasters } from "@/lib/db/schema";
+import type { RoasterPrior } from "@/lib/roasters/priors";
 
 export const dynamic = "force-dynamic";
 
@@ -99,14 +104,59 @@ export async function POST(req: Request) {
       );
     }
 
-    // Return same shape as analyze-bag
+    // Roaster prior lookup — mirror analyze-bag so the URL path benefits
+    // from the same DB + built-in priors. Without this every URL scan
+    // triggered the "I don't know X yet" Q&A even for well-known roasters
+    // like Hoppenworth & Ploch.
+    let roasterPrior: ReturnType<typeof toPriorSummary> | null = null;
+    if (extracted.roaster) {
+      let prior: RoasterPrior | null = null;
+      try {
+        const slug = canonicalRoasterSlug(extracted.roaster);
+        const direct = await db.select().from(roasters).where(eq(roasters.slug, slug)).limit(1);
+        if (direct.length > 0) {
+          prior = direct[0].data as RoasterPrior;
+        } else {
+          const viaAlias = await db
+            .select()
+            .from(roasters)
+            .where(sql`${roasters.aliases} @> ${JSON.stringify([slug])}::jsonb`)
+            .limit(1);
+          if (viaAlias.length > 0) prior = viaAlias[0].data as RoasterPrior;
+        }
+      } catch {}
+
+      if (!prior) {
+        const builtIn = getRoasterPrior(extracted.roaster);
+        if (builtIn.confidence !== "fallback") prior = builtIn;
+      }
+
+      if (prior) roasterPrior = toPriorSummary(prior);
+    }
+
     return NextResponse.json({
       extracted,
       clarifications: [],
-      roasterPrior: null,
+      roasterPrior,
     });
   } catch (err) {
     console.error("[analyze-url]", err);
     return NextResponse.json({ error: "Unexpected error" }, { status: 500 });
   }
+}
+
+function toPriorSummary(prior: RoasterPrior) {
+  return {
+    name: prior.name,
+    region: prior.region,
+    styleSummary: prior.styleSummary,
+    roastTendency: prior.roastTendency,
+    clarityVsSweetnessBias: prior.clarityVsSweetnessBias,
+    tempBias: prior.tempBias,
+    ratioBias: prior.ratioBias,
+    methodAffinities: prior.methodAffinities,
+    extractionRisks: prior.extractionRisks,
+    notes: prior.notes,
+    confidence: prior.confidence,
+  };
 }

--- a/src/components/flow/LightStepScan.tsx
+++ b/src/components/flow/LightStepScan.tsx
@@ -652,10 +652,7 @@ export default function LightStepScan() {
                             <div className="mt-2 space-y-2">
                               <div className="flex flex-wrap gap-2">
                                 {msg.chips.map(chip => (
-                                  <button key={chip} onClick={() => handleRoasterQAAnswer(chip)}
-                                    className="px-3 py-1.5 rounded-full border text-sm active:scale-95 transition-all"
-                                    style={{ borderColor: "var(--border)", color: "var(--muted-foreground)" }}
-                                  >{chip}</button>
+                                  <Chip key={chip} onClick={() => handleRoasterQAAnswer(chip)}>{chip}</Chip>
                                 ))}
                               </div>
                               <div className="flex gap-2">
@@ -707,15 +704,9 @@ export default function LightStepScan() {
                             <div className="mt-2 space-y-2">
                               <div className="flex flex-wrap gap-2">
                                 {msg.chips.map(chip => (
-                                  <button key={chip} onClick={() => handleClarificationAnswer(chip)}
-                                    className="px-3 py-1.5 rounded-full border text-sm active:scale-95 transition-all"
-                                    style={{ borderColor: "var(--border)", color: "var(--muted-foreground)" }}
-                                  >{chip}</button>
+                                  <Chip key={chip} onClick={() => handleClarificationAnswer(chip)}>{chip}</Chip>
                                 ))}
-                                <button onClick={() => handleClarificationAnswer("Not sure")}
-                                  className="px-3 py-1.5 rounded-full border text-sm active:scale-95 transition-all"
-                                  style={{ borderColor: "var(--border)", color: "var(--muted-foreground)" }}
-                                >Not sure</button>
+                                <Chip onClick={() => handleClarificationAnswer("Not sure")}>Not sure</Chip>
                               </div>
                               <div className="flex gap-2">
                                 <input type="text" value={freeText}
@@ -838,22 +829,25 @@ export default function LightStepScan() {
           {inputMethod === "link" && (
             <div className="rounded-2xl p-4 space-y-3" style={{ background: "var(--card)", border: "1px solid var(--border)" }}>
               <p className="label-eyebrow" style={{ color: "var(--muted-foreground)" }}>Paste a product URL</p>
-              <div className="flex items-center gap-2">
+              <div
+                className="flex items-center gap-1 rounded-2xl pl-4 pr-1.5 py-1.5"
+                style={{ background: "var(--secondary)", border: "1px solid var(--border)" }}
+              >
                 <input
                   type="url"
                   value={urlInput}
                   onChange={e => { setUrlInput(e.target.value); setUrlError(null); }}
                   onKeyDown={e => e.key === "Enter" && urlInput.trim() && handleUrlAnalyze()}
                   placeholder="https://..."
-                  className="flex-1 rounded-2xl px-4 py-3 text-base focus:outline-none"
-                  style={{ background: "var(--secondary)", border: "1px solid var(--border)", color: "var(--foreground)", fontSize: "16px" }}
+                  className="flex-1 min-w-0 bg-transparent text-base focus:outline-none"
+                  style={{ color: "var(--foreground)", fontSize: "16px" }}
                 />
                 <button
                   type="button"
                   onClick={handleUrlAnalyze}
                   disabled={!urlInput.trim() || isAnalyzingUrl}
                   aria-label={isAnalyzingUrl ? "Scanning" : "Scan URL"}
-                  className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full active:scale-95 transition-all disabled:opacity-40"
+                  className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full active:scale-95 transition-all disabled:opacity-40"
                   style={{ background: "var(--primary)", color: "var(--primary-foreground)" }}
                 >
                   {isAnalyzingUrl ? (
@@ -868,12 +862,25 @@ export default function LightStepScan() {
               )}
               {/* Show extracted info after URL scan */}
               {(draft.coffee?.name || draft.coffee?.roaster) && !isAnalyzingUrl && inputMethod === "link" && (
-                <div className="rounded-xl p-3 space-y-2" style={{ background: "var(--secondary)", border: "1px solid var(--border)" }}>
-                  <p className="label-eyebrow" style={{ color: "var(--muted-foreground)" }}>Extracted</p>
-                  {draft.coffee.roaster && <p className="text-sm" style={{ color: "var(--foreground)" }}>{draft.coffee.roaster}</p>}
-                  {draft.coffee.name && <p className="text-sm font-medium" style={{ color: "var(--foreground)" }}>{draft.coffee.name}</p>}
-                  {draft.coffee.origin && <p className="text-xs" style={{ color: "var(--muted-foreground)" }}>{draft.coffee.origin}</p>}
+                <div className="rounded-2xl p-4" style={{ background: "var(--secondary)", border: "1px solid var(--border)" }}>
+                  <p className="label-eyebrow mb-2" style={{ color: "var(--muted-foreground)" }}>Extracted</p>
+                  {draft.coffee.roaster && (
+                    <p className="text-xs mb-1" style={{ color: "var(--muted-foreground)" }}>{draft.coffee.roaster}</p>
+                  )}
+                  {draft.coffee.name && (
+                    <p className="font-fraunces text-lg leading-tight" style={{ color: "var(--foreground)" }}>{draft.coffee.name}</p>
+                  )}
+                  {draft.coffee.origin && (
+                    <p className="text-xs mt-1" style={{ color: "var(--muted-foreground)" }}>{draft.coffee.origin}</p>
+                  )}
                 </div>
+              )}
+              {/* Roaster prior — surfaces curated/DB profile for the URL path
+                  too. Previously only the photo path rendered this; URL
+                  scans hit a Q&A even for well-known roasters because the
+                  endpoint never looked up the prior. */}
+              {manualRoasterPrior && !isAnalyzingUrl && inputMethod === "link" && (
+                <RoasterProfileCard prior={manualRoasterPrior} compact />
               )}
               {/* Roaster Q&A after URL scan */}
               {roasterQA && !isAnalyzingUrl && (
@@ -889,10 +896,7 @@ export default function LightStepScan() {
                             <div className="mt-2 space-y-2">
                               <div className="flex flex-wrap gap-2">
                                 {msg.chips.map(chip => (
-                                  <button key={chip} onClick={() => handleRoasterQAAnswer(chip)}
-                                    className="px-3 py-1.5 rounded-full border text-sm active:scale-95 transition-all"
-                                    style={{ borderColor: "var(--border)", color: "var(--muted-foreground)" }}
-                                  >{chip}</button>
+                                  <Chip key={chip} onClick={() => handleRoasterQAAnswer(chip)}>{chip}</Chip>
                                 ))}
                               </div>
                             </div>


### PR DESCRIPTION
## Summary

Four problems Markus flagged on the paste-a-link path (LightStepScan + analyze-url):

1. **`/api/analyze-url` always returned `roasterPrior: null`** — even well-known roasters like Hoppenworth & Ploch fell through to the "I don't know X yet" Q&A. Mirror analyze-bag's lookup: try the `roasters` table by canonical slug then by alias, fall back to the built-in priors list, return the same prior-summary shape the photo path already returns.
2. **`RoasterProfileCard` never rendered for the URL path** even when the manual form had it. Render it now whenever a prior is available in the URL section.
3. **Extracted recap card** was three plain text rows. Introduced typo hierarchy — roaster muted small, coffee name Fraunces lg, origin muted small — same rhythm as the photo-path "Identified" card.
4. **Arrow Scan button** floated next to the URL pill as a separate bubble. Pulled it inside the pill on the right edge — single composite control instead of two disconnected ones, mirrors the ChatInput pattern.

Bonus: roaster-Q&A, clarification, and URL-Q&A chip rows were using inline-styled `<button>`s. Switched all three to the Light `<Chip>` primitive — the Germany / Netherlands / UK row now looks like every other chip in the flow.

## AI behavior note

Per the CLAUDE.md hard rule: the AI prompt, model (`claude-haiku-4-5`), and schema for `/api/analyze-url` are unchanged. The roaster-prior lookup is a post-processing DB augmentation of the AI response — same input → same AI output → just enriched with a prior that was missing before. The user-visible change (no more "I don't know" Q&A for known roasters) is the bug fix Markus requested.

## Test plan

- [ ] Paste a Hoppenworth & Ploch product URL → RoasterProfileCard appears, no Q&A.
- [ ] Paste an unknown-roaster URL → falls back to country Q&A (Chip primitive, looks consistent with the rest).
- [ ] Extracted card shows the coffee name in Fraunces, roaster + origin muted around it.
- [ ] Scan arrow button is inside the URL input pill, not floating next to it.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_