### PR TITLE
fix: flavor wheel lines more delicate

### DIFF
--- a/src/components/ui/FlavorWheel.tsx
+++ b/src/components/ui/FlavorWheel.tsx
@@ -222,9 +222,11 @@ export default function FlavorWheel({
   const baseFontSize = Math.max(6.5 * s, 5.8);
   const subFontSize  = Math.max(5.5 * s, 5.0);
 
-  // Gap line widths (in viewBox units)
-  const catLineW = 1.8 * s;
-  const subLineW = 1.2 * s;
+  // Gap line widths (in viewBox units). Kept delicate to pair with
+  // the label typography — too-thick dividers fought visually with
+  // the sans-serif weight of the labels.
+  const catLineW = 0.8 * s;
+  const subLineW = 0.5 * s;
 
   return (
     <svg


### PR DESCRIPTION
## Summary

Drops divider stroke weights to pair with the label typography:

| Divider | Before | After |
|---|---|---|
| Category | `1.8 × s` | `0.8 × s` (~55 % thinner) |
| Sub-category + ring | `1.2 × s` | `0.5 × s` (~58 % thinner) |

The original weights were tuned for the Dark theme where they had to hold their own against `#111` panels. On Light, against translucent cream-glass at 55 %, those weights read as heavy bars relative to the hairline-weight sans-serif of the labels. The new values still articulate the segment grid but no longer compete with the type.

## Test plan

- [ ] Open FlavorWheel in the brew Log step. Dividers and ring read as thin, delicate cream strokes — coherent with the label typography weight, not bars.
- [ ] Tonal states (active anthracite, has-sel taupe) still register: the wedge fills carry the state, the dividers just punctuate the grid.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_