### PR TITLE
fix: manifest theme + background match the light app

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,8 +4,8 @@
   "description": "Your personal coffee brew advisor & diary",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#0A0A0A",
-  "theme_color": "#0A0A0A",
+  "background_color": "#F3E5DC",
+  "theme_color": "#D4B8C9",
   "orientation": "portrait",
   "icons": [
     { "src": "/icons/icon-76.png",  "sizes": "76x76",   "type": "image/png", "purpose": "any" },


### PR DESCRIPTION
## Summary

`manifest.json` was still carrying `#0A0A0A` from the Dark era. Brings it in line with the rest of the Light system:

- `theme_color: #D4B8C9` — soft mauve-pink, matches viewport `themeColor` in `src/app/layout.tsx`. Android PWA reads this; status bar tints mauve.
- `background_color: #F3E5DC` — cream, used by Android/desktop PWA as the launch-splash background while the app boots. Used to flash black for a split second before the Cream Field painted; now matches.

## iOS PWA caveat

The iOS PWA status bar style is governed by `apple-mobile-web-app-status-bar-style` in the HTML meta tag (set via `appleWebApp.statusBarStyle` in `src/app/layout.tsx`, currently `default` since PR #116). That value is **frozen on the installed PWA at install time** — an existing installed PWA keeps its old `black-translucent` setting until removed from the home screen and re-added. This is an iOS-side behavior, not a service-worker cache.

## Test plan

- [ ] Android PWA: launch-splash background reads cream, then app paints. No black flash.
- [ ] Android PWA: system status bar tints mauve.
- [ ] iPhone PWA (after re-install): status bar is opaque white with black text.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_