### PR TITLE
fix(brew): countdown last-5s goes bold cleanly, no digit ghosting

### DIFF
--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -279,10 +279,15 @@ function LivePourSequence({
             <div className="mt-3 pt-3 border-t border-light-foreground/15 flex items-center justify-between">
               <span className="text-[12px] text-light-muted-foreground">{nextStep!.label}</span>
               <span
-                className={`font-mono-num text-[14px] font-medium ${
+                // key={nextCountdown} so React replaces the DOM node on every
+                // tick. Otherwise the infinite opacity pulse can be mid-cycle
+                // when the digit changes (6 → 5), and iOS Safari leaves the
+                // previous glyph faintly visible behind the new one.
+                key={nextCountdown}
+                className={`font-mono-num text-[14px] ${
                   nextCountdown <= 5
-                    ? "text-light-foreground animate-countdown-pulse"
-                    : "text-light-muted-foreground"
+                    ? "font-bold text-light-foreground animate-countdown-pulse"
+                    : "font-medium text-light-muted-foreground"
                 }`}
               >
                 in 0:{String(nextCountdown).padStart(2, "0")}
@@ -551,10 +556,13 @@ function ProseStepGuide({
               Next: {effectiveSteps[currentIdx + 1]}
             </span>
             <span
-              className={`font-mono-num text-[14px] font-medium ${
+              // see comment on the pour-countdown span above — same reason
+              // for keying on the tick.
+              key={nextCountdown}
+              className={`font-mono-num text-[14px] ${
                 nextCountdown <= 5
-                  ? "text-light-foreground animate-countdown-pulse"
-                  : "text-light-muted-foreground"
+                  ? "font-bold text-light-foreground animate-countdown-pulse"
+                  : "font-medium text-light-muted-foreground"
               }`}
             >
               {nextCountdown}s


### PR DESCRIPTION
## Summary

Markus reported on the brew step page: the warning countdown before the next pour (and the parallel "Next step" countdown) should go **bold** in the last 5 seconds, but the digits stack visually — "ein 6 unter der 5". Two coupled issues:

1. **No font-weight change.** The last-5s style only shifted color (muted → foreground) and added an opacity pulse — the weight stayed at `font-medium`. The design intent was bold.
2. **Cross-frame ghosting.** The infinite opacity pulse (0.7s period) was asynchronous to the 1s tick. When React swapped the digit (6 → 5) mid-pulse — e.g. at opacity 0.7 — iOS Safari kept the previous glyph faintly visible behind the new one.

## Fix

- `font-bold` kicks in below 5s (replaces the static `font-medium`).
- `key={nextCountdown}` on the span forces React to replace the DOM node on every tick, restarting the animation cleanly at opacity 1 and eliminating the cross-frame subpixel ghosting.

Applied to both countdown spans — the pour-step warning AND the bottom "Next: X in Ys" indicator.

## Test plan

- [ ] Start a brew with a pour-based recipe (V60, Kalita Wave, Orea). Watch the "Pour X in 0:0Y" indicator tick down — last 5s render bold, color shifts to foreground, opacity pulses cleanly with no ghosting digits.
- [ ] Same for the "Next: \<step\>" indicator below the timer when ≤15s remain on a step.
- [ ] Above 5s: stays muted + medium, no pulse. No regression.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_