### PR TITLE
fix: coffee detail hero uses cream scrim, headline readable again

### DIFF
--- a/src/app/(light)/coffees/[id]/page.tsx
+++ b/src/app/(light)/coffees/[id]/page.tsx
@@ -168,7 +168,18 @@ export default function CoffeeDetailPage() {
           <div className="relative h-72">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img src={coffee.bagPhotoUrl} alt={coffee.name} className="w-full h-full object-cover" />
-            <div className="absolute inset-0 card-scrim" />
+            {/* Cream-to-transparent scrim so the anthracite title stays
+                readable over a bag photo of any colour. The dark
+                card-scrim utility is for the dark theme — using it here
+                left anthracite text painted on near-black, illegible. */}
+            <div
+              aria-hidden
+              className="absolute inset-0 pointer-events-none"
+              style={{
+                background:
+                  "linear-gradient(to top, hsl(30 60% 92% / 0.95) 0%, hsl(30 60% 92% / 0.45) 45%, transparent 80%)",
+              }}
+            />
           </div>
         ) : (
           <div className="h-40 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 flex items-center justify-center">


### PR DESCRIPTION
## Summary

The `/coffees/[id]` hero overlaid the bag photo with the `.card-scrim` utility — a black-to-near-opaque gradient designed for the Dark theme (where the caption on top is white). On this Light page the caption is anthracite (`text-light-foreground`). Result: anthracite text painted on a near-black scrim → illegible. Exactly what showed up on the Shyira screenshot.

## Fix

Swaps to the same cream-to-transparent scrim pattern that `LightStepSummary` already uses for the same job (`src/components/flow/LightStepSummary.tsx:155-166`). Cream fades up from the bottom; the anthracite title sits on the cream-rich zone with full contrast regardless of what the underlying bag photo looks like.

`card-scrim` utility itself stays — still used by the legacy Dark `/brew/[id]` page (one of the surfaces in the Light-migration punch list).

## Test plan

- [ ] `/coffees/[id]` for a coffee with a light-coloured bag photo (e.g. Hoppenworth Shyira white bag): coffee name + roaster + roast date all read cleanly over the cream scrim.
- [ ] `/coffees/[id]` for a coffee with a dark bag photo: same — cream scrim brightens the bottom band so the anthracite text still reads.
- [ ] No bag photo (placeholder coffee bean icon): caption unaffected (no scrim path taken).

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_