### PR TITLE
feat: "I've been here" mode — café visits + binary rating

### DIFF
--- a/src/app/(light)/cafes/place/[slug]/page.tsx
+++ b/src/app/(light)/cafes/place/[slug]/page.tsx
@@ -2,8 +2,9 @@
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
-import { Menu } from "lucide-react";
+import { Menu, ThumbsUp, ThumbsDown } from "lucide-react";
 import type { Session } from "@/lib/types/session";
+import type { CafeVisit, CafeVisitRating } from "@/lib/types/cafes";
 import StarRating from "@/components/ui/light/StarRating";
 import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
 import { BREW_METHODS } from "@/lib/constants/brewMethods";
@@ -29,8 +30,11 @@ export default function CafeDetailPage() {
   const cafeName = decodeURIComponent(params.slug as string);
 
   const [sessions, setSessions] = useState<Session[]>([]);
+  const [visits, setVisits] = useState<CafeVisit[]>([]);
   const [loading, setLoading] = useState(true);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [visitModalOpen, setVisitModalOpen] = useState(false);
+  const [visitSaving, setVisitSaving] = useState(false);
 
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editMethod, setEditMethod] = useState("");
@@ -42,17 +46,50 @@ export default function CafeDetailPage() {
   const [deletingId, setDeletingId] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch("/api/sessions?mode=external&limit=200", { cache: "no-store" })
-      .then(r => r.json())
-      .then((data: Session[]) => {
-        const filtered = Array.isArray(data)
-          ? data.filter(s => s.place?.name === cafeName)
-          : [];
-        setSessions(filtered);
-      })
-      .catch(() => {})
-      .finally(() => setLoading(false));
+    Promise.all([
+      fetch("/api/sessions?mode=external&limit=200", { cache: "no-store" })
+        .then(r => r.json())
+        .then((data: Session[]) => {
+          const filtered = Array.isArray(data)
+            ? data.filter(s => s.place?.name === cafeName)
+            : [];
+          setSessions(filtered);
+        })
+        .catch(() => {}),
+      fetch(`/api/cafe-visits?cafeName=${encodeURIComponent(cafeName)}`, { cache: "no-store" })
+        .then(r => r.json())
+        .then((data: CafeVisit[]) => setVisits(Array.isArray(data) ? data : []))
+        .catch(() => {}),
+    ]).finally(() => setLoading(false));
   }, [cafeName]);
+
+  async function saveVisit(rating: CafeVisitRating) {
+    setVisitSaving(true);
+    try {
+      const location = sessions[0]?.place?.location;
+      const res = await fetch("/api/cafe-visits", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cafeName, location, rating }),
+      });
+      if (res.ok) {
+        const created: CafeVisit = await res.json();
+        setVisits(prev => [created, ...prev]);
+        setVisitModalOpen(false);
+      }
+    } finally {
+      setVisitSaving(false);
+    }
+  }
+
+  async function deleteVisit(id: string) {
+    try {
+      await fetch(`/api/cafe-visits/${id}`, { method: "DELETE" });
+      setVisits(prev => prev.filter(v => v.id !== id));
+    } catch {
+      // leave as-is on error
+    }
+  }
 
   function startEdit(s: Session) {
     setEditingId(s.id);
@@ -156,9 +193,9 @@ export default function CafeDetailPage() {
 
         {/* Stats + Open in Maps */}
         <div className="flex items-center gap-3 mt-2 flex-wrap">
-          {!loading && sessions.length > 0 && (
+          {!loading && (sessions.length > 0 || visits.length > 0) && (
             <p className="text-light-muted-foreground text-sm">
-              <span className="text-light-foreground">{sessions.length}</span> visit{sessions.length !== 1 ? "s" : ""}
+              <span className="text-light-foreground">{sessions.length + visits.length}</span> visit{(sessions.length + visits.length) !== 1 ? "s" : ""}
               {avgRating != null && (
                 <>
                   {" · "}
@@ -180,6 +217,16 @@ export default function CafeDetailPage() {
             Open in Maps
           </a>
         </div>
+
+        {/* "I've been here" — visit without logging a brew. opens a modal
+            with a binary thumb rating (come back / won't return). */}
+        <button
+          type="button"
+          onClick={() => setVisitModalOpen(true)}
+          className="mt-3 w-full h-12 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] text-sm font-medium active:scale-[0.98] transition-transform"
+        >
+          I&apos;ve been here
+        </button>
       </div>
 
       {/* Sessions list */}
@@ -190,13 +237,18 @@ export default function CafeDetailPage() {
               <div key={i} className="h-24 rounded-2xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 animate-pulse" />
             ))}
           </div>
-        ) : sessions.length === 0 ? (
+        ) : sessions.length === 0 && visits.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-[50vh] text-center gap-3">
             <p className="text-light-foreground font-medium">No sessions found</p>
-            <p className="text-light-muted-foreground text-sm">No visits logged for this café.</p>
+            <p className="text-light-muted-foreground text-sm">Tap &ldquo;I&apos;ve been here&rdquo; above to log a visit, or log a brew with this café selected.</p>
           </div>
         ) : (
           <div className="flex flex-col gap-3">
+            {/* Visit-only cards first (compact), sessions next. Both
+                sorted desc by recency within their own group. */}
+            {visits.map(v => (
+              <VisitCard key={v.id} visit={v} onDelete={() => deleteVisit(v.id)} />
+            ))}
             {sessions.map(s => {
               const method = s.brew?.methodUsed || s.place?.methodServed;
               const coffeeKey = s.coffee?.name && s.coffee?.roaster
@@ -357,6 +409,90 @@ export default function CafeDetailPage() {
       </div>
 
       <NavigationOverlay open={menuOpen} onClose={() => setMenuOpen(false)} />
+
+      {/* "I've been here" rating modal — binary thumbs (come back / won't
+          return). Saves to /api/cafe-visits and prepends to the list. */}
+      {visitModalOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-end sm:items-center justify-center px-5"
+          style={{ background: "rgba(28,22,19,0.45)" }}
+          onClick={() => !visitSaving && setVisitModalOpen(false)}
+        >
+          <div
+            className="w-full max-w-sm bg-[hsl(36_55%_96%)] rounded-3xl p-6 space-y-4 mb-6 sm:mb-0"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="space-y-1">
+              <h2 className="font-fraunces text-2xl text-light-foreground leading-tight">How was it?</h2>
+              <p className="text-light-muted-foreground text-sm">{cafeName}</p>
+            </div>
+            <div className="flex flex-col gap-2 pt-2">
+              <button
+                type="button"
+                disabled={visitSaving}
+                onClick={() => saveVisit("come-back")}
+                className="w-full h-14 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] font-medium flex items-center justify-center gap-3 active:scale-[0.98] transition-transform disabled:opacity-50"
+              >
+                <ThumbsUp className="w-5 h-5" strokeWidth={1.75} />
+                Would come back
+              </button>
+              <button
+                type="button"
+                disabled={visitSaving}
+                onClick={() => saveVisit("wont-return")}
+                className="w-full h-14 rounded-full border border-light-foreground/25 text-light-foreground font-medium flex items-center justify-center gap-3 active:scale-[0.98] transition-transform disabled:opacity-50 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150"
+              >
+                <ThumbsDown className="w-5 h-5" strokeWidth={1.75} />
+                Won&apos;t see me again
+              </button>
+            </div>
+            <button
+              type="button"
+              disabled={visitSaving}
+              onClick={() => setVisitModalOpen(false)}
+              className="w-full text-light-muted-foreground text-sm py-2"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function VisitCard({ visit, onDelete }: { visit: CafeVisit; onDelete: () => void }) {
+  const isPositive = visit.rating === "come-back";
+  const date = formatRelativeDate(visit.visitedAt);
+  return (
+    <div className="bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-2xl p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 min-w-0">
+          {isPositive ? (
+            <ThumbsUp className="w-4 h-4 shrink-0 text-light-foreground" strokeWidth={1.75} />
+          ) : (
+            <ThumbsDown className="w-4 h-4 shrink-0 text-light-muted-foreground" strokeWidth={1.75} />
+          )}
+          <span className="text-light-foreground text-sm font-medium truncate">
+            {isPositive ? "Would come back" : "Won't see me again"}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <span className="text-light-muted-foreground text-xs">{date}</span>
+          <button
+            onClick={onDelete}
+            aria-label="Delete visit"
+            className="p-1 text-light-muted-foreground/70 active:text-light-foreground transition-colors"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+      </div>
+      {visit.notes && (
+        <p className="text-light-muted-foreground text-sm mt-2 leading-relaxed">{visit.notes}</p>
+      )}
     </div>
   );
 }

--- a/src/app/api/cafe-visits/[id]/route.ts
+++ b/src/app/api/cafe-visits/[id]/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { cafeVisits } from "@/lib/db/schema";
+
+export const dynamic = "force-dynamic";
+
+export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    await db.delete(cafeVisits).where(eq(cafeVisits.id, params.id));
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("cafe-visits DELETE error:", err);
+    return NextResponse.json({ error: "internal" }, { status: 500 });
+  }
+}

--- a/src/app/api/cafe-visits/route.ts
+++ b/src/app/api/cafe-visits/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq, desc } from "drizzle-orm";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import { db } from "@/lib/db/client";
+import { cafeVisits } from "@/lib/db/schema";
+import type { CafeVisit } from "@/lib/types/cafes";
+
+export const dynamic = "force-dynamic";
+
+const VisitSchema = z.object({
+  cafeName: z.string().min(1).max(200),
+  location: z.string().max(300).optional(),
+  rating: z.enum(["come-back", "wont-return"]),
+  notes: z.string().max(2000).optional(),
+});
+
+function rowToVisit(r: typeof cafeVisits.$inferSelect): CafeVisit {
+  return {
+    id: r.id,
+    cafeName: r.cafeName,
+    location: r.location ?? undefined,
+    rating: r.rating,
+    notes: r.notes ?? undefined,
+    visitedAt: r.visitedAt.toISOString(),
+    visitedAtMs: r.visitedAtMs,
+  };
+}
+
+export async function GET(req: NextRequest) {
+  const cafeName = req.nextUrl.searchParams.get("cafeName");
+  try {
+    const rows = cafeName
+      ? await db.select().from(cafeVisits).where(eq(cafeVisits.cafeName, cafeName)).orderBy(desc(cafeVisits.visitedAtMs))
+      : await db.select().from(cafeVisits).orderBy(desc(cafeVisits.visitedAtMs)).limit(200);
+    return NextResponse.json(rows.map(rowToVisit));
+  } catch (err) {
+    console.error("cafe-visits GET error:", err);
+    return NextResponse.json([], { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const parsed = VisitSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid payload", details: parsed.error.issues }, { status: 400 });
+    }
+    const now = new Date();
+    const id = randomUUID();
+    await db.insert(cafeVisits).values({
+      id,
+      cafeName: parsed.data.cafeName,
+      location: parsed.data.location,
+      rating: parsed.data.rating,
+      notes: parsed.data.notes,
+      visitedAt: now,
+      visitedAtMs: now.getTime(),
+    });
+    return NextResponse.json({
+      id,
+      cafeName: parsed.data.cafeName,
+      location: parsed.data.location,
+      rating: parsed.data.rating,
+      notes: parsed.data.notes,
+      visitedAt: now.toISOString(),
+      visitedAtMs: now.getTime(),
+    } satisfies CafeVisit, { status: 201 });
+  } catch (err) {
+    console.error("cafe-visits POST error:", err);
+    return NextResponse.json({ error: "internal" }, { status: 500 });
+  }
+}

--- a/src/app/api/cafes/route.ts
+++ b/src/app/api/cafes/route.ts
@@ -1,23 +1,33 @@
 import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db/client";
-import { sessions } from "@/lib/db/schema";
+import { sessions, cafeVisits } from "@/lib/db/schema";
 import type { ExternalPlace, TasteResult, CoffeeIdentity } from "@/lib/types/session";
 import type { CafeSummary } from "@/lib/types/cafes";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  const rows = await db
-    .select({
-      createdAtMs: sessions.createdAtMs,
-      place: sessions.place,
-      coffee: sessions.coffee,
-      result: sessions.result,
-    })
-    .from(sessions)
-    .where(eq(sessions.mode, "external"))
-    .orderBy(sessions.createdAtMs);
+  const [sessionRows, visitRows] = await Promise.all([
+    db
+      .select({
+        createdAtMs: sessions.createdAtMs,
+        place: sessions.place,
+        coffee: sessions.coffee,
+        result: sessions.result,
+      })
+      .from(sessions)
+      .where(eq(sessions.mode, "external"))
+      .orderBy(sessions.createdAtMs),
+    db
+      .select({
+        cafeName: cafeVisits.cafeName,
+        location: cafeVisits.location,
+        visitedAtMs: cafeVisits.visitedAtMs,
+      })
+      .from(cafeVisits),
+  ]);
+  const rows = sessionRows;
 
   // Group by normalised café name
   const map = new Map<string, {
@@ -54,6 +64,29 @@ export async function GET() {
         ratedCount: rating ? 1 : 0,
         coffees: coffeeName ? [coffeeName] : [],
         lastVisitedMs: row.createdAtMs,
+      });
+    }
+  }
+
+  // Fold in cafe_visits rows. A visit may be for a café the user has
+  // ALSO brewed at (merge into existing entry) or a brand-new place
+  // (new entry with no coffees / rating yet).
+  for (const v of visitRows) {
+    if (!v.cafeName) continue;
+    const key = v.cafeName.toLowerCase().trim();
+    const entry = map.get(key);
+    if (entry) {
+      entry.visits++;
+      entry.lastVisitedMs = Math.max(entry.lastVisitedMs, v.visitedAtMs);
+    } else {
+      map.set(key, {
+        name: v.cafeName,
+        location: v.location ?? undefined,
+        visits: 1,
+        totalRating: 0,
+        ratedCount: 0,
+        coffees: [],
+        lastVisitedMs: v.visitedAtMs,
       });
     }
   }

--- a/src/lib/db/migrations/0011_add_cafe_visits.sql
+++ b/src/lib/db/migrations/0011_add_cafe_visits.sql
@@ -1,0 +1,31 @@
+-- 0011 — Cafe visits without a brew session
+--
+-- The "I've been here" mode: log a visit to a coffee shop without logging
+-- a brew session. Use case is the place was visited (the user remembers
+-- being there) but no specific cup was tracked. Rating is intentionally
+-- binary — would-come-back vs won't-return — because the brew context
+-- the star rating depends on isn't there.
+--
+-- Reuses cafe_name + location strings from session.place so the same
+-- name reads consistently in the Cafe Library aggregator (no foreign
+-- key into the bulk places table — that table is read-only reference
+-- data, visits are user-owned).
+--
+-- Run this file with:
+--   cat src/lib/db/migrations/0011_add_cafe_visits.sql | docker compose exec -T postgres psql -U brewlog -d brewlog
+
+CREATE TABLE IF NOT EXISTS cafe_visits (
+  id              text PRIMARY KEY,
+  cafe_name       text NOT NULL,
+  location        text,
+  rating          text NOT NULL CHECK (rating IN ('come-back', 'wont-return')),
+  notes           text,
+  visited_at      timestamptz NOT NULL DEFAULT now(),
+  visited_at_ms   bigint NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS cafe_visits_visited_at_ms_idx
+  ON cafe_visits (visited_at_ms DESC);
+
+CREATE INDEX IF NOT EXISTS cafe_visits_cafe_name_idx
+  ON cafe_visits (cafe_name);

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -85,6 +85,19 @@ export const coffees = pgTable("coffees", {
   inRotation: boolean("in_rotation").notNull().default(false),
 });
 
+// "I've been here" — visit-only café record without a brew session.
+// rating is intentionally binary ('come-back' | 'wont-return') since
+// there's no brew context for a star rating. See migration 0011.
+export const cafeVisits = pgTable("cafe_visits", {
+  id: text("id").primaryKey(),
+  cafeName: text("cafe_name").notNull(),
+  location: text("location"),
+  rating: text("rating").$type<"come-back" | "wont-return">().notNull(),
+  notes: text("notes"),
+  visitedAt: timestamp("visited_at", { withTimezone: true }).notNull().defaultNow(),
+  visitedAtMs: bigint("visited_at_ms", { mode: "number" }).notNull(),
+});
+
 export const preferences = pgTable("preferences", {
   key: text("key").primaryKey(),
   data: jsonb("data").notNull(),

--- a/src/lib/types/cafes.ts
+++ b/src/lib/types/cafes.ts
@@ -15,3 +15,17 @@ export interface Place {
   lat: number | null;
   lng: number | null;
 }
+
+// Visit-only café record without an attached brew session. Rating is
+// binary: did the user enjoy being there enough to return.
+export type CafeVisitRating = "come-back" | "wont-return";
+
+export interface CafeVisit {
+  id: string;
+  cafeName: string;
+  location?: string;
+  rating: CafeVisitRating;
+  notes?: string;
+  visitedAt: string;       // ISO timestamp
+  visitedAtMs: number;
+}


### PR DESCRIPTION
## Summary

New feature decoupled from the brew flow. You land on a café detail page you've never brewed at (or have but don't want to log a specific cup right now) and tap **"I've been here"** — a small modal opens with a binary rating, **Would come back** / **Won't see me again**, and the visit is recorded.

### Why binary instead of stars

Stars on sessions reflect the brew, not the place. A place rating answers "was the vibe good enough to return" — a fundamentally different signal that maps cleanly to two thumbs. Less friction than five stars + free text.

## Data model — migration 0011

```sql
CREATE TABLE cafe_visits (
  id              text PRIMARY KEY,
  cafe_name       text NOT NULL,
  location        text,
  rating          text NOT NULL CHECK (rating IN ('come-back', 'wont-return')),
  notes           text,
  visited_at      timestamptz DEFAULT now(),
  visited_at_ms   bigint NOT NULL
);
```

Separate table, not a polluted `sessions` row. The sessions schema requires a coffee identity; reusing it would mean placeholders + an else-case everywhere a session is rendered. Clean separation, cheap join.

## API

| Route | Method | Purpose |
|---|---|---|
| `/api/cafe-visits` | GET | List all (or `?cafeName=X`) |
| `/api/cafe-visits` | POST | Create — Zod-validated body, rating enum |
| `/api/cafe-visits/[id]` | DELETE | Remove |

## UI on `/cafes/place/[slug]`

- New "I've been here" anthracite pill below the stats / Open in Maps row.
- Tap opens a modal sheet (bottom-anchored on mobile, centered on wider screens) with the two thumb buttons.
- "Would come back" → filled-anthracite primary CTA + ThumbsUp icon.
- "Won't see me again" → cream-glass outlined secondary CTA + ThumbsDown icon.
- Visits render in the timeline **above the brew sessions** as small cream-glass cards: thumb icon + label + relative date + delete-x.
- Empty state copy updated to point at both paths.

## Café Library aggregation

`/api/cafes` folds in `cafe_visits` rows. Existing cafés get their visit count bumped. **New visit-only places get a fresh `CafeSummary` entry** with no coffees / no avg rating, just visits + `lastVisitedMs`. A thumbs-rated café that was never brewed at appears in `/cafes` alongside the brewed-at ones.

## Migration apply

Per CLAUDE.md the migrations are manual:

```bash
cd /opt/brewlog
cat src/lib/db/migrations/0011_add_cafe_visits.sql | docker compose exec -T postgres psql -U brewlog -d brewlog
```

## Scoped out (open for follow-up)

- Editing a visit (notes field is in the schema; no inline edit UI yet — delete + re-add for now).
- Entry point for brand-new cafés from `/cafes/map` (search a place then tap "I've been here" without first navigating to the slug).
- Weighting `lastVisitedMs` between sessions and visits.

## Test plan

- [ ] Apply migration 0011 on the VPS.
- [ ] Open `/cafes/place/[slug]` for an existing café → "I've been here" pill visible below Open in Maps.
- [ ] Tap → modal opens → tap "Would come back" → modal closes → a new card appears at the top of the list with the thumb-up icon and today's date.
- [ ] Tap delete-x on the visit card → card removes.
- [ ] Open `/cafes` Café Library → the rated café's visit count includes the visit just logged.
- [ ] Brand-new café (no sessions) — once we wire up the entry point (follow-up PR), should appear in the Library after a visit is logged.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_