### PR TITLE
fix: coffee field carries through to brew session detail without flash

### DIFF
--- a/src/app/(light)/brew/[id]/page.tsx
+++ b/src/app/(light)/brew/[id]/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { Menu } from "lucide-react";
 import CoffeeBeanGlow from "@/components/ui/light/CoffeeBeanGlow";
@@ -10,6 +10,7 @@ import type { Session } from "@/lib/types/session";
 import type { Coffee } from "@/lib/types/coffee";
 import { formatDate, formatSeconds } from "@/lib/utils/formatTime";
 import { useFieldConfig } from "@/lib/field/FieldContext";
+import { recallSessionField, rememberSessionField } from "@/lib/field/cache";
 
 export default function SessionDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -18,6 +19,13 @@ export default function SessionDetailPage() {
   const [loading, setLoading] = useState(true);
   const [menuOpen, setMenuOpen] = useState(false);
   const router = useRouter();
+
+  // Read the Field cache synchronously on mount — written by
+  // /coffees/[id] when it loads. If the user navigated here from
+  // there, this returns the cup's fieldZones immediately, so the
+  // page paints in the right colours from frame 1 instead of
+  // flashing default for the coffee fetch's ~300ms.
+  const cachedFieldZones = useMemo(() => recallSessionField(id), [id]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -31,7 +39,12 @@ export default function SessionDetailPage() {
         const coffeeId = s.coffee?.coffeeId;
         if (coffeeId) {
           const cRes = await fetch(`/api/coffees/${coffeeId}`, { cache: "no-store", signal: controller.signal });
-          if (cRes.ok) setCoffee(await cRes.json());
+          if (cRes.ok) {
+            const c: Coffee = await cRes.json();
+            setCoffee(c);
+            // Refresh the cache so subsequent visits hit the latest.
+            rememberSessionField(id, c.fieldZones);
+          }
         }
       } catch {
         setSession(null);
@@ -43,9 +56,12 @@ export default function SessionDetailPage() {
     return () => { clearTimeout(timer); controller.abort(); };
   }, [id]);
 
-  // Adopt this coffee's Field composition (same pattern as the Brew-Again
-  // paths). Falls back to default Field if coffee or fieldZones missing.
-  useFieldConfig(coffee?.fieldZones ? { fieldZones: coffee.fieldZones, rotation: 0 } : null);
+  // Adopt this coffee's Field composition. Prefer the freshly-fetched
+  // coffee, fall back to the session-storage cache primed by
+  // /coffees/[id], and finally to null (default Field) if neither
+  // source has fieldZones yet.
+  const activeFieldZones = coffee?.fieldZones ?? cachedFieldZones;
+  useFieldConfig(activeFieldZones ? { fieldZones: activeFieldZones, rotation: 0 } : null);
 
   if (loading) {
     return (

--- a/src/app/(light)/coffees/[id]/page.tsx
+++ b/src/app/(light)/coffees/[id]/page.tsx
@@ -11,6 +11,7 @@ import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
 import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
 import { useFlowStore } from "@/store/flowStore";
 import { useFieldConfig } from "@/lib/field/FieldContext";
+import { rememberSessionField } from "@/lib/field/cache";
 
 interface RoasterInfo {
   region?: string;
@@ -89,6 +90,13 @@ export default function CoffeeDetailPage() {
                     const bMs = (b as Session & { createdAtMs?: number }).createdAtMs ?? new Date(b.createdAt).getTime();
                     return bMs - aMs;
                   }));
+                  // Pre-warm the Field cache for every session of this
+                  // coffee so a downstream /brew/[id] navigation paints
+                  // the coffee's Field immediately on mount instead of
+                  // flashing through default for the coffee fetch.
+                  if (found.fieldZones) {
+                    coffeeSessions.forEach(s => rememberSessionField(s.id, found.fieldZones));
+                  }
                 })
                 .catch(() => {})
             : Promise.resolve(),

--- a/src/lib/field/cache.ts
+++ b/src/lib/field/cache.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import type { FieldZones } from "./types";
+
+/**
+ * Cross-page Field cache — bridges the visible flash between
+ * /coffees/[id] (which owns the coffee record + its fieldZones) and
+ * /brew/[id] (which only learns the coffeeId after its session fetch
+ * resolves, so without a hint it falls back to the Default Field for
+ * ~300ms until the coffee fetch lands).
+ *
+ * Stored in sessionStorage keyed by session id. CoffeeDetail
+ * pre-warms entries for all its sessions when it loads; BrewDetail
+ * reads synchronously on mount and applies the cached zones via
+ * useFieldConfig immediately — by the time the coffee fetch returns,
+ * the Field has already been painting in the cup's colours.
+ *
+ * sessionStorage chosen over a module-level Map so the cache survives
+ * service-worker-backed back/forward navigation in the PWA (where the
+ * JS heap can be reset). Cleared on tab close, which is fine — the
+ * cache is purely a paint-priming hint, not a source of truth.
+ */
+
+const KEY_PREFIX = "brewlog.fieldZones.bySession.";
+
+export function rememberSessionField(sessionId: string, zones: FieldZones | null | undefined): void {
+  if (typeof window === "undefined") return;
+  if (!sessionId || !zones) return;
+  try {
+    sessionStorage.setItem(KEY_PREFIX + sessionId, JSON.stringify(zones));
+  } catch {
+    // sessionStorage may be disabled or quota-exceeded — silent fail
+    // is fine, the cache is a hint, not a contract.
+  }
+}
+
+export function recallSessionField(sessionId: string | undefined | null): FieldZones | null {
+  if (typeof window === "undefined") return null;
+  if (!sessionId) return null;
+  try {
+    const raw = sessionStorage.getItem(KEY_PREFIX + sessionId);
+    if (!raw) return null;
+    return JSON.parse(raw) as FieldZones;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Problem: `/brew/[id]` only learns `coffee.fieldZones` after a two-step fetch chain (session → coffeeId → `/api/coffees/[id]` → fieldZones). While that round-trip runs the Field paints the Default cream gradient and only swaps to the coffee's gradient ~300 ms later. Visually: "the background of Coffee Single does not carry through" — exactly the feedback.

## Fix

A tiny `sessionStorage` cache keyed by session id (`src/lib/field/cache.ts`).

- **`/coffees/[id]`** already fetches the coffee record (with `fieldZones`) to render the detail page. When its sessions list resolves, it pre-warms the cache: `rememberSessionField(s.id, coffee.fieldZones)` for every session of this coffee. The page that *owns* the fieldZones writes them where the next page *needs* them.
- **`/brew/[id]`** reads the cache synchronously on mount via `useMemo`, before any fetch fires. `recallSessionField(id)` returns the cup's fieldZones if the user came from `/coffees/[id]` within the same tab. That value feeds `useFieldConfig` from frame 1, so the Field renders correctly while the session + coffee fetches run in the background. When the coffee fetch returns it refreshes the cache so subsequent visits hit the latest.

## Why sessionStorage

Over a module-level Map because the PWA's service worker can reset the JS heap on back/forward navigation, but sessionStorage survives. The cache is purely a paint-priming hint, not a source of truth — silent failure on disabled storage / quota is fine.

## Corner case

Opening `/brew/[id]` from a deep link or direct URL with no prior `/coffees/[id]` visit still triggers the fetch path and a brief default-Field flash. Acceptable — typical use is library → coffee → brew within a session.

## Test plan

- [ ] Navigate `/coffees` → `/coffees/[id]` → tap any SessionCard → `/brew/[id]`. Field paints the coffee's colours instantly, no flash to default cream.
- [ ] Use the back arrow → `/coffees/[id]` repaints the same colours.
- [ ] Repeat with a different coffee (different fieldZones). Each brew session detail should pick up its own cup's Field.
- [ ] Open `/brew/[id]` from a fresh tab (no prior visit) — graceful default-Field flash, then coffee Field kicks in once the fetch resolves.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_