### PR TITLE
feat: rotation gates brew-this shortcut

### DIFF
--- a/src/app/(light)/coffees/[id]/page.tsx
+++ b/src/app/(light)/coffees/[id]/page.tsx
@@ -240,19 +240,16 @@ export default function CoffeeDetailPage() {
         )}
       </div>
 
-      {/* Brew this — jumps straight to the brew context step with this coffee preloaded */}
+      {/* Action hierarchy — rotation first, then brew.
+          A coffee must be in rotation before it can be brewed: if it's
+          not in rotation the bag is gone or set aside, so the "Brew
+          this" shortcut is hidden until the user opts the bag in. */}
       <div className="px-5 pt-4 space-y-2">
-        <button
-          type="button"
-          onClick={brewThis}
-          className="w-full py-3.5 rounded-2xl text-sm font-medium bg-light-foreground text-[hsl(36_55%_96%)] active:scale-[0.98] transition-transform"
-        >
-          Brew this
-        </button>
         {/* Rotation toggle — marks this bag as "currently in rotation".
             The /api/greeting library snapshot uses this signal so the
             daily Haiku starter prioritises rotation bags over the rest
-            of the library. Optimistic update + best-effort PATCH. */}
+            of the library. Primary CTA when not in rotation; quieter
+            state pill once active. Optimistic update + best-effort PATCH. */}
         <button
           type="button"
           onClick={async () => {
@@ -267,14 +264,13 @@ export default function CoffeeDetailPage() {
               });
               if (!res.ok) throw new Error(`HTTP ${res.status}`);
             } catch {
-              // Revert on failure
               setCoffee((prev) => (prev ? { ...prev, inRotation: !next } : prev));
             }
           }}
-          className={`w-full py-3 rounded-2xl text-sm flex items-center justify-center gap-2 border transition-transform active:scale-[0.98] ${
+          className={`w-full py-3.5 rounded-2xl text-sm font-medium flex items-center justify-center gap-2 transition-transform active:scale-[0.98] ${
             coffee.inRotation
-              ? "bg-light-foreground/10 border-light-foreground/40 text-light-foreground"
-              : "bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border-light-foreground/15 text-light-muted-foreground"
+              ? "bg-light-foreground/10 border border-light-foreground/40 text-light-foreground"
+              : "bg-light-foreground text-[hsl(36_55%_96%)]"
           }`}
         >
           <svg className="w-4 h-4" viewBox="0 0 24 24" fill={coffee.inRotation ? "currentColor" : "none"} stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
@@ -282,6 +278,15 @@ export default function CoffeeDetailPage() {
           </svg>
           {coffee.inRotation ? "In rotation" : "Add to rotation"}
         </button>
+        {coffee.inRotation && (
+          <button
+            type="button"
+            onClick={brewThis}
+            className="w-full py-3.5 rounded-2xl text-sm font-medium bg-light-foreground text-[hsl(36_55%_96%)] active:scale-[0.98] transition-transform"
+          >
+            Brew this
+          </button>
+        )}
       </div>
 
       {/* Coffee scan details */}

--- a/src/app/(light)/coffees/page.tsx
+++ b/src/app/(light)/coffees/page.tsx
@@ -230,10 +230,28 @@ export default function CoffeesPage() {
 
                     {/* Text */}
                     <div className="flex-1 min-w-0">
-                      {coffee.roaster && (
-                        <p className="text-light-muted-foreground text-xs truncate mb-0.5">{coffee.roaster}</p>
-                      )}
-                      <p className="text-light-foreground text-sm font-medium leading-snug truncate">{coffee.name}</p>
+                      <div className="flex items-center gap-1.5">
+                        {coffee.roaster && (
+                          <p className="text-light-muted-foreground text-xs truncate mb-0.5 flex-1">{coffee.roaster}</p>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-1.5">
+                        {coffee.inRotation && (
+                          <svg
+                            className="w-3.5 h-3.5 shrink-0 text-light-foreground"
+                            viewBox="0 0 24 24"
+                            fill="currentColor"
+                            stroke="currentColor"
+                            strokeWidth={1.75}
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            aria-label="In rotation"
+                          >
+                            <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+                          </svg>
+                        )}
+                        <p className="text-light-foreground text-sm font-medium leading-snug truncate">{coffee.name}</p>
+                      </div>
                       {sub && (
                         <p className="text-light-muted-foreground text-xs truncate mt-0.5">{sub}</p>
                       )}
@@ -250,15 +268,20 @@ export default function CoffeesPage() {
                     </div>
                   </button>
 
-                  {/* Brew this — jumps to the brew context step with this coffee preloaded */}
-                  <button
-                    type="button"
-                    onClick={() => brewThis(coffee)}
-                    aria-label={`Brew ${coffee.name}`}
-                    className="shrink-0 px-3 py-2 rounded-full text-xs font-medium bg-light-foreground text-[hsl(36_55%_96%)] active:scale-95 transition-transform"
-                  >
-                    Brew
-                  </button>
+                  {/* Brew this — gated on rotation: an unrotated bag is
+                      assumed to be off the counter, so the shortcut hides
+                      until the user marks the coffee in rotation on the
+                      detail page. */}
+                  {coffee.inRotation && (
+                    <button
+                      type="button"
+                      onClick={() => brewThis(coffee)}
+                      aria-label={`Brew ${coffee.name}`}
+                      className="shrink-0 px-3 py-2 rounded-full text-xs font-medium bg-light-foreground text-[hsl(36_55%_96%)] active:scale-95 transition-transform"
+                    >
+                      Brew
+                    </button>
+                  )}
                 </div>
               );
             })}


### PR DESCRIPTION
## Summary

Aligns the coffee selection hierarchy with your mental model: a bag must be **in rotation** before it can be **brewed**. An un-rotated coffee in the library is treated as a record, not an actionable bag.

### Detail page (`/coffees/[id]`)
- Rotation toggle moves above "Brew this" and becomes the primary CTA (filled anthracite) until the bag is in rotation.
- "Brew this" only renders when `coffee.inRotation === true`.
- Once in rotation, the rotation toggle becomes a quieter state pill (outlined, star-filled), and "Brew this" takes the primary slot.

### Library list (`/coffees`)
- "Brew" pill on row level is gated on `coffee.inRotation` — un-rotated rows have no Brew shortcut.
- Rotation rows pick up a small star indicator inline with the coffee name (covers the HANDOVER punch-list item "list rows don't show the rotation star").

Server-side untouched — `coffees.in_rotation` already flows through type, schema, and row mapper.

## Test plan

- [ ] `/coffees/[id]` for a coffee NOT in rotation: only "Add to rotation" CTA visible (anthracite filled).
- [ ] Tap "Add to rotation" → button becomes "In rotation" state pill, "Brew this" CTA appears below.
- [ ] Tap "Brew this" → flow jumps to context step with the coffee preloaded.
- [ ] Tap "In rotation" state pill → reverts to "Add to rotation" CTA, "Brew this" disappears.
- [ ] `/coffees` list: rotation rows show a star next to the coffee name AND a "Brew" pill on the right.
- [ ] `/coffees` list: non-rotation rows have neither star nor Brew pill.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_