### PR TITLE
feat: light migrate /login + /onboarding

### DIFF
--- a/src/app/(light)/login/page.tsx
+++ b/src/app/(light)/login/page.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { startRegistration, startAuthentication } from "@simplewebauthn/browser";
-import CoffeeBeanGlow from "@/components/ui/CoffeeBeanGlow";
+import CoffeeBeanGlow from "@/components/ui/light/CoffeeBeanGlow";
 
 type Mode = "loading" | "login" | "register" | "pin";
 
@@ -155,9 +155,9 @@ export default function LoginPage() {
   // ── Loading ──────────────────────────────────────────────────────────────
   if (mode === "loading") {
     return (
-      <div className="min-h-svh bg-brew-bg flex flex-col items-center justify-center gap-6">
+      <div className="min-h-svh bg-transparent flex flex-col items-center justify-center gap-6">
         <CoffeeBeanGlow size={72} />
-        <p className="font-display text-white/40 text-sm tracking-widest uppercase">BrewLog</p>
+        <p className="font-fraunces text-light-foreground/50 text-sm tracking-widest uppercase">BrewLog</p>
       </div>
     );
   }
@@ -165,10 +165,10 @@ export default function LoginPage() {
   // ── PIN entry ────────────────────────────────────────────────────────────
   if (mode === "pin") {
     return (
-      <div className="min-h-svh bg-brew-bg flex flex-col items-center justify-center px-8 gap-10">
+      <div className="min-h-svh bg-transparent flex flex-col items-center justify-center px-8 gap-10">
         <div className="flex flex-col items-center gap-4">
           <CoffeeBeanGlow size={56} />
-          <p className="font-display text-white/40 text-sm tracking-widest uppercase">BrewLog</p>
+          <p className="font-fraunces text-light-foreground/50 text-sm tracking-widest uppercase">BrewLog</p>
         </div>
 
         <div className="w-full max-w-xs flex flex-col gap-4">
@@ -179,27 +179,27 @@ export default function LoginPage() {
             placeholder="PIN"
             value={pin}
             onChange={e => setPin(e.target.value)}
-            className="w-full bg-brew-surface border border-brew-border rounded-2xl px-4 py-4 text-white text-center text-2xl tracking-widest placeholder:text-brew-muted focus:outline-none focus:border-white/30"
+            className="w-full bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/20 rounded-2xl px-4 py-4 text-light-foreground text-center text-2xl tracking-widest placeholder:text-light-muted-foreground focus:outline-none focus:border-light-foreground/40"
             autoFocus
           />
-          {pinError && <p className="text-red-400 text-sm text-center">{pinError}</p>}
+          {pinError && <p className="text-[hsl(12_70%_45%)] text-sm text-center">{pinError}</p>}
           <button
             onClick={handlePin}
             disabled={pin.length < 4 || working}
-            className="w-full py-4 rounded-2xl bg-brew-accent text-black font-semibold text-base disabled:opacity-40 active:scale-95 transition-all"
+            className="w-full py-4 rounded-2xl bg-light-foreground text-[hsl(36_55%_96%)] font-semibold text-base disabled:opacity-40 active:scale-[0.98] transition-transform"
           >
             {working ? "Checking…" : "Unlock"}
           </button>
           <button
             onClick={() => { setMode("login"); setPin(""); setPinError(""); }}
-            className="text-brew-muted text-sm text-center py-2"
+            className="text-light-muted-foreground text-sm text-center py-2"
           >
             ← Use Face ID
           </button>
           <button
             onClick={handleResetPasskey}
             disabled={pin.length < 4 || working}
-            className="text-brew-muted text-xs text-center py-2 underline-offset-4 hover:underline disabled:opacity-40"
+            className="text-light-muted-foreground text-xs text-center py-2 underline-offset-4 hover:underline disabled:opacity-40"
           >
             Reset Face ID on this device
           </button>
@@ -210,22 +210,22 @@ export default function LoginPage() {
 
   // ── Face ID (login or register) ──────────────────────────────────────────
   return (
-    <div className="min-h-svh bg-brew-bg flex flex-col items-center justify-center px-8 gap-10">
+    <div className="min-h-svh bg-transparent flex flex-col items-center justify-center px-8 gap-10">
       <div className="flex flex-col items-center gap-4">
         <CoffeeBeanGlow size={72} />
-        <p className="font-display text-white/40 text-sm tracking-widest uppercase">BrewLog</p>
+        <p className="font-fraunces text-light-foreground/50 text-sm tracking-widest uppercase">BrewLog</p>
       </div>
 
       <div className="w-full max-w-xs flex flex-col gap-4">
         {error && (
-          <p className="text-amber-400 text-sm text-center leading-relaxed">{error}</p>
+          <p className="text-light-foreground/75 text-sm text-center leading-relaxed">{error}</p>
         )}
 
         {mode === "register" ? (
           <button
             onClick={handleRegister}
             disabled={working}
-            className="w-full py-5 rounded-2xl bg-brew-accent text-black font-semibold text-base flex items-center justify-center gap-3 active:scale-95 transition-all disabled:opacity-60"
+            className="w-full py-5 rounded-2xl bg-light-foreground text-[hsl(36_55%_96%)] font-semibold text-base flex items-center justify-center gap-3 active:scale-[0.98] transition-transform disabled:opacity-60"
           >
             {working ? <Spinner /> : <FaceIDIcon />}
             {working ? "Setting up…" : "Set up Face ID"}
@@ -234,7 +234,7 @@ export default function LoginPage() {
           <button
             onClick={triggerFaceID}
             disabled={working}
-            className="w-full py-5 rounded-2xl bg-brew-accent text-black font-semibold text-base flex items-center justify-center gap-3 active:scale-95 transition-all disabled:opacity-60"
+            className="w-full py-5 rounded-2xl bg-light-foreground text-[hsl(36_55%_96%)] font-semibold text-base flex items-center justify-center gap-3 active:scale-[0.98] transition-transform disabled:opacity-60"
           >
             {working ? <Spinner /> : <FaceIDIcon />}
             {working ? "Verifying…" : "Use Face ID"}
@@ -243,7 +243,7 @@ export default function LoginPage() {
 
         <button
           onClick={() => setMode("pin")}
-          className="text-brew-muted text-sm text-center py-2"
+          className="text-light-muted-foreground text-sm text-center py-2"
         >
           Use PIN instead
         </button>
@@ -269,6 +269,6 @@ function FaceIDIcon() {
 
 function Spinner() {
   return (
-    <div className="w-5 h-5 rounded-full border-2 border-black/30 border-t-black animate-spin" />
+    <div className="w-5 h-5 rounded-full border-2 border-[hsl(36_55%_96%)]/30 border-t-[hsl(36_55%_96%)] animate-spin" />
   );
 }

--- a/src/app/(light)/onboarding/page.tsx
+++ b/src/app/(light)/onboarding/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 import { useState } from "react";
-import Image from "next/image";
 import { useRouter } from "next/navigation";
 import type { UserPreferences } from "@/lib/types/preferences";
+import Chip from "@/components/ui/light/Chip";
 
 async function savePreferences(prefs: UserPreferences): Promise<void> {
   await fetch("/api/preferences", {
@@ -60,64 +60,54 @@ export default function OnboardingPage() {
   };
 
   return (
-    <div className="min-h-svh bg-brew-bg flex flex-col px-5">
-      <div className="pt-safe pt-12 pb-8">
-        <p className="text-brew-accent text-xs tracking-widest uppercase font-medium mb-3">Setup</p>
-        <h1 className="font-display text-4xl text-white leading-tight">
+    <div className="min-h-svh bg-transparent flex flex-col px-5">
+      <div className="pb-8" style={{ paddingTop: "calc(env(safe-area-inset-top) + 3rem)" }}>
+        <p className="text-light-muted-foreground text-xs tracking-widest uppercase font-medium mb-3">Setup</p>
+        <h1 className="font-fraunces text-4xl text-light-foreground leading-tight whitespace-pre-line">
           {step === "equipment" ? "What's in\nyour kitchen?" : "Your grinder"}
         </h1>
       </div>
 
       {step === "equipment" ? (
         <div className="flex-1 flex flex-col gap-6 pb-safe">
-          <p className="text-white/60 text-sm">Select everything you own — tap to toggle</p>
+          <p className="text-light-muted-foreground text-sm">Select everything you own — tap to toggle</p>
           <div className="flex flex-wrap gap-2">
             {EQUIPMENT_OPTIONS.map(e => {
               const selected = equipment.includes(e.id);
               return (
-                <button
+                <Chip
                   key={e.id}
-                  type="button"
+                  selected={selected}
                   onClick={() => toggleEquipment(e.id)}
-                  className={`px-4 py-2.5 rounded-full border text-sm font-medium transition-all active:scale-95 ${
-                    selected
-                      ? "border-brew-accent bg-brew-accent/15 text-brew-accent"
-                      : "border-brew-border text-white/60"
-                  }`}
                 >
-                  {selected && <span className="mr-1.5">✓</span>}{e.label}
-                </button>
+                  {e.label}
+                </Chip>
               );
             })}
           </div>
-          <div className="mt-auto pb-safe pt-4">
+          <div className="mt-auto pt-4" style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 1rem)" }}>
             <button
               type="button"
               onClick={() => setStep("grinder")}
               disabled={equipment.length === 0}
-              className="w-full h-14 rounded-full bg-white text-black font-semibold text-base active:scale-95 transition-all disabled:opacity-30"
+              className="w-full h-14 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] font-semibold text-base active:scale-[0.98] transition-transform disabled:opacity-30"
             >
               Next →
             </button>
           </div>
         </div>
       ) : (
-        <div className="flex-1 flex flex-col gap-6">
-          <p className="text-white/60 text-sm">Select your primary grinder</p>
+        <div className="flex-1 flex flex-col gap-6 pb-safe">
+          <p className="text-light-muted-foreground text-sm">Select your primary grinder</p>
           <div className="flex flex-wrap gap-2">
             {GRINDER_OPTIONS.map(g => (
-              <button
+              <Chip
                 key={g}
-                type="button"
+                selected={grinder === g}
                 onClick={() => setGrinder(prev => prev === g ? "" : g)}
-                className={`px-4 py-2.5 rounded-full border text-sm font-medium transition-all active:scale-95 ${
-                  grinder === g
-                    ? "border-brew-accent bg-brew-accent/15 text-brew-accent"
-                    : "border-brew-border text-white/60"
-                }`}
               >
-                {grinder === g && <span className="mr-1.5">✓</span>}{g}
-              </button>
+                {g}
+              </Chip>
             ))}
           </div>
 
@@ -127,16 +117,16 @@ export default function OnboardingPage() {
               value={grinderCustom}
               onChange={e => setGrinderCustom(e.target.value)}
               placeholder="Enter your grinder model..."
-              className="w-full bg-brew-surface border border-brew-border rounded-2xl px-4 py-3 text-white text-base placeholder:text-brew-muted focus:outline-none focus:border-white/30"
+              className="w-full bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/20 rounded-2xl px-4 py-3 text-light-foreground text-base placeholder:text-light-muted-foreground focus:outline-none focus:border-light-foreground/40"
               autoFocus
             />
           )}
 
-          <div className="mt-auto pb-safe pt-4 flex gap-3">
+          <div className="mt-auto pt-4 flex gap-3" style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 1rem)" }}>
             <button
               type="button"
               onClick={() => setStep("equipment")}
-              className="h-14 px-6 rounded-full bg-brew-surface border border-brew-border text-white font-medium active:scale-95 transition-all"
+              className="h-14 px-6 rounded-full bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/20 text-light-foreground font-medium active:scale-[0.98] transition-transform"
             >
               Back
             </button>
@@ -144,7 +134,7 @@ export default function OnboardingPage() {
               type="button"
               onClick={handleSave}
               disabled={saving}
-              className="flex-1 h-14 rounded-full bg-white text-black font-semibold text-base active:scale-95 transition-all disabled:opacity-60"
+              className="flex-1 h-14 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] font-semibold text-base active:scale-[0.98] transition-transform disabled:opacity-60"
             >
               {saving ? "Saving..." : "Start Brewing"}
             </button>


### PR DESCRIPTION
## Summary

Moves both authentication-related routes into the `(light)` route group:

```
src/app/login/page.tsx       → src/app/(light)/login/page.tsx
src/app/onboarding/page.tsx  → src/app/(light)/onboarding/page.tsx
```

Middleware redirects to `/login` URL which still resolves through the new path — no middleware changes needed.

## `/login`

- LightShell wrapper provides the default Field background (no coffee context pre-auth, so the default cream radial paints).
- Dark `CoffeeBeanGlow` import flipped to the Light variant (`@/components/ui/light/CoffeeBeanGlow`) — anthracite stroke matches the cream canvas instead of the peach-on-dark original.
- Primary CTA (Use Face ID / Set up Face ID / Unlock) now `bg-light-foreground` + cream text, mirroring the Brew-this and Save patterns used elsewhere.
- PIN input cream-glass with `light-foreground/20` border.
- Error states: PIN error uses warm rust `hsl(12 70% 45%)` for consistency with the destructive button language; the softer "Face ID unavailable" hint uses `text-light-foreground/75` (was amber-400 on dark — amber reads as warning on light too but foreground/75 is calmer and stays in palette).
- BrewLog wordmark switches to `font-fraunces` so the masthead reads in the editorial serif used across the rest of the Light app.

## `/onboarding`

- LightShell wrapper, default Field.
- Equipment + grinder selector pills converted to the `Chip` primitive (cream-glass default, taupe-on-cream selected via the same `Chip` used by `LightStepLog`). Drops the bespoke `✓`-prefix pattern — selected tone carries the affordance.
- Primary CTA (Next / Start Brewing) `bg-light-foreground` + cream.
- Back button cream-glass border.
- "Other" grinder input cream-glass with the same border treatment as `/login`'s PIN input.
- Heading uses `font-fraunces` matching the editorial voice of `/coffees` and `/cafes` headers.
- `paddingTop` / `paddingBottom` use `calc(env(safe-area-inset-*) + offset)` instead of `pt-safe`/`pb-safe` utilities so the safe-area is consistent across Light surfaces.

## Why this matters

Both pages used to live outside the Light scope marker so they kept the legacy Dark background (`bg-brew-bg`) and Dark tokens (`text-white/40`, `border-brew-border`, `bg-brew-accent text-black`). That meant entering the app cold-started on Dark, then flipped to cream after auth — a visible regression for a single-user app that's otherwise fully Light.

## Test plan

- [ ] Log out + open `/` — middleware redirects to `/login`, page paints cream with default Field, anthracite CTA reads "Use Face ID" or "Set up Face ID".
- [ ] Tap "Use PIN instead" — PIN entry view renders cream-glass input, anthracite "Unlock" button.
- [ ] Wrong PIN → rust error text, input clears.
- [ ] Right PIN → returns to `/`.
- [ ] Fresh device → onboarding shows after register. Equipment + grinder Chips toggle cleanly. Selected chips read with taupe-on-cream + inset shadow.
- [ ] Tap "Other" grinder → custom input appears with consistent styling.
- [ ] "Start Brewing" saves preferences and routes to `/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_