### PR TITLE
fix: login wordmark + CTA pills + session card transparency

### DIFF
--- a/src/app/(light)/login/page.tsx
+++ b/src/app/(light)/login/page.tsx
@@ -157,7 +157,9 @@ export default function LoginPage() {
     return (
       <div className="min-h-svh bg-transparent flex flex-col items-center justify-center gap-6">
         <CoffeeBeanGlow size={72} />
-        <p className="font-fraunces text-light-foreground/50 text-sm tracking-widest uppercase">BrewLog</p>
+        <p className="font-fraunces text-light-foreground/60 text-lg leading-tight text-center whitespace-pre-line">
+          {"Better taste\nthan sorry."}
+        </p>
       </div>
     );
   }
@@ -168,7 +170,9 @@ export default function LoginPage() {
       <div className="min-h-svh bg-transparent flex flex-col items-center justify-center px-8 gap-10">
         <div className="flex flex-col items-center gap-4">
           <CoffeeBeanGlow size={56} />
-          <p className="font-fraunces text-light-foreground/50 text-sm tracking-widest uppercase">BrewLog</p>
+          <p className="font-fraunces text-light-foreground/60 text-lg leading-tight text-center whitespace-pre-line">
+            {"Better taste\nthan sorry."}
+          </p>
         </div>
 
         <div className="w-full max-w-xs flex flex-col gap-4">
@@ -186,7 +190,7 @@ export default function LoginPage() {
           <button
             onClick={handlePin}
             disabled={pin.length < 4 || working}
-            className="w-full py-4 rounded-2xl bg-light-foreground text-[hsl(36_55%_96%)] font-semibold text-base disabled:opacity-40 active:scale-[0.98] transition-transform"
+            className="w-full h-14 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] font-semibold text-base disabled:opacity-40 active:scale-[0.98] transition-transform"
           >
             {working ? "Checking…" : "Unlock"}
           </button>
@@ -213,7 +217,9 @@ export default function LoginPage() {
     <div className="min-h-svh bg-transparent flex flex-col items-center justify-center px-8 gap-10">
       <div className="flex flex-col items-center gap-4">
         <CoffeeBeanGlow size={72} />
-        <p className="font-fraunces text-light-foreground/50 text-sm tracking-widest uppercase">BrewLog</p>
+        <p className="font-fraunces text-light-foreground/60 text-lg leading-tight text-center whitespace-pre-line">
+          {"Better taste\nthan sorry."}
+        </p>
       </div>
 
       <div className="w-full max-w-xs flex flex-col gap-4">
@@ -225,7 +231,7 @@ export default function LoginPage() {
           <button
             onClick={handleRegister}
             disabled={working}
-            className="w-full py-5 rounded-2xl bg-light-foreground text-[hsl(36_55%_96%)] font-semibold text-base flex items-center justify-center gap-3 active:scale-[0.98] transition-transform disabled:opacity-60"
+            className="w-full h-14 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] font-semibold text-base flex items-center justify-center gap-3 active:scale-[0.98] transition-transform disabled:opacity-60"
           >
             {working ? <Spinner /> : <FaceIDIcon />}
             {working ? "Setting up…" : "Set up Face ID"}
@@ -234,7 +240,7 @@ export default function LoginPage() {
           <button
             onClick={triggerFaceID}
             disabled={working}
-            className="w-full py-5 rounded-2xl bg-light-foreground text-[hsl(36_55%_96%)] font-semibold text-base flex items-center justify-center gap-3 active:scale-[0.98] transition-transform disabled:opacity-60"
+            className="w-full h-14 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] font-semibold text-base flex items-center justify-center gap-3 active:scale-[0.98] transition-transform disabled:opacity-60"
           >
             {working ? <Spinner /> : <FaceIDIcon />}
             {working ? "Verifying…" : "Use Face ID"}

--- a/src/components/session/SessionCard.tsx
+++ b/src/components/session/SessionCard.tsx
@@ -71,7 +71,7 @@ export default function SessionCard({ session, onDeleted }: SessionCardProps) {
   const swipeProgress = Math.min(offset / DELETE_THRESHOLD, 1);
 
   return (
-    <div className="relative overflow-hidden rounded-2xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15">
+    <div className="relative overflow-hidden rounded-2xl bg-[hsl(36_55%_96%/0.30)] backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15">
       {/* Delete button behind — hidden at rest, fades in during swipe */}
       <div
         className="absolute inset-y-0 right-0 flex items-stretch rounded-r-2xl overflow-hidden"
@@ -105,7 +105,7 @@ export default function SessionCard({ session, onDeleted }: SessionCardProps) {
           if (isOpen) { setOffset(0); return; }
           router.push(`/brew/${session.id}`);
         }}
-        className="relative bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 rounded-2xl px-4 py-3.5 cursor-pointer active:scale-[0.99] transition-transform"
+        className="relative bg-[hsl(36_55%_96%/0.30)] backdrop-blur-light-card backdrop-saturate-150 rounded-2xl px-4 py-3.5 cursor-pointer active:scale-[0.99] transition-transform"
       >
         {/* Headline row — brew method + rating */}
         <div className="flex items-start justify-between gap-3">


### PR DESCRIPTION
## Summary

Three small fixes from the screenshots:

1. **`/login` wordmark** — now `"Better taste\nthan sorry."` in Fraunces at `text-lg` with `whitespace-pre-line` so the second line breaks cleanly under the first. Replaces the old `BREWLOG` all-caps eyebrow which read as a placeholder.
2. **`/login` Face ID / Verifying / Unlock / Set up CTAs** — swapped from `rounded-2xl` (16 px corner radius) to `rounded-full` with a fixed `h-14`, matching the `/onboarding` Next + Start Brewing buttons. The rectangle-with-soft-corners read as a form button on a page that's otherwise editorial — the pill shape sits closer to the Light system's CTA vocabulary.
3. **SessionCard transparency** on `/coffees/[id]` All Brews — chips inside the card used `bg-light-card-default` (55 % cream), card itself also `bg-light-card-default`. Cream-on-cream lost contrast ("white on white" per the screenshot). Fixed by dropping the card to `bg-[hsl(36 55% 96% / 0.30)]` (30 % cream) while keeping chips at 55 %. The relative opacity gap creates the visual differentiation, and the Field gradient now shows through the card body like the rest of the Light system's cards-on-Field stack.

## Test plan

- [ ] `/login` cold launch: wordmark reads "Better taste / than sorry." in Fraunces, two lines.
- [ ] All `/login` primary CTAs are pill-shaped (full radius), not rounded rectangles.
- [ ] `/coffees/[id]` All Brews: each session card looks visibly more translucent than before, with the Field showing through. Flavor chips inside read clearly with daylight separation between card surface and chip.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_