### PR TITLE
revert(light): drop global scrim + revert tile filter

### DIFF
--- a/src/app/(light)/cafes/map/page.tsx
+++ b/src/app/(light)/cafes/map/page.tsx
@@ -38,10 +38,19 @@ export default function CafesMapPage() {
         />
       </div>
 
+      {/* Top scrim — cream → transparent fade so the title reads cleanly
+          against the tiles without a hard banner edge. */}
+      <div
+        className="pointer-events-none absolute top-0 left-0 right-0 z-[1099]"
+        style={{
+          height: "calc(env(safe-area-inset-top) + 7rem)",
+          background:
+            "linear-gradient(to bottom, hsl(36 55% 96% / 0.88) 0%, hsl(36 55% 96% / 0.45) 55%, transparent 100%)",
+        }}
+      />
+
       {/* Floating header — Coffee Library layout (title left, burger right).
-          The status-bar scrim now lives in LightShell so every Light route
-          shares the same cream wash up top; the header sits directly on
-          the warm-tinted tiles below it. */}
+          Sits on top of the scrim so the map shows through softly behind. */}
       <div
         className="absolute top-0 left-0 right-0 z-[1100] px-5 flex items-center justify-between"
         style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.25rem)" }}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -291,16 +291,13 @@
   }
 
   /* Light System — warm the Leaflet (Positron) tile pane on /cafes/map.
-   * Positron ships cold gray; sepia + hue-rotate pushes it into the same
-   * warm rosé/cream territory as the Field so the map doesn't read as a
-   * foreign element inside the Light shell. Values v2 — bumped sepia +
-   * hue-rotate further toward pink so the blue sea actually converts
-   * (the v1 values left water visibly cool, which created a hard cut
-   * between the cream status-bar scrim and the still-bluish tiles
-   * underneath at low zoom). Scoped to leaflet-tile-pane so labels and
-   * markers stay anthracite. */
+   * Positron ships cold gray; sepia + a small hue-rotate toward pink
+   * pushes it into the same warm rosé/cream territory as the Field so
+   * the map doesn't read as a foreign element inside the Light shell.
+   * Scoped to leaflet-tile-pane (under [data-light-scope]) so it doesn't
+   * touch markers / labels / popups, which stay anthracite. */
   [data-light-scope] .leaflet-tile-pane {
-    filter: sepia(0.6) hue-rotate(-22deg) saturate(0.7) brightness(1.06);
+    filter: sepia(0.4) hue-rotate(-15deg) saturate(0.7) brightness(1.04);
   }
 }
 

--- a/src/components/ui/light/LightShell.tsx
+++ b/src/components/ui/light/LightShell.tsx
@@ -31,29 +31,6 @@ export default function LightShell({ children }: { children: ReactNode }) {
     <FieldProvider>
       <div data-light-scope="true" className="font-chivo text-light-foreground min-h-dvh">
         <Field />
-        {/* Status-bar scrim — unifies the iOS PWA status-bar zone across
-         * every Light route. The Field below can vary from cream → pink
-         * → orange (especially with brew-flow rotation, or when the
-         * coffee-driven Field hits a warm zone), and the map page paints
-         * Positron tiles all the way to y=0. Without this scrim the
-         * system clock + icons sit on a different colour patch per page.
-         *
-         * Cream at ~85% opacity through the safe-area, fading to
-         * transparent over a 1.5rem buffer below. Page headers start at
-         * `safe-area + ~1.25rem` so they sit at the very tail of the
-         * fade — anthracite text reads cleanly against the soft cream
-         * wash. Fixed + pointer-events-none so the scrim floats over
-         * the Field (z=-10) and ordinary page content but stays out of
-         * the way of taps. Floating chrome that owns z >= 1000 (the
-         * map's burger + Nearby title) paints above the scrim. */}
-        <div
-          className="pointer-events-none fixed top-0 left-0 right-0 z-[5]"
-          style={{
-            height: "calc(env(safe-area-inset-top) + 2.5rem)",
-            background:
-              "linear-gradient(to bottom, hsl(36 55% 96% / 0.85) 0%, hsl(36 55% 96% / 0.85) 50%, hsl(36 55% 96% / 0.35) 75%, transparent 100%)",
-          }}
-        />
         {children}
       </div>
     </FieldProvider>


### PR DESCRIPTION
## Summary

Reverts PR #151 (global scrim in LightShell) and PR #152 (stronger tile filter + longer fade). End state = PR #149.

Markus' feedback after seeing it live: the global scrim washed Home with cream-yellow over the warm Field (ugly), and the PR #152 push toward pink on the tiles made the Map look worse than the original soft rosé.

- LightShell no longer adds a status-bar scrim — Field renders straight through to the top on every Light page.
- Map tile filter back to `sepia(0.4) hue-rotate(-15deg) saturate(0.7) brightness(1.04)` — the soft warm tint that worked.
- The map's bespoke 7rem cream→transparent scrim is restored on `/cafes/map` — local rosé wash was the right call for that page only.

## Test plan

- [ ] Home: status-bar area reads as the warm pink-peach Field, no creamy overlay.
- [ ] All other Light pages: same — no scrim wash.
- [ ] Map: original soft rosé top from PR #149 is back, tile colors are gentle warm cream (not the pinker PR #152 values).

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_