### PR TITLE
fix: login wordmark matches home hero (Fraunces 3xl)

### DIFF
--- a/src/app/(light)/login/page.tsx
+++ b/src/app/(light)/login/page.tsx
@@ -157,9 +157,9 @@ export default function LoginPage() {
     return (
       <div className="min-h-svh bg-transparent flex flex-col items-center justify-center gap-6">
         <CoffeeBeanGlow size={72} />
-        <p className="font-fraunces text-light-foreground/60 text-lg leading-tight text-center whitespace-pre-line">
-          {"Better taste\nthan sorry."}
-        </p>
+        <h1 className="font-fraunces text-3xl leading-[1.05] text-light-foreground text-center">
+          Better taste<br />than sorry.
+        </h1>
       </div>
     );
   }
@@ -217,9 +217,9 @@ export default function LoginPage() {
     <div className="min-h-svh bg-transparent flex flex-col items-center justify-center px-8 gap-10">
       <div className="flex flex-col items-center gap-4">
         <CoffeeBeanGlow size={72} />
-        <p className="font-fraunces text-light-foreground/60 text-lg leading-tight text-center whitespace-pre-line">
-          {"Better taste\nthan sorry."}
-        </p>
+        <h1 className="font-fraunces text-3xl leading-[1.05] text-light-foreground text-center">
+          Better taste<br />than sorry.
+        </h1>
       </div>
 
       <div className="w-full max-w-xs flex flex-col gap-4">


### PR DESCRIPTION
## Summary

Home renders the BTTS wordmark as:

```jsx
<h1 className="font-fraunces text-3xl leading-[1.05] text-light-foreground">
  Better taste<br />than sorry.
</h1>
```

Login was using a smaller `text-lg` Fraunces with `text-light-foreground/60` muted opacity — looked like a subtitle, not the wordmark. Unifying to the Home `<h1>` styling: Fraunces 3xl, leading 1.05, full anthracite, with the same `<br />` hard break so the layout reads as the same brand statement at every entry point.

Applied to all three Login states (loading, PIN entry, Face ID).

## Test plan

- [ ] `/login` loading + Face ID + PIN states: the wordmark reads exactly like the Home hero — same font weight, same size, full anthracite, line break between the two halves.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_