### PR TITLE
fix(chat): center-align + button with the chat pill

### DIFF
--- a/src/components/ui/light/ChatInput.tsx
+++ b/src/components/ui/light/ChatInput.tsx
@@ -262,7 +262,7 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
           onChange={handleInputChange}
         />
 
-        <div className="flex items-end gap-3">
+        <div className="flex items-center gap-3">
           {isVoiceActive ? (
             <button
               type="button"


### PR DESCRIPTION
## Summary

Markus spotted it: the + button and the chat pill weren't vertically centered. The outer flex row used `items-end` so the + sat bottom-flush with the pill instead of centered. Looks OK only when both are exactly 44px tall; the moment text wraps or an attachment is added the pill grows and the + button stays glued to the bottom — and even at min height the centres of the two bubbles drifted enough to be visible.

Swapped to `items-center` so the + sits at the pill's vertical midline regardless of pill height.

## Test plan

- [ ] Idle home screen: + and pill share a vertical centre line.
- [ ] Type a long multi-line message: + stays centred on the now-taller pill instead of bottom-flush.
- [ ] Attach a photo or coffee ref: + remains centred on the tall pill.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_