### PR TITLE
fix(home): drop the "Welcome to Better Taste Than Sorry" placeholder

### DIFF
--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -41,7 +41,6 @@ import type { NavAction } from "@/app/api/explore-agent/route";
  *     POST so they survive across sessions.
  */
 
-const FALLBACK_STARTER = "Welcome to Better Taste Than Sorry.";
 const IDLE_WINDOW_MS = 30 * 60 * 1000;
 
 function todayKey(): string {
@@ -96,7 +95,11 @@ export default function HomePage() {
   const [recentSessions, setRecentSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(false);
   const [interacted, setInteracted] = useState(false);
-  const [starter, setStarter] = useState<string>(FALLBACK_STARTER);
+  // Empty initial — the daily Starter is the AI-generated greeting from
+  // /api/greeting (cached per (date, time-bucket) in localStorage). No
+  // hardcoded placeholder: the slot stays empty until the real line
+  // lands, which is better UX than flashing a generic "Welcome…" string.
+  const [starter, setStarter] = useState<string>("");
   const conversationIdRef = useRef<string | null>(null);
 
   // Recent sessions for the agent's personal-context block.
@@ -377,9 +380,11 @@ export default function HomePage() {
         <section className="flex-1 min-h-0">
           {showStarter ? (
             <div className="flex h-full items-center px-5">
-              <p className="font-fraunces text-[40px] font-semibold leading-[1.05] tracking-[-0.01em] text-light-foreground">
-                {starter}
-              </p>
+              {starter && (
+                <p className="font-fraunces text-[40px] font-semibold leading-[1.05] tracking-[-0.01em] text-light-foreground">
+                  {starter}
+                </p>
+              )}
             </div>
           ) : (
             <ChatThread messages={messages} loading={loading} />


### PR DESCRIPTION
## Summary

Markus' report: the hero slot on Home flashed "Welcome to Better Taste Than Sorry." as a placeholder before the real AI-generated daily starter arrived from `/api/greeting`. Generic, on-brand-but-useless copy.

Fix:
- `starter` state initialises empty, not `FALLBACK_STARTER`.
- The `<p>` only renders when the real text arrives.
- `FALLBACK_STARTER` constant deleted.

If `/api/greeting` fails outright (or before the cache lands), the hero slot stays blank — chat input still works, eyebrow + burger still show. Cleaner than a generic flash.

## Test plan

- [ ] Fresh load (clear `brewlog.starter.*` from localStorage) → hero is blank for ~1-2s, then the Haiku-generated daily line appears.
- [ ] Cached state (revisit later in the same time-bucket) → cached starter shows immediately.
- [ ] Offline / API failure → hero stays blank, no "Welcome to…" flash. Chat input remains usable.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_