### PR TITLE
docs: update CLAUDE.md + HANDOVER.md after may polish day

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,8 @@ Removed routes: legacy Dark `page.tsx` (replaced by `(light)/page.tsx`), `match/
 | `questions` | GET suggestion questions for explore mode |
 | `alerts` | GET / POST coffee availability alert subscriptions |
 | `webhooks/coffee-alert` | Incoming webhook for coffee availability notifications |
+| `cafe-visits` | GET / POST — visit-only café logs with binary thumbs rating (independent of brew sessions) |
+| `cafe-visits/[id]` | DELETE — remove a logged visit |
 | `admin/seed` | Populate knowledge base (run once on new installs) |
 
 ### Components
@@ -170,7 +172,9 @@ lib/
 │   ├── 0006_add_what_to_explore.sql       # preferences column for explore prompts
 │   ├── 0007_add_conversations.sql         # conversations + conversation_messages tables
 │   ├── 0008_add_field_zones.sql           # coffees.field_zones jsonb (Field v1.1 persistence)
-│   └── 0009_add_in_rotation.sql           # coffees.in_rotation boolean (rotation marker)
+│   ├── 0009_add_in_rotation.sql           # coffees.in_rotation boolean (rotation marker)
+│   ├── 0010_rename_rvtc.sql                # bulk rename "Rösterei Vier / The Commonage" → "RVTC"
+│   └── 0011_add_cafe_visits.sql            # cafe_visits table — visit-only logs + binary thumbs rating
 │   # NOTE: 0001+ are applied manually via `psql` on the VPS — Drizzle journal does not track them.
 │   # Applying schema/code that references a new column BEFORE running the migration on the VPS
 │   # makes Drizzle SELECT 500 (column-strict). Always migrate VPS first, deploy code second.
@@ -229,13 +233,15 @@ lib/
 
 ### Database tables (Drizzle + Postgres)
 
-`sessions`, `coffees`, `auth_credentials`, `auth_challenges`, `preferences`, `roasters`, `knowledge`, `coffee_alerts`, `places`, `conversations`, `conversation_messages` (11 tables).
+`sessions`, `coffees`, `auth_credentials`, `auth_challenges`, `preferences`, `roasters`, `knowledge`, `coffee_alerts`, `places`, `conversations`, `conversation_messages`, `cafe_visits` (12 tables).
 
-Recent column additions on `coffees`:
-- `field_zones jsonb` (migration 0008) — persisted Field composition per coffee
-- `in_rotation boolean NOT NULL DEFAULT false` (migration 0009) — star toggle for "currently brewing this bag"
+Recent additions:
+- `coffees.field_zones jsonb` (migration 0008) — persisted Field composition per coffee
+- `coffees.in_rotation boolean NOT NULL DEFAULT false` (migration 0009) — star toggle for "currently brewing this bag"
+- **Migration 0010** (applied 2026-05) — bulk-rename roaster variants `"Rösterei Vier / The Commonage"` / `"RVTC – Rösterei Vier / The Commonage"` → `"RVTC"` across coffees + sessions JSONB + roasters priors cache.
+- **Migration 0011 + new `cafe_visits` table** (applied 2026-05) — schema: `id`, `cafe_name`, `location`, `rating` ('come-back' | 'wont-return'), `notes`, `visited_at`, `visited_at_ms`. Visit-only café logs without an attached brew session. Binary thumbs rating since there's no brew context for stars. Aggregated into `/api/cafes` so visit-only places appear in the Café Library.
 
-Both migrations applied manually on the VPS — see migration NOTE above.
+All migrations applied manually on the VPS — see migration NOTE above.
 
 ### Key dependencies
 
@@ -273,6 +279,15 @@ Both migrations applied manually on the VPS — see migration NOTE above.
 - Coffee Detail (`/coffees/[id]`) reads its coffee's Field via `useFieldConfig` (#123). Hero scrim flipped to cream-to-transparent (#121) so anthracite titles stay legible against any bag photo. Rotation toggle gates the "Brew this" CTA (#117) — out-of-rotation = bag-not-on-counter, no shortcut shown.
 - SessionCard (`/coffees/[id]` All-brews list) rewritten as a Light card (#120): brew method headline + recipe meta (date · dose · water · time) + flavor chips; swipe-to-delete button fades in proportional to swipe progress (#124) so it doesn't bleed through the translucent cream at rest.
 - Brew Session Detail (`/brew/[id]`) inherits the cup's Field via `lib/field/cache.ts` (#125) — `/coffees/[id]` pre-warms the cache for all its sessions when it loads, `/brew/[id]` reads synchronously on mount, so navigating between the two paints the same Field with no flash through default. Back arrow routes to `/coffees/[coffeeId]` (#126) instead of the library root, with router.back() as a fallback for legacy sessions whose `CoffeeIdentity` was persisted before `coffeeId` existed.
+
+**Late-May follow-ups (PR #139 → #145)**
+- Login wordmark renders as the Home hero ("Better taste / than sorry." in Fraunces 3xl, full anthracite) across all three login states (#139, #140). Login CTAs (Use Face ID / Unlock / Set up Face ID) are pill-shaped (rounded-full + h-14) matching the onboarding primary buttons.
+- SessionCard background dropped from 55 % to 30 % cream (#139) so the flavor chips inside (still at 55 %) pop visibly against the card — fixes the white-on-white screenshot.
+- Café Coffees-tab cross-link (#141): tapping a coffee that exists in the library routes to `/coffees/[coffeeId]` instead of the café-specific aggregate. Café-only coffees still land on `/cafes/coffee/[key]`.
+- Scan edit affordance (#143): the `EditableRow` rows on the bag confirmation step always render with a visible underline + pencil icon. Roaster + Coffee rows always show (were `!== undefined`-gated, so unextracted bags had no editable rows). Lets the user shorten long names like "El Congo by Carlos Montero – Don Eli" → "El Congo" at scan time.
+- Orea V4 four-bottom variants (#144): new SVGs `orea-classic.svg` / `orea-open.svg` / `orea-apex.svg` / `orea-fast.svg` in `public/brew-icons/`. `BrewMethodIcon.brewIconSrc` switches on the variant keyword inside the orea branch; legacy "Orea V4 Wide" falls back to Classic. `BREW_METHODS` replaced the single `orea` entry with four kebab-case ids aligned to the `LightStepContext` picker labels.
+- **"I've been here" mode (#145)** — `cafe_visits` table + `/api/cafe-visits` + modal on `/cafes/place/[slug]` with binary thumbs rating. Visits appear in the café's timeline alongside brew sessions, and roll into `/api/cafes` so visit-only places appear in the Café Library.
+- Database renames (#142, migration 0010 applied 2026-05): all variants of `Rösterei Vier / The Commonage` collapsed to `RVTC` across `coffees.roaster`, `sessions.coffee.roaster` JSONB, and the `roasters` priors cache.
 
 **FlavorWheel Light palette (#128–#131)**
 - Direct conversion (no theme prop). The wheel is intrinsically monochrome — `scaFlavorWheel.ts` gives every category a near-identical dark gray, so differentiation comes from icons + label opacity + active/has-sel tonal lifts, not from per-category brand color.
@@ -371,10 +386,14 @@ Both migrations applied manually on the VPS — see migration NOTE above.
 
 ### ❌ Not Done / Known Gaps
 
-**Open items** (post-Light-migration; live ranking lives in HANDOVER.md):
-1. `/coffees` "Show only rotation" filter — list shows the star indicator (#117) but no toggle yet to filter the list to rotation bags only
-2. `LightStepScan` Card/Chip refactor — 1400 lines with bespoke buttons that should route through the `Card` + `Chip` primitives. Code quality, no visible UX change
-3. Aromatic Goal validation — PR #72 added the intent to `/api/recommend` but per the Hard Rule it needs sample-before/after against a delicate coffee on the deployed PWA
+**Open items** (live ranking lives in HANDOVER.md):
+1. **`/cafes/map` Light pass** — currently Dark with CartoCDN dark tiles + default Leaflet blue markers. Sticks out hard against the rest of the Light app. Owner: next session. Sketch in HANDOVER.md.
+2. **`/cafes/map` "I've been here" entry point** — coupled with map work. Once the user can search a brand-new place and tap it, expose the "I've been here" modal directly from the map without first going through `/cafes/place/[slug]`.
+3. `/coffees` "Show only rotation" filter — list shows the star indicator (#117) but no toggle yet to filter the list to rotation bags only
+4. `LightStepScan` Card/Chip refactor — 1400 lines with bespoke buttons that should route through the `Card` + `Chip` primitives. Code quality, no visible UX change
+5. Aromatic Goal validation — PR #72 added the intent to `/api/recommend` but per the Hard Rule it needs sample-before/after against a delicate coffee on the deployed PWA
+6. **Cafe visit notes edit UI** — `cafe_visits.notes` column exists but UI only lets you delete + re-add, no inline edit. Cheap follow-up.
+7. **Deploy workflow harden** — May 2026 deploy hit a Docker name conflict when manual `up -d` raced with GitHub Action. `deploy.yml` should add `docker compose down` (or `up --remove-orphans --force-recreate`) before bringing app back up.
 
 **Permanent gaps**
 - Photo uploads: stored under `bags/` — old sessions scanned before this convention have no `bagPhotoUrl`

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,48 +1,123 @@
 # Session Handover — May 2026
 
-> Snapshot at the end of the Light migration arc. Read this once when picking up a new Claude session; persistent rules + tokens live in `CLAUDE.md`. This file is **state**, not policy.
+> Snapshot at the end of a long polish + feature day after the Light migration arc. Persistent rules + tokens live in `CLAUDE.md`. This file is **state**, not policy.
 
 ---
 
-## The headline: Light migration is done
+## Top priority for next session
 
-Every visited route now lives in `(light)/` and renders with the BTTS Light theme (Cream + Fraunces/Chivo + anthracite + generative Field). The single Dark route left is `cafes/map/page.tsx` — intentional, because Leaflet's CartoCDN dark tiles fit the full-screen map.
+**`/cafes/map` polish + integration with "I've been here".** The map page is the single sore thumb left: it still renders dark CartoCDN tiles with default Leaflet blue markers while everything around it is Light cream + anthracite. Two coupled jobs:
 
-### What shipped this arc (PR #113 → #137)
+1. **Map theme** — swap the tile provider away from the dark Carto. Best options:
+   - CartoCDN `voyager` or `positron` (light, neutral, retina-friendly) — easiest swap
+   - Stadia "Outdoors" or "Light" (slightly warmer cream feel) — closer to BTTS aesthetic
+   - OpenStreetMap raw default — beige, very Light, no API key
+   - Custom JSON style (vector tiles) — full control but more setup
+   - Hacky last resort: CSS `filter: invert(0.95) hue-rotate(180deg)` on the existing dark layer — works at zero infra cost but image-heavy areas (parks, photos) look weird
+2. **Markers** — Leaflet's default blue droplet doesn't match anything else in the app. Replace with anthracite circle markers (or custom SVG with the coffee-bean glow icon). Differentiate visited (filled anthracite) vs unvisited (outline only). Maybe cluster at low zoom.
+3. **"I've been here" entry from the map** (coupled feature) — once the user can tap a place on the map, expose the visit modal directly. New flow:
+   - Tap a marker → small popup with the place name + "I've been here" pill + "Open detail →"
+   - "I've been here" → opens the same modal we built in PR #145, POSTs to `/api/cafe-visits` with the place's name + location
+   - The visited flag immediately reflects on the marker style
+4. **Search bar** — currently functional but could surface own visited/brewed cafés separately from generic search hits. Lower priority.
 
-**Routes migrated**
-- `/brew/[id]` Session Detail (PR #122) — Brew-method as headline, Field carries from `/coffees/[id]` via `lib/field/cache.ts`, sections styled like the coffee detail
-- `/cafes` + `/cafes/place/[slug]` + `/cafes/coffee/[id]` (PR #134) — Cafés tab uses text-only Light cards (no photo in `CafeSummary`); Coffees tab uses the same full-bleed photo-strip card as Coffee Library; inline edit panel restyled
-- `/login` + `/onboarding` (PR #135) — Light tokens throughout, Onboarding selectors use the `Chip` primitive
-- `/taste` (PR #136) — Light Header + burger, FlavorWheel radar now renders on cream, bar charts use anthracite fills on `foreground/10` tracks
-- `/loading` global state (PR #137) — Light CoffeeBeanGlow on inline cream bg so route transitions don't flash dark before LightShell mounts
+Look at `src/app/cafes/map/page.tsx` (62 lines) and `src/components/cafes/CafeMap.tsx` for the structure. `places` table on the VPS has 6,202 rows; the map page reads from `/api/places` with a city / token search.
 
-**Architectural fixes**
-- `/coffees/[id]` adopts its own Field via `useFieldConfig` (PR #123) — was only handing zones to flowStore for the brew flow, the detail page itself never painted in the cup's colours
-- `lib/field/cache.ts` (PR #125) — sessionStorage cache keyed by session id. `/coffees/[id]` pre-warms for all its sessions on load; `/brew/[id]` reads synchronously on mount. Removes the ~300 ms flash through default while the coffee fetch resolved
-- SessionCard rewrite (PR #120) — Brew-method as headline, recipe meta line (date · dose · water · time), Light flavor chips, swipe-to-delete fades in with swipe progress (PR #124) instead of bleeding through the translucent card at rest
-- Coffee Library card architecture (PRs #127, #132, #133) — full-bleed 96 px photo strip on the left (was a 56 px circular thumb with an unreadable 8 px count badge), brew count moves to the right column above the Brew CTA, both centered on the same vertical axis
-- Rotation gates the Brew CTA (PR #117) — out-of-rotation rows have no Brew shortcut; star indicator on rotation rows in the library list
-- Hero scrim flip on `/coffees/[id]` (PR #121) — cream-to-transparent instead of `.card-scrim`'s black-to-near-opaque (Dark utility) so anthracite titles stay legible on any bag photo
-- Brew session back goes to `/coffees/[coffeeId]` (PR #126) with `router.back()` as a fallback for legacy sessions whose `CoffeeIdentity` was persisted before `coffeeId` existed
+After the map work, the whole app reads one consistent Light language end-to-end.
 
-**FlavorWheel Light (PRs #128–#131)**
-- Direct conversion (no theme prop). Canvas transparent; cream-glass panels; anthracite text + icons via `currentColor`. Whole-wedge tonal state — tapping a category darkens both rings together. Thin cream ring divider between inner and outer; stroke weights tuned to 0.8 / 0.5 viewport units to match the label typography weight.
+---
 
-**PWA chrome (PRs #113–#119)**
-- `themeColor: #D4B8C9` (soft mauve-pink) on viewport AND `manifest.json` — Android PWA + Safari URL bar tints mauve
-- `manifest.background_color: #F3E5DC` (cream) — Android splash matches the Field base, no black flash
-- `appleWebApp.statusBarStyle: "default"` (was `black-translucent`) — iOS PWA gets an opaque system status bar instead of the see-through one that exposed a hard color cut
-- `html { background-color: #F3E5DC }` — the canvas under the Field is now cream, so even if the gradient is thin at the very top pixels (status bar area extended under the webview via `viewportFit: cover`), no dark bleed-through
+## What shipped today (PRs #138 → #145)
 
-**Chip vocabulary unified (PR #126, #127)**
-- One static-tag style across SessionCard, `/coffees/[id]` (Bag notes + You taste), `/brew/[id]` flavor notes + Pill component, LightStepSummary, Café Library, Café detail: `px-3 py-1.5`, 12 px medium, `bg-light-card-default` + backdrop blur, anthracite text — matches the `Chip` primitive's default state used in `LightStepLog`.
+### Docs
+- **PR #138** — Post-light-migration docs refresh (CLAUDE.md routes table, components, Status snapshot; HANDOVER.md full rewrite from in-flight to closed). Today's PRs continue the line.
 
-**Cleanup (PR #137)**
-- Deleted: `RadarChart.tsx` (orphan), Dark `Chip.tsx` (orphan), `BottomNav.tsx` (allowlist empty since #136)
-- Simplified: `ScrollContainer` (no allowlist, no nav-padding reserve), `loading.tsx` (Light + inline cream bg)
-- Dropped from globals.css: `--nav-bottom-padding` CSS var
-- Kept (still consumed): Dark `CoffeeBeanGlow` (via `PhotoUpload` + CSS shim), Dark `StarRating` (via `CafeMap` for the intentional-Dark map page)
+### Login + UX fixes
+- **PR #139** — Login wordmark "Better taste / than sorry." replaces the BREWLOG eyebrow. Login CTAs swapped to pill shape (`rounded-full h-14`) matching the onboarding primary buttons. SessionCard background dropped from 55 % → 30 % cream so the flavor chips at 55 % visibly pop.
+- **PR #140** — Login wordmark restyled to **exactly** match the Home `<h1>` — Fraunces 3xl, leading 1.05, full anthracite, with `<br />` line break. Same brand statement at every entry point.
+
+### Routing fix
+- **PR #141** — `/cafes` Coffees-tab tap now lands on the Coffee Library detail (`/coffees/[coffeeId]`) when the bag exists in the library; falls back to the café-only aggregate (`/cafes/coffee/[key]`) only for café-only coffees. Reverts PR #134's blanket routing.
+
+### Scan editing
+- **PR #143** — `EditableRow` discoverability:
+  - Underline switched from `decoration-white/20` (invisible on cream) → `decoration-light-foreground/30`
+  - Added a small pencil icon on the right edge of every row
+  - Roaster + Coffee rows always render (were `!== undefined`-gated); empty value shows "tap to edit"
+  - Lets the user shorten "El Congo by Carlos Montero – Don Eli" → "El Congo" at scan time.
+
+### Roaster rebrand
+- **PR #142** — Migration `0010_rename_rvtc.sql`. Collapses every variant of `Rösterei Vier / The Commonage` → `RVTC` across `coffees.roaster`, the `sessions.coffee.roaster` JSONB field, and the `roasters` priors cache.
+- **Applied on the VPS 2026-05** — `UPDATE 3` coffees + `UPDATE 16` sessions + `DELETE 1` cached roaster prior.
+
+### Orea V4 bottoms
+- **PR #144** — Four distinct bottom variants now render with their own icons. New SVGs in `public/brew-icons/`: `orea-classic.svg` (central plate + cross of 4 flow slots), `orea-open.svg` (clean donut), `orea-apex.svg` (8 inward-pointing triangular teeth), `orea-fast.svg` (8 short radial bars between inner + outer ring). `BrewMethodIcon.brewIconSrc` switches on the variant keyword inside the orea branch — legacy "Orea V4 Wide" falls back to Classic. `BREW_METHODS` replaced the single `orea` entry with four kebab-case ids (`orea-classic`, `orea-open`, `orea-apex`, `orea-fast`) aligned to the `LightStepContext` picker labels.
+
+### "I've been here" — new feature
+- **PR #145** — Visit-only café log with a binary thumbs rating.
+  - New table `cafe_visits` (migration `0011_add_cafe_visits.sql`, applied on VPS 2026-05). Schema: `id`, `cafe_name`, `location`, `rating` ('come-back' | 'wont-return'), `notes`, `visited_at`, `visited_at_ms`.
+  - New API `/api/cafe-visits` (GET + POST) and `/api/cafe-visits/[id]` (DELETE), Zod-validated payloads.
+  - UI on `/cafes/place/[slug]`: anthracite "I've been here" pill below Open in Maps → modal sheet with ThumbsUp "Would come back" / ThumbsDown "Won't see me again". Visits render in the timeline above brew sessions as small cream-glass cards with a delete-x.
+  - `/api/cafes` aggregation folds in `cafe_visits` rows. Visit-only places now appear in the Café Library with the visit count.
+
+---
+
+## Deploy quirk we hit
+
+GitHub Actions auto-deploy + manual `docker compose up -d app` raced on the VPS and produced a Docker container name conflict (`/588a8065ea44_brewlog-app-1 is already in use by container 75746d301bda...`). Resolved by `docker rm -f brewlog-app-1 && docker compose up -d app`. App is live with all today's changes.
+
+**Followup for next session:** harden `.github/workflows/deploy.yml` so it tolerates the race — add `docker compose down` before `up -d`, or pass `--remove-orphans --force-recreate`. See open item #7 below.
+
+---
+
+## Live state on VPS (verified 2026-05)
+
+```
+sessions          → indexed feed table
+coffees           → 23 rows; all with field_zones populated
+                    RVTC rename applied (UPDATE 3 in #142)
+coffees.in_rotation column exists
+sessions.coffee.roaster JSONB renamed where it referenced old RVTC name (UPDATE 16)
+cafe_visits       → new table (migration 0011 applied)
+places            → 6,202 rows (manual bulk load, no Git seed)
+preferences       → user equipment + grinder + location
+roasters          → cached priors, RVTC stale row deleted (will lazily regenerate)
+knowledge         → seed-insights.mjs populated
+coffee_alerts     → user subscriptions
+auth_credentials  → WebAuthn passkey
+conversations + conversation_messages → BTTS chat history
+```
+
+12 tables total now.
+
+---
+
+## Open items (live ranking)
+
+1. **`/cafes/map` Light pass + "I've been here" entry from map** — see Top priority section above. Coupled job, single session.
+2. **`/coffees` "Show only rotation" filter** — list shows the star indicator but no toggle yet to filter to rotation bags only. Small, scoped.
+3. **`LightStepScan` Card/Chip refactor** — 1400 lines with bespoke buttons that should route through the `Card` + `Chip` primitives. Code quality, no visible UX change.
+4. **Aromatic Goal validation** — PR #72 added the intent to `/api/recommend`. Per the Hard Rule it needs sample-before/after on the deployed PWA against a delicate coffee. Needs real brews.
+5. **Cafe visit notes UI** — `cafe_visits.notes` column exists; UI only lets you delete + re-add a visit. Cheap follow-up: inline note edit on the visit card.
+6. **Deploy workflow harden** — `.github/workflows/deploy.yml` needs to tolerate manual + automated `up -d` races (see Deploy quirk above).
+
+---
+
+## Pitfalls discovered (don't re-learn these)
+
+- **Docker name conflict on parallel `up -d`.** Manual `docker compose up -d app` while a GitHub Action is running the same command races. Resolution: `docker rm -f brewlog-app-1 && docker compose up -d app`. Future deploys should harden the workflow (open item #6).
+- **iOS PWA caches `apple-mobile-web-app-status-bar-style` at install time.** Changing the meta tag does not update an already-installed PWA on iPhone. User has to delete the PWA from the home screen AND clear Safari → Advanced → Website Data for the domain, then re-install.
+- **Tailwind only scans `src/{app,components,pages}`.** `src/lib/**` is NOT in `tailwind.config.ts` `content`. Utility classes that live only in lib are silently never generated. If you need a shared visual constant in lib, export it as a raw CSS value and apply via inline `style={{ background: ... }}` at the call site.
+- **html canvas default.** `html { background-color: #F3E5DC }` (cream). `body { background-color: #0E0B0A }` by default, dropped to `transparent` only when `body:has([data-light-scope="true"])` matches. Light routes therefore show the cream canvas behind the Field; the legacy Dark `cafes/map` keeps its dark body. `loading.tsx` explicitly sets `background: #F3E5DC` inline because it renders BEFORE LightShell mounts.
+- **Next.js standalone Docker image** does NOT expose `@anthropic-ai/sdk` as `node_modules/@anthropic-ai`. Backfill script started failing with `ERR_MODULE_NOT_FOUND` until rewritten to call the Messages API over plain `fetch`. `pg` IS in standalone deps (traced via Drizzle).
+- **`lovable-v7/` must be in `.dockerignore`.** Without it the Docker `COPY . .` drags the Vite-targeted Lovable export into the build context and Next.js's worker tries to compile it → `react-router-dom not found` → deploy fails.
+- **Drizzle SELECT * is column-strict.** Adding a column to the schema BEFORE running the SQL migration on the VPS makes `/api/coffees` 500 with "column does not exist". Migrations must be applied to the DB BEFORE the schema/code that references them deploys.
+- **`min-h-full flex flex-col` does not give children definite height.** `flex-1` inside collapses to 0. Leaflet container needed `h-dvh flex flex-col` + `flex-1 min-h-0`.
+- **The `[data-light-scope]` CSS shim** in `globals.css` catches inline `var(--card)` etc. for un-migrated components inside the Light tree — but NOT hardcoded hex values like `#2A241C`. Those need explicit Light tokens at the source.
+- **CSS `filter: brightness(0)` under `[data-light-scope]`** is the trick used to invert hardcoded-white SVGs (`BrewMethodIcon` assets, original `CoffeeBeanGlow`) without forking the components.
+- **localStorage starter cache.** Versioned key `brewlog.starter.v4.<date>.<bucket>`. Bumping the version is the canonical invalidation. If you change the greeting prompt, bump the cache to `v5`.
+- **Hard Rule on AI behavior changes.** Any prompt / model / schema-enum change to `/api/recommend`, `/api/greeting`, `/api/match`, etc. needs sample-before-after outputs per `CLAUDE.md`. Cannot validate from this remote env — Markus runs on the deployed PWA.
+- **Manual migrations.** SQL files in `src/lib/db/migrations/` are NOT auto-applied. Run on VPS: `cat src/lib/db/migrations/00XX_*.sql | docker compose exec -T postgres psql -U brewlog -d brewlog`. The Drizzle journal only tracks `0000_init`. Today's apply pattern (0010, 0011) is the canonical workflow.
 
 ---
 
@@ -56,118 +131,81 @@ src/
 │   │   ├── layout.tsx          ← LightShell
 │   │   ├── brew/
 │   │   │   ├── new/page.tsx    ← Brew flow step switcher
-│   │   │   └── [id]/page.tsx   ← Session detail (Light per #122)
+│   │   │   └── [id]/page.tsx   ← Session detail
 │   │   ├── coffees/
 │   │   │   ├── page.tsx        ← Library list (photo-strip cards)
 │   │   │   └── [id]/page.tsx   ← Coffee detail + rotation toggle
 │   │   ├── cafes/
 │   │   │   ├── page.tsx        ← Café Library (tabbed)
-│   │   │   ├── place/[slug]/   ← Single café + inline edit
+│   │   │   ├── place/[slug]/   ← Single café + inline edit + "I've been here" modal
 │   │   │   └── coffee/[id]/    ← Coffee tasted out
-│   │   ├── taste/page.tsx      ← Taste profile + FlavorWheel radar
-│   │   ├── login/page.tsx
+│   │   ├── taste/page.tsx
+│   │   ├── login/page.tsx      ← Fraunces 3xl wordmark + pill CTAs
 │   │   ├── onboarding/page.tsx
 │   │   └── past-conversations/
-│   ├── cafes/map/page.tsx      ← Only Dark route left (intentional)
+│   ├── cafes/map/page.tsx      ← Only Dark route left (next session's target)
+│   ├── api/
+│   │   ├── cafe-visits/        ← NEW — POST/GET, DELETE/[id]
+│   │   ├── cafes/route.ts      ← Now folds in cafe_visits aggregation
+│   │   └── …
 │   ├── loading.tsx             ← Light cream bg + Light bean
 │   ├── layout.tsx              ← Root: PWA meta + ScrollContainer
-│   ├── api/                    ← API routes
 │   └── globals.css             ← [data-light-scope] shims live here
 ├── components/
 │   ├── flow/                   ← LightStep*.tsx (seven brew steps)
 │   ├── ui/
-│   │   ├── light/              ← Light primitives (LightShell, Field, Card,
-│   │   │                          Section, Footnote, Hero, CTA, CTAWarmth,
-│   │   │                          Chip, ActionPill, ChatInput, ChatThread,
-│   │   │                          NavigationOverlay, AttachmentSheet,
-│   │   │                          ReferenceCoffeePicker, StarRating,
-│   │   │                          CircularTimer, CoffeeBeanGlow)
-│   │   ├── FlavorWheel.tsx     ← Light palette in place (no fork)
+│   │   ├── light/              ← Light primitives
+│   │   ├── FlavorWheel.tsx     ← Light palette in place
+│   │   ├── BrewMethodIcon.tsx  ← Routes Orea variants to specific SVGs
 │   │   ├── PhotoUpload.tsx     ← Uses Dark CoffeeBeanGlow + CSS-shim invert
 │   │   ├── StarRating.tsx      ← Dark — only CafeMap consumes it
-│   │   └── …                   ← Shared neutrals (Button, NumberStepper, etc.)
+│   │   └── …
 │   ├── layout/
 │   │   ├── ScrollContainer.tsx ← Root wrapper (100dvh + hidden scroll)
 │   │   └── BottomSpacer.tsx
 │   ├── cafes/CafeMap.tsx       ← Leaflet (used by /cafes/map only)
-│   └── session/SessionCard.tsx ← Light — only /coffees/[id] All-brews uses it
+│   └── session/SessionCard.tsx ← Light, 30% card opacity so chips pop
 ├── lib/
-│   ├── field/                  ← v1.1 zones, types, defaultZones, schema,
-│   │                              composeGradient, FieldContext, mapNotesToZones,
-│   │                              cache.ts (NEW — session-id keyed Field hint)
-│   ├── claude/                 ← recommend.ts, analyzeBag.ts, escher.ts, …
-│   ├── db/                     ← schema.ts (Drizzle), helpers.ts (rowToCoffee),
-│   │                              migrations/00xx_*.sql
-│   └── types/                  ← coffee.ts, session.ts, cafes.ts, preferences.ts
+│   ├── field/                  ← v1.1 zones + cache.ts (coffee↔brew Field carry)
+│   ├── claude/                 ← recommend.ts, analyzeBag.ts, …
+│   ├── db/
+│   │   ├── schema.ts           ← + cafeVisits table
+│   │   ├── helpers.ts
+│   │   └── migrations/         ← 0000..0011 (0010 + 0011 applied 2026-05)
+│   └── types/                  ← + CafeVisit, CafeVisitRating in cafes.ts
 └── store/
-    └── flowStore.ts            ← Zustand brew flow state + fieldZones slot
+    └── flowStore.ts
+public/brew-icons/
+├── orea-classic.svg            ← NEW (#144)
+├── orea-open.svg                ← NEW
+├── orea-apex.svg                ← NEW
+├── orea-fast.svg                ← NEW
+└── orea-v4.png                  ← legacy fallback, no longer routed
 ```
-
----
-
-## Open items
-
-Roughly in priority order:
-
-1. **`/coffees` "Show only rotation" filter** — list shows the star indicator (#117) but no filter toggle. A 4th pill alongside Recent / Favorites / Roaster, or a sub-toggle. Small, scoped.
-2. **`LightStepScan` Card/Chip refactor** — 1400 lines with bespoke buttons that should route through the `Card` + `Chip` primitives. Code quality only; no visible UX change. Big diff, low risk.
-3. **Aromatic Goal validation** — PR #72 added the intent to `/api/recommend`. Per the Hard Rule on AI behavior changes (CLAUDE.md), it needs sample-before/after on the deployed PWA against a delicate coffee (Geisha, Wush Wush, Pink Bourbon). Markus said "Yes Go" but never explicitly tested recipe outputs.
-
----
-
-## Pitfalls discovered (don't re-learn these)
-
-- **iOS PWA caches `apple-mobile-web-app-status-bar-style` at install time.** Changing the meta tag does not update an already-installed PWA on iPhone. The user has to delete the PWA from the home screen AND clear Safari → Advanced → Website Data for the domain, then re-install. The same applies to `theme_color` on installed Android PWAs in some browsers — Service Workers can cache `manifest.json` (precached with revision hash) so a fresh manifest doesn't reach the chrome until the SW updates.
-- **Tailwind only scans `src/{app,components,pages}`.** `src/lib/**` is NOT in `tailwind.config.ts` `content`. Utility classes that live only in lib (e.g. arbitrary-value classes like `bg-[linear-gradient(...)]`) are silently never generated and vanish at runtime. If you need a shared visual constant in lib, export it as a raw CSS value and apply via inline `style={{ background: ... }}` at the call site (see `src/lib/theme/gradients.ts`).
-- **html canvas default.** `html { background-color: #F3E5DC }` (cream). `body { background-color: #0E0B0A }` by default, dropped to `transparent` only when `body:has([data-light-scope="true"])` matches. Light routes therefore show the cream canvas behind the Field; the legacy Dark `cafes/map` keeps its dark body. Loading state explicitly sets `background: #F3E5DC` inline because it renders BEFORE LightShell mounts.
-- **Next.js standalone Docker image** does NOT expose `@anthropic-ai/sdk` as `node_modules/@anthropic-ai`. Backfill script started failing with `ERR_MODULE_NOT_FOUND` until rewritten to call the Messages API over plain `fetch`. `pg` IS in standalone deps (traced via Drizzle).
-- **`lovable-v7/` must be in `.dockerignore`.** Without it the Docker `COPY . .` drags the Vite-targeted Lovable export into the build context and Next.js's worker tries to compile it → `react-router-dom not found` → deploy fails (PR #69).
-- **Drizzle SELECT * is column-strict.** Adding a column to the schema BEFORE running the SQL migration on the VPS makes `/api/coffees` 500 with "column does not exist". Migrations must be applied to the DB BEFORE the schema/code that references them deploys.
-- **`min-h-full flex flex-col` does not give children definite height.** `flex-1` inside collapses to 0. Leaflet container needed `h-dvh flex flex-col` + `flex-1 min-h-0` (PR #101).
-- **The `[data-light-scope]` CSS shim** in `globals.css` catches inline `var(--card)` etc. for un-migrated components inside the Light tree — but NOT hardcoded hex values like `#2A241C`. Those need explicit Light tokens at the source.
-- **CSS `filter: brightness(0)` under `[data-light-scope]`** is the trick used to invert hardcoded-white SVGs (`BrewMethodIcon` assets, original `CoffeeBeanGlow`) without forking the components.
-- **localStorage starter cache.** Versioned key `brewlog.starter.v4.<date>.<bucket>`. Bumping the version is the canonical invalidation. If you change the greeting prompt, bump the cache to `v5`.
-- **Hard Rule on AI behavior changes.** Any prompt / model / schema-enum change to `/api/recommend`, `/api/greeting`, `/api/match`, etc. needs sample-before-after outputs per `CLAUDE.md`. Cannot validate from this remote env — Markus runs on the deployed PWA.
-- **Auto-deploy** is GitHub Actions → SSH → Hetzner (`.github/workflows/deploy.yml`). Direct push to `main` blocked; PR-only workflow with `enable_pr_auto_merge` (mergeMethod SQUASH).
-- **Manual migrations.** SQL files in `src/lib/db/migrations/` are NOT auto-applied. Run on VPS per CLAUDE.md: `cat src/lib/db/migrations/00XX_*.sql | docker compose exec -T postgres psql -U brewlog -d brewlog`. The Drizzle journal only tracks `0000_init`.
 
 ---
 
 ## Conventions cheat sheet
 
-- **Tokens:** `text-light-foreground` (anthracite), `text-light-muted-foreground`, `bg-light-card-default` (cream glass), `bg-light-card-selected` (warm taupe), `border-light-foreground/15`, `shadow-light-card-pressed`
+- **Tokens:** `text-light-foreground` (anthracite), `text-light-muted-foreground`, `bg-light-card-default` (cream glass 55 %), `bg-light-card-selected` (warm taupe), `border-light-foreground/15`, `shadow-light-card-pressed`
 - **Cream highlight on dark elements:** `text-[hsl(36_55%_96%)]` (e.g. CTA text on anthracite button)
-- **Destructive (delete, error):** `bg-[hsl(12_70%_45%)]` warm rust — used by SessionCard swipe-delete + brew-session delete confirm modal
+- **Card variants:** default cards use `bg-light-card-default` (55 %); SessionCard (chips inside) uses `bg-[hsl(36_55%_96%/0.30)]` — the lower opacity so child chips visibly contrast.
+- **Destructive (delete, error):** `bg-[hsl(12_70%_45%)]` warm rust
 - **Hero question:** `font-fraunces font-semibold text-[40px] leading-[1.05] tracking-[-0.01em]`
 - **Headline (route title):** `font-fraunces text-3xl text-light-foreground leading-none`
+- **Wordmark (Home + Login):** `<h1 className="font-fraunces text-3xl leading-[1.05] text-light-foreground">Better taste<br />than sorry.</h1>` — exact same markup, two entry points
 - **Eyebrow:** uppercase tracked, `text-light-muted-foreground text-xs tracking-widest`
 - **Unified chip / tag:** `inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground`
+- **Primary CTA pill:** `w-full h-14 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] font-semibold` + `active:scale-[0.98] transition-transform`
 - **Field rotation per brew step:** see `STEP_ROTATION` map in `LightFlowShell.tsx`
-- **Light scope marker:** `[data-light-scope]` attribute set by LightShell wraps everything in the (light) route group. Use it for CSS rules that should ONLY apply to Light routes.
-
----
-
-## Live state on VPS (verified 2026-05)
-
-```
-sessions          → indexed feed table
-coffees           → 23 rows, all with field_zones populated
-coffees.in_rotation column exists (migration 0009 applied)
-places            → 6,202 rows (manual bulk load, no Git seed)
-preferences       → user equipment + grinder + location
-roasters          → custom roaster priors
-knowledge         → seed-insights.mjs populated
-coffee_alerts     → user subscriptions
-auth_credentials  → WebAuthn passkey
-conversations + conversation_messages → BTTS chat history
-```
+- **Light scope marker:** `[data-light-scope]` attribute set by LightShell wraps everything in the (light) route group
 
 ---
 
 ## Where to start next session
 
-Light migration is closed. Most likely next moves: (1) Rotation filter on `/coffees`, (2) `LightStepScan` refactor for code quality, (3) Aromatic Goal validation on the deployed PWA. Any of these is scoped enough for a single session.
+Map polish + visit entry from map is the obvious next move — see the Top priority section. After that the punchlist is small enough that you could go down it in one session: rotation filter, scan refactor, visit notes UI, deploy workflow hardening. Aromatic Goal validation needs Markus on the deployed PWA brewing actual coffee.
 
-Before any prompt change to `/api/greeting`, `/api/recommend`, etc.: read the **Hard Rule on AI behaviour changes** in CLAUDE.md. Sample real outputs on the deployed PWA — Markus validates.
+Before any prompt change to `/api/greeting`, `/api/recommend`, etc.: read the **Hard Rule on AI behaviour changes** in CLAUDE.md.
 
 Read **`CLAUDE.md`** as the persistent context; this file only for the in-flight state.


### PR DESCRIPTION
## Summary

Today landed PRs #138–#145 plus two DB migrations (0010 + 0011, both applied on VPS) plus a manual deploy clean-up. Brings both docs back current and queues up the map polish + visit-from-map work as the obvious next-session target.

### `CLAUDE.md`

- **API routes**: added `/api/cafe-visits` (GET/POST) and `/api/cafe-visits/[id]` (DELETE)
- **DB tables**: 11 → 12 (`cafe_visits`)
- **Migrations folder**: added `0010_rename_rvtc.sql` and `0011_add_cafe_visits.sql` with one-liners
- **Recent additions**: noted #142 (RVTC rename, applied 2026-05) and #145 (cafe_visits table + visit-only mode)
- **Current Status snapshot**: added "Late-May follow-ups (PR #139–#145)" block covering wordmark + CTA pills + SessionCard transparency, café-coffee library link, scan editing discoverability, Orea V4 four-bottom variants, and the "I've been here" feature
- **Open items rewritten**: map polish + visit-from-map promoted to #1+#2 (coupled). Added new items: cafe visit notes edit UI and deploy workflow hardening (today's Docker race)

### `HANDOVER.md` — full rewrite

- **"Top priority for next session"** section leads with `/cafes/map` Light pass + visit-from-map entry point. Includes specific tile-provider options (Carto Positron/Voyager, Stadia Outdoors, OSM raw, CSS filter hack), marker treatment ideas (anthracite circles, visited vs unvisited differentiation), and the coupled visit modal flow
- **What shipped today**: one-line summary per PR (#138–#145) including the deploy quirk hit on the VPS
- **Live state on VPS**: refreshed with today's migrations (UPDATE 3 + 16 on RVTC, new `cafe_visits` table) verified from operator output
- **Open items**: 6 items ranked. Map at the top
- **Pitfalls**: added the Docker name-conflict race we discovered today
- **File tree**: added cafe-visits API dir, the four new Orea SVGs, SessionCard at 30 % bg, `cafe_visits` in db/schema + types
- **Conventions cheat sheet**: added the SessionCard variant note and the unified-wordmark markup (Home + Login share the same `<h1>`)

## Test plan

- [ ] Read CLAUDE.md and HANDOVER.md cold — would a new Claude session know to tackle the map next, why it's coupled with the visit feature, and that 0010 + 0011 migrations are already applied?
- [ ] Verify the route table in CLAUDE.md matches the actual `src/app/` filesystem
- [ ] Verify the DB tables list reads 12

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_