### PR TITLE
fix: scan edit rows visibly editable + always available

### DIFF
--- a/src/components/flow/LightStepScan.tsx
+++ b/src/components/flow/LightStepScan.tsx
@@ -487,12 +487,13 @@ export default function LightStepScan() {
                     <span className="label-eyebrow" style={{ color: "var(--muted-foreground)" }}>Identified</span>
                     <span className="text-xs" style={{ color: "var(--muted-foreground)" }}>Tap to correct</span>
                   </div>
-                  {draft.coffee.roaster !== undefined && (
-                    <EditableRow label="Roaster" value={draft.coffee.roaster || ""} onChange={v => setCoffee({ roaster: v })} suggestions={existingRoasters} />
-                  )}
-                  {draft.coffee.name !== undefined && (
-                    <EditableRow label="Coffee" value={draft.coffee.name || ""} onChange={v => setCoffee({ name: v })} />
-                  )}
+                  {/* Roaster + Coffee always shown so the user can shorten
+                      a long name (e.g. "El Congo by Carlos Montero – Don
+                      Eli" → "El Congo") or add a missing roaster on a
+                      photo-extracted bag. Both rows are tap-to-edit and
+                      now show a pencil icon to advertise that. */}
+                  <EditableRow label="Roaster" value={draft.coffee.roaster || ""} onChange={v => setCoffee({ roaster: v })} suggestions={existingRoasters} />
+                  <EditableRow label="Coffee" value={draft.coffee.name || ""} onChange={v => setCoffee({ name: v })} />
                   {draft.coffee.origin !== undefined && (
                     <EditableRow
                       label="Origin"
@@ -1398,8 +1399,20 @@ function EditableRow({ label, value, onChange, suggestions }: { label: string; v
       className="w-full flex items-baseline justify-between gap-4 group text-left"
     >
       <span className="text-light-muted-foreground text-sm shrink-0">{label}</span>
-      <span className="text-light-foreground text-sm text-right group-active:text-light-foreground transition-colors underline underline-offset-2 decoration-white/20">
-        {value || <span className="text-light-muted-foreground italic">tap to add</span>}
+      <span className="flex items-baseline gap-1.5 text-right min-w-0">
+        <span className="text-light-foreground text-sm group-active:text-light-foreground transition-colors underline underline-offset-2 decoration-light-foreground/30 truncate">
+          {value || <span className="text-light-muted-foreground italic">tap to edit</span>}
+        </span>
+        <svg
+          className="w-3 h-3 shrink-0 text-light-muted-foreground/60"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={1.5}
+          aria-hidden
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125" />
+        </svg>
       </span>
     </button>
   );


### PR DESCRIPTION
## Summary

Your feedback: *"Kaffee-Namen anpassen/kürzen — Ich müsste in der Lage sein, dass bei Scan anzupassen."*

The infrastructure was already there (`EditableRow` component, tap-to-edit with inline input), but the affordance was invisible in practice:

1. **Underline decoration was invisible.** `decoration-white/20` (white at 20 % opacity) on a cream card → effectively no underline. Switched to `decoration-light-foreground/30` (anthracite at 30 %) so the underline reads against the Light surface.
2. **No edit icon.** Added a small pencil glyph (same icon used by the café-detail session edit button) on the right edge of each row. Value text and icon share a baseline; value truncates if long so the icon stays in frame for very long names like "El Congo by Carlos Montero – Don Eli".
3. **Roaster + Coffee rows were conditional on `!== undefined`.** If the AI extraction returned no key for either, the row didn't render and the user couldn't add one. Both rows now **always show** — empty value falls back to the italic "tap to edit" placeholder.

Placeholder copy `tap to add` → `tap to edit` since the rows now appear with extracted values too — `edit` covers both add-from-empty and shorten-existing.

## Test plan

- [ ] Scan a bag with a long coffee name (e.g. "El Congo by Carlos Montero – Don Eli") → the Coffee row shows the extracted name with a visible underline + pencil icon on the right.
- [ ] Tap the row → input opens prefilled with the long name → edit to "El Congo" → blur → row reads the shortened name.
- [ ] Same flow for Roaster ("RVTC – Rösterei Vier / The Commonage" → "RVTC").
- [ ] Bag where AI extracted no roaster: Roaster row still appears with "tap to edit" placeholder → user can add manually.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_