### PR TITLE
feat(light): global status-bar scrim — soft cream wash across all routes

### DIFF
--- a/src/app/(light)/cafes/map/page.tsx
+++ b/src/app/(light)/cafes/map/page.tsx
@@ -38,19 +38,10 @@ export default function CafesMapPage() {
         />
       </div>
 
-      {/* Top scrim — cream → transparent fade so the title reads cleanly
-          against the tiles without a hard banner edge. */}
-      <div
-        className="pointer-events-none absolute top-0 left-0 right-0 z-[1099]"
-        style={{
-          height: "calc(env(safe-area-inset-top) + 7rem)",
-          background:
-            "linear-gradient(to bottom, hsl(36 55% 96% / 0.88) 0%, hsl(36 55% 96% / 0.45) 55%, transparent 100%)",
-        }}
-      />
-
       {/* Floating header — Coffee Library layout (title left, burger right).
-          Sits on top of the scrim so the map shows through softly behind. */}
+          The status-bar scrim now lives in LightShell so every Light route
+          shares the same cream wash up top; the header sits directly on
+          the warm-tinted tiles below it. */}
       <div
         className="absolute top-0 left-0 right-0 z-[1100] px-5 flex items-center justify-between"
         style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.25rem)" }}

--- a/src/components/ui/light/LightShell.tsx
+++ b/src/components/ui/light/LightShell.tsx
@@ -31,6 +31,29 @@ export default function LightShell({ children }: { children: ReactNode }) {
     <FieldProvider>
       <div data-light-scope="true" className="font-chivo text-light-foreground min-h-dvh">
         <Field />
+        {/* Status-bar scrim — unifies the iOS PWA status-bar zone across
+         * every Light route. The Field below can vary from cream → pink
+         * → orange (especially with brew-flow rotation, or when the
+         * coffee-driven Field hits a warm zone), and the map page paints
+         * Positron tiles all the way to y=0. Without this scrim the
+         * system clock + icons sit on a different colour patch per page.
+         *
+         * Cream at ~85% opacity through the safe-area, fading to
+         * transparent over a 1.5rem buffer below. Page headers start at
+         * `safe-area + ~1.25rem` so they sit at the very tail of the
+         * fade — anthracite text reads cleanly against the soft cream
+         * wash. Fixed + pointer-events-none so the scrim floats over
+         * the Field (z=-10) and ordinary page content but stays out of
+         * the way of taps. Floating chrome that owns z >= 1000 (the
+         * map's burger + Nearby title) paints above the scrim. */}
+        <div
+          className="pointer-events-none fixed top-0 left-0 right-0 z-[5]"
+          style={{
+            height: "calc(env(safe-area-inset-top) + 1.5rem)",
+            background:
+              "linear-gradient(to bottom, hsl(36 55% 96% / 0.85) 0%, hsl(36 55% 96% / 0.85) 60%, transparent 100%)",
+          }}
+        />
         {children}
       </div>
     </FieldProvider>


### PR DESCRIPTION
## Summary

You spotted on `/cafes/map` that the iOS PWA status-bar zone is just whatever the page paints at y=0 — and the map's soft cream/rosé top looked good. You wanted that everywhere instead of the variable patches the Field produces on most routes.

This adds a single fixed scrim inside `LightShell` so every Light route shares the same soft cream wash up top:
- Cream at 85% opacity through `env(safe-area-inset-top)`
- Fades to transparent over a 1.5rem buffer below
- `pointer-events-none` + z=5 so it floats over the Field but never blocks taps
- Floating chrome at z >= 1000 (map's "Nearby" title + burger) stays on top

Page headers anchored at `safe-area + ~1.25rem` (Café Library, Coffee Library, Nearby, Café detail, etc.) sit at the very tail of the fade. Anthracite text reads cleanly against the soft cream wash.

Removed the map's own bespoke 7rem scrim — the global one replaces it. Title still reads fine because the warm filter on Positron already lifts tile contrast.

## Test plan

- [ ] `/cafes/map`: status-bar zone is soft cream/rosé (same look as before, but now sourced from LightShell, not the map page itself).
- [ ] `/coffees`: status-bar zone now reads as soft cream instead of whatever Field patch was up there.
- [ ] `/cafes`, `/taste`, `/`, `/past-conversations`: same soft cream zone across all of them.
- [ ] `/brew/new` through every step (scan → context → recommend → brew → log → summary): status-bar stays cream even as the Field rotates 25° per step.
- [ ] No clipping of titles or the back button at the top of any page.
- [ ] Map's title + burger still render above everything; tap-through unaffected.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_