### PR TITLE
fix(nav): burger menu opens on top of the map chrome

### DIFF
--- a/src/components/ui/light/NavigationOverlay.tsx
+++ b/src/components/ui/light/NavigationOverlay.tsx
@@ -55,7 +55,12 @@ export default function NavigationOverlay({ open, onClose }: NavigationOverlayPr
       role="dialog"
       aria-modal="true"
       aria-label="Navigation"
-      className="fixed inset-0 z-50 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150"
+      // z must clear every floating chrome layer in the app. The map's
+      // header / scrim / search / popup cards live at z-1000..1100, and
+      // the visit-modal sheet sits at z-2000 inside CafeMap.tsx, so the
+      // old z-50 left the menu opening behind the map UI. z-[2100] keeps
+      // top-level navigation on top of everything.
+      className="fixed inset-0 z-[2100] bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150"
     >
       {/* Close button — same coordinates as the Burger that opened it
           (§7.1: "mirroring placement so thumb knows where to look"). */}


### PR DESCRIPTION
## Summary

Markus' report: tapping the burger on `/cafes/map` opens the menu **behind** the map chrome — looks transparent / odd.

Cause: `NavigationOverlay` rendered at `z-50`. Fine on every Light page except the map, where the floating header, scrim, search input, popup cards and locate-me button all live at `z-1000..1100`, and the visit modal sits at `z-2000`. The menu landed below all of that.

Fix: bump `NavigationOverlay` to `z-[2100]` — clears the map's chrome and the visit modal too, so top-level navigation always wins regardless of route.

## Test plan

- [ ] `/cafes/map`: tap burger → menu opens **above** the map, header, search bar, and any open popup card. Tap Close X or any item → menu dismisses cleanly.
- [ ] Other Light pages (`/`, `/coffees`, `/cafes`, `/taste`, `/brew/new`): burger still works as before, no regression.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_