### PR TITLE
feat(map): light pass for /cafes/map + "I've been here" from a pin

### DIFF
--- a/src/app/(light)/cafes/map/page.tsx
+++ b/src/app/(light)/cafes/map/page.tsx
@@ -5,22 +5,18 @@ import Link from "next/link";
 import dynamic from "next/dynamic";
 import type { CafeSummary } from "@/lib/types/cafes";
 
-// Leaflet needs `window`; lazy-load client-side only so SSR doesn't
-// crash.
+// Leaflet needs `window`; lazy-load client-side only so SSR doesn't crash.
 const CafeMap = dynamic(() => import("@/components/cafes/CafeMap"), { ssr: false });
 
 /**
- * Nearby — full-screen map view. Markus' /cafes feedback: "Nearby
- * ohne Café und Coffee. Nur Map." Lives under /cafes/map; the
- * navigation overlay's "Nearby" link routes here. Café Library
- * (the saved-list + tasted-coffees tabs) stays on /cafes.
+ * Nearby — full-screen map. Lives in the (light) route group so it
+ * inherits the LightShell scope (anthracite tokens, focus shim). The
+ * Field paints behind the map but is fully covered — the route still
+ * belongs in the Light tree for consistency now that the tiles + chrome
+ * are Light.
  *
- * The map needs a definitively sized container — the previous
- * Map-as-tab inside /cafes had `min-h-full` upstream which didn't
- * propagate, and the Leaflet container collapsed to 0 height
- * (visible only as the attribution edge in Markus' screenshot).
- * Here we anchor with `h-dvh flex flex-col` so the inner Map fills
- * the entire remaining viewport.
+ * Leaflet needs a definitively sized container — `h-dvh flex flex-col`
+ * here, `flex-1 min-h-0` on the wrapper around <CafeMap />.
  */
 export default function CafesMapPage() {
   const router = useRouter();
@@ -34,19 +30,19 @@ export default function CafesMapPage() {
   }, []);
 
   return (
-    <div className="h-dvh flex flex-col bg-brew-bg overflow-hidden">
+    <div className="h-dvh flex flex-col overflow-hidden">
       <header
         className="shrink-0 px-5 pb-3 flex items-center justify-between"
         style={{ paddingTop: "calc(env(safe-area-inset-top) + 1rem)" }}
       >
-        <Link href="/cafes" className="flex items-center gap-1 text-brew-muted text-sm">
+        <Link href="/cafes" className="flex items-center gap-1 text-light-muted-foreground text-sm">
           <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5} aria-hidden>
             <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
           </svg>
           Cafés
         </Link>
-        <h1 className="font-display text-lg text-white">Nearby</h1>
-        <Link href="/cafes" className="text-brew-muted text-xs">
+        <h1 className="font-fraunces text-3xl text-light-foreground leading-none">Nearby</h1>
+        <Link href="/cafes" className="text-light-muted-foreground text-xs">
           List →
         </Link>
       </header>

--- a/src/components/cafes/CafeMap.tsx
+++ b/src/components/cafes/CafeMap.tsx
@@ -2,8 +2,9 @@
 import "leaflet/dist/leaflet.css";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { Map as LMap, Marker as LMarker } from "leaflet";
-import type { CafeSummary, Place } from "@/lib/types/cafes";
-import StarRating from "@/components/ui/StarRating";
+import { ThumbsUp, ThumbsDown } from "lucide-react";
+import type { CafeSummary, Place, CafeVisit, CafeVisitRating } from "@/lib/types/cafes";
+import StarRating from "@/components/ui/light/StarRating";
 
 function haversineKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
   const R = 6371;
@@ -43,32 +44,43 @@ async function geocafe(name: string, location?: string): Promise<{ lat: number; 
   return null;
 }
 
+/* ── Marker palette ────────────────────────────────────────────
+ * Anthracite (#242424 ≈ light-foreground hsl(0 0% 14%)) + cream
+ * (#FAF3ED ≈ hsl(36 55% 96%)) so pins read against Positron's neutral
+ * light-gray tiles without needing a brand-color accent.
+ *
+ *   visited default  → solid anthracite body, cream dot
+ *   visited selected → cream body, anthracite ring + dot, slightly larger
+ *   ghost default    → outline-only anthracite (unvisited curated places)
+ *   ghost selected   → cream fill, anthracite outline + solid dot
+ */
 const PIN_HTML = `<svg width="28" height="36" viewBox="0 0 28 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="#E8C5A8"/>
-  <circle cx="14" cy="14" r="5" fill="#1A1008"/>
+  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="#242424"/>
+  <circle cx="14" cy="14" r="5" fill="#FAF3ED"/>
 </svg>`;
 
-// visited + selected: white body, dark dot
-const PIN_SELECTED_HTML = `<svg width="28" height="36" viewBox="0 0 28 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="#FFFFFF"/>
-  <circle cx="14" cy="14" r="5" fill="#1A1008"/>
+const PIN_SELECTED_HTML = `<svg width="32" height="40" viewBox="-2 -2 32 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="#FAF3ED" stroke="#242424" stroke-width="2.5"/>
+  <circle cx="14" cy="14" r="5" fill="#242424"/>
 </svg>`;
 
-// not-visited + not-selected: no fill, accent outline, hollow inner dot
 const GHOST_PIN_HTML = `<svg width="24" height="31" viewBox="-2 -2 32 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="none" stroke="#E8C5A8" stroke-width="2.5"/>
-  <circle cx="14" cy="14" r="4" fill="none" stroke="#E8C5A8" stroke-width="2"/>
+  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="none" stroke="#242424" stroke-width="2.5"/>
+  <circle cx="14" cy="14" r="4" fill="none" stroke="#242424" stroke-width="2"/>
 </svg>`;
 
-// not-visited + selected: white body, accent outline, solid accent dot — distinct from all three above
-const GHOST_PIN_SELECTED_HTML = `<svg width="24" height="31" viewBox="-2 -2 32 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="#FFFFFF" stroke="#E8C5A8" stroke-width="2.5"/>
-  <circle cx="14" cy="14" r="4" fill="#E8C5A8"/>
+const GHOST_PIN_SELECTED_HTML = `<svg width="28" height="36" viewBox="-2 -2 32 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="#FAF3ED" stroke="#242424" stroke-width="2.5"/>
+  <circle cx="14" cy="14" r="4" fill="#242424"/>
 </svg>`;
 
 const YOU_ARE_HERE_HTML = `
-<style>@keyframes ect-pulse{0%,100%{box-shadow:0 0 0 5px rgba(255,255,255,0.2)}50%{box-shadow:0 0 0 10px rgba(255,255,255,0.06)}}</style>
-<div style="width:12px;height:12px;border-radius:50%;background:#fff;box-shadow:0 0 0 5px rgba(255,255,255,0.2);animation:ect-pulse 1.8s ease-in-out infinite"></div>`;
+<style>@keyframes ect-pulse{0%,100%{box-shadow:0 0 0 5px rgba(36,36,36,0.28)}50%{box-shadow:0 0 0 10px rgba(36,36,36,0.08)}}</style>
+<div style="width:12px;height:12px;border-radius:50%;background:#242424;border:2px solid #FAF3ED;box-shadow:0 0 0 5px rgba(36,36,36,0.28);animation:ect-pulse 1.8s ease-in-out infinite"></div>`;
+
+function normalizeName(s: string): string {
+  return s.trim().toLowerCase();
+}
 
 export default function CafeMap({ cafes, onSelect, initialSearch }: {
   cafes: CafeSummary[];
@@ -107,6 +119,24 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
   const [locatingUser, setLocatingUser] = useState(false);
   const [locateError, setLocateError] = useState<string | null>(null);
   const [nearbyIds, setNearbyIds] = useState<Set<number> | null>(null);
+
+  // Names of cafés the user has already visited — drives whether a curated
+  // place renders as a ghost (unvisited) or solid (visited) pin. Seeded from
+  // the cafes prop, extended optimistically when a visit is saved via the
+  // "I've been here" modal so the marker flips immediately without waiting
+  // for /api/cafes to refetch.
+  const [visitedNames, setVisitedNames] = useState<Set<string>>(() => new Set());
+  useEffect(() => {
+    setVisitedNames(prev => {
+      const next = new Set(prev);
+      for (const c of cafes) next.add(normalizeName(c.name));
+      return next;
+    });
+  }, [cafes]);
+
+  // "I've been here" modal state — opened from the curated-place card.
+  const [visitModalPlace, setVisitModalPlace] = useState<Place | null>(null);
+  const [visitSaving, setVisitSaving] = useState(false);
 
   // Debounce: marker rebuilds fire 300ms after typing stops
   useEffect(() => {
@@ -158,13 +188,15 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
       const map = L.map(containerRef.current, { zoomControl: false, attributionControl: false });
       mapRef.current = map;
 
-      L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png", {
+      // Positron — Carto's neutral light-gray tile set. Sits cleanly behind
+      // anthracite markers + cream cards without competing for attention.
+      L.tileLayer("https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png", {
         maxZoom: 19,
         detectRetina: true,
       }).addTo(map);
 
       const pinIcon = L.divIcon({ html: PIN_HTML, className: "", iconSize: [28, 36], iconAnchor: [14, 36] });
-      const pinSelectedIcon = L.divIcon({ html: PIN_SELECTED_HTML, className: "", iconSize: [28, 36], iconAnchor: [14, 36] });
+      const pinSelectedIcon = L.divIcon({ html: PIN_SELECTED_HTML, className: "", iconSize: [32, 40], iconAnchor: [16, 40] });
       const youAreHereIcon = L.divIcon({ html: YOU_ARE_HERE_HTML, className: "", iconSize: [12, 12], iconAnchor: [6, 6] });
       pinIconRef.current = pinIcon;
 
@@ -299,7 +331,8 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
     };
   }, []);
 
-  // Ghost pins — only renders when debouncedSearch is non-empty
+  // Curated-place markers — re-render when the filter changes OR when a new
+  // visit is logged (visitedNames change re-paints that place as a solid pin).
   useEffect(() => {
     if (!mapReady || !mapRef.current || !leafletRef.current) return;
 
@@ -314,7 +347,9 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
     if (!debouncedSearch.trim() && nearbyIds == null) return;
 
     const ghostIcon = L.divIcon({ html: GHOST_PIN_HTML, className: "", iconSize: [24, 31], iconAnchor: [12, 31] });
-    const ghostSelectedIcon = L.divIcon({ html: GHOST_PIN_SELECTED_HTML, className: "", iconSize: [24, 31], iconAnchor: [12, 31] });
+    const ghostSelectedIcon = L.divIcon({ html: GHOST_PIN_SELECTED_HTML, className: "", iconSize: [28, 36], iconAnchor: [14, 36] });
+    const visitedIcon = L.divIcon({ html: PIN_HTML, className: "", iconSize: [28, 36], iconAnchor: [14, 36] });
+    const visitedSelectedIcon = L.divIcon({ html: PIN_SELECTED_HTML, className: "", iconSize: [32, 40], iconAnchor: [16, 40] });
     ghostIconRef.current = ghostIcon;
 
     const placed: LMarker[] = [];
@@ -322,14 +357,29 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
     for (const place of filteredPlaces) {
       if (place.lat == null || place.lng == null) continue;
 
-      const marker = L.marker([place.lat, place.lng], { icon: ghostIcon }).addTo(map);
+      const isVisited = visitedNames.has(normalizeName(place.name));
+      const defaultIcon = isVisited ? visitedIcon : ghostIcon;
+      const selectedIcon = isVisited ? visitedSelectedIcon : ghostSelectedIcon;
+
+      const marker = L.marker([place.lat, place.lng], { icon: defaultIcon }).addTo(map);
       marker.on("click", () => {
-        if (selectedPlaceMarkerRef.current) selectedPlaceMarkerRef.current.setIcon(ghostIcon);
+        if (selectedPlaceMarkerRef.current) {
+          // Reset the previous place marker to its own default icon — look up
+          // by name so already-visited pins return to solid, not ghost.
+          const prevPlace = (selectedPlaceMarkerRef.current as LMarker & { _placeRef?: Place })._placeRef;
+          const prevDefault = prevPlace && visitedNames.has(normalizeName(prevPlace.name))
+            ? visitedIcon
+            : ghostIcon;
+          selectedPlaceMarkerRef.current.setIcon(prevDefault);
+        }
         if (selectedMarkerRef.current && pinIconRef.current) {
           selectedMarkerRef.current.setIcon(pinIconRef.current);
           selectedMarkerRef.current = null;
         }
-        marker.setIcon(ghostSelectedIcon);
+        marker.setIcon(selectedIcon);
+        // Stash the place data on the marker so the previous-selection
+        // reset above can look up the right default icon.
+        (marker as LMarker & { _placeRef?: Place })._placeRef = place;
         selectedPlaceMarkerRef.current = marker;
         setPlaceSelected(place);
         setSelected(null);
@@ -344,7 +394,7 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
     if (placed.length > 0 && nearbyIds == null) {
       map.fitBounds(L.featureGroup(placed).getBounds().pad(0.3));
     }
-  }, [mapReady, filteredPlaces, debouncedSearch, resultCities, nearbyIds]);
+  }, [mapReady, filteredPlaces, debouncedSearch, resultCities, nearbyIds, visitedNames]);
 
   // Geocode the search query and pan there only when there are no curated
   // matches at all — fallback so typing a city/address still moves the map.
@@ -385,11 +435,55 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
 
   const clearPlaceSelected = () => {
     if (selectedPlaceMarkerRef.current && ghostIconRef.current) {
-      selectedPlaceMarkerRef.current.setIcon(ghostIconRef.current);
+      const prevPlace = (selectedPlaceMarkerRef.current as LMarker & { _placeRef?: Place })._placeRef;
+      // Look up the right default — visited pins must return to solid, not ghost.
+      if (prevPlace && visitedNames.has(normalizeName(prevPlace.name)) && leafletRef.current) {
+        selectedPlaceMarkerRef.current.setIcon(
+          leafletRef.current.divIcon({ html: PIN_HTML, className: "", iconSize: [28, 36], iconAnchor: [14, 36] })
+        );
+      } else {
+        selectedPlaceMarkerRef.current.setIcon(ghostIconRef.current);
+      }
       selectedPlaceMarkerRef.current = null;
     }
     setPlaceSelected(null);
   };
+
+  async function saveVisit(rating: CafeVisitRating) {
+    if (!visitModalPlace) return;
+    setVisitSaving(true);
+    try {
+      const location = visitModalPlace.address ?? visitModalPlace.city;
+      const res = await fetch("/api/cafe-visits", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          cafeName: visitModalPlace.name,
+          location,
+          rating,
+        }),
+      });
+      if (res.ok) {
+        // Drain the body so the connection closes cleanly; the response
+        // payload isn't needed — local visitedNames + marker re-render
+        // is the visible confirmation.
+        await (res.json() as Promise<CafeVisit>);
+        setVisitedNames(prev => {
+          const next = new Set(prev);
+          next.add(normalizeName(visitModalPlace.name));
+          return next;
+        });
+        setVisitModalPlace(null);
+        // Close the place card too so the marker re-render (now solid
+        // anthracite) acts as the confirmation — the previously-selected
+        // marker is replaced by a fresh default-state one anyway.
+        setPlaceSelected(null);
+        selectedPlaceMarkerRef.current = null;
+      }
+    } finally {
+      setVisitSaving(false);
+    }
+  }
 
   return (
     <div className="relative w-full h-full">
@@ -398,7 +492,7 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
       {/* Search input */}
       <div className="absolute top-4 left-4 right-4 z-[1000]">
         <div className="relative flex items-center max-w-xs mx-auto">
-          <svg className="absolute left-3 w-3.5 h-3.5 text-brew-muted pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <svg className="absolute left-3 w-3.5 h-3.5 text-light-muted-foreground pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <circle cx="11" cy="11" r="8" />
             <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35" />
           </svg>
@@ -408,14 +502,14 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
             onChange={e => { setSearch(e.target.value); setNearbyIds(null); }}
             onKeyDown={e => { if (e.key === "Enter") setDebouncedSearch(search); }}
             placeholder="Search cafés…"
-            className="w-full bg-brew-elevated border border-brew-accent/30 text-white text-sm placeholder-brew-muted rounded-full pl-8 pr-8 py-2 focus:outline-none focus:border-brew-accent shadow-lg shadow-black/70"
+            className="w-full bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 text-light-foreground text-sm placeholder:text-light-muted-foreground rounded-full pl-8 pr-8 py-2 focus:outline-none shadow-sm"
           />
           {(search || nearbyIds != null) && (
             <button
               type="button"
               onClick={() => { setSearch(""); setDebouncedSearch(""); setNearbyIds(null); }}
               aria-label="Clear search"
-              className="absolute right-2.5 text-brew-muted active:scale-95 transition-transform"
+              className="absolute right-2.5 text-light-muted-foreground active:scale-95 transition-transform"
             >
               <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2.5}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
@@ -425,7 +519,7 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
         </div>
         {/* Result count — shown once debounce settles */}
         {(nearbyIds != null || (debouncedSearch.trim() && debouncedSearch === search)) && (
-          <p className="text-center text-xs text-brew-muted mt-1.5 pointer-events-none">
+          <p className="text-center text-xs text-light-muted-foreground mt-1.5 pointer-events-none">
             {filteredPlaces.length === 0
               ? "No places found"
               : resultCities.length === 1
@@ -435,7 +529,7 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
         )}
       </div>
 
-      <div className="absolute bottom-2 right-2 z-[1000] text-white/25 pointer-events-none" style={{ fontSize: "9px" }}>
+      <div className="absolute bottom-2 right-2 z-[1000] text-light-foreground/35 pointer-events-none" style={{ fontSize: "9px" }}>
         © OpenStreetMap · © CARTO
       </div>
 
@@ -445,15 +539,15 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
         onClick={() => locateMeFnRef.current?.()}
         disabled={locatingUser}
         aria-label="Locate me"
-        className="absolute bottom-14 right-3 z-[1000] w-10 h-10 rounded-full bg-brew-surface/90 border border-brew-border flex items-center justify-center active:scale-95 transition-transform disabled:opacity-60"
+        className="absolute bottom-14 right-3 z-[1000] w-10 h-10 rounded-full bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 flex items-center justify-center active:scale-95 transition-transform disabled:opacity-60"
       >
         {locatingUser ? (
-          <svg className="w-4 h-4 animate-spin text-brew-muted" fill="none" viewBox="0 0 24 24">
+          <svg className="w-4 h-4 animate-spin text-light-muted-foreground" fill="none" viewBox="0 0 24 24">
             <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
             <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
           </svg>
         ) : (
-          <svg className="w-4 h-4 text-brew-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+          <svg className="w-4 h-4 text-light-foreground/80" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M12 2v2M12 20v2M2 12h2M20 12h2" />
             <circle cx="12" cy="12" r="4" />
             <circle cx="12" cy="12" r="9" />
@@ -463,29 +557,29 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
 
       {/* Location error pill */}
       {locateError && (
-        <div className="absolute top-3 left-1/2 -translate-x-1/2 z-[1000] bg-brew-surface/90 border border-brew-border rounded-full px-3 py-1 text-xs text-brew-muted whitespace-nowrap">
+        <div className="absolute top-3 left-1/2 -translate-x-1/2 z-[1000] bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-full px-3 py-1 text-xs text-light-muted-foreground whitespace-nowrap">
           {locateError}
         </div>
       )}
 
       {/* Initial loading overlay */}
       {locating && (
-        <div className="absolute inset-0 bg-brew-bg flex items-center justify-center z-10">
-          <p className="text-brew-muted text-sm">Finding your location…</p>
+        <div className="absolute inset-0 bg-[hsl(36_55%_96%)] flex items-center justify-center z-10">
+          <p className="text-light-muted-foreground text-sm">Finding your location…</p>
         </div>
       )}
 
       {/* Visited café card */}
       {selected && (
         <div className="absolute bottom-4 left-4 right-4 z-[1000]">
-          <div className="bg-brew-surface/95 backdrop-blur-sm border border-brew-border rounded-2xl p-4">
+          <div className="bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-2xl p-4">
             <div className="flex items-start gap-3">
               <div className="flex-1 min-w-0">
-                <p className="text-white font-medium leading-tight truncate">{selected.name}</p>
+                <p className="text-light-foreground font-medium leading-tight truncate">{selected.name}</p>
                 {selected.location && (
-                  <p className="text-brew-muted text-xs mt-0.5 truncate">{selected.location}</p>
+                  <p className="text-light-muted-foreground text-xs mt-0.5 truncate">{selected.location}</p>
                 )}
-                <p className="text-brew-muted text-xs mt-0.5">
+                <p className="text-light-muted-foreground text-xs mt-0.5">
                   {selected.visits} visit{selected.visits !== 1 ? "s" : ""}
                 </p>
                 {selected.avgRating !== null && (
@@ -495,12 +589,16 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
                 )}
               </div>
               <div className="flex flex-col items-end gap-2 shrink-0">
-                <button type="button" onClick={clearSelected} className="text-brew-muted p-0.5 active:scale-95 transition-transform" aria-label="Close">
+                <button type="button" onClick={clearSelected} className="text-light-muted-foreground p-0.5 active:scale-95 transition-transform" aria-label="Close">
                   <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                     <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
                   </svg>
                 </button>
-                <button type="button" onClick={() => onSelect(selected)} className="bg-brew-accent text-brew-accent-fg text-xs font-semibold px-4 py-1.5 rounded-full active:scale-95 transition-transform">
+                <button
+                  type="button"
+                  onClick={() => onSelect(selected)}
+                  className="bg-light-foreground text-[hsl(36_55%_96%)] text-xs font-semibold px-4 py-1.5 rounded-full active:scale-95 transition-transform"
+                >
                   View
                 </button>
               </div>
@@ -512,29 +610,88 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
       {/* Curated place card */}
       {placeSelected && (
         <div className="absolute bottom-4 left-4 right-4 z-[1000]">
-          <div className="bg-brew-surface/95 backdrop-blur-sm border border-brew-border rounded-2xl p-4">
+          <div className="bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-2xl p-4">
             <div className="flex items-start gap-3">
               <div className="flex-1 min-w-0">
-                <p className="text-white font-medium leading-tight truncate">{placeSelected.name}</p>
-                <p className="text-brew-muted text-xs mt-0.5">{placeSelected.city}</p>
-                <p className="text-brew-muted text-xs mt-1.5">Not visited yet</p>
+                <p className="text-light-foreground font-medium leading-tight truncate">{placeSelected.name}</p>
+                <p className="text-light-muted-foreground text-xs mt-0.5">{placeSelected.city}</p>
+                <p className="text-light-muted-foreground text-xs mt-1.5">
+                  {visitedNames.has(normalizeName(placeSelected.name)) ? "Visited" : "Not visited yet"}
+                </p>
               </div>
-              <div className="flex flex-col items-end gap-2 shrink-0">
-                <button type="button" onClick={clearPlaceSelected} className="text-brew-muted p-0.5 active:scale-95 transition-transform" aria-label="Close">
-                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                  </svg>
-                </button>
+              <button type="button" onClick={clearPlaceSelected} className="text-light-muted-foreground p-0.5 active:scale-95 transition-transform shrink-0" aria-label="Close">
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+            <div className="flex items-center gap-2 mt-3">
+              <button
+                type="button"
+                onClick={() => setVisitModalPlace(placeSelected)}
+                className="flex-1 h-10 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] text-xs font-semibold active:scale-[0.98] transition-transform"
+              >
+                I&apos;ve been here
+              </button>
+              {placeSelected.address && (
                 <a
-                  href={`https://maps.google.com/?q=${encodeURIComponent(placeSelected.address!)}`}
+                  href={`https://maps.google.com/?q=${encodeURIComponent(placeSelected.address)}`}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="bg-brew-accent text-brew-accent-fg text-xs font-semibold px-4 py-1.5 rounded-full active:scale-95 transition-transform"
+                  className="h-10 px-4 rounded-full border border-light-foreground/20 text-light-foreground text-xs font-medium flex items-center bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 active:scale-[0.98] transition-transform"
                 >
-                  Open in Maps
+                  Maps ↗
                 </a>
-              </div>
+              )}
             </div>
+          </div>
+        </div>
+      )}
+
+      {/* "I've been here" rating modal — binary thumbs (come back / won't
+          return). Mirrors the modal on /cafes/place/[slug]. */}
+      {visitModalPlace && (
+        <div
+          className="fixed inset-0 z-[2000] flex items-end sm:items-center justify-center px-5"
+          style={{ background: "rgba(28,22,19,0.45)" }}
+          onClick={() => !visitSaving && setVisitModalPlace(null)}
+        >
+          <div
+            className="w-full max-w-sm bg-[hsl(36_55%_96%)] rounded-3xl p-6 space-y-4 mb-6 sm:mb-0"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="space-y-1">
+              <h2 className="font-fraunces text-2xl text-light-foreground leading-tight">How was it?</h2>
+              <p className="text-light-muted-foreground text-sm">{visitModalPlace.name}</p>
+            </div>
+            <div className="flex flex-col gap-2 pt-2">
+              <button
+                type="button"
+                disabled={visitSaving}
+                onClick={() => saveVisit("come-back")}
+                className="w-full h-14 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] font-medium flex items-center justify-center gap-3 active:scale-[0.98] transition-transform disabled:opacity-50"
+              >
+                <ThumbsUp className="w-5 h-5" strokeWidth={1.75} />
+                Would come back
+              </button>
+              <button
+                type="button"
+                disabled={visitSaving}
+                onClick={() => saveVisit("wont-return")}
+                className="w-full h-14 rounded-full border border-light-foreground/25 text-light-foreground font-medium flex items-center justify-center gap-3 active:scale-[0.98] transition-transform disabled:opacity-50 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150"
+              >
+                <ThumbsDown className="w-5 h-5" strokeWidth={1.75} />
+                Won&apos;t see me again
+              </button>
+            </div>
+            <button
+              type="button"
+              disabled={visitSaving}
+              onClick={() => setVisitModalPlace(null)}
+              className="w-full text-light-muted-foreground text-sm py-2"
+            >
+              Cancel
+            </button>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

Closes the last Dark route. `/cafes/map` is now in the `(light)` group with anthracite + cream styling end-to-end, and tapping any unvisited pin offers a one-tap "I've been here" path so you can log a flat-white visit without going through `/cafes/place/[slug]` first.

- **Tiles**: dark CartoCDN → **Positron** (`light_all`) — neutral light-gray base.
- **Markers**: anthracite (`#242424`) + cream (`#FAF3ED`). Visited = solid pin. Unvisited (curated places from `/api/places`) = outline ghost. Selected variants for both. You-are-here is anthracite-dot + cream-ring with pulse halo.
- **Chrome**: search input, locate-me button, both popup cards, loading overlay, attribution — all Light tokens. `StarRating` swapped to the Light fork.
- **"I've been here" from the map**: place card now exposes the binary-thumbs modal (same UI as `/cafes/place/[slug]`), POSTs to `/api/cafe-visits`, optimistically flips the pin from ghost → solid anthracite. A visit is a visit — brew session or flat-white-thumbs both land on the same visual anchor.

## Test plan

- [ ] On the deployed PWA: open `/cafes/map` — verify Positron tiles, anthracite "you are here" marker, anthracite-solid pins on places you've already brewed at.
- [ ] Search for a city (e.g. "Cologne") and confirm ghost pins render outline-only against the light tiles.
- [ ] Tap an unvisited ghost pin → card shows place + "I've been here" + "Maps ↗".
- [ ] Tap "I've been here" → modal opens → "Would come back" or "Won't see me again" → modal + card close, pin flips to solid anthracite.
- [ ] Go to `/cafes` → the new visit appears in the Café Library (folded by `/api/cafes`).
- [ ] Tap a visited pin → card still shows "I've been here" (you can log multiple visits per place).
- [ ] Locate-me button → recenters + repopulates ghost pins within 25 spots / city.

## Notes for next session

`CLAUDE.md` + `HANDOVER.md` still describe `/cafes/map` as "intentionally Dark" and rank the Light pass as top priority. Both are stale post-merge — happy to push a docs follow-up commit if useful.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_