### PR TITLE
refactor(scan): replace 5 bespoke selection buttons with &lt;Card&gt; primitive

### DIFF
--- a/src/app/(light)/cafes/map/page.tsx
+++ b/src/app/(light)/cafes/map/page.tsx
@@ -1,26 +1,25 @@
 "use client";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
 import dynamic from "next/dynamic";
+import { Menu } from "lucide-react";
 import type { CafeSummary } from "@/lib/types/cafes";
+import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
 
 // Leaflet needs `window`; lazy-load client-side only so SSR doesn't crash.
 const CafeMap = dynamic(() => import("@/components/cafes/CafeMap"), { ssr: false });
 
 /**
- * Nearby — full-screen map. Lives in the (light) route group so it
- * inherits the LightShell scope (anthracite tokens, focus shim). The
- * Field paints behind the map but is fully covered — the route still
- * belongs in the Light tree for consistency now that the tiles + chrome
- * are Light.
- *
- * Leaflet needs a definitively sized container — `h-dvh flex flex-col`
- * here, `flex-1 min-h-0` on the wrapper around <CafeMap />.
+ * Nearby — full-bleed map. The Light Coffee Library pattern (title left,
+ * burger right) but anchored as floating chrome over an edge-to-edge map,
+ * so there's no hard tonal cut between a cream header bar and the tiles.
+ * The map fills 100dvh; a soft cream→transparent scrim at the top keeps
+ * the title legible against the warm-tinted Positron tiles.
  */
 export default function CafesMapPage() {
   const router = useRouter();
   const [cafes, setCafes] = useState<CafeSummary[]>([]);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => {
     fetch("/api/cafes", { cache: "no-store" })
@@ -30,29 +29,44 @@ export default function CafesMapPage() {
   }, []);
 
   return (
-    <div className="h-dvh flex flex-col overflow-hidden">
-      <header
-        className="shrink-0 px-5 pb-3 flex items-center justify-between"
-        style={{ paddingTop: "calc(env(safe-area-inset-top) + 1rem)" }}
-      >
-        <Link href="/cafes" className="flex items-center gap-1 text-light-muted-foreground text-sm">
-          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5} aria-hidden>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
-          </svg>
-          Cafés
-        </Link>
-        <h1 className="font-fraunces text-3xl text-light-foreground leading-none">Nearby</h1>
-        <Link href="/cafes" className="text-light-muted-foreground text-xs">
-          List →
-        </Link>
-      </header>
-
-      <div className="flex-1 min-h-0">
+    <div className="h-dvh relative overflow-hidden">
+      {/* Edge-to-edge map */}
+      <div className="absolute inset-0">
         <CafeMap
           cafes={cafes}
           onSelect={(cafe) => router.push(`/cafes/place/${encodeURIComponent(cafe.name)}`)}
         />
       </div>
+
+      {/* Top scrim — cream → transparent fade so the title reads cleanly
+          against the tiles without a hard banner edge. */}
+      <div
+        className="pointer-events-none absolute top-0 left-0 right-0 z-[1099]"
+        style={{
+          height: "calc(env(safe-area-inset-top) + 7rem)",
+          background:
+            "linear-gradient(to bottom, hsl(36 55% 96% / 0.88) 0%, hsl(36 55% 96% / 0.45) 55%, transparent 100%)",
+        }}
+      />
+
+      {/* Floating header — Coffee Library layout (title left, burger right).
+          Sits on top of the scrim so the map shows through softly behind. */}
+      <div
+        className="absolute top-0 left-0 right-0 z-[1100] px-5 flex items-center justify-between"
+        style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.25rem)" }}
+      >
+        <h1 className="font-fraunces text-3xl text-light-foreground leading-none">Nearby</h1>
+        <button
+          type="button"
+          onClick={() => setMenuOpen(true)}
+          aria-label="Open menu"
+          className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150 active:scale-95 transition-transform"
+        >
+          <Menu className="h-5 w-5" strokeWidth={1.5} />
+        </button>
+      </div>
+
+      <NavigationOverlay open={menuOpen} onClose={() => setMenuOpen(false)} />
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -289,6 +289,16 @@
   [data-light-scope] [data-brew-method-icon] {
     filter: brightness(0);
   }
+
+  /* Light System — warm the Leaflet (Positron) tile pane on /cafes/map.
+   * Positron ships cold gray; sepia + a small hue-rotate toward pink
+   * pushes it into the same warm rosé/cream territory as the Field so
+   * the map doesn't read as a foreign element inside the Light shell.
+   * Scoped to leaflet-tile-pane (under [data-light-scope]) so it doesn't
+   * touch markers / labels / popups, which stay anthracite. */
+  [data-light-scope] .leaflet-tile-pane {
+    filter: sepia(0.4) hue-rotate(-15deg) saturate(0.7) brightness(1.04);
+  }
 }
 
 /*

--- a/src/components/cafes/CafeMap.tsx
+++ b/src/components/cafes/CafeMap.tsx
@@ -489,8 +489,12 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
     <div className="relative w-full h-full">
       <div ref={containerRef} className="absolute inset-0" />
 
-      {/* Search input */}
-      <div className="absolute top-4 left-4 right-4 z-[1000]">
+      {/* Search input — pushed below the floating page header (Nearby +
+          burger live above this in the page layout). */}
+      <div
+        className="absolute left-4 right-4 z-[1000]"
+        style={{ top: "calc(env(safe-area-inset-top) + 4.75rem)" }}
+      >
         <div className="relative flex items-center max-w-xs mx-auto">
           <svg className="absolute left-3 w-3.5 h-3.5 text-light-muted-foreground pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <circle cx="11" cy="11" r="8" />
@@ -607,42 +611,42 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
         </div>
       )}
 
-      {/* Curated place card */}
+      {/* Curated place card — same shape as the visited card so taps feel
+          consistent: meta on the left, close + single primary action on
+          the right. Visited / not-visited reads from the pin colour, so
+          no redundant text label here. */}
       {placeSelected && (
         <div className="absolute bottom-4 left-4 right-4 z-[1000]">
           <div className="bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-2xl p-4">
             <div className="flex items-start gap-3">
               <div className="flex-1 min-w-0">
                 <p className="text-light-foreground font-medium leading-tight truncate">{placeSelected.name}</p>
-                <p className="text-light-muted-foreground text-xs mt-0.5">{placeSelected.city}</p>
-                <p className="text-light-muted-foreground text-xs mt-1.5">
-                  {visitedNames.has(normalizeName(placeSelected.name)) ? "Visited" : "Not visited yet"}
-                </p>
+                <p className="text-light-muted-foreground text-xs mt-0.5 truncate">{placeSelected.city}</p>
+                {placeSelected.address && (
+                  <a
+                    href={`https://maps.google.com/?q=${encodeURIComponent(placeSelected.address)}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center mt-2 text-xs text-light-muted-foreground active:scale-95 transition-transform"
+                  >
+                    Open in Maps ↗
+                  </a>
+                )}
               </div>
-              <button type="button" onClick={clearPlaceSelected} className="text-light-muted-foreground p-0.5 active:scale-95 transition-transform shrink-0" aria-label="Close">
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-            <div className="flex items-center gap-2 mt-3">
-              <button
-                type="button"
-                onClick={() => setVisitModalPlace(placeSelected)}
-                className="flex-1 h-10 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] text-xs font-semibold active:scale-[0.98] transition-transform"
-              >
-                I&apos;ve been here
-              </button>
-              {placeSelected.address && (
-                <a
-                  href={`https://maps.google.com/?q=${encodeURIComponent(placeSelected.address)}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="h-10 px-4 rounded-full border border-light-foreground/20 text-light-foreground text-xs font-medium flex items-center bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 active:scale-[0.98] transition-transform"
+              <div className="flex flex-col items-end gap-2 shrink-0">
+                <button type="button" onClick={clearPlaceSelected} className="text-light-muted-foreground p-0.5 active:scale-95 transition-transform" aria-label="Close">
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setVisitModalPlace(placeSelected)}
+                  className="bg-light-foreground text-[hsl(36_55%_96%)] text-xs font-semibold px-4 py-1.5 rounded-full active:scale-95 transition-transform whitespace-nowrap"
                 >
-                  Maps ↗
-                </a>
-              )}
+                  I&apos;ve been here
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/flow/LightStepScan.tsx
+++ b/src/components/flow/LightStepScan.tsx
@@ -4,6 +4,7 @@ import { useFlowStore } from "@/store/flowStore";
 import LightFlowShell from "@/components/ui/light/LightFlowShell";
 import PhotoUpload from "@/components/ui/PhotoUpload";
 import Chip from "@/components/ui/light/Chip";
+import Card, { CardIcon, CardTitle, CardSubText } from "@/components/ui/light/Card";
 import Hero from "@/components/ui/light/Hero";
 import type { BagAnalysisResult, RoasterPriorSummary } from "@/lib/claude/analyzeBag";
 import type { Coffee as CoffeeLibEntry } from "@/lib/types/coffee";
@@ -442,29 +443,24 @@ export default function LightStepScan() {
 
         {/* Input method cards */}
         <div className="flex flex-col gap-3">
-          {/* Photo — primary large card. Tap triggers iOS picker
-              directly; the inputMethod state stays in sync so the
-              extracted-info expansion below renders after a successful
-              file pick. Tapping again re-opens the picker (lets the
-              user re-select before any file has been chosen). */}
-          <button
-            type="button"
-            onClick={() => {
-              setInputMethod("photo");
-              setShowManualForm(false);
-              photoInputRef.current?.click();
-            }}
-            className="w-full rounded-2xl border p-5 text-center flex flex-col items-center gap-2 transition-all active:scale-[0.98]"
-            style={{
-              background: inputMethod === "photo" ? "hsl(28 22% 84% / 0.7)" : "var(--card)",
-              borderColor: inputMethod === "photo" ? "var(--primary)" : "var(--border)",
-              boxShadow: inputMethod === "photo" ? "inset 0 2px 4px rgba(60,40,30,0.12)" : undefined,
-            }}
-          >
-            <Camera size={24} style={{ color: "var(--primary)" }} />
-            <p className="font-medium text-sm" style={{ color: "var(--foreground)" }}>Take a photo or choose from library</p>
-            <p className="text-xs" style={{ color: "var(--muted-foreground)" }}>Claude reads the label and extracts all details</p>
-          </button>
+          {/* Photo — primary large card. Tap triggers iOS picker directly;
+              the inputMethod state stays in sync so the extracted-info
+              expansion below renders after a successful file pick. */}
+          <div className="h-[120px]">
+            <Card
+              selected={inputMethod === "photo"}
+              onClick={() => {
+                setInputMethod("photo");
+                setShowManualForm(false);
+                photoInputRef.current?.click();
+              }}
+              ariaLabel="Take a photo or choose from library"
+            >
+              <CardIcon><Camera className="h-6 w-6" strokeWidth={1.5} /></CardIcon>
+              <CardTitle>Take a photo or choose from library</CardTitle>
+              <CardSubText>Claude reads the label and extracts all details</CardSubText>
+            </Card>
+          </div>
 
           {/* Photo upload + analysis (expanded when photo selected) */}
           {inputMethod === "photo" && (
@@ -739,32 +735,26 @@ export default function LightStepScan() {
 
           {/* Secondary: Manual + Link (side by side) */}
           <div className="grid grid-cols-2 gap-3">
-            <button
-              type="button"
-              onClick={() => { setInputMethod(inputMethod === "manual" ? null : "manual"); setShowManualForm(inputMethod !== "manual"); loadRoasters(); }}
-              className="rounded-2xl border p-4 text-center flex flex-col items-center gap-2 transition-all active:scale-[0.98]"
-              style={{
-                background: inputMethod === "manual" ? "hsl(28 22% 84% / 0.7)" : "var(--card)",
-                borderColor: inputMethod === "manual" ? "var(--primary)" : "var(--border)",
-                boxShadow: inputMethod === "manual" ? "inset 0 2px 4px rgba(60,40,30,0.12)" : undefined,
-              }}
-            >
-              <PenLine size={20} style={{ color: "var(--primary)" }} />
-              <span className="text-sm font-medium" style={{ color: "var(--foreground)" }}>Enter manually</span>
-            </button>
-            <button
-              type="button"
-              onClick={() => setInputMethod(inputMethod === "link" ? null : "link")}
-              className="rounded-2xl border p-4 text-center flex flex-col items-center gap-2 transition-all active:scale-[0.98]"
-              style={{
-                background: inputMethod === "link" ? "hsl(28 22% 84% / 0.7)" : "var(--card)",
-                borderColor: inputMethod === "link" ? "var(--primary)" : "var(--border)",
-                boxShadow: inputMethod === "link" ? "inset 0 2px 4px rgba(60,40,30,0.12)" : undefined,
-              }}
-            >
-              <Link2 size={20} style={{ color: "var(--primary)" }} />
-              <span className="text-sm font-medium" style={{ color: "var(--foreground)" }}>Paste a link</span>
-            </button>
+            <div className="h-[88px]">
+              <Card
+                selected={inputMethod === "manual"}
+                onClick={() => { setInputMethod(inputMethod === "manual" ? null : "manual"); setShowManualForm(inputMethod !== "manual"); loadRoasters(); }}
+                ariaLabel="Enter manually"
+              >
+                <CardIcon><PenLine className="h-5 w-5" strokeWidth={1.5} /></CardIcon>
+                <CardTitle>Enter manually</CardTitle>
+              </Card>
+            </div>
+            <div className="h-[88px]">
+              <Card
+                selected={inputMethod === "link"}
+                onClick={() => setInputMethod(inputMethod === "link" ? null : "link")}
+                ariaLabel="Paste a link"
+              >
+                <CardIcon><Link2 className="h-5 w-5" strokeWidth={1.5} /></CardIcon>
+                <CardTitle>Paste a link</CardTitle>
+              </Card>
+            </div>
           </div>
 
           {/* Manual form (expanded when manual selected) */}
@@ -948,23 +938,16 @@ export default function LightStepScan() {
           <p className="label-eyebrow mb-3" style={{ color: "var(--muted-foreground)" }}>Then Choose</p>
           <div className="grid grid-cols-2 gap-3">
             {SCAN_MODES.map(m => (
-              <button
-                key={m.id}
-                type="button"
-                onClick={() => setSelectedMode(m.id)}
-                className="rounded-2xl border p-4 text-center flex flex-col items-center gap-2 transition-all active:scale-[0.98]"
-                style={{
-                  background: selectedMode === m.id ? "hsl(28 22% 84% / 0.7)" : "var(--card)",
-                  borderColor: selectedMode === m.id ? "var(--primary)" : "var(--border)",
-                  boxShadow: selectedMode === m.id ? "inset 0 2px 4px rgba(60,40,30,0.12)" : undefined,
-                }}
-              >
-                <m.Icon size={20} style={{ color: selectedMode === m.id ? "var(--primary)" : "var(--muted-foreground)" }} />
-                <span className="text-sm font-medium"
-                  style={{ color: selectedMode === m.id ? "var(--primary)" : "var(--muted-foreground)" }}>
-                  {m.label}
-                </span>
-              </button>
+              <div key={m.id} className="h-[88px]">
+                <Card
+                  selected={selectedMode === m.id}
+                  onClick={() => setSelectedMode(m.id)}
+                  ariaLabel={m.label}
+                >
+                  <CardIcon><m.Icon className="h-5 w-5" strokeWidth={1.5} /></CardIcon>
+                  <CardTitle>{m.label}</CardTitle>
+                </Card>
+              </div>
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Summary

Targeted slice of the LightStepScan refactor from the HANDOVER open-items list. Replaces the five copy-pasted bespoke selection buttons (Photo / Manual / Link, plus the two SCAN_MODES "Brew at home" / "Coffee shop") with the canonical `<Card>` primitive from `src/components/ui/light/Card.tsx`.

The remaining inline-style sprawl in the file (Identified info panel, Manual form, Link panel, chat bubbles, etc.) is intentionally left untouched — that's a separate, larger pass with real visual-regression risk across many states.

## Visual delta

The bespoke buttons predate `<Card>` so the look shifts slightly to the canonical Light primitive:
- Corners: `rounded-2xl` → `rounded-3xl` (rounder)
- Border: removed (Card uses the cream-glass background alone, no 1px outline)
- SCAN_MODES "Then Choose" cards: icon + label no longer dim when unselected — the cream→taupe background tone alone signals state, matching every other Card consumer in the brew flow

Logic is byte-for-byte the same: same callbacks, same toggle semantics, same `photoInputRef` trigger on Photo tap, same `loadRoasters()` on Manual tap.

## Test plan

- [ ] Open `/brew/new` (Scan step). All five cards render with rounded corners + no 1px border.
- [ ] Tap Photo → iOS picker opens; Photo card shows selected tone (taupe).
- [ ] Tap Manual → form expands below; Manual card shows selected tone, Photo deselects.
- [ ] Tap Manual again → form collapses; tone returns to default cream.
- [ ] Tap Link → URL input expands; Link card selected.
- [ ] After identifying a coffee, tap "Brew at home" / "Coffee shop" — tone shifts but the icon/label stay anthracite (no longer mute when unselected).
- [ ] Continue button gates as before (needs coffee info + mode selected).

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_