### PR TITLE
fix: session card light theme + brew method as headline

### DIFF
--- a/src/components/session/SessionCard.tsx
+++ b/src/components/session/SessionCard.tsx
@@ -2,8 +2,9 @@
 import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import type { Session } from "@/lib/types/session";
-import StarRating from "@/components/ui/StarRating";
+import StarRating from "@/components/ui/light/StarRating";
 import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
+import { formatSeconds } from "@/lib/utils/formatTime";
 
 interface SessionCardProps {
   session: Session;
@@ -13,21 +14,28 @@ interface SessionCardProps {
 const DELETE_THRESHOLD = 80;
 
 export default function SessionCard({ session, onDeleted }: SessionCardProps) {
-  const { coffee, result, recommendation } = session;
+  const router = useRouter();
+  const { brew, result, recommendation, createdAt } = session;
 
-  const roaster = coffee?.roaster || "";
-  const name = coffee?.name || "Coffee Session";
-  const method = session.brew?.methodUsed || recommendation?.primaryMethod || "";
-  const hasPhoto = !!coffee?.bagPhotoUrl;
+  const method = brew?.methodUsed || recommendation?.primaryMethod || "Brew";
+  const dose = brew?.doseGrams ?? recommendation?.primaryRecipe.doseGrams;
+  const water = brew?.waterGrams ?? recommendation?.primaryRecipe.waterGrams;
+  const timeSec = brew?.actualTimeSec ?? recommendation?.primaryRecipe.targetTimeSec;
+  const rating = result?.rating;
+  const tags = result?.flavorNotes?.slice(0, 4) ?? [];
+
+  const date = createdAt
+    ? new Date(createdAt).toLocaleDateString("en-GB", { day: "numeric", month: "short" })
+    : "";
+
+  const recipeBits: string[] = [];
+  if (dose != null) recipeBits.push(`${dose}g`);
+  if (water != null) recipeBits.push(`${water}g`);
+  if (timeSec != null) recipeBits.push(formatSeconds(timeSec));
 
   const [offset, setOffset] = useState(0);
   const [deleting, setDeleting] = useState(false);
   const startXRef = useRef<number | null>(null);
-  const router = useRouter();
-
-  const date = session.createdAt
-    ? new Date(session.createdAt).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })
-    : "";
 
   const handleTouchStart = (e: React.TouchEvent) => {
     startXRef.current = e.touches[0].clientX;
@@ -39,8 +47,7 @@ export default function SessionCard({ session, onDeleted }: SessionCardProps) {
   };
   const handleTouchEnd = () => {
     startXRef.current = null;
-    if (offset >= DELETE_THRESHOLD) setOffset(DELETE_THRESHOLD);
-    else setOffset(0);
+    setOffset(offset >= DELETE_THRESHOLD ? DELETE_THRESHOLD : 0);
   };
 
   const handleDelete = async () => {
@@ -55,19 +62,17 @@ export default function SessionCard({ session, onDeleted }: SessionCardProps) {
   };
 
   if (deleting) return null;
-
   const isOpen = offset >= DELETE_THRESHOLD;
-  const tags = result?.flavorNotes?.slice(0, 3) ?? [];
 
   return (
-    <div className="relative overflow-hidden rounded-2xl" style={{ background: "var(--card)" }}>
+    <div className="relative overflow-hidden rounded-2xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15">
       {/* Delete button behind */}
       <div className="absolute inset-y-0 right-0 flex items-stretch rounded-r-2xl overflow-hidden">
         <button
           type="button"
           onClick={handleDelete}
-          className="w-20 flex flex-col items-center justify-center gap-1 text-white active:opacity-80"
-          style={{ background: "var(--destructive)" }}
+          aria-label="Delete session"
+          className="w-20 flex flex-col items-center justify-center gap-1 text-[hsl(36_55%_96%)] active:opacity-80 bg-[hsl(12_70%_45%)]"
         >
           <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
@@ -76,95 +81,54 @@ export default function SessionCard({ session, onDeleted }: SessionCardProps) {
         </button>
       </div>
 
-      {/* Card */}
+      {/* Card body — translates left to reveal delete */}
       <div
         style={{
           transform: `translateX(-${isOpen ? DELETE_THRESHOLD : offset}px)`,
           transition: startXRef.current === null ? "transform 0.2s ease" : "none",
-          background: "var(--card)",
-          borderColor: "var(--border)",
         }}
         onTouchStart={handleTouchStart}
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
-        onClick={() => { if (isOpen) { setOffset(0); return; } router.push(`/brew/${session.id}`); }}
-        className="relative border rounded-2xl overflow-hidden cursor-pointer active:scale-[0.98] transition-transform"
+        onClick={() => {
+          if (isOpen) { setOffset(0); return; }
+          router.push(`/brew/${session.id}`);
+        }}
+        className="relative bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 rounded-2xl px-4 py-3.5 cursor-pointer active:scale-[0.99] transition-transform"
       >
-        {/* Photo header — only when bag photo is available */}
-        {hasPhoto && (
-          <div className="relative h-36 overflow-hidden">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={coffee!.bagPhotoUrl!}
-              alt={name}
-              className="absolute inset-0 w-full h-full object-cover"
-            />
-            <div className="absolute inset-0 bg-gradient-to-t from-black/75 via-black/10 to-transparent" />
-            {/* Method + date overlay at bottom of photo */}
-            <div className="absolute bottom-0 left-0 right-0 px-4 pb-3 flex items-center justify-between gap-2">
-              {method && (
-                <div className="flex items-center gap-1.5 min-w-0">
-                  <BrewMethodIcon method={method} className="w-4 h-4 shrink-0 opacity-90" />
-                  <span className="text-white/80 text-xs truncate">{method}</span>
-                </div>
-              )}
-              {date && <span className="text-white/55 text-xs shrink-0">{date}</span>}
-            </div>
+        {/* Headline row — brew method + rating */}
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-2 min-w-0 flex-1">
+            <BrewMethodIcon method={method} className="w-5 h-5 shrink-0 opacity-80" />
+            <h3 className="font-fraunces text-light-foreground text-lg leading-tight truncate">{method}</h3>
           </div>
-        )}
-
-        {/* Content */}
-        <div className="px-4 py-4">
-          {/* Roaster */}
-          {roaster && (
-            <p className="text-xs mb-1.5 truncate" style={{ color: "var(--muted-foreground)" }}>{roaster}</p>
-          )}
-
-          {/* Coffee name + rating */}
-          <div className="flex items-start justify-between gap-2">
-            <h3 className="font-semibold text-[15px] leading-snug flex-1" style={{ color: "var(--foreground)" }}>{name}</h3>
-            {result?.rating != null && (
-              <div className="shrink-0 mt-0.5">
-                <StarRating value={result.rating} readonly size="sm" />
-              </div>
-            )}
-          </div>
-
-          {/* Method + date row — only when no photo */}
-          {!hasPhoto && (
-            <div className="flex items-center gap-1.5 mt-2.5">
-              {method && <BrewMethodIcon method={method} className="w-4 h-4" />}
-              {method && (
-                <span className="text-xs truncate" style={{ color: "var(--muted-foreground)" }}>{method}</span>
-              )}
-              {date && (
-                <>
-                  {method && <span className="text-xs" style={{ color: "var(--muted-foreground)" }}>·</span>}
-                  <span className="text-xs shrink-0" style={{ color: "var(--muted-foreground)" }}>{date}</span>
-                </>
-              )}
-            </div>
-          )}
-
-          {/* Flavor tags */}
-          {tags.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 mt-3">
-              {tags.map(tag => (
-                <span
-                  key={tag}
-                  className="text-xs capitalize px-2.5 py-0.5 rounded-full border"
-                  style={{
-                    color: "var(--primary)",
-                    borderColor: "var(--border)",
-                    background: "#2A241C",
-                  }}
-                >
-                  {tag}
-                </span>
-              ))}
+          {rating != null && (
+            <div className="shrink-0 mt-1">
+              <StarRating value={rating} readonly size="sm" />
             </div>
           )}
         </div>
+
+        {/* Meta row — date + recipe summary */}
+        {(date || recipeBits.length > 0) && (
+          <p className="text-light-muted-foreground text-xs mt-1.5 truncate">
+            {[date, ...recipeBits].filter(Boolean).join(" · ")}
+          </p>
+        )}
+
+        {/* Flavor notes */}
+        {tags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mt-3">
+            {tags.map(tag => (
+              <span
+                key={tag}
+                className="text-xs capitalize px-2.5 py-0.5 rounded-full bg-light-foreground/8 text-light-foreground/80"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Reworks `SessionCard` — the only consumer left is the "All brews" list on the coffee detail page (`/coffees/[id]`). Previously it carried its Dark-route styling onto the Light page:

- `var(--card) #171311` body, `var(--primary) peach` text, hardcoded `#2A241C` flavor pill background → dark blobs on cream cards
- Redundant bag photo header (the page hero already shows the photo one section above)
- Redundant roaster + coffee name (we're already on this coffee's page)

## New hierarchy

> "Da wir eh im Coffee sind, sollte Headline die Brew Methode sein."

| Slot | Content |
|---|---|
| Headline | Brew method icon + name (Fraunces 18px) |
| Trailing | Star rating |
| Meta line | Date · dose · water · time (muted, joined by `·`) |
| Body | Flavor notes as Light-token chips (foreground/8 background — no hex blobs) |

Removed: photo header, roaster line, coffee-name line. All redundant on the coffee detail page.

Swipe-to-delete preserved. Destructive color forked to warm rust (`hsl(12 70% 45%)`) so it reads correctly against the cream card.

StarRating import flipped to the Light variant (was importing the Dark one, which renders peach stars).

## Scope

`SessionCard` now only consumes Light-system tokens. It has exactly one consumer (`/coffees/[id]` All-brews list), so no Dark-route regression risk.

## Test plan

- [ ] `/coffees/[id]`: cards read as cream glass with anthracite text, brew method as the dominant line.
- [ ] Recipe meta line shows actual values (16g · 250g · 3:30) for past sessions.
- [ ] Flavor notes render as soft chips, not dark blobs.
- [ ] Swipe-left reveals delete; tap card opens `/brew/[id]`.
- [ ] Sessions without dose/water/time still render (meta line collapses gracefully).

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_