### PR TITLE
fix: library right column items-center

### DIFF
--- a/src/app/(light)/coffees/page.tsx
+++ b/src/app/(light)/coffees/page.tsx
@@ -275,7 +275,7 @@ export default function CoffeesPage() {
                       Renders even when the coffee is not in rotation —
                       count still shows, button just hides. */}
                   {(brewLabel || coffee.inRotation) && (
-                    <div className="flex flex-col items-end justify-center gap-1.5 pr-3 shrink-0">
+                    <div className="flex flex-col items-center justify-center gap-1.5 pr-3 shrink-0">
                       {brewLabel && (
                         <span className="text-light-muted-foreground text-[11px] whitespace-nowrap">{brewLabel}</span>
                       )}


### PR DESCRIPTION
## Summary

Aligns the brew count text and the Brew pill on the same horizontal centerline instead of right-aligning both to the card edge. The two pieces of the right column read as one stacked unit, so they should share a centerline rather than hug the border independently.

Single change: `items-end` → `items-center` on the right column flex container.

## Test plan

- [ ] Library card in rotation: "3 brews" text sits directly above the Brew pill, both centered on the same vertical axis.
- [ ] Library card with brews but no rotation: "3 brews" sits centered in the right column with the same padding offset.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_