### PR TITLE
fix(deploy): force-recreate stale app containers before up

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,5 +14,22 @@ jobs:
           printf '%s\n' "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts
+          # Defensive sequence:
+          #   1. fetch + hard reset to origin/main
+          #   2. build new app image (existing container still runs — no downtime yet)
+          #   3. nuke any container belonging to the app service. covers
+          #      both the well-named "brewlog-app-1" and any
+          #      "<hash>_brewlog-app-1" half-renamed leftover from a
+          #      previous recreate that failed midway (the race that bit
+          #      us when manual `docker compose up -d app` overlapped
+          #      with a workflow run — see HANDOVER.md). Postgres + Caddy
+          #      + Ofelia containers untouched.
+          #   4. start the app service fresh.
           ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
-            "cd ${{ secrets.DEPLOY_PATH }} && git fetch origin main && git reset --hard origin/main && docker compose build app && docker compose up -d app"
+            "set -e; cd ${{ secrets.DEPLOY_PATH }} \
+             && git fetch origin main \
+             && git reset --hard origin/main \
+             && docker compose build app \
+             && (docker ps -aq --filter 'label=com.docker.compose.project=brewlog' --filter 'label=com.docker.compose.service=app' | xargs -r docker rm -f) \
+             && (docker ps -aq --filter 'name=brewlog-app' | xargs -r docker rm -f) \
+             && docker compose up -d app"


### PR DESCRIPTION
## Summary

Second time this evening a deploy hit:

```
Container brewlog-app-1 Error response from daemon: Conflict.
The container name "/<hash>_brewlog-app-1" is already in use by container "<other hash>".
You have to remove (or rename) that container to be able to reuse that name.
```

**Cause:** when a previous recreate failed midway (or a manual `docker compose up -d app` overlapped with a workflow run), Docker leaves a leftover container with a half-renamed name like `/<hash>_brewlog-app-1`. The next `docker compose up -d app` can't create the new container because the temp name slot is occupied.

## Fix

Explicit two-pass cleanup before the `up`:

1. **By compose label** (`project=brewlog` + `service=app`) — catches both well-named and half-renamed leftovers as long as Docker Compose set the labels (it does).
2. **By name prefix** (`brewlog-app*`) — fallback for any container created outside of Docker Compose somehow.

Both passes pipe through `xargs -r` so they no-op cleanly when the filter returns nothing (first deploy on a fresh host).

### Ordering matters

| Step | Effect |
|---|---|
| `git fetch + reset --hard origin/main` | sync code |
| `docker compose build app` | old container still serves traffic, no downtime |
| `xargs ... docker rm -f` (twice) | brief ~5–10 s gap |
| `docker compose up -d app` | new container takes over |

`set -e` added to the SSH command so any step failure halts the rest instead of silently proceeding.

Postgres / Caddy / Ofelia containers are **not touched** — the filters explicitly target the app service only.

## Test plan

- [ ] Merge → triggers a fresh deploy → workflow self-heals (cleans up whatever's stuck on the VPS from the failed run) and the app comes back up.
- [ ] Verify on VPS afterwards: `docker ps` shows a single `brewlog-app-1` container, no half-named leftovers.
- [ ] Subsequent code pushes deploy without name conflicts even if a manual `docker compose up` happens concurrently.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Taw5CnzsRZxS7azohZqgW)_