### PR TITLE
fix: flavor wheel ring divider between inner + outer

### DIFF
--- a/src/components/ui/FlavorWheel.tsx
+++ b/src/components/ui/FlavorWheel.tsx
@@ -410,6 +410,18 @@ export default function FlavorWheel({
         });
       })}
 
+      {/* Ring divider between inner (category) and outer (sub-category)
+          rings. Punctuates the transition so the eye reads the two
+          rings as distinct levels of the hierarchy instead of flowing
+          straight from "Floral" into "Tea / Citrus". Same divider
+          cream as the radial separators, matched stroke weight. */}
+      <circle
+        cx={cx} cy={cy} r={rInner}
+        fill="none"
+        stroke={PALETTE.divider}
+        strokeWidth={subLineW}
+      />
+
       {/* ── center circle ── */}
       <circle
         cx={cx} cy={cy} r={rCenter - 1}


### PR DESCRIPTION
## Summary

Adds a thin cream circle at `rInner` so the inner category ring and the outer sub-category ring read as distinct levels of the hierarchy. Without it the eye flowed straight from "Floral" into "Tea / Citrus" with no visual stop — exactly what your screenshot showed.

Uses the same `PALETTE.divider` cream and `subLineW` stroke weight as the sub-category radial separators so the line system stays one consistent palette. Painted after the radial dividers so all the cream strokes resolve as a single grid overlay.

## Test plan

- [ ] Open FlavorWheel in the brew Log step. A subtle cream ring runs between the inner (category) and outer (sub-category) rings.
- [ ] The ring respects the active wedge — it sits on top of all segments equally, so the active anthracite-tint wedge still reads as one continuous piece across both rings, just with a hairline visual punctuation between them.
- [ ] Radial dividers (category and sub-category) intersect the ring cleanly without breaks.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_