### PR TITLE
fix(nav): burger ↔ X overlay land on the exact same coordinates

### DIFF
--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -363,7 +363,10 @@ export default function HomePage() {
   return (
     <>
       <main className="flex h-dvh flex-col">
-        <header className="flex shrink-0 items-center justify-between pl-5 pr-5 pt-12 pb-3">
+        <header
+          className="flex shrink-0 items-start justify-between px-5 pb-3"
+          style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.25rem)" }}
+        >
           <h1 className="font-fraunces text-3xl leading-[1.05] text-light-foreground">
             Better taste<br />than sorry.
           </h1>

--- a/src/components/ui/light/NavigationOverlay.tsx
+++ b/src/components/ui/light/NavigationOverlay.tsx
@@ -63,12 +63,17 @@ export default function NavigationOverlay({ open, onClose }: NavigationOverlayPr
       className="fixed inset-0 z-[2100] bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150"
     >
       {/* Close button — same coordinates as the Burger that opened it
-          (§7.1: "mirroring placement so thumb knows where to look"). */}
+          (§7.1: "mirroring placement so thumb knows where to look").
+          Pages anchor their burger at `calc(safe-area-inset-top + 1.25rem)`
+          from the top and `px-5` (20px) from the right, so mirror those
+          exactly here. The old `top-12` (48px, no safe-area) drifted
+          ~20px above the burger on any notched device. */}
       <button
         type="button"
         onClick={onClose}
         aria-label="Close menu"
-        className="absolute right-5 top-12 flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
+        style={{ top: "calc(env(safe-area-inset-top) + 1.25rem)" }}
+        className="absolute right-5 flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
       >
         <X className="h-5 w-5" strokeWidth={1.5} />
       </button>


### PR DESCRIPTION
## Summary

Markus: "Burger drücken und das X im Menü sollen exakt an der gleichen Stelle landen — keine 2-Bubble-Verschiebung."

Two issues compounded:
1. **Home header** used `pt-12` (48px flat, ignoring safe-area). Every other Light page uses `calc(env(safe-area-inset-top) + 1.25rem)`. So the burger already sat at a different Y on Home vs Café Library / Coffee Library / etc.
2. **NavigationOverlay X** used `top-12` — same hardcoded 48px, also safe-area-blind. On notched devices it drifted ~20px above the burger on every page except Home.

## Fix

- Both pin to `calc(env(safe-area-inset-top) + 1.25rem)` — the same anchor every other Light burger already uses.
- Home header switched from `items-center` to `items-start` so the burger pins to the top edge of the two-line title, instead of floating between the two lines (which is what made the X land on top of it cleanly).

## Test plan

- [ ] On every Light page: tap burger → X appears at the **exact** same coordinates as the burger was. No visible jump.
- [ ] Home page: burger now sits at top edge of "Better taste" line, not centred between the two lines.
- [ ] Status-bar zone clearance: burger isn't crammed under the notch on any page.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_