### PR TITLE
fix: standard chip style + swipe-delete only visible during swipe

### DIFF
--- a/src/app/(light)/brew/[id]/page.tsx
+++ b/src/app/(light)/brew/[id]/page.tsx
@@ -193,7 +193,7 @@ export default function SessionDetailPage() {
           {result.flavorNotes?.length > 0 && (
             <div className="flex flex-wrap gap-1.5 mb-3">
               {result.flavorNotes.map(f => (
-                <span key={f} className="text-xs capitalize px-2.5 py-0.5 rounded-full bg-light-foreground/8 text-light-foreground/80">
+                <span key={f} className="text-xs capitalize px-2.5 py-0.5 rounded-full border border-light-foreground/20 text-light-foreground/75">
                   {f}
                 </span>
               ))}
@@ -250,7 +250,7 @@ function Stat({ label, value }: { label: string; value: string }) {
 
 function Pill({ children }: { children: React.ReactNode }) {
   return (
-    <span className="text-xs px-2.5 py-0.5 rounded-full border border-light-foreground/15 text-light-foreground/75">
+    <span className="text-xs px-2.5 py-0.5 rounded-full border border-light-foreground/20 text-light-foreground/75">
       {children}
     </span>
   );

--- a/src/app/(light)/coffees/[id]/page.tsx
+++ b/src/app/(light)/coffees/[id]/page.tsx
@@ -324,7 +324,7 @@ export default function CoffeeDetailPage() {
               <span className="text-light-muted-foreground text-sm shrink-0 w-24">Bag notes</span>
               <div className="flex flex-wrap gap-1.5">
                 {tastingNotes.map(note => (
-                  <span key={note} className="text-xs capitalize px-2 py-0.5 rounded-full border border-light-foreground/15 text-light-foreground/60">
+                  <span key={note} className="text-xs capitalize px-2.5 py-0.5 rounded-full border border-light-foreground/20 text-light-foreground/75">
                     {note}
                   </span>
                 ))}
@@ -336,7 +336,7 @@ export default function CoffeeDetailPage() {
               <span className="text-light-muted-foreground text-sm shrink-0 w-24">You taste</span>
               <div className="flex flex-wrap gap-1.5">
                 {commonNotes.map(note => (
-                  <span key={note} className="text-xs capitalize px-2 py-0.5 rounded-full bg-light-foreground/8 text-light-foreground/80">
+                  <span key={note} className="text-xs capitalize px-2.5 py-0.5 rounded-full border border-light-foreground/20 text-light-foreground/75">
                     {note}
                   </span>
                 ))}

--- a/src/components/session/SessionCard.tsx
+++ b/src/components/session/SessionCard.tsx
@@ -63,15 +63,26 @@ export default function SessionCard({ session, onDeleted }: SessionCardProps) {
 
   if (deleting) return null;
   const isOpen = offset >= DELETE_THRESHOLD;
+  // Fade the delete button in as the swipe progresses. At rest (offset
+  // 0) it's fully transparent so it doesn't bleed through the
+  // translucent cream card and confuse the user about whether it's a
+  // design element. By the time the user has dragged past the
+  // threshold the button is fully opaque and tappable.
+  const swipeProgress = Math.min(offset / DELETE_THRESHOLD, 1);
 
   return (
     <div className="relative overflow-hidden rounded-2xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15">
-      {/* Delete button behind */}
-      <div className="absolute inset-y-0 right-0 flex items-stretch rounded-r-2xl overflow-hidden">
+      {/* Delete button behind — hidden at rest, fades in during swipe */}
+      <div
+        className="absolute inset-y-0 right-0 flex items-stretch rounded-r-2xl overflow-hidden"
+        style={{ opacity: swipeProgress, transition: startXRef.current === null ? "opacity 0.2s ease" : "none" }}
+        aria-hidden={!isOpen}
+      >
         <button
           type="button"
           onClick={handleDelete}
           aria-label="Delete session"
+          tabIndex={isOpen ? 0 : -1}
           className="w-20 flex flex-col items-center justify-center gap-1 text-[hsl(36_55%_96%)] active:opacity-80 bg-[hsl(12_70%_45%)]"
         >
           <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -116,13 +127,15 @@ export default function SessionCard({ session, onDeleted }: SessionCardProps) {
           </p>
         )}
 
-        {/* Flavor notes */}
+        {/* Flavor notes — standard bordered chip (matches the rest of
+            the Light surfaces). Solid-fill 8% bg was invisible against
+            the cream card. */}
         {tags.length > 0 && (
           <div className="flex flex-wrap gap-1.5 mt-3">
             {tags.map(tag => (
               <span
                 key={tag}
-                className="text-xs capitalize px-2.5 py-0.5 rounded-full bg-light-foreground/8 text-light-foreground/80"
+                className="text-xs capitalize px-2.5 py-0.5 rounded-full border border-light-foreground/20 text-light-foreground/75"
               >
                 {tag}
               </span>


### PR DESCRIPTION
## Summary

Two visual issues on `/coffees/[id]` and `/brew/[id]`, both visible in the screenshot you sent:

### 1. Chips invisible — standardize on one style

Flavor / note chips were rendered with `bg-light-foreground/8` — 8 % anthracite background on a 55 % translucent cream card is effectively invisible. The labels read as plain prose floating on the card with no chip affordance ("Green Tea", "Grapefruit" etc. in your screenshot looked like text, not chips).

There was already a bordered style for "Bag notes" on `/coffees/[id]` that read fine. Aligned everything to **one standard** across:
- SessionCard flavor notes
- `/coffees/[id]` "Bag notes" + "You taste"
- `/brew/[id]` flavor notes
- `/brew/[id]` `Pill` component (Body / Acidity / Flow / Timing / …)

```
px-2.5 py-0.5 rounded-full
border border-light-foreground/20
text-light-foreground/75
```

### 2. SessionCard swipe-delete fades in during swipe

The warm rust delete button (`hsl(12 70% 45%)`) was visible at rest as an orange strip on the right side of every card. The card body is `bg-light-card-default` (55 % cream), so the solid rust button behind bled through. Your message captured the confusion: *"Ist der delete dahinter für den seine to delete oder?"*

Now hidden at rest (opacity 0) and fades in as the swipe progresses:
```
opacity = min(offset / DELETE_THRESHOLD, 1)
```

By the time the user has dragged past the threshold the button is fully opaque and tappable. `tabIndex` follows the open state so the button isn't focusable when invisible. Transition syncs with the card-body translate animation so opacity and motion stay coupled.

## Test plan

- [ ] `/coffees/[id]`: flavor chips on session cards are visibly outlined pills, not invisible text.
- [ ] `/coffees/[id]`: "Bag notes" and "You taste" chip lists both render with the same bordered style.
- [ ] `/brew/[id]`: flavor chips, brew-notes pills, taste pills all share one visual style.
- [ ] `/coffees/[id]` session card at rest: no orange strip on the right — card looks like a single cream pill.
- [ ] Swipe a card left: rust delete button fades in proportionally with the slide. Past threshold, tap reveals the action.
- [ ] Release before threshold: card snaps back, delete button fades back out.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_