### PR TITLE
fix(light): kill the hard cut between scrim and map tiles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -291,13 +291,16 @@
   }
 
   /* Light System — warm the Leaflet (Positron) tile pane on /cafes/map.
-   * Positron ships cold gray; sepia + a small hue-rotate toward pink
-   * pushes it into the same warm rosé/cream territory as the Field so
-   * the map doesn't read as a foreign element inside the Light shell.
-   * Scoped to leaflet-tile-pane (under [data-light-scope]) so it doesn't
-   * touch markers / labels / popups, which stay anthracite. */
+   * Positron ships cold gray; sepia + hue-rotate pushes it into the same
+   * warm rosé/cream territory as the Field so the map doesn't read as a
+   * foreign element inside the Light shell. Values v2 — bumped sepia +
+   * hue-rotate further toward pink so the blue sea actually converts
+   * (the v1 values left water visibly cool, which created a hard cut
+   * between the cream status-bar scrim and the still-bluish tiles
+   * underneath at low zoom). Scoped to leaflet-tile-pane so labels and
+   * markers stay anthracite. */
   [data-light-scope] .leaflet-tile-pane {
-    filter: sepia(0.4) hue-rotate(-15deg) saturate(0.7) brightness(1.04);
+    filter: sepia(0.6) hue-rotate(-22deg) saturate(0.7) brightness(1.06);
   }
 }
 

--- a/src/components/ui/light/LightShell.tsx
+++ b/src/components/ui/light/LightShell.tsx
@@ -49,9 +49,9 @@ export default function LightShell({ children }: { children: ReactNode }) {
         <div
           className="pointer-events-none fixed top-0 left-0 right-0 z-[5]"
           style={{
-            height: "calc(env(safe-area-inset-top) + 1.5rem)",
+            height: "calc(env(safe-area-inset-top) + 2.5rem)",
             background:
-              "linear-gradient(to bottom, hsl(36 55% 96% / 0.85) 0%, hsl(36 55% 96% / 0.85) 60%, transparent 100%)",
+              "linear-gradient(to bottom, hsl(36 55% 96% / 0.85) 0%, hsl(36 55% 96% / 0.85) 50%, hsl(36 55% 96% / 0.35) 75%, transparent 100%)",
           }}
         />
         {children}


### PR DESCRIPTION
## Summary

Side-by-side from Markus: Home reads smooth top-to-bottom (cream scrim fades into the warm Field, no edge), but Map has a hard horizontal cut — the cream stops, cold gray tiles begin. Two reinforcing problems:

1. **Tile filter too weak.** The v1 values (sepia 0.4, hue-rotate -15deg, saturate 0.7) didn't fully convert the blue sea. At low zoom the Mediterranean / Atlantic dominate and stay visibly cool, so the moment the scrim hits transparent you get a sharp warm → cold transition.
2. **Scrim fade too short.** 1.5rem with a single midpoint — not enough headroom to mask the contrast.

## Fix

- Tile filter bumped to `sepia(0.6) hue-rotate(-22deg) saturate(0.7) brightness(1.06)`. Pushes the sea into sepia-pink territory and lifts the whole tile layer into the same warm cream/rosé family as the scrim — so by the time the fade ends, the baseline below is already in family.
- Scrim height 1.5rem → 2.5rem with an intermediate stop (cream 0.35 at 75%). The fade decelerates into transparent instead of cliff-edging. Every Light page benefits — the status-bar zone now eases into whatever the Field/tiles are doing below, not stops dead.

## Test plan

- [ ] Side-by-side Home + Map status-bar zone — both ease into their respective backgrounds, no horizontal seam on the Map.
- [ ] Brew flow steps 1–6 — the per-step Field rotation still shows through; the cream fade just softens the top edge.
- [ ] Coffee Library / Café Library / Taste / Past Conversations — soft cream zone, page titles read crisply.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_