### PR TITLE
fix: ios pwa status bar opaque white instead of translucent

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -47,7 +47,7 @@ export const metadata: Metadata = {
   manifest: "/manifest.json",
   appleWebApp: {
     capable: true,
-    statusBarStyle: "black-translucent",
+    statusBarStyle: "default",
     title: "BrewLog",
   },
 };


### PR DESCRIPTION
## Summary

Flip iOS PWA `apple-mobile-web-app-status-bar-style` from `black-translucent` to `default`. On the installed iPhone PWA this swaps the see-through bar (which is what caused the hard color cut you saw between the Field gradient and the iOS system tint) for a clean opaque white system status bar with black text.

### Trade-off
The layout no longer extends behind the status bar on iOS. `env(safe-area-inset-top)` returns ~0 instead of ~44pt, so existing `padding-top: calc(env(safe-area-inset-top) + 1.5rem)` collapses to ~1.5rem. The Fraunces hero now sits 1.5rem under the white bar instead of behind it — same headroom feel since the bar itself supplies the visual breathing room.

### Android stays mauve
`themeColor: #D4B8C9` is unchanged. Android PWA + Safari URL bar still tint mauve. Apple ignores `theme-color` for installed PWAs, so iOS falls back to the `default` style above.

## Test plan

- [ ] iPhone PWA: status bar is opaque white with black text, no transparent overlap.
- [ ] iPhone PWA: hero content has reasonable headroom under the white bar (no overlap, no awkward gap).
- [ ] iPhone PWA all routes: home, brew flow, coffees library, cafes — check the spacing on each.
- [ ] Android PWA: status bar still tints mauve (unaffected by this change).

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_