### PR TITLE
docs: post-light-migration update for CLAUDE.md + HANDOVER.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,9 @@ Replace the filename with the actual migration file. You should see `INSERT 0 N`
 
 ### Pages (`src/app/`)
 
-Routes are split between the **`(light)` route group** (BTTS Light theme — Cream background, Fraunces/Chivo, anthracite foreground, generative Field) and the legacy **Dark** surfaces still pending migration. The `(light)` segment is URL-invisible — `/coffees` resolves through `(light)/coffees/page.tsx`. `LightShell` wraps everything in the group and sets the `[data-light-scope]` data attribute used by the CSS shim in `globals.css`.
+Light migration is **complete** as of PRs #134–#137. Every visited route lives inside the **`(light)` route group** (BTTS Light theme — Cream background, Fraunces/Chivo, anthracite foreground, generative Field) and inherits `LightShell` from `(light)/layout.tsx`. The `(light)` segment is URL-invisible — `/coffees` resolves through `(light)/coffees/page.tsx`. `LightShell` sets the `[data-light-scope]` data attribute used by the CSS shim in `globals.css`.
+
+The single remaining Dark route is `cafes/map/page.tsx` and that's intentional (dark Leaflet tiles).
 
 | Route | Theme | Purpose |
 |-------|-------|---------|
@@ -39,20 +41,20 @@ Routes are split between the **`(light)` route group** (BTTS Light theme — Cre
 | `(light)/past-conversations/page.tsx` | Light | Conversation history list (archived chats) |
 | `(light)/past-conversations/[id]/page.tsx` | Light | Single past conversation thread (read-only replay) |
 | `(light)/brew/new/page.tsx` | Light | Multi-step brew flow — routes `flowStore.step` to the right `LightStep*` component |
-| `(light)/coffees/page.tsx` | Light | Coffee library — searchable list (burger top-right, no BottomNav) |
-| `(light)/coffees/[id]/page.tsx` | Light | Coffee detail — Field + Brew-this CTA + rotation star toggle + rating history + brew signatures |
-| `layout.tsx` | — | Root layout: auth check, PWA meta tags, font preloads |
-| `login/page.tsx` | Dark | Passkey (WebAuthn) login UI |
-| `onboarding/page.tsx` | Dark | First-run equipment / grinder / preferences wizard |
-| `brew/[id]/page.tsx` | Dark | Read-only session detail (reached from SessionCard on /home diary) |
-| `cafes/page.tsx` | Dark | Café Library — tabbed list (Cafés + Coffees tasted out) |
+| `(light)/brew/[id]/page.tsx` | Light | Read-only session detail — Brew-method as headline, Field of the linked coffee, sections for recipe / brew notes / taste / reasoning |
+| `(light)/coffees/page.tsx` | Light | Coffee library — searchable list with full-bleed bag-photo card (96 px left strip), brew count over Brew CTA in the right column |
+| `(light)/coffees/[id]/page.tsx` | Light | Coffee detail — Field + rotation toggle + gated Brew CTA + rating history + brew signatures |
+| `(light)/cafes/page.tsx` | Light | Café Library — tabbed list (Cafés + Coffees tasted out), photo-strip cards in the Coffees tab |
+| `(light)/cafes/place/[slug]/page.tsx` | Light | Single café detail + inline session edit panel |
+| `(light)/cafes/coffee/[id]/page.tsx` | Light | Coffee tasted at an external location, cross-links to library coffee via `coffeeId` |
+| `(light)/taste/page.tsx` | Light | Taste profile — Avg rating + rated count + AI summary + FlavorWheel (profile mode) + top flavors / rating trend / body / acidity / origins / processes / methods |
+| `(light)/login/page.tsx` | Light | Passkey (WebAuthn) login UI + PIN fallback + reset path |
+| `(light)/onboarding/page.tsx` | Light | First-run equipment + grinder wizard (uses the Chip primitive) |
+| `layout.tsx` | — | Root layout: PWA meta tags, font preloads, `<ScrollContainer>` wrapper |
+| `loading.tsx` | Light | Global loading state — Light CoffeeBeanGlow on inline cream bg (renders before LightShell mounts) |
 | `cafes/map/page.tsx` | Dark *(intentional)* | Nearby — full-screen Leaflet map (CartoCDN dark tiles); needs `h-dvh flex flex-col` + `flex-1 min-h-0` so Leaflet gets a non-zero container |
-| `cafes/place/[slug]/page.tsx` | Dark | Individual café detail (menu, coffees tasted) |
-| `cafes/coffee/[id]/page.tsx` | Dark | Coffee tasted at an external location |
-| `taste/page.tsx` | Dark | Taste profile + AI-written summary + RadarChart |
-| `library/page.tsx` | Dark | Navigation hub (small, low-traffic) |
 
-Removed in the BTTS Light arc: legacy `page.tsx` (Dark home, replaced by `(light)/page.tsx`), `match/page.tsx` + `/api/match` (taste-match flow folded into `/api/explore-agent`), `explore/page.tsx` (replaced by inline chat on home). See HANDOVER.md for the punch-list of Dark routes still pending Light migration.
+Removed routes: legacy Dark `page.tsx` (replaced by `(light)/page.tsx`), `match/page.tsx` + `/api/match` (folded into `/api/explore-agent`), `explore/page.tsx` (replaced by inline chat on home), `library/page.tsx` (the Coffee Library / Café Library picker — redundant once `NavigationOverlay` gained direct entries for both).
 
 ### API Routes (`src/app/api/`)
 
@@ -119,13 +121,15 @@ All Light. The Dark `Step*.tsx` files (`FlowShell`, `StepMode`, `StepScan`, `Ste
 **Light UI primitives (`src/components/ui/light/`):**
 `LightShell` (wraps `(light)` group, sets `[data-light-scope]`), `LightFlowShell` (drives `useFieldConfig` per step, scrolls top on step change), `Field` (reads FieldContext → renders `composeFieldGradient(zones, rotation)` fixed -z-10), `Card`, `Section`, `Footnote`, `Chip`, `Hero` (eyebrow + Fraunces 40px question), `CTA` (anthracite button + cream text), `CTAWarmth`, `ActionPill` (Brew-Again candidates on home), `ChatInput`, `ChatThread`, `AttachmentSheet`, `NavigationOverlay` (full-screen menu — Home / Past Conversations / New Session / Coffee Library / Nearby / Café Library / Taste Profile), `ReferenceCoffeePicker`, `StarRating` (rotation toggle + log rating), `CircularTimer` (Light fork — anchored to Date.now, visibility-snap), `CoffeeBeanGlow` (anthracite stroke fork).
 
-**Dark UI primitives (`src/components/ui/`):**
-`Button`, `Chip`, `CoffeeBeanGlow`, `FlavorWheel` (still Dark inside `LightStepLog` — opt-in, deferred), `BrewMethodIcon` (inverted via `[data-light-scope] { filter: brightness(0) }` shim instead of forking), `NumberStepper`, `PhotoUpload`, `PlaceSearch`, `ProgressDots`, `RadarChart`, `StarRating`, `ThinkingDots`, `WaveformBars`.
+**Shared / Dark-era UI primitives (`src/components/ui/`):**
+`Button`, `CoffeeBeanGlow` (kept for `PhotoUpload`; CSS shim `[data-light-scope] { filter: brightness(0) }` inverts it to anthracite at the consumer), `FlavorWheel` (now Light palette in place — canvas transparent, cream-glass panels, anthracite text/icons), `BrewMethodIcon` (inverted via the same shim), `NumberStepper`, `PhotoUpload`, `PlaceSearch`, `ProgressDots`, `StarRating` (still consumed by `CafeMap` only), `ThinkingDots`, `WaveformBars`.
+
+Removed during the Light cleanup (PR #137): `BottomNav`, Dark `Chip`, `RadarChart` — all orphaned once their consumers migrated.
 
 **Layout (`src/components/layout/`):**
-`BottomNav` (allowlist: `/taste`, `/library`, `/cafes` only — Light routes opt out), `ScrollContainer`, `BottomSpacer`
+`ScrollContainer` (root 100dvh wrapper with hidden scroll — no more allowlist, no nav-padding reserve), `BottomSpacer`
 
-**Session:** `SessionCard` (Dark, used on home diary feed)
+**Session:** `SessionCard` (Light, consumed only by `/coffees/[id]` All-brews list — Brew-method as headline, Field's cream-glass cards, swipe-to-delete with rust-red destructive button)
 **Cafés:** `CafeMap` (Leaflet — consumed by `/cafes/map`)
 
 ### `src/lib/`
@@ -178,8 +182,12 @@ lib/
 │   ├── composeGradient.ts     # zones + rotation → CSS radial/conic gradient sandwich
 │   ├── schema.ts              # Zod schema for persisted field_zones
 │   ├── mapNotesToZones.ts     # Haiku call: tasting notes → weighted zone composition
+│   ├── cache.ts               # sessionStorage cache keyed by session id — /coffees/[id] pre-warms,
+│   │                            /brew/[id] reads on mount so the cup's Field paints from frame 1
+│   │                            instead of flashing default while the coffee fetch resolves
 │   └── FieldContext.tsx       # React Context Provider + useFieldConfig() hook
-│   # Consumed by <Field> (src/components/ui/light/Field.tsx) and LightFlowShell.
+│   # Consumed by <Field> (src/components/ui/light/Field.tsx), LightFlowShell, and the
+│   # /coffees/[id] + /brew/[id] detail pages (which both call useFieldConfig directly).
 │   # LightFlowShell rotates 25° per brew step (scan 0° → context 25° → recommend 50° → brew 75° → log 100° → summary 125°).
 ├── knowledge/
 │   ├── insights.ts / news.ts / hints.ts / questions.ts / alerts.ts
@@ -250,12 +258,36 @@ Both migrations applied manually on the VPS — see migration NOTE above.
 ## Current Status — Snapshot May 2026
 
 ### ✅ Done
-**BTTS Light migration (PR #65 → #103)**
-- Whole brew flow + Home + Coffee Library now run under the `(light)` route group with the BTTS Light theme — Cream background, Fraunces 40px hero, Chivo body, anthracite foreground, generative Field background.
+**BTTS Light migration — complete (PR #65 → #137)**
+- Every visited surface lives in the `(light)` route group with the BTTS Light theme — Cream background, Fraunces 40 px hero, Chivo body, anthracite foreground, generative Field background.
 - Light primitives stack: `LightShell`, `LightFlowShell`, `Field`, `Card`, `Section`, `Footnote`, `Chip`, `Hero`, `CTA`, `CTAWarmth`, `ActionPill`, `ChatInput`, `ChatThread`, `NavigationOverlay`, `StarRating`, `CircularTimer` (fork), `CoffeeBeanGlow` (fork).
 - Atomic cut-over (PR #95) renamed `(light)/brew/preview` → `(light)/brew/new` and deleted ~4,300 lines of Dark step code (`Step*.tsx` + `FlowShell.tsx` + Dark `CircularTimer`).
-- `[data-light-scope]` CSS shim in `globals.css` adapts un-migrated Dark components (BrewMethodIcon via `filter: brightness(0)`; `var(--card)` tokens; CoffeeBeanGlow inversion) without forking the components.
-- Dark surfaces still pending Light migration: `/cafes`, `/cafes/place/[slug]`, `/cafes/coffee/[id]`, `/taste`, `/brew/[id]`, `/login`, `/onboarding`, `/library`. `/cafes/map` stays Dark intentionally (dark CartoCDN tiles). See HANDOVER.md punch list.
+- `[data-light-scope]` CSS shim in `globals.css` adapts shared Dark-era components (`BrewMethodIcon`, original `CoffeeBeanGlow`) via `filter: brightness(0)` so they read as anthracite inside the Light tree without being forked.
+- Migrated this arc (Sep–May 2026): `/brew/[id]` (#122), `/coffees/[id]` Field adoption (#123), SessionCard rewrite (#120), `/cafes` + `/cafes/place/[slug]` + `/cafes/coffee/[id]` (#134), `/login` + `/onboarding` (#135), `/taste` (#136). Only `/cafes/map` remains Dark — intentional for the dark CartoCDN tiles.
+- Cleanup pass (#137): removed `BottomNav`, `RadarChart`, Dark `Chip` (all orphaned post-migration); `loading.tsx` flipped to Light with explicit cream bg so route transitions don't flash dark; `ScrollContainer` simplified (no allowlist, no nav-padding reserve); `--nav-bottom-padding` CSS var dropped.
+- PWA chrome aligned (#113–#119): `themeColor: #D4B8C9` (mauve) on viewport + `manifest.json`, `manifest.background_color: #F3E5DC` (cream so the splash matches the Field base), `appleWebApp.statusBarStyle: "default"`, `html { background-color: #F3E5DC }` so the Light cream is the baseline even if the Field gradient is thin at the very top pixels.
+
+**UI polish across the Light surfaces**
+- Chip vocabulary unified across SessionCard, `/coffees/[id]`, `/brew/[id]`, `LightStepSummary`, Café Library, Café detail — all static tags now share the `Chip` primitive's default cream-glass look (`px-3 py-1.5`, 12 px, `bg-light-card-default` + backdrop blur, anthracite text). Bordered outline variant was a regression noticed in #124 and reverted in #126.
+- Coffee Library card architecture (#127, #132, #133): full-bleed 96 px bag-photo strip on the left, content middle, right column with brew count over the Brew CTA (centered, not edge-aligned). Brew CTA gated on `inRotation` so out-of-rotation rows don't dangle an action they shouldn't trigger (#117).
+- Coffee Detail (`/coffees/[id]`) reads its coffee's Field via `useFieldConfig` (#123). Hero scrim flipped to cream-to-transparent (#121) so anthracite titles stay legible against any bag photo. Rotation toggle gates the "Brew this" CTA (#117) — out-of-rotation = bag-not-on-counter, no shortcut shown.
+- SessionCard (`/coffees/[id]` All-brews list) rewritten as a Light card (#120): brew method headline + recipe meta (date · dose · water · time) + flavor chips; swipe-to-delete button fades in proportional to swipe progress (#124) so it doesn't bleed through the translucent cream at rest.
+- Brew Session Detail (`/brew/[id]`) inherits the cup's Field via `lib/field/cache.ts` (#125) — `/coffees/[id]` pre-warms the cache for all its sessions when it loads, `/brew/[id]` reads synchronously on mount, so navigating between the two paints the same Field with no flash through default. Back arrow routes to `/coffees/[coffeeId]` (#126) instead of the library root, with router.back() as a fallback for legacy sessions whose `CoffeeIdentity` was persisted before `coffeeId` existed.
+
+**FlavorWheel Light palette (#128–#131)**
+- Direct conversion (no theme prop). The wheel is intrinsically monochrome — `scaFlavorWheel.ts` gives every category a near-identical dark gray, so differentiation comes from icons + label opacity + active/has-sel tonal lifts, not from per-category brand color.
+- Canvas → transparent so the Field paints through. Category segments → cream-glass at 55 % (`bg-light-card-default` token), taupe lift for has-selection, anthracite press at 18 % alpha for active. Outer sub-category ring mirrors the same three states at slightly weaker alpha so the inner ring stays primary. Whole-wedge tonal state — tapping a category darkens both rings together.
+- Thin cream ring divider between inner and outer rings (#130); divider stroke weights dropped to 0.8 / 0.5 viewport units (#131) to match the label typography weight.
+- Icons refactored to `currentColor` with the wrapping `<g>` setting `color`, single icon-path source.
+
+**Generative Field v1.1 (PRs #78 → #100)**
+- Each coffee gets its own background gradient composition derived from tasting notes.
+- 6-zone perceptual palette (fruity-bright, fruity-deep, floral, nutty-cocoa, spice-earth, sweet-caramel); composition stored as weighted JSON in `coffees.field_zones`.
+- Haiku call (`src/lib/field/mapNotesToZones.ts`) maps tasting notes → zone weights on first scan.
+- `LightFlowShell` rotates Field 25° per brew step (scan 0°, mode 0°, context 25°, recommend 50°, brew 75°, log 100°, summary 125°) — visual progress signal.
+- Brew-Again paths (ActionPill on home, `/coffees` list, `/coffees/[id]`) lift `fieldZones` from `coffees.field_zones` so the cup-specific Field travels with the user into the flow.
+- Backfill (`scripts/backfill-field-zones.mjs`) ran on production: 23/23 existing coffees mapped (no skips).
+- Variety fallback (Phase 4 — derive Field from variety knowledge for coffees without tasting notes) deferred as currently moot.
 
 **Generative Field v1.1 (PRs #78 → #100)**
 - Each coffee gets its own background gradient composition derived from tasting notes.
@@ -339,16 +371,10 @@ Both migrations applied manually on the VPS — see migration NOTE above.
 
 ### ❌ Not Done / Known Gaps
 
-**Light migration punch list** (roughly priority order — see HANDOVER.md for the live ranking):
-1. `/coffees` rotation indicator + filter — list rows don't show the star yet; "Show only rotation" toggle would scan faster
-2. `/cafes` Light migration — high-traffic, last big Library surface
-3. `/cafes/place/[slug]` + `/cafes/coffee/[id]` Light — small follow-ons after `/cafes`
-4. `/taste` Light + RadarChart Light — taste profile + AI summary
-5. FlavorWheel Light SVG — currently Dark inside `LightStepLog` (opt-in, rarely opened — deferred per migration plan)
-6. `/brew/[id]` Session Detail Light — reached via SessionCard
-7. Dark `Chip.tsx` removal — only Dark consumer left is `/brew/[id]`
-8. `LightStepScan` Card/Chip refactor — 1400 lines with bespoke buttons that should route through `Card` + `Chip` primitives
-9. Aromatic Goal validation — PR #72 added the intent to `/api/recommend` but per the Hard Rule it needs sample-before/after against a delicate coffee on the deployed PWA
+**Open items** (post-Light-migration; live ranking lives in HANDOVER.md):
+1. `/coffees` "Show only rotation" filter — list shows the star indicator (#117) but no toggle yet to filter the list to rotation bags only
+2. `LightStepScan` Card/Chip refactor — 1400 lines with bespoke buttons that should route through the `Card` + `Chip` primitives. Code quality, no visible UX change
+3. Aromatic Goal validation — PR #72 added the intent to `/api/recommend` but per the Hard Rule it needs sample-before/after against a delicate coffee on the deployed PWA
 
 **Permanent gaps**
 - Photo uploads: stored under `bags/` — old sessions scanned before this convention have no `bagPhotoUrl`

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,93 +1,131 @@
 # Session Handover — May 2026
 
-> Snapshot of where the project stands at the end of the long Brew-Flow Light migration + Field v1.1 + Coffee Rotation arc. Read this once when picking up a new Claude session; the persistent rules + tokens live in `CLAUDE.md`. This file is **state**, not policy.
+> Snapshot at the end of the Light migration arc. Read this once when picking up a new Claude session; persistent rules + tokens live in `CLAUDE.md`. This file is **state**, not policy.
 
 ---
 
-## What just shipped (PR #65 → #102)
+## The headline: Light migration is done
 
-### Light brew flow — end-to-end ✅
-All seven steps migrated and cut over. `/brew/new` resolves through `(light)/brew/new/page.tsx`. Dark `StepScan/StepMode/StepContext/StepRecommend/StepBrew/StepLog/StepSummary/FlowShell/CircularTimer` files **deleted** (~4,300 lines). Light forks under `src/components/flow/LightStep*.tsx` are the only surviving step files.
+Every visited route now lives in `(light)/` and renders with the BTTS Light theme (Cream + Fraunces/Chivo + anthracite + generative Field). The single Dark route left is `cafes/map/page.tsx` — intentional, because Leaflet's CartoCDN dark tiles fit the full-screen map.
 
-### Generative Field v1.1 — live ✅
-- `src/lib/field/{zones,defaultZones,types,composeGradient,mapNotesToZones,schema,FieldContext}.tsx`
-- DB column `coffees.field_zones jsonb` (migration 0008 — **applied on VPS**)
-- `<Field>` in `src/components/ui/light/Field.tsx` reads `FieldContext`, paints via `composeFieldGradient(zones, rotation)`
-- LightFlowShell drives `useFieldConfig` per step: scan 0°, mode 0°, context 25°, recommend 50°, brew 75°, log 100°, summary 125°
-- 23 existing coffees backfilled via `scripts/backfill-field-zones.mjs` — every coffee in the library now has a personal Field
-- Brew-Again paths lift `fieldZones` from `coffees.field_zones` (ActionPill, /coffees list, /coffees/[id])
+### What shipped this arc (PR #113 → #137)
 
-### Generative Field v1.1 — deliberately deferred
-- **Phase 4 Variety Fallback** — for coffees with no tasting notes, derive Field from variety knowledge. Currently moot (backfill output: `skipped no notes: 0`) but useful for future no-notes scans.
+**Routes migrated**
+- `/brew/[id]` Session Detail (PR #122) — Brew-method as headline, Field carries from `/coffees/[id]` via `lib/field/cache.ts`, sections styled like the coffee detail
+- `/cafes` + `/cafes/place/[slug]` + `/cafes/coffee/[id]` (PR #134) — Cafés tab uses text-only Light cards (no photo in `CafeSummary`); Coffees tab uses the same full-bleed photo-strip card as Coffee Library; inline edit panel restyled
+- `/login` + `/onboarding` (PR #135) — Light tokens throughout, Onboarding selectors use the `Chip` primitive
+- `/taste` (PR #136) — Light Header + burger, FlavorWheel radar now renders on cream, bar charts use anthracite fills on `foreground/10` tracks
+- `/loading` global state (PR #137) — Light CoffeeBeanGlow on inline cream bg so route transitions don't flash dark before LightShell mounts
 
-### Coffee Rotation marker ✅
-- DB column `coffees.in_rotation boolean default false` (migration 0009 — **applied on VPS**)
-- Star toggle on `/coffees/[id]` under the Brew-this button (optimistic PATCH)
-- Greeting prompt's library snapshot prefixes rotation entries with `★ IN ROTATION |`
-- New `ROTATION DISCIPLINE` block in the greeting system prompt — prefer rotation bags as the day's invitation
-- `/coffees` list does NOT yet surface the rotation marker visually (open item, see below)
+**Architectural fixes**
+- `/coffees/[id]` adopts its own Field via `useFieldConfig` (PR #123) — was only handing zones to flowStore for the brew flow, the detail page itself never painted in the cup's colours
+- `lib/field/cache.ts` (PR #125) — sessionStorage cache keyed by session id. `/coffees/[id]` pre-warms for all its sessions on load; `/brew/[id]` reads synchronously on mount. Removes the ~300 ms flash through default while the coffee fetch resolved
+- SessionCard rewrite (PR #120) — Brew-method as headline, recipe meta line (date · dose · water · time), Light flavor chips, swipe-to-delete fades in with swipe progress (PR #124) instead of bleeding through the translucent card at rest
+- Coffee Library card architecture (PRs #127, #132, #133) — full-bleed 96 px photo strip on the left (was a 56 px circular thumb with an unreadable 8 px count badge), brew count moves to the right column above the Brew CTA, both centered on the same vertical axis
+- Rotation gates the Brew CTA (PR #117) — out-of-rotation rows have no Brew shortcut; star indicator on rotation rows in the library list
+- Hero scrim flip on `/coffees/[id]` (PR #121) — cream-to-transparent instead of `.card-scrim`'s black-to-near-opaque (Dark utility) so anthracite titles stay legible on any bag photo
+- Brew session back goes to `/coffees/[coffeeId]` (PR #126) with `router.back()` as a fallback for legacy sessions whose `CoffeeIdentity` was persisted before `coffeeId` existed
 
-### Greeting Haiku — bug fixes
-- Time-of-day discipline added to the prompt (no more "Late night" at 18:44)
-- Library snapshot uses `formatLibraryForPrompt` (with usage signal) instead of bare roaster+name
-- localStorage cache keyed by `brewlog.starter.v4.<date>.<bucket>` — regenerates 5x per day at tod-bucket boundaries instead of once per calendar day
-- `/api/greeting` (src/app/api/greeting/route.ts) already passes time-of-day + library snapshot + rotation prefix
+**FlavorWheel Light (PRs #128–#131)**
+- Direct conversion (no theme prop). Canvas transparent; cream-glass panels; anthracite text + icons via `currentColor`. Whole-wedge tonal state — tapping a category darkens both rings together. Thin cream ring divider between inner and outer; stroke weights tuned to 0.8 / 0.5 viewport units to match the label typography weight.
 
-### Coffee Library Light migration ✅ (PR #102)
-`/coffees` + `/coffees/[id]` moved under `(light)` route group, all surfaces light-tokenised.
+**PWA chrome (PRs #113–#119)**
+- `themeColor: #D4B8C9` (soft mauve-pink) on viewport AND `manifest.json` — Android PWA + Safari URL bar tints mauve
+- `manifest.background_color: #F3E5DC` (cream) — Android splash matches the Field base, no black flash
+- `appleWebApp.statusBarStyle: "default"` (was `black-translucent`) — iOS PWA gets an opaque system status bar instead of the see-through one that exposed a hard color cut
+- `html { background-color: #F3E5DC }` — the canvas under the Field is now cream, so even if the gradient is thin at the very top pixels (status bar area extended under the webview via `viewportFit: cover`), no dark bleed-through
 
-### Nearby map ✅ (PR #101)
-`/cafes/map` is the new full-screen Map view (Leaflet, dark CartoCDN tiles). `NavigationOverlay` "Nearby" → `/cafes/map`; "Café Library" → `/cafes`. Original `/cafes` is the tabbed list (Cafés + Coffees), no Map tab any more.
+**Chip vocabulary unified (PR #126, #127)**
+- One static-tag style across SessionCard, `/coffees/[id]` (Bag notes + You taste), `/brew/[id]` flavor notes + Pill component, LightStepSummary, Café Library, Café detail: `px-3 py-1.5`, 12 px medium, `bg-light-card-default` + backdrop blur, anthracite text — matches the `Chip` primitive's default state used in `LightStepLog`.
 
-### Reference material
-- `lovable-v7/` — committed Lovable v7 export. **Excluded from Docker build context** via `.dockerignore` (PR #69). Used by humans when porting per-view content (card labels, footnote copy, exact section counts).
-
----
-
-## Light route inventory
-
-| Route | State |
-|---|---|
-| `/` (Home BTTS) | Light ✅ |
-| `/past-conversations` + `/past-conversations/[id]` | Light ✅ |
-| `/brew/new` | Light ✅ (cut-over PR #95) |
-| `/coffees` + `/coffees/[id]` | Light ✅ (PR #102) |
-| `/cafes` (tabbed list) | **Dark** ❌ |
-| `/cafes/map` (Nearby) | Dark intentionally — dark Carto tiles, full-screen map |
-| `/cafes/place/[slug]` | **Dark** ❌ |
-| `/cafes/coffee/[id]` | **Dark** ❌ |
-| `/brew/[id]` (session detail edit) | **Dark** ❌ |
-| `/taste` | **Dark** ❌ |
-| `/onboarding` | **Dark** ❌ |
-| `/login` | **Dark** ❌ |
-| `/library` (hub picker) | **Dark** ❌ (small, low traffic) |
+**Cleanup (PR #137)**
+- Deleted: `RadarChart.tsx` (orphan), Dark `Chip.tsx` (orphan), `BottomNav.tsx` (allowlist empty since #136)
+- Simplified: `ScrollContainer` (no allowlist, no nav-padding reserve), `loading.tsx` (Light + inline cream bg)
+- Dropped from globals.css: `--nav-bottom-padding` CSS var
+- Kept (still consumed): Dark `CoffeeBeanGlow` (via `PhotoUpload` + CSS shim), Dark `StarRating` (via `CafeMap` for the intentional-Dark map page)
 
 ---
 
-## Open punch list
+## Where files live now
 
-Roughly in priority order. Numbers are Markus' tentative ranking from earlier in this session.
+```
+src/
+├── app/
+│   ├── (light)/                ← Every visited route (LightShell wraps via layout.tsx)
+│   │   ├── page.tsx            ← Home BTTS
+│   │   ├── layout.tsx          ← LightShell
+│   │   ├── brew/
+│   │   │   ├── new/page.tsx    ← Brew flow step switcher
+│   │   │   └── [id]/page.tsx   ← Session detail (Light per #122)
+│   │   ├── coffees/
+│   │   │   ├── page.tsx        ← Library list (photo-strip cards)
+│   │   │   └── [id]/page.tsx   ← Coffee detail + rotation toggle
+│   │   ├── cafes/
+│   │   │   ├── page.tsx        ← Café Library (tabbed)
+│   │   │   ├── place/[slug]/   ← Single café + inline edit
+│   │   │   └── coffee/[id]/    ← Coffee tasted out
+│   │   ├── taste/page.tsx      ← Taste profile + FlavorWheel radar
+│   │   ├── login/page.tsx
+│   │   ├── onboarding/page.tsx
+│   │   └── past-conversations/
+│   ├── cafes/map/page.tsx      ← Only Dark route left (intentional)
+│   ├── loading.tsx             ← Light cream bg + Light bean
+│   ├── layout.tsx              ← Root: PWA meta + ScrollContainer
+│   ├── api/                    ← API routes
+│   └── globals.css             ← [data-light-scope] shims live here
+├── components/
+│   ├── flow/                   ← LightStep*.tsx (seven brew steps)
+│   ├── ui/
+│   │   ├── light/              ← Light primitives (LightShell, Field, Card,
+│   │   │                          Section, Footnote, Hero, CTA, CTAWarmth,
+│   │   │                          Chip, ActionPill, ChatInput, ChatThread,
+│   │   │                          NavigationOverlay, AttachmentSheet,
+│   │   │                          ReferenceCoffeePicker, StarRating,
+│   │   │                          CircularTimer, CoffeeBeanGlow)
+│   │   ├── FlavorWheel.tsx     ← Light palette in place (no fork)
+│   │   ├── PhotoUpload.tsx     ← Uses Dark CoffeeBeanGlow + CSS-shim invert
+│   │   ├── StarRating.tsx      ← Dark — only CafeMap consumes it
+│   │   └── …                   ← Shared neutrals (Button, NumberStepper, etc.)
+│   ├── layout/
+│   │   ├── ScrollContainer.tsx ← Root wrapper (100dvh + hidden scroll)
+│   │   └── BottomSpacer.tsx
+│   ├── cafes/CafeMap.tsx       ← Leaflet (used by /cafes/map only)
+│   └── session/SessionCard.tsx ← Light — only /coffees/[id] All-brews uses it
+├── lib/
+│   ├── field/                  ← v1.1 zones, types, defaultZones, schema,
+│   │                              composeGradient, FieldContext, mapNotesToZones,
+│   │                              cache.ts (NEW — session-id keyed Field hint)
+│   ├── claude/                 ← recommend.ts, analyzeBag.ts, escher.ts, …
+│   ├── db/                     ← schema.ts (Drizzle), helpers.ts (rowToCoffee),
+│   │                              migrations/00xx_*.sql
+│   └── types/                  ← coffee.ts, session.ts, cafes.ts, preferences.ts
+└── store/
+    └── flowStore.ts            ← Zustand brew flow state + fieldZones slot
+```
 
-1. **`/coffees` rotation indicator + filter** — list rows don't show the star yet; "Show only rotation" filter would make the list scannable
-2. **`/cafes` Light migration** — high-traffic, last big Library surface
-3. **`/cafes/place/[slug]` + `/cafes/coffee/[id]` Light** — small follow-ons after `/cafes`
-4. **`/taste` Light + RadarChart Light** — taste profile page with AI summary
-5. **FlavorWheel Light SVG** — currently Dark inside LightStepLog (jarring but rarely opened, deferred per the migration plan)
-6. **`/brew/[id]` Session Detail Light** — reached via SessionCard on /home + diary
-7. **Dark `Chip.tsx` removal** — once `/brew/[id]` is Light, the last Dark Chip consumer is gone
-8. **LightStepScan Card/Chip primitive refactor** — Markus flagged "many different chip and card designs" earlier; refactor StepScan's custom buttons through the Card + Chip primitives
-9. **Aromatic Goal validation** — PR #72 added the aromatic intent to `/api/recommend` but per CLAUDE.md hard rule it needs sample-validation. Markus said "Yes Go" but never explicitly tested recipe outputs. Run 2–3 test brews with goal "Aromatic / Floral" on a delicate coffee (Geisha, Wush Wush, Pink Bourbon) and compare to "Bright / Clarity" on the same bag
+---
+
+## Open items
+
+Roughly in priority order:
+
+1. **`/coffees` "Show only rotation" filter** — list shows the star indicator (#117) but no filter toggle. A 4th pill alongside Recent / Favorites / Roaster, or a sub-toggle. Small, scoped.
+2. **`LightStepScan` Card/Chip refactor** — 1400 lines with bespoke buttons that should route through the `Card` + `Chip` primitives. Code quality only; no visible UX change. Big diff, low risk.
+3. **Aromatic Goal validation** — PR #72 added the intent to `/api/recommend`. Per the Hard Rule on AI behavior changes (CLAUDE.md), it needs sample-before/after on the deployed PWA against a delicate coffee (Geisha, Wush Wush, Pink Bourbon). Markus said "Yes Go" but never explicitly tested recipe outputs.
 
 ---
 
 ## Pitfalls discovered (don't re-learn these)
 
+- **iOS PWA caches `apple-mobile-web-app-status-bar-style` at install time.** Changing the meta tag does not update an already-installed PWA on iPhone. The user has to delete the PWA from the home screen AND clear Safari → Advanced → Website Data for the domain, then re-install. The same applies to `theme_color` on installed Android PWAs in some browsers — Service Workers can cache `manifest.json` (precached with revision hash) so a fresh manifest doesn't reach the chrome until the SW updates.
+- **Tailwind only scans `src/{app,components,pages}`.** `src/lib/**` is NOT in `tailwind.config.ts` `content`. Utility classes that live only in lib (e.g. arbitrary-value classes like `bg-[linear-gradient(...)]`) are silently never generated and vanish at runtime. If you need a shared visual constant in lib, export it as a raw CSS value and apply via inline `style={{ background: ... }}` at the call site (see `src/lib/theme/gradients.ts`).
+- **html canvas default.** `html { background-color: #F3E5DC }` (cream). `body { background-color: #0E0B0A }` by default, dropped to `transparent` only when `body:has([data-light-scope="true"])` matches. Light routes therefore show the cream canvas behind the Field; the legacy Dark `cafes/map` keeps its dark body. Loading state explicitly sets `background: #F3E5DC` inline because it renders BEFORE LightShell mounts.
 - **Next.js standalone Docker image** does NOT expose `@anthropic-ai/sdk` as `node_modules/@anthropic-ai`. Backfill script started failing with `ERR_MODULE_NOT_FOUND` until rewritten to call the Messages API over plain `fetch`. `pg` IS in standalone deps (traced via Drizzle).
-- **`lovable-v7/` must be in `.dockerignore`**. Without it the Docker `COPY . .` drags the Vite-targeted Lovable export into the build context and Next.js's worker tries to compile it → `react-router-dom not found` → deploy fails. Fix in PR #69.
-- **Drizzle SELECT * is column-strict.** Adding `coffees.in_rotation` to the schema BEFORE running the SQL migration on the VPS made `/api/coffees` 500 with "column in_rotation does not exist". Coffee Library appeared empty (Markus' bug report between PR #97 and #99). Migrations must be applied to the DB BEFORE the schema/code that references them deploys.
+- **`lovable-v7/` must be in `.dockerignore`.** Without it the Docker `COPY . .` drags the Vite-targeted Lovable export into the build context and Next.js's worker tries to compile it → `react-router-dom not found` → deploy fails (PR #69).
+- **Drizzle SELECT * is column-strict.** Adding a column to the schema BEFORE running the SQL migration on the VPS makes `/api/coffees` 500 with "column does not exist". Migrations must be applied to the DB BEFORE the schema/code that references them deploys.
 - **`min-h-full flex flex-col` does not give children definite height.** `flex-1` inside collapses to 0. Leaflet container needed `h-dvh flex flex-col` + `flex-1 min-h-0` (PR #101).
-- **The `[data-light-scope]` CSS shim** in globals.css catches inline `var(--card)` etc. for un-migrated components inside the Light tree — but NOT hardcoded hex values like `#2A241C`. Those need explicit Light tokens at the source.
-- **CSS `filter: brightness(0)` under `[data-light-scope]`** is the trick used to invert hardcoded-white SVGs (BrewMethodIcon assets, original CoffeeBeanGlow) without forking the components.
+- **The `[data-light-scope]` CSS shim** in `globals.css` catches inline `var(--card)` etc. for un-migrated components inside the Light tree — but NOT hardcoded hex values like `#2A241C`. Those need explicit Light tokens at the source.
+- **CSS `filter: brightness(0)` under `[data-light-scope]`** is the trick used to invert hardcoded-white SVGs (`BrewMethodIcon` assets, original `CoffeeBeanGlow`) without forking the components.
 - **localStorage starter cache.** Versioned key `brewlog.starter.v4.<date>.<bucket>`. Bumping the version is the canonical invalidation. If you change the greeting prompt, bump the cache to `v5`.
 - **Hard Rule on AI behavior changes.** Any prompt / model / schema-enum change to `/api/recommend`, `/api/greeting`, `/api/match`, etc. needs sample-before-after outputs per `CLAUDE.md`. Cannot validate from this remote env — Markus runs on the deployed PWA.
 - **Auto-deploy** is GitHub Actions → SSH → Hetzner (`.github/workflows/deploy.yml`). Direct push to `main` blocked; PR-only workflow with `enable_pr_auto_merge` (mergeMethod SQUASH).
@@ -95,76 +133,25 @@ Roughly in priority order. Numbers are Markus' tentative ranking from earlier in
 
 ---
 
-## Where files live
-
-```
-src/
-├── app/
-│   ├── (light)/                ← Light route group (LightShell wraps these)
-│   │   ├── page.tsx            ← Home BTTS
-│   │   ├── layout.tsx          ← Wraps in LightShell
-│   │   ├── brew/new/page.tsx   ← Brew flow step switcher
-│   │   ├── coffees/
-│   │   │   ├── page.tsx        ← Library list
-│   │   │   └── [id]/page.tsx   ← Coffee detail
-│   │   └── past-conversations/
-│   ├── api/                    ← API routes (greeting, analyze-bag, recommend, etc.)
-│   ├── cafes/                  ← Dark — list, map, place, coffee
-│   ├── brew/[id]/              ← Dark session detail
-│   ├── taste/                  ← Dark taste profile
-│   ├── login/, onboarding/, library/
-│   └── globals.css             ← [data-light-scope] shims live here
-├── components/
-│   ├── flow/                   ← LightStep*.tsx (the seven brew steps)
-│   ├── ui/
-│   │   ├── light/              ← Light primitives (Card, Section, Footnote, Hero,
-│   │   │                          CTA, CTAWarmth, Chip, LightFlowShell, LightShell,
-│   │   │                          Field, StarRating, CircularTimer, CoffeeBeanGlow,
-│   │   │                          ActionPill, ChatInput, ChatThread,
-│   │   │                          NavigationOverlay, AttachmentSheet,
-│   │   │                          ReferenceCoffeePicker)
-│   │   └── *.tsx               ← Dark primitives still consumed by Dark routes
-│   ├── cafes/CafeMap.tsx       ← Leaflet map (used by /cafes/map)
-│   └── session/SessionCard.tsx ← Dark — used on /home diary feed
-├── lib/
-│   ├── field/                  ← v1.1 zones, types, defaultZones, schema,
-│   │                              composeGradient, FieldContext, mapNotesToZones
-│   ├── claude/                 ← recommend.ts, analyzeBag.ts, escher.ts, etc.
-│   ├── db/                     ← schema.ts (Drizzle), helpers.ts (rowToCoffee),
-│   │                              migrations/0008_add_field_zones.sql,
-│   │                              migrations/0009_add_in_rotation.sql
-│   └── types/                  ← coffee.ts, session.ts, cafes.ts, preferences.ts
-└── store/
-    └── flowStore.ts            ← Zustand brew flow state + fieldZones slot
-
-scripts/
-├── backfill-field-zones.mjs    ← v1.1 Phase 5 — already ran on prod (23/23)
-└── (existing migrate-/seed- scripts)
-
-lovable-v7/                     ← Read-only design reference, .dockerignore'd
-specs/                          ← design-system-v1.0.md, v1.1-generative-field.md
-docs/                           ← coffee-experts.md (mirror of lib/knowledge),
-                                    grind-settings.md
-```
-
----
-
 ## Conventions cheat sheet
 
 - **Tokens:** `text-light-foreground` (anthracite), `text-light-muted-foreground`, `bg-light-card-default` (cream glass), `bg-light-card-selected` (warm taupe), `border-light-foreground/15`, `shadow-light-card-pressed`
 - **Cream highlight on dark elements:** `text-[hsl(36_55%_96%)]` (e.g. CTA text on anthracite button)
+- **Destructive (delete, error):** `bg-[hsl(12_70%_45%)]` warm rust — used by SessionCard swipe-delete + brew-session delete confirm modal
 - **Hero question:** `font-fraunces font-semibold text-[40px] leading-[1.05] tracking-[-0.01em]`
-- **Eyebrow:** `.label-eyebrow` utility (Chivo 11/600 uppercase tracked 0.14em)
-- **Field rotation per step:** see `STEP_ROTATION` map in LightFlowShell.tsx
+- **Headline (route title):** `font-fraunces text-3xl text-light-foreground leading-none`
+- **Eyebrow:** uppercase tracked, `text-light-muted-foreground text-xs tracking-widest`
+- **Unified chip / tag:** `inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground`
+- **Field rotation per brew step:** see `STEP_ROTATION` map in `LightFlowShell.tsx`
 - **Light scope marker:** `[data-light-scope]` attribute set by LightShell wraps everything in the (light) route group. Use it for CSS rules that should ONLY apply to Light routes.
 
 ---
 
-## Live state on VPS (verified)
+## Live state on VPS (verified 2026-05)
 
 ```
 sessions          → indexed feed table
-coffees           → 23 rows, all with field_zones populated (Phase 5 done)
+coffees           → 23 rows, all with field_zones populated
 coffees.in_rotation column exists (migration 0009 applied)
 places            → 6,202 rows (manual bulk load, no Git seed)
 preferences       → user equipment + grinder + location
@@ -179,8 +166,8 @@ conversations + conversation_messages → BTTS chat history
 
 ## Where to start next session
 
-Ask Markus what's on the punch list. Most likely candidates: `/cafes` Light migration (#2 above) or `/taste` Light (#4). Both are scoped similarly — single-page refactors with the same sed-driven token mapping pattern used for `/coffees`.
+Light migration is closed. Most likely next moves: (1) Rotation filter on `/coffees`, (2) `LightStepScan` refactor for code quality, (3) Aromatic Goal validation on the deployed PWA. Any of these is scoped enough for a single session.
 
-Before any prompt changes to `/api/greeting`, `/api/recommend`, etc.: read the **Hard Rule on AI behaviour changes** in CLAUDE.md. Sample real outputs on the deployed PWA — Markus will validate.
+Before any prompt change to `/api/greeting`, `/api/recommend`, etc.: read the **Hard Rule on AI behaviour changes** in CLAUDE.md. Sample real outputs on the deployed PWA — Markus validates.
 
-Read **`CLAUDE.md`** as the persistent context, this file only for the in-flight state.
+Read **`CLAUDE.md`** as the persistent context; this file only for the in-flight state.


### PR DESCRIPTION
## Summary

Both docs were anchored in mid-migration assumptions and listed Dark routes that have since shipped to Light. Updates them to the post-#137 state.

### `CLAUDE.md`

- **Pages table**: intro flipped from "routes split between (light) and legacy Dark" to "Light is complete, single Dark route left is `/cafes/map` (intentional)". New `(light)` entries: `brew/[id]`, `cafes`, `cafes/place/[slug]`, `cafes/coffee/[id]`, `taste`, `login`, `onboarding`. `loading.tsx` added. `library/page.tsx` listed in removed-routes section.
- **Dark UI primitives**: dropped `Chip` + `RadarChart` (deleted). `FlavorWheel` reclassified — no longer Dark, Light palette in place. `StarRating` noted as `CafeMap`-only. Explicit callout of components removed in the cleanup pass.
- **Layout**: `BottomNav` removed. `ScrollContainer` described as "root 100 dvh wrapper, no allowlist".
- **SessionCard**: Dark → Light, consumer is `/coffees/[id]` All-brews.
- **`src/lib/field/` tree**: `cache.ts` entry added with the pre-warm / synchronous-read behaviour spelled out.
- **Current Status — Snapshot**: largely rewritten — "BTTS Light migration — complete", cleanup block (#137), PWA chrome alignment (#113–#119), UI polish (chip unification, library card photo-fullbleed, rotation gating, hero cream scrim, SessionCard rewrite, Brew session back, Field cache), FlavorWheel Light palette (#128–#131).
- **Open items**: trimmed from 9 to 3 — only the genuinely-open work remains (rotation filter, LightStepScan refactor, Aromatic Goal validation).

### `HANDOVER.md` — full rewrite

File used to be "mid-migration in-flight state". Now reads as "migration is closed; here's what shipped, where files live, what's open, the pitfalls we found":

1. Headline: Light migration is done
2. What shipped this arc (PRs #113–#137) split into routes / architectural fixes / FlavorWheel / PWA chrome / chip unification / cleanup
3. Updated file-tree map — single Dark route called out, `cache.ts` noted, BottomNav removed, SessionCard relabelled Light
4. Open items (same 3 from CLAUDE.md)
5. Pitfalls section expanded — added iOS PWA status-bar caching and the html canvas default rule (both bit us this arc), plus the Tailwind lib-scan trap
6. Conventions cheat sheet picks up the destructive rust token, the headline pattern, the unified chip class string
7. Live VPS state unchanged
8. "Where to start next session" rewritten — migration is no longer the obvious next move

## Test plan

- [ ] Read CLAUDE.md and HANDOVER.md cold. Mentally simulate a new Claude session picking these up — would it know that `/cafes` is Light, where the Field cache lives, why `/cafes/map` is still Dark?
- [ ] Verify the route table matches the actual `src/app/` filesystem (single `(light)/` group + `cafes/map/` Dark + `loading.tsx`).

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_