### PR TITLE
fix(taste): promote "What you love, over time" to its own section title

### DIFF
--- a/src/app/(light)/taste/page.tsx
+++ b/src/app/(light)/taste/page.tsx
@@ -199,19 +199,23 @@ export default function TastePage() {
           <p className="text-light-muted-foreground/60 text-xs ml-auto self-end">All time</p>
         </div>
 
-        {/* AI narrative summary */}
+        {/* AI narrative summary — section title is the old header subline,
+            which has nowhere else to live since the Light System convention
+            is headline-only (no sub-lines). */}
         {(summaryLoading || summary) && (
-          <div className="bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-2xl px-4 py-4">
-            {summaryLoading && !summary ? (
-              <div className="space-y-2">
-                <div className="h-3 bg-light-foreground/10 rounded-full w-full animate-pulse" />
-                <div className="h-3 bg-light-foreground/10 rounded-full w-5/6 animate-pulse" />
-                <div className="h-3 bg-light-foreground/10 rounded-full w-4/6 animate-pulse" />
-              </div>
-            ) : (
-              <p className="text-light-foreground/85 text-sm leading-relaxed">{summary}</p>
-            )}
-          </div>
+          <Section title="What you love, over time">
+            <div className="bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-2xl px-4 py-4">
+              {summaryLoading && !summary ? (
+                <div className="space-y-2">
+                  <div className="h-3 bg-light-foreground/10 rounded-full w-full animate-pulse" />
+                  <div className="h-3 bg-light-foreground/10 rounded-full w-5/6 animate-pulse" />
+                  <div className="h-3 bg-light-foreground/10 rounded-full w-4/6 animate-pulse" />
+                </div>
+              ) : (
+                <p className="text-light-foreground/85 text-sm leading-relaxed">{summary}</p>
+              )}
+            </div>
+          </Section>
         )}
 
         {/* Flavor Profile — SCA wheel with radar overlay */}
@@ -321,7 +325,6 @@ function Header({ onMenu }: { onMenu: () => void }) {
     <div className="px-5 pb-4 flex items-start justify-between gap-3" style={{ paddingTop: 'calc(env(safe-area-inset-top) + 1.25rem)' }}>
       <div>
         <h1 className="font-fraunces text-3xl text-light-foreground leading-none">Taste Profile</h1>
-        <p className="text-light-muted-foreground text-sm mt-1.5">What you love, over time</p>
       </div>
       <button
         type="button"


### PR DESCRIPTION
## Summary

Markus' rule across Light: no headline carries a sub-line. The Taste Profile page had "What you love, over time" sitting as a sub-line under the h1 — out of pattern with every other Library / Profile header.

Moved the phrase to the section title above the AI taste-summary card. It actually describes that AI haiku semantically, and the uppercase-tracked `<Section>` style matches "FLAVOR PROFILE", "TOP FLAVORS", "RATING TREND", etc. that already exist below.

## Test plan

- [ ] `/taste`: h1 is just "Taste Profile" — no sub-line.
- [ ] Above the AI summary card: small uppercase-tracked "WHAT YOU LOVE, OVER TIME" eyebrow, same style as the other section labels.
- [ ] When the summary is still loading (skeleton bars), the section title is still rendered.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_