### PR TITLE
fix: library card photo fullbleed + brew count + summary chip unify

### DIFF
--- a/src/app/(light)/coffees/page.tsx
+++ b/src/app/(light)/coffees/page.tsx
@@ -199,42 +199,42 @@ export default function CoffeesPage() {
           <div className="flex flex-col gap-2">
             {filteredCoffees.map(coffee => {
               const sub = [coffee.origin, coffee.process].filter(Boolean).join(" · ");
+              const brewCount = coffee.sessionCount;
+              const brewLabel = brewCount > 0 ? `${brewCount} brew${brewCount === 1 ? "" : "s"}` : null;
               return (
                 <div
                   key={coffee.id}
-                  className="flex items-center gap-3 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-2xl p-3 w-full"
+                  className="flex items-stretch bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-2xl overflow-hidden w-full"
                 >
-                  {/* Tap target — opens detail page */}
+                  {/* Tap target — opens detail page. Full-card click area
+                      uses items-stretch so the photo fills the left edge
+                      flush with the card border, no padding gap. */}
                   <button
                     type="button"
                     onClick={() => router.push(`/coffees/${coffee.id}`)}
-                    className="flex items-center gap-3 flex-1 min-w-0 text-left active:opacity-80 transition-opacity"
+                    className="flex items-stretch flex-1 min-w-0 text-left active:opacity-80 transition-opacity"
                   >
-                    {/* Thumbnail */}
-                    <div className="relative w-14 h-14 rounded-xl overflow-hidden bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 shrink-0">
+                    {/* Photo — full-height left strip (w-24 = 96px).
+                        Bag photos are portrait-ish; this gives more of
+                        the label visible than a 56px circular thumb. */}
+                    <div className="relative w-24 shrink-0 bg-light-card-default">
                       {coffee.bagPhotoUrl ? (
                         // eslint-disable-next-line @next/next/no-img-element
-                        <img src={coffee.bagPhotoUrl} alt={coffee.name} className="w-full h-full object-cover" />
+                        <img src={coffee.bagPhotoUrl} alt={coffee.name} className="absolute inset-0 w-full h-full object-cover" />
                       ) : (
-                        <div className="w-full h-full flex items-center justify-center">
-                          <svg className="w-6 h-6 text-light-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                        <div className="absolute inset-0 flex items-center justify-center">
+                          <svg className="w-7 h-7 text-light-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
                             <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636" />
                           </svg>
                         </div>
                       )}
-                      {/* Session count badge */}
-                      <div className="absolute top-0.5 right-0.5 bg-light-foreground rounded-full w-4 h-4 flex items-center justify-center">
-                        <span className="text-[hsl(36_55%_96%)] font-mono-num" style={{ fontSize: "8px" }}>{coffee.sessionCount}</span>
-                      </div>
                     </div>
 
                     {/* Text */}
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-1.5">
-                        {coffee.roaster && (
-                          <p className="text-light-muted-foreground text-xs truncate mb-0.5 flex-1">{coffee.roaster}</p>
-                        )}
-                      </div>
+                    <div className="flex-1 min-w-0 px-3.5 py-3">
+                      {coffee.roaster && (
+                        <p className="text-light-muted-foreground text-xs truncate mb-0.5">{coffee.roaster}</p>
+                      )}
                       <div className="flex items-center gap-1.5">
                         {coffee.inRotation && (
                           <svg
@@ -260,11 +260,21 @@ export default function CoffeesPage() {
                           Roasted {new Date(coffee.latestRoastDate).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })}
                         </p>
                       )}
-                      {coffee.avgRating != null && coffee.avgRating > 0 && (
-                        <div className="mt-1.5">
-                          <StarRating value={coffee.avgRating} readonly size="sm" />
+                      {/* Rating + brew count share one row. brew count
+                          replaces the tiny 8px badge that used to sit on
+                          the thumbnail and was effectively unreadable. */}
+                      {(coffee.avgRating != null && coffee.avgRating > 0) || brewLabel ? (
+                        <div className="mt-1.5 flex items-center gap-2">
+                          {coffee.avgRating != null && coffee.avgRating > 0 && (
+                            <StarRating value={coffee.avgRating} readonly size="sm" />
+                          )}
+                          {brewLabel && (
+                            <span className="text-light-muted-foreground text-xs">
+                              {coffee.avgRating != null && coffee.avgRating > 0 ? "· " : ""}{brewLabel}
+                            </span>
+                          )}
                         </div>
-                      )}
+                      ) : null}
                     </div>
                   </button>
 
@@ -273,14 +283,16 @@ export default function CoffeesPage() {
                       until the user marks the coffee in rotation on the
                       detail page. */}
                   {coffee.inRotation && (
-                    <button
-                      type="button"
-                      onClick={() => brewThis(coffee)}
-                      aria-label={`Brew ${coffee.name}`}
-                      className="shrink-0 px-3 py-2 rounded-full text-xs font-medium bg-light-foreground text-[hsl(36_55%_96%)] active:scale-95 transition-transform"
-                    >
-                      Brew
-                    </button>
+                    <div className="flex items-center pr-3">
+                      <button
+                        type="button"
+                        onClick={() => brewThis(coffee)}
+                        aria-label={`Brew ${coffee.name}`}
+                        className="shrink-0 px-3 py-2 rounded-full text-xs font-medium bg-light-foreground text-[hsl(36_55%_96%)] active:scale-95 transition-transform"
+                      >
+                        Brew
+                      </button>
+                    </div>
                   )}
                 </div>
               );

--- a/src/components/flow/LightStepSummary.tsx
+++ b/src/components/flow/LightStepSummary.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import { useFlowStore } from "@/store/flowStore";
 import { useRouter } from "next/navigation";
 import LightFlowShell from "@/components/ui/light/LightFlowShell";
-import Chip from "@/components/ui/light/Chip";
 import LightStarRating from "@/components/ui/light/StarRating";
 import CoffeeBeanGlow from "@/components/ui/light/CoffeeBeanGlow";
 import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
@@ -261,11 +260,14 @@ export default function LightStepSummary() {
         )}
 
         {result?.flavorNotes && result.flavorNotes.length > 0 && (
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap gap-1.5">
             {result.flavorNotes.map((f) => (
-              <Chip key={f} size="sm" selected>
+              <span
+                key={f}
+                className="inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight capitalize backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground"
+              >
                 {f}
-              </Chip>
+              </span>
             ))}
           </div>
         )}


### PR DESCRIPTION
## Summary

Three follow-ups from the latest screenshots.

### 1. Coffee Library card — photo fills the left edge

Cards used a 56×56 rounded-square thumbnail with a tiny 16×16 session-count badge in the corner whose **8 px font was effectively unreadable**. Moved the photo to occupy the full left edge of the card (w-24 = 96 px, full card height, flush with the card border via `items-stretch` + `overflow-hidden` on the container). Bag labels are portrait-oriented, so a tall 96 px strip shows more of the label than a 56 px circular thumb.

Fallback for coffees without `bagPhotoUrl`: existing placeholder coffee-bean icon centered in the photo strip area.

### 2. Brew count moves to the rating row

The unreadable session-count badge is gone. Brew count joins the rating row as small muted meta:

```
★★★★☆ · 3 brews
```

Row collapses gracefully when either rating or count is absent. Plural handled (1 brew vs 3 brews).

### 3. LightStepSummary flavor notes — consistent with the rest

`LightStepSummary` rendered flavor notes with `<Chip selected>` — taupe-on-cream `Chip` primitive in the **selected** tonal state. The chip unification in PR #126 standardized every other flavor / note pill across the Light surfaces on the `Chip` primitive's **default cream-glass** look. Summary was missed because it was using the same primitive but with `selected={true}`.

Swapped to the unified inline span pattern so the post-brew summary now reads with the same visual vocabulary as `/coffees/[id]`, `/brew/[id]`, and `SessionCard`. `Chip` import dropped from `LightStepSummary` (no other consumer in that file).

## Test plan

- [ ] `/coffees` library cards: bag photo fills the left edge full-height, no padding gap. Photo and the cream content area read as one continuous card with the photo as a strip.
- [ ] Coffees without bag photo: placeholder bean icon centered.
- [ ] Rating row shows "★★★★☆ · 3 brews" (or "1 brew" for singletons).
- [ ] After completing a brew, the post-brew summary screen renders flavor notes as the same cream-glass chips used everywhere else (not the taupe selected variant).

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_