### PR TITLE
fix(past-conversations): match the other library headers' top padding

### DIFF
--- a/src/app/(light)/past-conversations/page.tsx
+++ b/src/app/(light)/past-conversations/page.tsx
@@ -67,7 +67,10 @@ export default function PastConversationsPage() {
   return (
     <>
       <main className="flex h-dvh flex-col">
-        <header className="flex shrink-0 items-center justify-between pl-5 pr-5 pt-12 pb-3">
+        <header
+          className="flex shrink-0 items-center justify-between px-5 pb-3"
+          style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.25rem)" }}
+        >
           <h1 className="font-fraunces text-3xl leading-none text-light-foreground">
             Past conversations
           </h1>


### PR DESCRIPTION
## Summary

PR #159 standardised Home + Coffees + Cafés + Taste + Nearby on `calc(env(safe-area-inset-top) + 1.25rem)` for header padding-top, but missed `/past-conversations` — it still used the flat `pt-12` (48px, no safe-area). Markus spotted the inconsistency.

Same anchor as every other library page now.

## Test plan

- [ ] `/past-conversations` header sits at the same top-line as `/coffees`, `/cafes`, `/taste`, `/cafes/map`, `/` — burger circle and title share their Y coordinate across all of them.
- [ ] Tap burger on `/past-conversations` → X overlay lands on the exact same spot.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_