### PR TITLE
fix: coffee detail page adopts its own field composition

### DIFF
--- a/src/app/(light)/coffees/[id]/page.tsx
+++ b/src/app/(light)/coffees/[id]/page.tsx
@@ -10,6 +10,7 @@ import CoffeeBeanGlow from "@/components/ui/light/CoffeeBeanGlow";
 import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
 import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
 import { useFlowStore } from "@/store/flowStore";
+import { useFieldConfig } from "@/lib/field/FieldContext";
 
 interface RoasterInfo {
   region?: string;
@@ -100,6 +101,11 @@ export default function CoffeeDetailPage() {
     }
     load();
   }, [id]);
+
+  // Adopt this coffee's Field composition so the page paints in its
+  // cup-specific colours, matching the brew-session detail and the
+  // brew flow's "Brew Again" path.
+  useFieldConfig(coffee?.fieldZones ? { fieldZones: coffee.fieldZones, rotation: 0 } : null);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary

`/coffees/[id]` was only handing `coffee.fieldZones` to the flowStore from the `brewThis()` handler (so the next page in the brew flow paints with the coffee's Field). It never called `useFieldConfig` on its own page, so while sitting on the coffee detail the user saw the generic **Default Field** instead of the cup's customized one.

Now mirrors the pattern from `/brew/[id]` (PR #122): once the coffee fetch resolves, `useFieldConfig({ fieldZones: coffee.fieldZones, rotation: 0 })` writes the composition into `FieldContext` and the `LightShell`'s Field paints the personalized gradient stack.

Unmount of the hook resets to default Field, so navigating away (e.g. to `/coffees`) does not leak this coffee's Field into the library list.

## Coverage now

| Surface | Field source |
|---|---|
| `(light)/` home | default |
| `/coffees` list | default |
| `/coffees/[id]` detail | **this coffee's `fieldZones`** (new) |
| `/brew/[id]` session detail | this coffee's `fieldZones` (PR #122) |
| `/brew/new` flow | flowStore (set by ActionPill / `brewThis()` from list or detail) |

## Test plan

- [ ] Open a coffee with a distinctive tasting-notes profile (e.g. a fruity Yirgacheffe vs a chocolatey Brazil) — the Field tones should differ noticeably between them on the detail page.
- [ ] Navigate from `/coffees` → coffee detail → back: the Field on `/coffees` resets to default, no leak from the visited coffee.
- [ ] Tap "Brew this" → the brew flow paints with the same Field (already worked via flowStore).

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_