### PR TITLE
feat: light migrate /cafes + place + cafe-coffee detail

### DIFF
--- a/src/app/(light)/cafes/coffee/[id]/page.tsx
+++ b/src/app/(light)/cafes/coffee/[id]/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 import { useEffect, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
+import { Menu } from "lucide-react";
 import type { Session } from "@/lib/types/session";
-import StarRating from "@/components/ui/StarRating";
+import StarRating from "@/components/ui/light/StarRating";
+import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
 import { BREW_METHODS } from "@/lib/constants/brewMethods";
 
 function formatRelativeDate(iso: string): string {
@@ -23,10 +25,12 @@ function toCoffeeKey(roaster: string, name: string): string {
 
 export default function CafeCoffeeDetailPage() {
   const params = useParams();
+  const router = useRouter();
   const coffeeKey = params.id as string;
 
   const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editMethod, setEditMethod] = useState("");
@@ -71,7 +75,7 @@ export default function CafeCoffeeDetailPage() {
       ? { ...s.result, freeNotes: editNotes || undefined }
       : undefined;
 
-    setSessions((prev: Session[]) => prev.map((sess: Session) =>
+    setSessions(prev => prev.map(sess =>
       sess.id === s.id
         ? { ...sess, brew: brewUpdate, ...(resultUpdate ? { result: resultUpdate } : {}) }
         : sess
@@ -96,50 +100,65 @@ export default function CafeCoffeeDetailPage() {
   const coffee = sessions[0]?.coffee;
   const avgRating = sessions.length > 0
     ? (() => {
-        const rated = sessions.filter((s: Session) => s.result?.rating);
+        const rated = sessions.filter(s => s.result?.rating);
         if (rated.length === 0) return null;
-        return Math.round(rated.reduce((sum: number, x: Session) => sum + (x.result?.rating ?? 0), 0) / rated.length * 10) / 10;
+        return Math.round(rated.reduce((sum, x) => sum + (x.result?.rating ?? 0), 0) / rated.length * 10) / 10;
       })()
     : null;
 
   const uniqueCafes = Array.from(new Set(
-    (sessions.map((s: Session) => s.place?.name) as (string | undefined)[]).filter((n): n is string => Boolean(n))
+    (sessions.map(s => s.place?.name) as (string | undefined)[]).filter((n): n is string => Boolean(n))
   ));
   const sub = coffee ? [coffee.origin, coffee.process].filter(Boolean).join(" · ") : "";
 
   return (
-    <div className="min-h-full bg-brew-bg flex flex-col pb-8">
+    <div className="min-h-full bg-transparent flex flex-col pb-8">
 
       {/* Header */}
       <div className="px-5 pb-4" style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.25rem)" }}>
-        <Link href="/cafes?tab=coffees" className="flex items-center gap-1 text-brew-muted text-sm mb-3 w-fit">
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
-          </svg>
-          Coffees
-        </Link>
+        <div className="flex items-start justify-between gap-3 mb-2">
+          <button
+            type="button"
+            onClick={() => router.push("/cafes?tab=coffees")}
+            className="flex items-center gap-1 text-light-muted-foreground text-sm mt-1"
+            aria-label="Back to Coffees"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+            </svg>
+            Coffees
+          </button>
+          <button
+            type="button"
+            onClick={() => setMenuOpen(true)}
+            aria-label="Open menu"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150 active:scale-95 transition-transform"
+          >
+            <Menu className="h-5 w-5" strokeWidth={1.5} />
+          </button>
+        </div>
 
         {loading ? (
           <div className="space-y-2">
-            <div className="h-8 w-48 bg-brew-surface rounded-full animate-pulse" />
-            <div className="h-4 w-32 bg-brew-surface rounded-full animate-pulse" />
+            <div className="h-8 w-48 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 rounded-full animate-pulse" />
+            <div className="h-4 w-32 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 rounded-full animate-pulse" />
           </div>
         ) : coffee ? (
           <>
             {coffee.roaster && (
-              <p className="text-brew-muted text-sm mb-0.5">{coffee.roaster}</p>
+              <p className="text-light-muted-foreground text-sm mb-0.5">{coffee.roaster}</p>
             )}
-            <h1 className="font-display text-3xl text-white leading-none">{coffee.name}</h1>
-            {sub && <p className="text-brew-muted text-sm mt-1">{sub}</p>}
-            <p className="text-brew-muted text-sm mt-1.5">
-              {sessions.length} session{sessions.length !== 1 ? "s" : ""}
+            <h1 className="font-fraunces text-3xl text-light-foreground leading-none">{coffee.name}</h1>
+            {sub && <p className="text-light-muted-foreground text-sm mt-1">{sub}</p>}
+            <p className="text-light-muted-foreground text-sm mt-1.5">
+              <span className="text-light-foreground">{sessions.length}</span> session{sessions.length !== 1 ? "s" : ""}
               {avgRating != null && (
-                <> · <span className="text-white">{avgRating.toFixed(1)}</span> avg</>
+                <> · <span className="text-light-foreground">{avgRating.toFixed(1)}</span> avg</>
               )}
             </p>
           </>
         ) : (
-          <h1 className="font-display text-3xl text-white leading-none">Coffee</h1>
+          <h1 className="font-fraunces text-3xl text-light-foreground leading-none">Coffee</h1>
         )}
 
         {/* Cafés that served it */}
@@ -148,7 +167,7 @@ export default function CafeCoffeeDetailPage() {
             {uniqueCafes.map(name => (
               <span
                 key={name}
-                className="text-xs text-brew-muted border border-brew-border rounded-lg px-2 py-0.5"
+                className="inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground"
               >
                 {name}
               </span>
@@ -162,36 +181,36 @@ export default function CafeCoffeeDetailPage() {
         {loading ? (
           <div className="flex flex-col gap-3">
             {[1, 2, 3].map(i => (
-              <div key={i} className="h-24 rounded-2xl bg-brew-surface animate-pulse" />
+              <div key={i} className="h-24 rounded-2xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 animate-pulse" />
             ))}
           </div>
         ) : sessions.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-[50vh] text-center gap-3">
-            <p className="text-white font-medium">No sessions found</p>
-            <p className="text-brew-muted text-sm">Could not find sessions for this coffee.</p>
+            <p className="text-light-foreground font-medium">No sessions found</p>
+            <p className="text-light-muted-foreground text-sm">Could not find sessions for this coffee.</p>
           </div>
         ) : (
           <div className="flex flex-col gap-3">
-            {sessions.map((s: Session) => {
+            {sessions.map(s => {
               const method = s.brew?.methodUsed || s.place?.methodServed;
-              const sub = s.coffee ? [s.coffee.origin, s.coffee.process].filter(Boolean).join(" · ") : "";
+              const sessionSub = s.coffee ? [s.coffee.origin, s.coffee.process].filter(Boolean).join(" · ") : "";
               const isEditing = editingId === s.id;
 
               return (
-                <div key={s.id} className="bg-brew-surface border border-brew-border rounded-2xl p-4">
+                <div key={s.id} className="bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-2xl p-4">
                   <div className="flex items-start justify-between gap-3">
                     <div className="flex-1 min-w-0">
                       {s.place?.name && (
-                        <p className="text-brew-accent text-xs font-medium truncate mb-0.5">{s.place.name}</p>
+                        <p className="text-light-foreground/85 text-xs font-medium truncate mb-0.5">{s.place.name}</p>
                       )}
                       {s.place?.location && (
-                        <p className="text-brew-muted text-xs truncate">{s.place.location}</p>
+                        <p className="text-light-muted-foreground text-xs truncate">{s.place.location}</p>
                       )}
-                      {sub && <p className="text-brew-muted text-xs mt-0.5">{sub}</p>}
+                      {sessionSub && <p className="text-light-muted-foreground text-xs mt-0.5">{sessionSub}</p>}
                     </div>
                     <div className="flex items-start gap-2 shrink-0">
                       <div className="text-right">
-                        <p className="text-brew-muted text-xs">{formatRelativeDate(s.createdAt)}</p>
+                        <p className="text-light-muted-foreground text-xs">{formatRelativeDate(s.createdAt)}</p>
                         {s.result?.rating != null && s.result.rating > 0 && (
                           <div className="mt-1">
                             <StarRating value={s.result.rating} readonly size="sm" />
@@ -200,7 +219,7 @@ export default function CafeCoffeeDetailPage() {
                       </div>
                       <button
                         onClick={() => isEditing ? setEditingId(null) : startEdit(s)}
-                        className="p-1 rounded-lg text-brew-muted active:text-white transition-colors mt-0.5"
+                        className="p-1 rounded-lg text-light-muted-foreground active:text-light-foreground transition-colors mt-0.5"
                         aria-label="Edit brew details"
                       >
                         <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
@@ -211,53 +230,42 @@ export default function CafeCoffeeDetailPage() {
                   </div>
 
                   {(method || s.brew?.doseGrams || s.brew?.waterGrams || s.brew?.actualTimeSec) && (
-                    <div className="mt-2 flex flex-wrap gap-1.5">
-                      {method && (
-                        <span className="text-xs text-brew-muted border border-brew-border rounded-lg px-2 py-0.5">{method}</span>
-                      )}
+                    <div className="mt-2.5 flex flex-wrap gap-1.5">
+                      {method && <SummaryChip>{method}</SummaryChip>}
                       {(s.brew?.doseGrams || s.brew?.waterGrams) && (
-                        <span className="text-xs text-brew-muted border border-brew-border rounded-lg px-2 py-0.5">
+                        <SummaryChip>
                           {[s.brew.doseGrams ? `${s.brew.doseGrams}g` : null, s.brew.waterGrams ? `${s.brew.waterGrams}ml` : null].filter(Boolean).join(" / ")}
-                        </span>
+                        </SummaryChip>
                       )}
                       {s.brew?.actualTimeSec && (
-                        <span className="text-xs text-brew-muted border border-brew-border rounded-lg px-2 py-0.5">
+                        <SummaryChip>
                           {Math.floor(s.brew.actualTimeSec / 60)}:{String(s.brew.actualTimeSec % 60).padStart(2, "0")}
-                        </span>
+                        </SummaryChip>
                       )}
                     </div>
                   )}
 
                   {s.result?.flavorNotes && s.result.flavorNotes.length > 0 ? (
                     <div className="mt-2 flex flex-wrap gap-1.5">
-                      {s.result.flavorNotes.slice(0, 3).map((note: string) => (
-                        <span
-                          key={note}
-                          className="text-xs text-brew-muted border border-brew-border rounded-lg px-2 py-0.5"
-                        >
-                          {note}
-                        </span>
+                      {s.result.flavorNotes.slice(0, 3).map(note => (
+                        <SummaryChip key={note}>{note}</SummaryChip>
                       ))}
                     </div>
                   ) : s.coffee?.tastingNotesFromBag && s.coffee.tastingNotesFromBag.length > 0 ? (
                     <div className="mt-2 flex flex-wrap gap-1.5">
-                      {s.coffee.tastingNotesFromBag.slice(0, 3).map((note: string) => (
-                        <span
-                          key={note}
-                          className="text-xs text-brew-muted border border-dashed border-brew-border rounded-lg px-2 py-0.5 italic"
-                        >
-                          {note}
-                        </span>
+                      {s.coffee.tastingNotesFromBag.slice(0, 3).map(note => (
+                        <SummaryChip key={note} dashed>{note}</SummaryChip>
                       ))}
                     </div>
                   ) : null}
 
-                  {/* Coffee Library cross-link */}
-                  {s.coffee?.name && s.coffee?.roaster && (
+                  {/* Library cross-link — to the bag's coffee detail
+                      in /coffees (different from the cafe-coffee key) */}
+                  {s.coffee?.coffeeId && (
                     <div className="mt-2">
                       <Link
-                        href={`/coffees/${toCoffeeKey(s.coffee.roaster, s.coffee.name)}`}
-                        className="inline-flex items-center gap-1 text-xs text-brew-accent border border-brew-accent/30 rounded-lg px-2 py-0.5"
+                        href={`/coffees/${s.coffee.coffeeId}`}
+                        className="inline-flex items-center gap-1 text-xs text-light-foreground/70 border border-light-foreground/20 rounded-full px-2.5 py-0.5"
                       >
                         Coffee Library
                         <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -269,18 +277,18 @@ export default function CafeCoffeeDetailPage() {
 
                   {/* Inline edit panel */}
                   <div className={`overflow-hidden transition-all duration-300 ${isEditing ? "max-h-[30rem] opacity-100 mt-3" : "max-h-0 opacity-0"}`}>
-                    <div className="border-t border-brew-border pt-3 space-y-3">
+                    <div className="border-t border-light-foreground/15 pt-3 space-y-3">
                       <div>
-                        <p className="text-brew-muted text-xs mb-1.5">Method</p>
+                        <p className="text-light-muted-foreground text-xs mb-1.5">Method</p>
                         <div className="flex gap-1.5 overflow-x-auto pb-1" style={{ scrollbarWidth: "none" }}>
                           {BREW_METHODS.map(m => (
                             <button
                               key={m.id}
                               onClick={() => setEditMethod(editMethod === m.label ? "" : m.label)}
-                              className={`shrink-0 px-2.5 py-1 rounded-lg text-xs border transition-colors ${
+                              className={`shrink-0 px-2.5 py-1 rounded-full text-xs border transition-colors ${
                                 editMethod === m.label
-                                  ? "bg-brew-accent text-brew-bg border-brew-accent"
-                                  : "text-brew-muted border-brew-border"
+                                  ? "bg-light-foreground text-[hsl(36_55%_96%)] border-light-foreground"
+                                  : "text-light-muted-foreground border-light-foreground/20 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150"
                               }`}
                             >
                               {m.label}
@@ -290,47 +298,20 @@ export default function CafeCoffeeDetailPage() {
                       </div>
 
                       <div className="grid grid-cols-2 gap-2">
-                        <div>
-                          <label className="text-brew-muted text-xs block mb-1">Dose (g)</label>
-                          <input
-                            type="number"
-                            value={editDose}
-                            onChange={e => setEditDose(e.target.value)}
-                            placeholder="—"
-                            className="w-full bg-brew-bg border border-brew-border rounded-lg px-2.5 py-1.5 text-white text-sm"
-                          />
-                        </div>
-                        <div>
-                          <label className="text-brew-muted text-xs block mb-1">Water (ml)</label>
-                          <input
-                            type="number"
-                            value={editWater}
-                            onChange={e => setEditWater(e.target.value)}
-                            placeholder="—"
-                            className="w-full bg-brew-bg border border-brew-border rounded-lg px-2.5 py-1.5 text-white text-sm"
-                          />
-                        </div>
+                        <LabeledNumber label="Dose (g)" value={editDose} onChange={setEditDose} />
+                        <LabeledNumber label="Water (ml)" value={editWater} onChange={setEditWater} />
                       </div>
 
-                      <div>
-                        <label className="text-brew-muted text-xs block mb-1">Time (seconds)</label>
-                        <input
-                          type="number"
-                          value={editTime}
-                          onChange={e => setEditTime(e.target.value)}
-                          placeholder="—"
-                          className="w-full bg-brew-bg border border-brew-border rounded-lg px-2.5 py-1.5 text-white text-sm"
-                        />
-                      </div>
+                      <LabeledNumber label="Time (seconds)" value={editTime} onChange={setEditTime} />
 
                       <div>
-                        <label className="text-brew-muted text-xs block mb-1">Notes</label>
+                        <label className="text-light-muted-foreground text-xs block mb-1">Notes</label>
                         <textarea
                           value={editNotes}
                           onChange={e => setEditNotes(e.target.value)}
                           placeholder="Add notes..."
                           rows={2}
-                          className="w-full bg-brew-bg border border-brew-border rounded-lg px-2.5 py-1.5 text-white text-sm resize-none"
+                          className="w-full bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/20 rounded-xl px-2.5 py-1.5 text-light-foreground text-sm resize-none placeholder:text-light-muted-foreground"
                         />
                       </div>
 
@@ -338,13 +319,13 @@ export default function CafeCoffeeDetailPage() {
                         <button
                           onClick={() => saveEdit(s)}
                           disabled={saving}
-                          className="flex-1 py-1.5 bg-brew-accent text-brew-bg text-sm font-medium rounded-lg"
+                          className="flex-1 py-2 rounded-xl bg-light-foreground text-[hsl(36_55%_96%)] text-sm font-medium disabled:opacity-50"
                         >
                           Save
                         </button>
                         <button
                           onClick={() => setEditingId(null)}
-                          className="flex-1 py-1.5 bg-brew-surface border border-brew-border text-brew-muted text-sm rounded-lg"
+                          className="flex-1 py-2 rounded-xl border border-light-foreground/20 text-light-muted-foreground text-sm bg-light-card-default backdrop-blur-light-card backdrop-saturate-150"
                         >
                           Cancel
                         </button>
@@ -357,6 +338,35 @@ export default function CafeCoffeeDetailPage() {
           </div>
         )}
       </div>
+
+      <NavigationOverlay open={menuOpen} onClose={() => setMenuOpen(false)} />
+    </div>
+  );
+}
+
+function SummaryChip({ children, dashed = false }: { children: React.ReactNode; dashed?: boolean }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground ${
+        dashed ? "border border-dashed border-light-foreground/30 italic" : ""
+      }`}
+    >
+      {children}
+    </span>
+  );
+}
+
+function LabeledNumber({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
+  return (
+    <div>
+      <label className="text-light-muted-foreground text-xs block mb-1">{label}</label>
+      <input
+        type="number"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        placeholder="—"
+        className="w-full bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/20 rounded-xl px-2.5 py-1.5 text-light-foreground text-sm placeholder:text-light-muted-foreground"
+      />
     </div>
   );
 }

--- a/src/app/(light)/cafes/page.tsx
+++ b/src/app/(light)/cafes/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 import { useEffect, useState, useMemo, type ReactNode } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import Link from "next/link";
+import { Menu } from "lucide-react";
 import type { CafeSummary } from "@/lib/types/cafes";
 import type { Session, CoffeeIdentity } from "@/lib/types/session";
-import StarRating from "@/components/ui/StarRating";
+import StarRating from "@/components/ui/light/StarRating";
+import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
 
 type Tab = "cafes" | "coffees";
 
@@ -62,6 +63,7 @@ export default function CafesPage() {
   const searchParams = useSearchParams();
   const initialTab: Tab = searchParams.get("tab") === "coffees" ? "coffees" : "cafes";
   const [activeTab, setActiveTab] = useState<Tab>(initialTab);
+  const [menuOpen, setMenuOpen] = useState(false);
   const router = useRouter();
 
   const [cafes, setCafes] = useState<CafeSummary[]>([]);
@@ -91,7 +93,7 @@ export default function CafesPage() {
   }, [activeTab, sessionsFetched]);
 
   const cafeCoffees = useMemo(() => deriveCafeCoffees(externalSessions), [externalSessions]);
-  const totalVisits = cafes.reduce((sum: number, cafe: CafeSummary) => sum + cafe.visits, 0);
+  const totalVisits = cafes.reduce((sum, cafe) => sum + cafe.visits, 0);
 
   const tabs: { id: Tab; label: string }[] = [
     { id: "cafes", label: "Cafés" },
@@ -99,27 +101,34 @@ export default function CafesPage() {
   ];
 
   return (
-    <div className="min-h-full bg-brew-bg flex flex-col pb-8">
+    <div className="min-h-full bg-transparent flex flex-col pb-8">
 
       {/* Header */}
       <div className="px-5 pb-4" style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.25rem)" }}>
-        <Link href="/library" className="flex items-center gap-1 text-brew-muted text-sm mb-3 w-fit">
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
-          </svg>
-          Library
-        </Link>
-        <h1 className="font-display text-3xl text-white leading-none">Café Library</h1>
+        <div className="flex items-center justify-between mb-2">
+          <h1 className="font-fraunces text-3xl leading-none text-light-foreground">Café Library</h1>
+          <button
+            type="button"
+            onClick={() => setMenuOpen(true)}
+            aria-label="Open menu"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150 active:scale-95 transition-transform"
+          >
+            <Menu className="h-5 w-5" strokeWidth={1.5} />
+          </button>
+        </div>
         {!cafesLoading && (
-          <p className="text-brew-muted text-sm mt-1.5">
+          <p className="text-light-muted-foreground text-sm">
             {cafes.length === 0
               ? "No café visits yet"
-              : `${cafes.length} café${cafes.length !== 1 ? "s" : ""} · ${totalVisits} visit${totalVisits !== 1 ? "s" : ""}`}
+              : <>
+                  <span className="text-light-foreground">{cafes.length.toLocaleString()}</span> café{cafes.length !== 1 ? "s" : ""} ·{" "}
+                  <span className="text-light-foreground">{totalVisits.toLocaleString()}</span> visit{totalVisits !== 1 ? "s" : ""}
+                </>}
           </p>
         )}
       </div>
 
-      {/* Tab bar */}
+      {/* Tab bar — matches the filter-pill style on /coffees */}
       <div className="px-5 mb-4 flex gap-2">
         {tabs.map(t => (
           <button
@@ -128,8 +137,8 @@ export default function CafesPage() {
             onClick={() => setActiveTab(t.id)}
             className={`px-4 py-1.5 rounded-full text-xs font-medium transition-all ${
               activeTab === t.id
-                ? "bg-brew-accent text-brew-accent-fg"
-                : "bg-brew-surface border border-brew-border text-brew-muted"
+                ? "bg-light-foreground text-[hsl(36_55%_96%)]"
+                : "bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 text-light-muted-foreground"
             }`}
           >
             {t.label}
@@ -142,9 +151,15 @@ export default function CafesPage() {
           <CafesTab cafes={cafes} loading={cafesLoading} onSelect={cafe => router.push(`/cafes/place/${encodeURIComponent(cafe.name)}`)} />
         )}
         {activeTab === "coffees" && (
-          <CoffeesTab coffees={cafeCoffees} loading={sessionsLoading} onSelect={key => router.push(`/coffees/${key}`)} />
+          <CoffeesTab
+            coffees={cafeCoffees}
+            loading={sessionsLoading}
+            onSelect={key => router.push(`/cafes/coffee/${key}`)}
+          />
         )}
       </div>
+
+      <NavigationOverlay open={menuOpen} onClose={() => setMenuOpen(false)} />
     </div>
   );
 }
@@ -168,18 +183,18 @@ function CafesTab({ cafes, loading, onSelect }: { cafes: CafeSummary[]; loading:
           key={cafe.name}
           type="button"
           onClick={() => onSelect(cafe)}
-          className="w-full bg-brew-surface border border-brew-border rounded-2xl p-4 text-left active:scale-[0.98] transition-transform"
+          className="w-full bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-2xl p-4 text-left active:scale-[0.99] transition-transform"
         >
           <div className="flex items-start justify-between gap-3">
             <div className="flex-1 min-w-0">
-              <p className="text-white font-medium leading-tight truncate">{cafe.name}</p>
+              <p className="text-light-foreground font-medium leading-tight truncate">{cafe.name}</p>
               {cafe.location && (
-                <p className="text-brew-muted text-xs mt-0.5 truncate">{cafe.location}</p>
+                <p className="text-light-muted-foreground text-xs mt-0.5 truncate">{cafe.location}</p>
               )}
             </div>
             <div className="text-right shrink-0">
-              <p className="text-brew-muted text-xs">{formatRelativeDate(cafe.lastVisitedMs)}</p>
-              <p className="text-white/60 text-xs mt-0.5">
+              <p className="text-light-muted-foreground text-xs">{formatRelativeDate(cafe.lastVisitedMs)}</p>
+              <p className="text-light-foreground/70 text-xs mt-0.5">
                 {cafe.visits} visit{cafe.visits !== 1 ? "s" : ""}
               </p>
             </div>
@@ -196,7 +211,7 @@ function CafesTab({ cafes, loading, onSelect }: { cafes: CafeSummary[]; loading:
               {cafe.coffees.map(name => (
                 <span
                   key={name}
-                  className="text-xs text-brew-muted border border-brew-border rounded-lg px-2 py-0.5"
+                  className="inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground"
                 >
                   {name}
                 </span>
@@ -209,7 +224,7 @@ function CafesTab({ cafes, loading, onSelect }: { cafes: CafeSummary[]; loading:
   );
 }
 
-/* ── Coffees tab ───────────────────────────────────────────── */
+/* ── Coffees tab — Coffee-Library-style cards with full-bleed photo on left ── */
 
 function CoffeesTab({ coffees, loading, onSelect }: { coffees: CafeCoffee[]; loading: boolean; onSelect: (key: string) => void }) {
   if (loading) return <LoadingSkeletons />;
@@ -225,53 +240,56 @@ function CoffeesTab({ coffees, loading, onSelect }: { coffees: CafeCoffee[]; loa
     <div className="flex flex-col gap-2">
       {coffees.map(({ key, coffee, cafes, avgRating, visitCount }) => {
         const sub = [coffee.origin, coffee.process].filter(Boolean).join(" · ");
+        const cafeLine = cafes.slice(0, 2).join(", ");
+        const visitLabel = `${visitCount} tasting${visitCount === 1 ? "" : "s"}`;
         return (
-          <button
+          <div
             key={key}
-            type="button"
-            onClick={() => onSelect(key)}
-            className="flex items-center gap-3 w-full bg-brew-surface border border-brew-border rounded-2xl p-3 text-left active:scale-[0.98] transition-transform"
+            className="flex items-stretch bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-2xl overflow-hidden w-full"
           >
-            {/* Thumbnail */}
-            <div className="relative w-14 h-14 rounded-xl overflow-hidden bg-brew-elevated shrink-0">
-              {coffee.bagPhotoUrl ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img src={coffee.bagPhotoUrl} alt={coffee.name} className="w-full h-full object-cover" />
-              ) : (
-                <div className="w-full h-full flex items-center justify-center">
-                  <CoffeeIcon className="w-6 h-6 text-brew-muted" />
-                </div>
-              )}
-              <div className="absolute top-0.5 right-0.5 bg-black/70 rounded-full w-4 h-4 flex items-center justify-center">
-                <span className="text-white font-mono-num" style={{ fontSize: "8px" }}>{visitCount}</span>
+            <button
+              type="button"
+              onClick={() => onSelect(key)}
+              className="flex items-stretch flex-1 min-w-0 text-left active:opacity-80 transition-opacity"
+            >
+              {/* Photo strip — full card height, same dimensions as the
+                  coffee library card. */}
+              <div className="relative w-24 shrink-0 bg-light-card-default">
+                {coffee.bagPhotoUrl ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={coffee.bagPhotoUrl} alt={coffee.name} className="absolute inset-0 w-full h-full object-cover" />
+                ) : (
+                  <div className="absolute inset-0 flex items-center justify-center">
+                    <CoffeeIcon className="w-7 h-7 text-light-muted-foreground" />
+                  </div>
+                )}
               </div>
-            </div>
 
-            {/* Text */}
-            <div className="flex-1 min-w-0">
-              {coffee.roaster && (
-                <p className="text-brew-muted text-xs truncate mb-0.5">{coffee.roaster}</p>
-              )}
-              <p className="text-white text-sm font-medium leading-snug truncate">{coffee.name}</p>
-              {sub && (
-                <p className="text-brew-muted text-xs truncate mt-0.5">{sub}</p>
-              )}
-              {cafes.length > 0 && (
-                <p className="text-brew-muted text-xs truncate mt-0.5">
-                  {cafes.slice(0, 2).join(", ")}
-                </p>
-              )}
-              {avgRating != null && avgRating > 0 && (
-                <div className="mt-1.5">
-                  <StarRating value={avgRating} readonly size="sm" />
-                </div>
-              )}
-            </div>
+              <div className="flex-1 min-w-0 px-3.5 py-3">
+                {coffee.roaster && (
+                  <p className="text-light-muted-foreground text-xs truncate mb-0.5">{coffee.roaster}</p>
+                )}
+                <p className="text-light-foreground text-sm font-medium leading-snug truncate">{coffee.name}</p>
+                {sub && (
+                  <p className="text-light-muted-foreground text-xs truncate mt-0.5">{sub}</p>
+                )}
+                {cafeLine && (
+                  <p className="text-light-muted-foreground text-xs truncate mt-0.5">{cafeLine}</p>
+                )}
+                {avgRating != null && avgRating > 0 && (
+                  <div className="mt-1.5">
+                    <StarRating value={avgRating} readonly size="sm" />
+                  </div>
+                )}
+              </div>
+            </button>
 
-            <svg className="w-4 h-4 text-brew-muted shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-            </svg>
-          </button>
+            {/* Right column: tasting count. No Brew CTA — these are
+                cafe coffees, not in the user's brewing rotation. */}
+            <div className="flex flex-col items-center justify-center pr-3 shrink-0">
+              <span className="text-light-muted-foreground text-[11px] whitespace-nowrap">{visitLabel}</span>
+            </div>
+          </div>
         );
       })}
     </div>
@@ -284,7 +302,7 @@ function LoadingSkeletons() {
   return (
     <div className="flex flex-col gap-3">
       {[1, 2, 3].map(i => (
-        <div key={i} className="h-28 rounded-2xl bg-brew-surface animate-pulse" />
+        <div key={i} className="h-28 rounded-2xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 animate-pulse" />
       ))}
     </div>
   );
@@ -293,18 +311,18 @@ function LoadingSkeletons() {
 function EmptyState({ icon, title, body }: { icon: ReactNode; title: string; body: string }) {
   return (
     <div className="flex flex-col items-center justify-center h-[50vh] text-center gap-4">
-      <div className="w-16 h-16 rounded-full bg-brew-surface border border-brew-border flex items-center justify-center">
+      <div className="w-16 h-16 rounded-full bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 flex items-center justify-center">
         {icon}
       </div>
       <div>
-        <p className="text-white font-medium">{title}</p>
-        <p className="text-brew-muted text-sm mt-1 max-w-[240px]">{body}</p>
+        <p className="text-light-foreground font-medium">{title}</p>
+        <p className="text-light-muted-foreground text-sm mt-1 max-w-[240px]">{body}</p>
       </div>
     </div>
   );
 }
 
-function LocationIcon({ className = "w-7 h-7 text-brew-muted" }: { className?: string }) {
+function LocationIcon({ className = "w-7 h-7 text-light-muted-foreground" }: { className?: string }) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -313,7 +331,7 @@ function LocationIcon({ className = "w-7 h-7 text-brew-muted" }: { className?: s
   );
 }
 
-function CoffeeIcon({ className = "w-7 h-7 text-brew-muted" }: { className?: string }) {
+function CoffeeIcon({ className = "w-7 h-7 text-light-muted-foreground" }: { className?: string }) {
   return (
     <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
       <path strokeLinecap="round" strokeLinejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75" />

--- a/src/app/(light)/cafes/place/[slug]/page.tsx
+++ b/src/app/(light)/cafes/place/[slug]/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 import { useEffect, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
+import { Menu } from "lucide-react";
 import type { Session } from "@/lib/types/session";
-import StarRating from "@/components/ui/StarRating";
+import StarRating from "@/components/ui/light/StarRating";
+import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
 import { BREW_METHODS } from "@/lib/constants/brewMethods";
 
 function formatRelativeDate(iso: string): string {
@@ -23,10 +25,12 @@ function toCoffeeKey(roaster: string, name: string): string {
 
 export default function CafeDetailPage() {
   const params = useParams();
+  const router = useRouter();
   const cafeName = decodeURIComponent(params.slug as string);
 
   const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editMethod, setEditMethod] = useState("");
@@ -72,7 +76,7 @@ export default function CafeDetailPage() {
       ? { ...s.result, freeNotes: editNotes || undefined }
       : undefined;
 
-    setSessions((prev: Session[]) => prev.map((sess: Session) =>
+    setSessions(prev => prev.map(sess =>
       sess.id === s.id
         ? { ...sess, brew: brewUpdate, ...(resultUpdate ? { result: resultUpdate } : {}) }
         : sess
@@ -109,9 +113,9 @@ export default function CafeDetailPage() {
   const location = sessions[0]?.place?.location;
   const avgRating = sessions.length > 0
     ? (() => {
-        const rated = sessions.filter((s: Session) => s.result?.rating);
+        const rated = sessions.filter(s => s.result?.rating);
         if (rated.length === 0) return null;
-        return Math.round(rated.reduce((sum: number, x: Session) => sum + (x.result?.rating ?? 0), 0) / rated.length * 10) / 10;
+        return Math.round(rated.reduce((sum, x) => sum + (x.result?.rating ?? 0), 0) / rated.length * 10) / 10;
       })()
     : null;
 
@@ -120,30 +124,45 @@ export default function CafeDetailPage() {
     : `https://maps.google.com/maps?q=${encodeURIComponent(cafeName)}`;
 
   return (
-    <div className="min-h-full bg-brew-bg flex flex-col pb-8">
+    <div className="min-h-full bg-transparent flex flex-col pb-8">
 
       {/* Header */}
       <div className="px-5 pb-4" style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.25rem)" }}>
-        <Link href="/cafes" className="flex items-center gap-1 text-brew-muted text-sm mb-3 w-fit">
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
-          </svg>
-          Cafés
-        </Link>
-        <h1 className="font-display text-3xl text-white leading-none">{cafeName}</h1>
+        <div className="flex items-start justify-between gap-3 mb-2">
+          <button
+            type="button"
+            onClick={() => router.push("/cafes")}
+            className="flex items-center gap-1 text-light-muted-foreground text-sm mt-1"
+            aria-label="Back to Cafés"
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+            </svg>
+            Cafés
+          </button>
+          <button
+            type="button"
+            onClick={() => setMenuOpen(true)}
+            aria-label="Open menu"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150 active:scale-95 transition-transform"
+          >
+            <Menu className="h-5 w-5" strokeWidth={1.5} />
+          </button>
+        </div>
+        <h1 className="font-fraunces text-3xl text-light-foreground leading-none">{cafeName}</h1>
         {location && (
-          <p className="text-brew-muted text-sm mt-1">{location}</p>
+          <p className="text-light-muted-foreground text-sm mt-1">{location}</p>
         )}
 
         {/* Stats + Open in Maps */}
         <div className="flex items-center gap-3 mt-2 flex-wrap">
           {!loading && sessions.length > 0 && (
-            <p className="text-brew-muted text-sm">
-              {sessions.length} visit{sessions.length !== 1 ? "s" : ""}
+            <p className="text-light-muted-foreground text-sm">
+              <span className="text-light-foreground">{sessions.length}</span> visit{sessions.length !== 1 ? "s" : ""}
               {avgRating != null && (
                 <>
                   {" · "}
-                  <span className="text-white">{avgRating.toFixed(1)}</span> avg
+                  <span className="text-light-foreground">{avgRating.toFixed(1)}</span> avg
                 </>
               )}
             </p>
@@ -152,7 +171,7 @@ export default function CafeDetailPage() {
             href={mapsUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="flex items-center gap-1.5 px-3 py-1 bg-brew-surface border border-brew-border rounded-full text-xs text-brew-muted active:scale-95 transition-transform"
+            className="flex items-center gap-1.5 px-3 py-1 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-full text-xs text-light-muted-foreground active:scale-95 transition-transform"
           >
             <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M15 10.5a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -168,17 +187,17 @@ export default function CafeDetailPage() {
         {loading ? (
           <div className="flex flex-col gap-3">
             {[1, 2, 3].map(i => (
-              <div key={i} className="h-24 rounded-2xl bg-brew-surface animate-pulse" />
+              <div key={i} className="h-24 rounded-2xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 animate-pulse" />
             ))}
           </div>
         ) : sessions.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-[50vh] text-center gap-3">
-            <p className="text-white font-medium">No sessions found</p>
-            <p className="text-brew-muted text-sm">No visits logged for this café.</p>
+            <p className="text-light-foreground font-medium">No sessions found</p>
+            <p className="text-light-muted-foreground text-sm">No visits logged for this café.</p>
           </div>
         ) : (
           <div className="flex flex-col gap-3">
-            {sessions.map((s: Session) => {
+            {sessions.map(s => {
               const method = s.brew?.methodUsed || s.place?.methodServed;
               const coffeeKey = s.coffee?.name && s.coffee?.roaster
                 ? toCoffeeKey(s.coffee.roaster, s.coffee.name)
@@ -187,22 +206,22 @@ export default function CafeDetailPage() {
               const isEditing = editingId === s.id;
 
               return (
-                <div key={s.id} className="bg-brew-surface border border-brew-border rounded-2xl p-4">
+                <div key={s.id} className="bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-2xl p-4">
                   <div className="flex items-start justify-between gap-3">
                     <div className="flex-1 min-w-0">
                       {s.coffee?.name && (
                         <>
                           {s.coffee.roaster && (
-                            <p className="text-brew-muted text-xs truncate">{s.coffee.roaster}</p>
+                            <p className="text-light-muted-foreground text-xs truncate">{s.coffee.roaster}</p>
                           )}
-                          <p className="text-white text-sm font-medium leading-snug truncate">{s.coffee.name}</p>
-                          {sub && <p className="text-brew-muted text-xs mt-0.5">{sub}</p>}
+                          <p className="text-light-foreground text-sm font-medium leading-snug truncate">{s.coffee.name}</p>
+                          {sub && <p className="text-light-muted-foreground text-xs mt-0.5">{sub}</p>}
                         </>
                       )}
                     </div>
                     <div className="flex items-start gap-2 shrink-0">
                       <div className="text-right">
-                        <p className="text-brew-muted text-xs">{formatRelativeDate(s.createdAt)}</p>
+                        <p className="text-light-muted-foreground text-xs">{formatRelativeDate(s.createdAt)}</p>
                         {s.result?.rating != null && s.result.rating > 0 && (
                           <div className="mt-1">
                             <StarRating value={s.result.rating} readonly size="sm" />
@@ -211,7 +230,7 @@ export default function CafeDetailPage() {
                       </div>
                       <button
                         onClick={() => isEditing ? setEditingId(null) : startEdit(s)}
-                        className="p-1 rounded-lg text-brew-muted active:text-white transition-colors mt-0.5"
+                        className="p-1 rounded-lg text-light-muted-foreground active:text-light-foreground transition-colors mt-0.5"
                         aria-label="Edit brew details"
                       >
                         <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
@@ -221,44 +240,33 @@ export default function CafeDetailPage() {
                     </div>
                   </div>
 
+                  {/* Recipe summary chips — unified cream-glass style */}
                   {(method || s.brew?.doseGrams || s.brew?.waterGrams || s.brew?.actualTimeSec) && (
-                    <div className="mt-2 flex flex-wrap gap-1.5">
-                      {method && (
-                        <span className="text-xs text-brew-muted border border-brew-border rounded-lg px-2 py-0.5">{method}</span>
-                      )}
+                    <div className="mt-2.5 flex flex-wrap gap-1.5">
+                      {method && <SummaryChip>{method}</SummaryChip>}
                       {(s.brew?.doseGrams || s.brew?.waterGrams) && (
-                        <span className="text-xs text-brew-muted border border-brew-border rounded-lg px-2 py-0.5">
+                        <SummaryChip>
                           {[s.brew.doseGrams ? `${s.brew.doseGrams}g` : null, s.brew.waterGrams ? `${s.brew.waterGrams}ml` : null].filter(Boolean).join(" / ")}
-                        </span>
+                        </SummaryChip>
                       )}
                       {s.brew?.actualTimeSec && (
-                        <span className="text-xs text-brew-muted border border-brew-border rounded-lg px-2 py-0.5">
+                        <SummaryChip>
                           {Math.floor(s.brew.actualTimeSec / 60)}:{String(s.brew.actualTimeSec % 60).padStart(2, "0")}
-                        </span>
+                        </SummaryChip>
                       )}
                     </div>
                   )}
 
                   {s.result?.flavorNotes && s.result.flavorNotes.length > 0 ? (
                     <div className="mt-2 flex flex-wrap gap-1.5">
-                      {s.result.flavorNotes.slice(0, 3).map((note: string) => (
-                        <span
-                          key={note}
-                          className="text-xs text-brew-muted border border-brew-border rounded-lg px-2 py-0.5"
-                        >
-                          {note}
-                        </span>
+                      {s.result.flavorNotes.slice(0, 3).map(note => (
+                        <SummaryChip key={note}>{note}</SummaryChip>
                       ))}
                     </div>
                   ) : s.coffee?.tastingNotesFromBag && s.coffee.tastingNotesFromBag.length > 0 ? (
                     <div className="mt-2 flex flex-wrap gap-1.5">
-                      {s.coffee.tastingNotesFromBag.slice(0, 3).map((note: string) => (
-                        <span
-                          key={note}
-                          className="text-xs text-brew-muted border border-dashed border-brew-border rounded-lg px-2 py-0.5 italic"
-                        >
-                          {note}
-                        </span>
+                      {s.coffee.tastingNotesFromBag.slice(0, 3).map(note => (
+                        <SummaryChip key={note} dashed>{note}</SummaryChip>
                       ))}
                     </div>
                   ) : null}
@@ -266,10 +274,10 @@ export default function CafeDetailPage() {
                   {coffeeKey && (
                     <div className="mt-2">
                       <Link
-                        href={`/coffees/${coffeeKey}`}
-                        className="inline-flex items-center gap-1 text-xs text-brew-accent border border-brew-accent/30 rounded-lg px-2 py-0.5"
+                        href={`/cafes/coffee/${coffeeKey}`}
+                        className="inline-flex items-center gap-1 text-xs text-light-foreground/70 border border-light-foreground/20 rounded-full px-2.5 py-0.5"
                       >
-                        Coffee Library
+                        Coffee detail
                         <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                           <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
                         </svg>
@@ -279,18 +287,18 @@ export default function CafeDetailPage() {
 
                   {/* Inline edit panel */}
                   <div className={`overflow-hidden transition-all duration-300 ${isEditing ? "max-h-[30rem] opacity-100 mt-3" : "max-h-0 opacity-0"}`}>
-                    <div className="border-t border-brew-border pt-3 space-y-3">
+                    <div className="border-t border-light-foreground/15 pt-3 space-y-3">
                       <div>
-                        <p className="text-brew-muted text-xs mb-1.5">Method</p>
+                        <p className="text-light-muted-foreground text-xs mb-1.5">Method</p>
                         <div className="flex gap-1.5 overflow-x-auto pb-1" style={{ scrollbarWidth: "none" }}>
                           {BREW_METHODS.map(m => (
                             <button
                               key={m.id}
                               onClick={() => setEditMethod(editMethod === m.label ? "" : m.label)}
-                              className={`shrink-0 px-2.5 py-1 rounded-lg text-xs border transition-colors ${
+                              className={`shrink-0 px-2.5 py-1 rounded-full text-xs border transition-colors ${
                                 editMethod === m.label
-                                  ? "bg-brew-accent text-brew-bg border-brew-accent"
-                                  : "text-brew-muted border-brew-border"
+                                  ? "bg-light-foreground text-[hsl(36_55%_96%)] border-light-foreground"
+                                  : "text-light-muted-foreground border-light-foreground/20 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150"
                               }`}
                             >
                               {m.label}
@@ -300,47 +308,20 @@ export default function CafeDetailPage() {
                       </div>
 
                       <div className="grid grid-cols-2 gap-2">
-                        <div>
-                          <label className="text-brew-muted text-xs block mb-1">Dose (g)</label>
-                          <input
-                            type="number"
-                            value={editDose}
-                            onChange={e => setEditDose(e.target.value)}
-                            placeholder="—"
-                            className="w-full bg-brew-bg border border-brew-border rounded-lg px-2.5 py-1.5 text-white text-sm"
-                          />
-                        </div>
-                        <div>
-                          <label className="text-brew-muted text-xs block mb-1">Water (ml)</label>
-                          <input
-                            type="number"
-                            value={editWater}
-                            onChange={e => setEditWater(e.target.value)}
-                            placeholder="—"
-                            className="w-full bg-brew-bg border border-brew-border rounded-lg px-2.5 py-1.5 text-white text-sm"
-                          />
-                        </div>
+                        <LabeledNumber label="Dose (g)" value={editDose} onChange={setEditDose} />
+                        <LabeledNumber label="Water (ml)" value={editWater} onChange={setEditWater} />
                       </div>
 
-                      <div>
-                        <label className="text-brew-muted text-xs block mb-1">Time (seconds)</label>
-                        <input
-                          type="number"
-                          value={editTime}
-                          onChange={e => setEditTime(e.target.value)}
-                          placeholder="—"
-                          className="w-full bg-brew-bg border border-brew-border rounded-lg px-2.5 py-1.5 text-white text-sm"
-                        />
-                      </div>
+                      <LabeledNumber label="Time (seconds)" value={editTime} onChange={setEditTime} />
 
                       <div>
-                        <label className="text-brew-muted text-xs block mb-1">Notes</label>
+                        <label className="text-light-muted-foreground text-xs block mb-1">Notes</label>
                         <textarea
                           value={editNotes}
                           onChange={e => setEditNotes(e.target.value)}
                           placeholder="Add notes..."
                           rows={2}
-                          className="w-full bg-brew-bg border border-brew-border rounded-lg px-2.5 py-1.5 text-white text-sm resize-none"
+                          className="w-full bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/20 rounded-xl px-2.5 py-1.5 text-light-foreground text-sm resize-none placeholder:text-light-muted-foreground"
                         />
                       </div>
 
@@ -348,13 +329,13 @@ export default function CafeDetailPage() {
                         <button
                           onClick={() => saveEdit(s)}
                           disabled={saving}
-                          className="flex-1 py-1.5 bg-brew-accent text-brew-bg text-sm font-medium rounded-lg"
+                          className="flex-1 py-2 rounded-xl bg-light-foreground text-[hsl(36_55%_96%)] text-sm font-medium disabled:opacity-50"
                         >
                           Save
                         </button>
                         <button
                           onClick={() => setEditingId(null)}
-                          className="flex-1 py-1.5 bg-brew-surface border border-brew-border text-brew-muted text-sm rounded-lg"
+                          className="flex-1 py-2 rounded-xl border border-light-foreground/20 text-light-muted-foreground text-sm bg-light-card-default backdrop-blur-light-card backdrop-saturate-150"
                         >
                           Cancel
                         </button>
@@ -362,7 +343,7 @@ export default function CafeDetailPage() {
                       <button
                         onClick={() => deleteSession(s.id)}
                         disabled={deletingId === s.id}
-                        className="w-full py-1.5 text-red-400/70 text-xs rounded-lg border border-red-900/30 active:scale-95 transition-all disabled:opacity-40"
+                        className="w-full py-2 rounded-xl bg-[hsl(12_70%_45%)] text-[hsl(36_55%_96%)] text-xs font-medium active:scale-[0.99] transition-transform disabled:opacity-40"
                       >
                         {deletingId === s.id ? "Deleting…" : "Delete session"}
                       </button>
@@ -374,6 +355,35 @@ export default function CafeDetailPage() {
           </div>
         )}
       </div>
+
+      <NavigationOverlay open={menuOpen} onClose={() => setMenuOpen(false)} />
+    </div>
+  );
+}
+
+function SummaryChip({ children, dashed = false }: { children: React.ReactNode; dashed?: boolean }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground ${
+        dashed ? "border border-dashed border-light-foreground/30 italic" : ""
+      }`}
+    >
+      {children}
+    </span>
+  );
+}
+
+function LabeledNumber({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
+  return (
+    <div>
+      <label className="text-light-muted-foreground text-xs block mb-1">{label}</label>
+      <input
+        type="number"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        placeholder="—"
+        className="w-full bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/20 rounded-xl px-2.5 py-1.5 text-light-foreground text-sm placeholder:text-light-muted-foreground"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Migrates the three remaining café routes into the `(light)` route group. `src/app/cafes/map/page.tsx` stays Dark per docs (full-screen Leaflet with CartoCDN dark tiles — intentional).

```
src/app/cafes/page.tsx                 → src/app/(light)/cafes/page.tsx
src/app/cafes/place/[slug]/page.tsx    → src/app/(light)/cafes/place/[slug]/page.tsx
src/app/cafes/coffee/[id]/page.tsx     → src/app/(light)/cafes/coffee/[id]/page.tsx
```

## `/cafes` (Café Library)

- `LightShell` wrapper → Field + NavigationOverlay burger replaces the `/library` back-link.
- **Tab pills** match the filter row on `/coffees` (filled anthracite when active, cream-glass card border when inactive).
- **Stats subtitle** ("X cafés · Y visits") follows the `/coffees` pattern with bold highlighted numerics.
- **Cafés tab**: text-only Light card (no photo — `CafeSummary` carries no image). Name + location + visits + last-visited on the right, stars + unified-style coffee chips below.
- **Coffees tab**: full-bleed photo card mirroring the `/coffees` list from PRs #127/#132/#133. Left photo strip 96 px, right column shows "X tastings" (no Brew CTA — these are café-only coffees, not in your brewing rotation).
- **Routing fix**: Coffees tab used to push to `/coffees/${key}` with the synthetic `roaster__name` key, but `/coffees/[id]` expects a real `coffee.id` UUID and would 404. Switched to `/cafes/coffee/${key}` which is the route actually designed for this lookup.

## `/cafes/place/[slug]` (single café)

- LightShell wrapper, NavigationOverlay burger, cream back-arrow to `/cafes`.
- Sessions list converted to Light cards (cream-glass, anthracite text, Light `StarRating`, summary chips in the unified style).
- "Open in Maps" pill restyled cream-glass.
- **Inline edit panel**: method picker pills become cream-glass tabs (filled anthracite when selected); inputs use cream-glass with `light-foreground/20` borders; delete button picks up the warm rust `hsl(12 70% 45%)` from `SessionCard` for consistency.
- Coffee-detail cross-link points to `/cafes/coffee/${key}` (the in-café route) rather than the broken `/coffees/${key}` it used before.

## `/cafes/coffee/[id]` (café coffee aggregate)

- LightShell + burger + back arrow to `/cafes?tab=coffees`.
- Header shows roaster + name + origin/process + session count + avg rating in the same anthracite typography hierarchy as `/coffees/[id]`.
- Cafés-served-at chips use unified cream-glass style.
- Session cards mirror `place/[slug]` structure.
- **Library cross-link** now uses `session.coffee.coffeeId` (when present) pointing to `/coffees/${coffeeId}` — the correct route for the real library coffee, distinct from the café-coffee aggregate.

## Consistency

Shared Light primitives across all three pages: `bg-light-card-default + backdrop-blur-light-card + backdrop-saturate-150` for surfaces, `text-light-foreground + text-light-muted-foreground` for type, the unified chip pattern (`px-3 py-1.5`, 12 px, cream-glass bg, anthracite text), 11 px right-column meta. One consistent visual vocabulary across café and coffee surfaces — your direction was "Konsistenz und Lesbarkeit".

## Test plan

- [ ] `/cafes`: tabs read like the filter row on `/coffees`. Cafés tab shows text cards with name + location + visits/last-visit. Coffees tab shows photo cards with "X tastings" on the right.
- [ ] Tap a Café card → `/cafes/place/[slug]`. Header has back arrow + burger. Sessions render as cream-glass cards. Edit button opens the inline panel cleanly. Save persists. Delete uses the warm rust button.
- [ ] Tap a Coffee card → `/cafes/coffee/[key]`. Header shows roaster + name + cafés-served-at chips. Sessions render. Library cross-link only appears for sessions whose coffee has `coffeeId`.
- [ ] Burger on any of the three pages opens NavigationOverlay.
- [ ] `/cafes/map` still works (Dark Leaflet, untouched).

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_