### PR TITLE
feat: theme-color soft mauve-pink

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,7 +37,7 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
-  themeColor: "#0E0B0A",
+  themeColor: "#D4B8C9",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary

- Bump PWA `themeColor` from cream `#F3E5DC` (PR #113) to soft mauve-pink `#D4B8C9` per your pick.
- Affects Safari URL bar tint and Android PWA system status bar.
- iOS PWA: still unchanged — `apple-mobile-web-app-status-bar-style: black-translucent` wins on iPhone (Apple does not honour `theme-color` for installed PWAs).

## Test plan

- [ ] Safari iOS / desktop: URL bar tints soft mauve.
- [ ] Android Chrome PWA: status bar tints soft mauve.
- [ ] iOS PWA: status bar unchanged (Field still paints behind it).

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_