### PR TITLE
fix: cafe coffees link to library when bag is in the library

### DIFF
--- a/src/app/(light)/cafes/page.tsx
+++ b/src/app/(light)/cafes/page.tsx
@@ -154,7 +154,14 @@ export default function CafesPage() {
           <CoffeesTab
             coffees={cafeCoffees}
             loading={sessionsLoading}
-            onSelect={key => router.push(`/cafes/coffee/${key}`)}
+            onSelect={(key, coffeeId) => {
+              // Prefer the Coffee Library detail page when the bag has
+              // a library row (coffeeId set on the persisted CoffeeIdentity).
+              // Falls back to the cafe-only synthetic detail for coffees
+              // that were tasted out but never logged at home.
+              if (coffeeId) router.push(`/coffees/${coffeeId}`);
+              else router.push(`/cafes/coffee/${key}`);
+            }}
           />
         )}
       </div>
@@ -226,7 +233,7 @@ function CafesTab({ cafes, loading, onSelect }: { cafes: CafeSummary[]; loading:
 
 /* ── Coffees tab — Coffee-Library-style cards with full-bleed photo on left ── */
 
-function CoffeesTab({ coffees, loading, onSelect }: { coffees: CafeCoffee[]; loading: boolean; onSelect: (key: string) => void }) {
+function CoffeesTab({ coffees, loading, onSelect }: { coffees: CafeCoffee[]; loading: boolean; onSelect: (key: string, coffeeId: string | undefined) => void }) {
   if (loading) return <LoadingSkeletons />;
   if (coffees.length === 0) return (
     <EmptyState
@@ -249,7 +256,7 @@ function CoffeesTab({ coffees, loading, onSelect }: { coffees: CafeCoffee[]; loa
           >
             <button
               type="button"
-              onClick={() => onSelect(key)}
+              onClick={() => onSelect(key, coffee.coffeeId)}
               className="flex items-stretch flex-1 min-w-0 text-left active:opacity-80 transition-opacity"
             >
               {/* Photo strip — full card height, same dimensions as the


### PR DESCRIPTION
## Summary

Reverts PR #134's blanket routing of `/cafes` Coffees tab to `/cafes/coffee/${key}`. When you tap a coffee you've brewed both at home **and** at a café, you expect the Library detail page (with Field, rotation toggle, all-brews list) — not the café-only aggregate that filters by synthetic `roaster__name` key.

## New logic

```ts
if (coffee.coffeeId) router.push(`/coffees/${coffeeId}`);
else                 router.push(`/cafes/coffee/${key}`);
```

`CoffeeIdentity` already carries an optional `coffeeId` on every session persisted after the coffees table existed. Café-only coffees that were tasted out but never logged at home have no `coffeeId` — they still land on the café-specific aggregate (which exists exactly for this case).

`CoffeesTab` `onSelect` signature widened to take `(key, coffeeId)` so the click handler picks the right destination without re-deriving it from the synthetic key.

## Test plan

- [ ] Open `/cafes` → Coffees tab → tap a coffee you've **also** brewed at home → lands on `/coffees/[coffeeId]` (Coffee Library detail).
- [ ] Tap a coffee you've **only** tasted at a café → lands on `/cafes/coffee/[synthetic_key]` (cafe-aggregate detail).
- [ ] Both routes back-link cleanly to `/cafes?tab=coffees`.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_