### PR TITLE
fix: flavor wheel divider overshoot + whole-wedge tonal states

### DIFF
--- a/src/components/ui/FlavorWheel.tsx
+++ b/src/components/ui/FlavorWheel.tsx
@@ -41,15 +41,17 @@ const PALETTE = {
   // the card-default so they read as separation lines without competing
   // with the labels.
   divider: "hsl(30 60% 92%)",
-  // Category segments
+  // Inner ring — category segments
   panelDefault: "hsl(36 55% 96% / 0.55)",
   panelHasSel: "hsl(30 30% 80% / 0.70)",
   panelActive: "hsl(0 0% 14% / 0.18)",
-  // Sub-category segments (outer ring) — same hue, lower fill weight
-  // so the category ring stays primary visually.
-  subPanel: "hsl(36 55% 96%)",
-  subPanelOpacityDefault: 0.35,
-  subPanelOpacityActive: 0.65,
+  // Outer ring — sub-category segments. Mirrors the inner ring's three
+  // tonal states (default cream-glass, taupe has-sel, anthracite press)
+  // at slightly weaker alpha so the inner ring stays the primary read.
+  // Whole-wedge active treatment: tapping a category darkens both rings.
+  subPanelDefault: "hsl(36 55% 96% / 0.55)",
+  subPanelHasSel: "hsl(30 30% 80% / 0.50)",
+  subPanelActive: "hsl(0 0% 14% / 0.12)",
   // Center circle
   center: "hsl(36 55% 96%)",
   centerStroke: "hsl(0 0% 14% / 0.15)",
@@ -61,8 +63,8 @@ const PALETTE = {
   textOpacityActive: 0.95,
   textOpacityHasSel: 0.85,
   textOpacityDefault: 0.65,
-  subTextOpacityActive: 0.80,
-  subTextOpacityDefault: 0.42,
+  subTextOpacityActive: 0.85,
+  subTextOpacityDefault: 0.55,
   // Radar polygon (profile mode)
   radarFill: "hsl(0 0% 14% / 0.10)",
   radarStroke: "hsl(0 0% 14%)",
@@ -329,7 +331,9 @@ export default function FlavorWheel({
               </text>
             )}
 
-            {/* Sub-category ring */}
+            {/* Sub-category ring — fill mirrors the inner-ring state of
+                the parent category so the whole pie-wedge reacts together
+                (active and has-sel both ripple through). */}
             {subKeys.map((sub, si) => {
               const subStart = catStart + subSlice * si;
               const subEnd   = catStart + subSlice * (si + 1);
@@ -339,12 +343,15 @@ export default function FlavorWheel({
               const subPos   = polar(cx, cy, subTextR, subMid);
               const subRot   = radialRotation(subMid);
 
+              const subFill = isActive ? PALETTE.subPanelActive
+                : hasSel ? PALETTE.subPanelHasSel
+                : PALETTE.subPanelDefault;
+
               return (
                 <g key={sub}>
                   <path
                     d={subPath}
-                    fill={PALETTE.subPanel}
-                    fillOpacity={isActive ? PALETTE.subPanelOpacityActive : PALETTE.subPanelOpacityDefault}
+                    fill={subFill}
                     stroke="none"
                   />
                   <text
@@ -368,12 +375,15 @@ export default function FlavorWheel({
         );
       })}
 
-      {/* ── Even-width radial dividers — drawn on top of segments ── */}
+      {/* ── Even-width radial dividers — drawn on top of segments.
+          End exactly at rOuter (was rOuter + 2): with the transparent
+          canvas the overshoot painted cream spikes beyond the wheel
+          edge against the Field gradient. ── */}
       {/* Category boundaries: full height rCenter → rOuter */}
       {SCA_CATEGORIES.map((_, i) => {
         const angle = slice * i - Math.PI / 2;
         const p1 = polar(cx, cy, rCenter, angle);
-        const p2 = polar(cx, cy, rOuter + 2, angle);
+        const p2 = polar(cx, cy, rOuter, angle);
         return (
           <line key={`cdiv-${i}`}
             x1={p1.x} y1={p1.y} x2={p2.x} y2={p2.y}
@@ -390,7 +400,7 @@ export default function FlavorWheel({
         return subKeys.slice(1).map((_, si) => {
           const angle = catStart + subSlice * (si + 1);
           const p1 = polar(cx, cy, rInner, angle);
-          const p2 = polar(cx, cy, rOuter + 2, angle);
+          const p2 = polar(cx, cy, rOuter, angle);
           return (
             <line key={`sdiv-${cat}-${si}`}
               x1={p1.x} y1={p1.y} x2={p2.x} y2={p2.y}


### PR DESCRIPTION
## Summary

Three issues from the deployed screenshot, all rooted in the Dark→Light port leaving some Dark-era assumptions intact.

### 1. Divider lines overshot the outer ring

Lines extended 2 viewport units past `rOuter`. In the Dark theme that overshoot disappeared into the solid `#111` canvas. With the canvas now transparent, those 2 units painted **cream spikes outside the wheel edge** against the Field gradient — visible as small "rays" between top segments. Clipped to exactly `rOuter` in both divider loops.

### 2. Outer ring tonal logic was inverted relative to inner ring

| State | Inner ring | Outer ring (before) | Outer ring (after) |
|---|---|---|---|
| Default | `hsl(36 55% 96% / 0.55)` cream-glass | `hsl(36 55% 96%)` @ 0.35 (washed out) | `hsl(36 55% 96% / 0.55)` (matches inner) |
| Has-selection | `hsl(30 30% 80% / 0.70)` taupe | unchanged, still default | `hsl(30 30% 80% / 0.50)` taupe |
| Active | `hsl(0 0% 14% / 0.18)` anthracite press | `hsl(36 55% 96%)` @ 0.65 (got *lighter*) | `hsl(0 0% 14% / 0.12)` anthracite press |

Outer ring now reads brighter / more solid at rest, darker / anthracite when its parent category is active — exactly inverted from the previous behavior. Slightly weaker alpha than the inner ring (0.12 vs 0.18, 0.50 vs 0.70) so the inner ring stays the primary read within an active wedge.

### 3. Whole-wedge active + has-sel

Has-sel and active tonal lifts only ever fired on the inner ring; the outer ring kept its single "is parent active?" branch and ignored has-sel entirely. Now the outer ring uses the same three-way switch (`active > hasSel > default`), so:

- Tapping a category darkens the **whole pie-wedge** (both rings)
- A category with picks shows the taupe lift across **both rings** at once

Sub-text default opacity also nudged `0.42 → 0.55` so the outer labels still read clearly against the now-more-solid cream panels (the previous weak alpha relied on a washed-out panel for indirect contrast).

## Test plan

- [ ] Open the FlavorWheel in the brew flow Log step. No cream spikes protruding above/around the wheel edge.
- [ ] At rest: both inner and outer rings read at similar visibility. Sub-cat labels (Berry, Citrus, Tea, …) are easy to read.
- [ ] Tap a category: the entire pie-wedge (inner cat + outer sub-cats) darkens together with anthracite tint. Other categories unchanged.
- [ ] Select a flavor (e.g. Almond in Nutty & Cocoa), then close the active category by tapping the centre × — the parent wedge keeps a taupe lift across both rings (has-sel), other categories are default cream.
- [ ] Tap a different category: previous wedge falls back to taupe (has-sel) or default (no picks); new wedge becomes active.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_