### PR TITLE
fix: html canvas reads cream, kills the black statusbar leak

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -85,7 +85,14 @@
 
   html {
     height: 100%;
-    background-color: #0E0B0A;
+    /* Cream canvas — the BTTS Light baseline. Dark routes still paint
+       body as solid #0E0B0A which covers this entirely, so they're
+       unaffected. The reason this is cream and not dark: viewportFit:
+       cover extends the PWA webview under the iOS/Android system
+       status bar. If the Field gradient is thin or transparent in
+       its uppermost pixels, the html canvas shows through there —
+       cream is the right fallback for the Light app, dark was not. */
+    background-color: #F3E5DC;
   }
 
   body {


### PR DESCRIPTION
## Summary

Root cause of "Statusbar bleibt schwarz" on Light routes:

```css
html { background-color: #0E0B0A; }                        /* dark canvas */
body { background-color: #0E0B0A; }                        /* dark default */
body:has([data-light-scope="true"]) { background: transparent; }
```

Light routes drop `body` to transparent so the Field gradient shows. But `html` stays dark. With `viewport-fit: cover`, the PWA webview extends under the iOS/Android system status bar — at those uppermost pixels the Field gradient layers are at low/zero alpha (radial stops at 50-60%), so the dark `html` canvas bleeds through and the status bar reads black.

**Fix:** flip `html` background to cream (`#F3E5DC`, the BTTS Light baseline). Dark routes are untouched — their `body` is solid `#0E0B0A` which covers `html` entirely.

## How this relates to the other PRs in this thread

- PR #115 — `themeColor: #D4B8C9` (mauve): what Android Chrome PWA paints on the system bar.
- PR #116 — `appleWebApp.statusBarStyle: "default"`: what iOS draws on top.
- PR #118 — `manifest.json` cleanup: removed `#0A0A0A` background_color/theme_color, set cream/mauve.
- **PR (this one):** what the OS shows when the page underneath has nothing solid in that exact pixel.

All four are required. The first three were correct but couldn't help on Light routes because the `html` canvas was still dark.

## User-side action

Service Workers cache `manifest.json` (precached with revision hash). Old installs may still serve the old manifest. To pick up everything:

**Android Firefox PWA:** Firefox → Settings → Site Permissions → bettertastethansorry.com → Delete site data → re-add to home screen.

**iOS Safari PWA:** iOS Settings → Safari → Advanced → Website Data → swipe-delete bettertastethansorry.com → reopen in Safari → add to home screen.

## Test plan

- [ ] iOS Safari PWA (after re-install + cleared site data): status bar area is cream / Field colors, NOT black.
- [ ] Android Firefox PWA (after re-install + cleared site data): status bar tints mauve from `theme_color`.
- [ ] Dark routes (`/cafes`, `/taste`, etc.): unchanged — still solid dark.
- [ ] Initial paint before React mounts: cream flash, not dark.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_