### PR TITLE
feat: orea v4 — 4 bottom variants with distinct icons

### DIFF
--- a/public/brew-icons/orea-apex.svg
+++ b/public/brew-icons/orea-apex.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Orea V4 Apex (Conical) — outer rim + 8 inward-pointing triangular teeth + open center -->
+  <circle cx="50" cy="50" r="42" />
+  <g transform="rotate(0 50 50)"><polygon points="84,46 84,54 70,50" /></g>
+  <g transform="rotate(45 50 50)"><polygon points="84,46 84,54 70,50" /></g>
+  <g transform="rotate(90 50 50)"><polygon points="84,46 84,54 70,50" /></g>
+  <g transform="rotate(135 50 50)"><polygon points="84,46 84,54 70,50" /></g>
+  <g transform="rotate(180 50 50)"><polygon points="84,46 84,54 70,50" /></g>
+  <g transform="rotate(225 50 50)"><polygon points="84,46 84,54 70,50" /></g>
+  <g transform="rotate(270 50 50)"><polygon points="84,46 84,54 70,50" /></g>
+  <g transform="rotate(315 50 50)"><polygon points="84,46 84,54 70,50" /></g>
+</svg>

--- a/public/brew-icons/orea-classic.svg
+++ b/public/brew-icons/orea-classic.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Orea V4 Classic bottom — outer brewer rim + central plate with cross-shaped flow slots -->
+  <circle cx="50" cy="50" r="42" />
+  <circle cx="50" cy="50" r="20" />
+  <line x1="50" y1="38" x2="50" y2="46" stroke-width="4" />
+  <line x1="50" y1="54" x2="50" y2="62" stroke-width="4" />
+  <line x1="38" y1="50" x2="46" y2="50" stroke-width="4" />
+  <line x1="54" y1="50" x2="62" y2="50" stroke-width="4" />
+</svg>

--- a/public/brew-icons/orea-fast.svg
+++ b/public/brew-icons/orea-fast.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Orea V4 Fast (Flat) — outer rim + inner ring + 8 short radial bars between them -->
+  <circle cx="50" cy="50" r="42" />
+  <circle cx="50" cy="50" r="18" />
+  <g stroke-width="3" stroke-linecap="round">
+    <g transform="rotate(0 50 50)"><line x1="50" y1="22" x2="50" y2="32" /></g>
+    <g transform="rotate(45 50 50)"><line x1="50" y1="22" x2="50" y2="32" /></g>
+    <g transform="rotate(90 50 50)"><line x1="50" y1="22" x2="50" y2="32" /></g>
+    <g transform="rotate(135 50 50)"><line x1="50" y1="22" x2="50" y2="32" /></g>
+    <g transform="rotate(180 50 50)"><line x1="50" y1="22" x2="50" y2="32" /></g>
+    <g transform="rotate(225 50 50)"><line x1="50" y1="22" x2="50" y2="32" /></g>
+    <g transform="rotate(270 50 50)"><line x1="50" y1="22" x2="50" y2="32" /></g>
+    <g transform="rotate(315 50 50)"><line x1="50" y1="22" x2="50" y2="32" /></g>
+  </g>
+</svg>

--- a/public/brew-icons/orea-open.svg
+++ b/public/brew-icons/orea-open.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Orea V4 Open bottom — clean donut, large unobstructed center for fastest flow -->
+  <circle cx="50" cy="50" r="42" />
+  <circle cx="50" cy="50" r="24" />
+</svg>

--- a/src/components/ui/BrewMethodIcon.tsx
+++ b/src/components/ui/BrewMethodIcon.tsx
@@ -10,7 +10,16 @@ export function brewIconSrc(method?: string): string {
   if (m.includes("kalita"))                                     return "/brew-icons/kalita.png";
   if (m.includes("chemex"))                                     return "/brew-icons/chemex.svg";
   if (m.includes("clever"))                                     return "/brew-icons/clever-dripper.png";
-  if (m.includes("orea"))                                       return "/brew-icons/orea-v4.png";
+  // Orea V4 — four bottom variants share the same brewer body but
+  // visually differ from above. Each gets a top-down filter-plate
+  // icon. Legacy sessions whose method was just "Orea V4 Wide" or
+  // "Orea" with no bottom keyword fall through to Classic.
+  if (m.includes("orea")) {
+    if (m.includes("open")) return "/brew-icons/orea-open.svg";
+    if (m.includes("apex")) return "/brew-icons/orea-apex.svg";
+    if (m.includes("fast")) return "/brew-icons/orea-fast.svg";
+    return "/brew-icons/orea-classic.svg";
+  }
   if (m.includes("moccamaster") || m.includes("mocca"))         return "/brew-icons/moccamaster.png";
   return "/brew-icons/v60.png";
 }

--- a/src/lib/constants/brewMethods.ts
+++ b/src/lib/constants/brewMethods.ts
@@ -12,7 +12,15 @@ export interface BrewMethod {
 export const BREW_METHODS: BrewMethod[] = [
   { id: "v60", label: "V60", emoji: "☕", defaultTemp: 98, defaultDose: 23, defaultWater: 350, defaultTimeSec: 210, category: "pour-over" },
   { id: "v60-drip-assist", label: "V60 + Drip Assist", emoji: "☕", defaultTemp: 98, defaultDose: 34, defaultWater: 520, defaultTimeSec: 240, category: "pour-over" },
-  { id: "orea", label: "Orea V4", emoji: "⬡", defaultTemp: 94, defaultDose: 17, defaultWater: 270, defaultTimeSec: 150, category: "pour-over" },
+  // Orea V4 — same brewer body, four interchangeable bottoms. Each
+  // bottom changes flow rate dramatically (Apex most restrictive →
+  // Open fastest), so each gets its own picker entry + icon. Defaults
+  // skew with the bottom's character: Apex / Classic target clarity-
+  // forward dialing, Open / Fast push faster contact time.
+  { id: "orea-classic", label: "Orea Classic", emoji: "⬡", defaultTemp: 94, defaultDose: 17, defaultWater: 270, defaultTimeSec: 150, category: "pour-over" },
+  { id: "orea-open",    label: "Orea Open",    emoji: "⬡", defaultTemp: 94, defaultDose: 17, defaultWater: 270, defaultTimeSec: 140, category: "pour-over" },
+  { id: "orea-apex",    label: "Orea Apex",    emoji: "⬡", defaultTemp: 95, defaultDose: 17, defaultWater: 255, defaultTimeSec: 165, category: "pour-over" },
+  { id: "orea-fast",    label: "Orea Fast",    emoji: "⬡", defaultTemp: 93, defaultDose: 17, defaultWater: 270, defaultTimeSec: 140, category: "pour-over" },
   { id: "origami-cone", label: "Origami (cone)", emoji: "◇", defaultTemp: 96, defaultDose: 17, defaultWater: 255, defaultTimeSec: 180, category: "pour-over" },
   { id: "origami-wave", label: "Origami (wave)", emoji: "◇", defaultTemp: 94, defaultDose: 17, defaultWater: 255, defaultTimeSec: 200, category: "pour-over" },
   { id: "kalita", label: "Kalita Wave", emoji: "△", defaultTemp: 94, defaultDose: 15, defaultWater: 250, defaultTimeSec: 210, category: "pour-over" },


### PR DESCRIPTION
## Summary

The Orea V4 is one brewer body with **four interchangeable filter bottoms** — Classic, Open, Apex (conical), Fast — each changing flow rate dramatically. `LightStepContext` already offered the 4 variants in the brew flow picker, but every session rendered the same generic `orea-v4.png`, so three Orea brews on `/coffees/[id]` all looked identical.

## What's new

### 4 distinct SVG icons (top-down view of each bottom)

| File | Visual |
|---|---|
| `public/brew-icons/orea-classic.svg` | Outer rim + central plate with cross of 4 flow slots |
| `public/brew-icons/orea-open.svg` | Clean donut — outer rim + large open inner ring |
| `public/brew-icons/orea-apex.svg` | Outer rim + 8 inward-pointing triangular teeth (rotate-transform every 45°) |
| `public/brew-icons/orea-fast.svg` | Outer rim + inner ring + 8 short radial bars between them |

All use `stroke="white"` at 100×100 viewBox. The existing `[data-light-scope]` CSS shim inverts white → anthracite via `filter: brightness(0)`, same pattern as `chemex.svg`.

### Routing

`BrewMethodIcon.brewIconSrc` switches inside the Orea branch:

```ts
if (m.includes("orea")) {
  if (m.includes("open")) return "/brew-icons/orea-open.svg";
  if (m.includes("apex")) return "/brew-icons/orea-apex.svg";
  if (m.includes("fast")) return "/brew-icons/orea-fast.svg";
  return "/brew-icons/orea-classic.svg";    // legacy "Orea V4 Wide" + plain "Orea" fall here
}
```

### Picker list

`BREW_METHODS`: replaces the single `{ id: "orea", label: "Orea V4" }` entry with four kebab-case ids matching `LightStepContext` labels: `orea-classic` / `orea-open` / `orea-apex` / `orea-fast`. Defaults per variant skew with the bottom's character — Apex slightly hotter + tighter ratio, Open / Fast slightly shorter time.

### Unchanged

The substring-matching logic in `recommend`, `brewSignature`, `extractor` — they all use `m.includes("orea")` so any variant string flows through. The knowledge layer's brewer matcher already maps `orea` + variants to the recipe corpus.

## Test plan

- [ ] `/coffees/[id]` All Brews: three Orea sessions with different bottoms now show three distinct icons.
- [ ] `/brew/new` Context step: tap "Orea Apex" → flows through to `/brew/[id]` rendering the Apex icon.
- [ ] `/cafes/place/[slug]` edit panel: method picker shows 4 separate Orea options.
- [ ] Legacy session with `methodUsed = "Orea V4 Wide (Classic bottom)"`: still renders, falls back to the Classic SVG.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_