### PR TITLE
fix: brew session back goes to coffee detail + chip styles unify

### DIFF
--- a/src/app/(light)/brew/[id]/page.tsx
+++ b/src/app/(light)/brew/[id]/page.tsx
@@ -89,7 +89,21 @@ export default function SessionDetailPage() {
   const method = brew?.methodUsed || recommendation?.primaryMethod || "Brew";
   const recipe = recommendation?.primaryRecipe;
 
-  const backTarget = sessionCoffee?.coffeeId ? `/coffees/${sessionCoffee.coffeeId}` : "/coffees";
+  // Back resolution — prefer the deterministic /coffees/[id] target so
+  // the user lands on the exact detail page they came from, regardless
+  // of browser history (deep links, multi-tab use). The fetched
+  // coffee.id is the canonical source; sessionCoffee.coffeeId is the
+  // older fallback (some legacy sessions persisted CoffeeIdentity
+  // without coffeeId). If neither resolves, fall back to router.back()
+  // — typical for external/cafe sessions that have no library coffee.
+  const targetCoffeeId = coffee?.id ?? sessionCoffee?.coffeeId;
+  const handleBack = () => {
+    if (targetCoffeeId) {
+      router.push(`/coffees/${targetCoffeeId}`);
+    } else {
+      router.back();
+    }
+  };
 
   return (
     <div className="min-h-svh bg-transparent flex flex-col">
@@ -117,7 +131,7 @@ export default function SessionDetailPage() {
 
         {/* Back */}
         <button
-          onClick={() => router.push(backTarget)}
+          onClick={handleBack}
           aria-label="Back"
           className="absolute left-4 w-10 h-10 rounded-full bg-light-card-default/85 backdrop-blur-light-card backdrop-blur-sm flex items-center justify-center text-light-foreground"
           style={{ top: "calc(env(safe-area-inset-top) + 1rem)" }}
@@ -209,7 +223,7 @@ export default function SessionDetailPage() {
           {result.flavorNotes?.length > 0 && (
             <div className="flex flex-wrap gap-1.5 mb-3">
               {result.flavorNotes.map(f => (
-                <span key={f} className="text-xs capitalize px-2.5 py-0.5 rounded-full border border-light-foreground/20 text-light-foreground/75">
+                <span key={f} className="inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight capitalize backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground">
                   {f}
                 </span>
               ))}
@@ -238,7 +252,7 @@ export default function SessionDetailPage() {
 
       {/* Delete */}
       <div className="px-5 py-6 pb-safe pb-8">
-        <DeleteButton sessionId={session.id} onDeleted={() => router.push(backTarget)} />
+        <DeleteButton sessionId={session.id} onDeleted={handleBack} />
       </div>
 
       <NavigationOverlay open={menuOpen} onClose={() => setMenuOpen(false)} />
@@ -266,7 +280,7 @@ function Stat({ label, value }: { label: string; value: string }) {
 
 function Pill({ children }: { children: React.ReactNode }) {
   return (
-    <span className="text-xs px-2.5 py-0.5 rounded-full border border-light-foreground/20 text-light-foreground/75">
+    <span className="inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground">
       {children}
     </span>
   );

--- a/src/app/(light)/coffees/[id]/page.tsx
+++ b/src/app/(light)/coffees/[id]/page.tsx
@@ -332,7 +332,7 @@ export default function CoffeeDetailPage() {
               <span className="text-light-muted-foreground text-sm shrink-0 w-24">Bag notes</span>
               <div className="flex flex-wrap gap-1.5">
                 {tastingNotes.map(note => (
-                  <span key={note} className="text-xs capitalize px-2.5 py-0.5 rounded-full border border-light-foreground/20 text-light-foreground/75">
+                  <span key={note} className="inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight capitalize backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground">
                     {note}
                   </span>
                 ))}
@@ -344,7 +344,7 @@ export default function CoffeeDetailPage() {
               <span className="text-light-muted-foreground text-sm shrink-0 w-24">You taste</span>
               <div className="flex flex-wrap gap-1.5">
                 {commonNotes.map(note => (
-                  <span key={note} className="text-xs capitalize px-2.5 py-0.5 rounded-full border border-light-foreground/20 text-light-foreground/75">
+                  <span key={note} className="inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight capitalize backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground">
                     {note}
                   </span>
                 ))}

--- a/src/components/session/SessionCard.tsx
+++ b/src/components/session/SessionCard.tsx
@@ -127,15 +127,15 @@ export default function SessionCard({ session, onDeleted }: SessionCardProps) {
           </p>
         )}
 
-        {/* Flavor notes — standard bordered chip (matches the rest of
-            the Light surfaces). Solid-fill 8% bg was invisible against
-            the cream card. */}
+        {/* Flavor notes — matches the Chip primitive default look
+            used in LightStepLog (taste log) so static tags and
+            interactive chips share one visual language. */}
         {tags.length > 0 && (
           <div className="flex flex-wrap gap-1.5 mt-3">
             {tags.map(tag => (
               <span
                 key={tag}
-                className="text-xs capitalize px-2.5 py-0.5 rounded-full border border-light-foreground/20 text-light-foreground/75"
+                className="inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight capitalize backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground"
               >
                 {tag}
               </span>


### PR DESCRIPTION
## Summary

Two user reports, both surface-level but visible.

### 1. Brew session back goes to Coffee Detail, not Library

The back arrow on `/brew/[id]` routed to `/coffees` (library) instead of `/coffees/[coffeeId]` (the page the user came from). Cause: the `backTarget` fallback chain only checked `sessionCoffee.coffeeId`, which is **undefined on legacy sessions** whose `CoffeeIdentity` was persisted before the `coffeeId` field existed.

Fix: prefer the freshly-fetched `coffee.id` (canonical, present whenever the coffee exists in the library), then fall back to `sessionCoffee.coffeeId`, and only if neither resolves use `router.back()` (covers external/cafe sessions with no library row). Same handler drives the hero back arrow and the delete-confirmation `onDeleted` redirect.

### 2. Chips — unify two visual languages

There were **two** static-tag styles in the Light surfaces:

| Surface | Style |
|---|---|
| `LightStepLog` (Taste Log) — interactive `Chip` | Cream-glass filled pill (`bg-light-card-default` + backdrop blur), 12-13px, no border |
| Detail pages (introduced by PR #124) — static tags | Bordered outline (`border-light-foreground/20`), 12px, transparent bg |

You asked: "Why do Bag notes / Brew notes / Taste notes on the detail pages look different from the chips in the Taste Log?" Answer: historically two iterations, never unified.

Unified around the `Chip`-primitive look:
```
px-3 py-1.5
text-[12px] font-medium leading-tight
bg-light-card-default backdrop-blur-light-card backdrop-saturate-150
text-light-foreground
rounded-full inline-flex items-center
```

Applied to:
- `SessionCard` flavor tags
- `/coffees/[id]` "Bag notes" + "You taste"
- `/brew/[id]` flavor notes
- `/brew/[id]` local `Pill` helper (Body / Acidity / Flow / Timing / …)

All static tags now share the same cream-glass identity as the interactive `Chip` primitive's default state. One visual vocabulary across the Light surfaces.

## Test plan

- [ ] On `/brew/[id]` (a normal home-brewed session), tap the back arrow → lands on `/coffees/[coffeeId]`, not `/coffees`.
- [ ] On `/brew/[id]` for an external/cafe session with no `coffeeId` → back goes to the previous page (router.back).
- [ ] On `/brew/[id]` after a delete confirm → routes to the coffee detail (same target as back).
- [ ] Static tags on `/coffees/[id]` (Bag notes, You taste), `/brew/[id]` (flavor notes, brew pills, taste pills), and `SessionCard` flavor tags all render as the same cream-glass pill — visually matching the interactive Chip in `LightStepLog`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_