### PR TITLE
fix(scan): persist + render all extracted bag fields, parity for link flow

### DIFF
--- a/src/app/(light)/coffees/[id]/page.tsx
+++ b/src/app/(light)/coffees/[id]/page.tsx
@@ -143,6 +143,11 @@ export default function CoffeeDetailPage() {
   const variety = latestCoffee?.variety;
   const roastLevel = latestCoffee?.roastLevel;
   const region = latestCoffee?.region;
+  const farm = latestCoffee?.farm;
+  const altitude = latestCoffee?.altitudeMeters;
+  const process = latestCoffee?.process || coffee.process;
+  const fermentationStyle = latestCoffee?.fermentationStyle;
+  const cuppingScore = latestCoffee?.cuppingScore;
   const tastingNotes = latestCoffee?.tastingNotesFromBag ?? [];
   const commonNotes = coffee.commonNotes ?? [];
   const origin = latestCoffee?.origin || coffee.origin;
@@ -315,12 +320,17 @@ export default function CoffeeDetailPage() {
       </div>
 
       {/* Coffee scan details */}
-      {(roastDate || variety || roastLevel || region || tastingNotes.length > 0 || commonNotes.length > 0) && (
+      {(roastDate || variety || roastLevel || region || farm || altitude || process || fermentationStyle || cuppingScore || tastingNotes.length > 0 || commonNotes.length > 0) && (
         <div className="px-5 py-4 border-b border-light-foreground/15 space-y-2">
           <p className="text-light-muted-foreground text-xs uppercase tracking-widest mb-3">Coffee Details</p>
           {variety && <DetailRow label="Variety" value={variety} />}
+          {process && <DetailRow label="Process" value={process} />}
+          {fermentationStyle && <DetailRow label="Fermentation" value={fermentationStyle} />}
           {roastLevel && <DetailRow label="Roast" value={roastLevel} />}
           {region && <DetailRow label="Region" value={region} />}
+          {farm && <DetailRow label="Farm" value={farm} />}
+          {altitude != null && <DetailRow label="Altitude" value={`${altitude} m`} />}
+          {cuppingScore != null && <DetailRow label="Cupping score" value={String(cuppingScore)} />}
           {roastDate && (
             <DetailRow
               label="Roast date"

--- a/src/app/api/analyze-url/route.ts
+++ b/src/app/api/analyze-url/route.ts
@@ -11,17 +11,24 @@ import type { RoasterPrior } from "@/lib/roasters/priors";
 export const dynamic = "force-dynamic";
 
 const UrlExtractSchema = z.object({
-  roaster: z.string().optional(),
-  name: z.string().optional(),
-  origin: z.string().optional(),
-  region: z.string().optional(),
-  variety: z.string().optional(),
-  process: z.string().optional(),
-  fermentationStyle: z.string().optional(),
-  roastLevel: z.string().optional(),
-  roastDate: z.string().optional(),
-  cuppingScore: z.number().optional(),
-  tastingNotesFromBag: z.array(z.string()).optional(),
+  extracted: z
+    .object({
+      roaster: z.string().optional(),
+      name: z.string().optional(),
+      origin: z.string().optional(),
+      region: z.string().optional(),
+      farm: z.string().optional(),
+      variety: z.string().optional(),
+      process: z.string().optional(),
+      fermentationStyle: z.string().optional(),
+      roastLevel: z.string().optional(),
+      roastDate: z.string().optional(),
+      altitudeMeters: z.number().optional(),
+      cuppingScore: z.number().optional(),
+      tastingNotesFromBag: z.array(z.string()).optional(),
+    })
+    .passthrough(),
+  clarifications: z.array(z.string()).optional(),
 });
 
 export async function POST(req: Request) {
@@ -82,11 +89,44 @@ export async function POST(req: Request) {
     const client = new Anthropic();
     const response = await client.messages.create({
       model: "claude-haiku-4-5",
-      max_tokens: 512,
+      max_tokens: 768,
       messages: [
         {
           role: "user",
-          content: `Extract coffee product details from this webpage text. Return ONLY a valid JSON object with these fields (omit any fields you cannot find with confidence): roaster (string), name (string), origin (string), region (string), variety (string), process (string — Natural/Washed/Honey/Anaerobic), fermentationStyle (string — the specific sub-style or protocol, e.g. "Spontaneous Anaerobic", "Starter-culture Natural", "Thermal-shock Washed", "Carbonic Maceration 72h" — only include when the page names a specific protocol), roastLevel (string — Light/Medium-Light/Medium/Dark), roastDate (ISO date string YYYY-MM-DD if found), cuppingScore (number — SCA / Q-grade if printed, e.g. 87.5), tastingNotesFromBag (array of short flavor note strings).\n\nWebpage text:\n${text}`,
+          content: `Extract coffee product details from this webpage text. Return ONLY a valid JSON object with this exact shape:
+
+{
+  "extracted": {
+    "roaster": string,
+    "name": string,
+    "origin": string,
+    "region": string,
+    "farm": string,
+    "variety": string,
+    "process": "Natural" | "Washed" | "Honey" | "Anaerobic" | "Other",
+    "fermentationStyle": string,
+    "roastLevel": "Light" | "Medium-Light" | "Medium" | "Dark",
+    "roastDate": "YYYY-MM-DD",
+    "altitudeMeters": number,
+    "cuppingScore": number,
+    "tastingNotesFromBag": string[]
+  },
+  "clarifications": string[]
+}
+
+Inside "extracted": omit any field you cannot find with confidence (do not return null — just omit). fermentationStyle is the specific sub-style or protocol, e.g. "Spontaneous Anaerobic", "Starter-culture Natural", "Thermal-shock Washed", "Carbonic Maceration 72h" — only include when the page names a specific protocol. cuppingScore is the SCA / Q-grade if printed (e.g. 87.5). altitudeMeters is the grow elevation in metres (e.g. 1750).
+
+"clarifications": list up to 2 natural-language questions about the most important remaining unknowns, prioritising in this order: (1) variety if unknown, (2) tasting notes if the array is empty, (3) altitude if unknown, (4) region/farm if unclear. Examples:
+- "I couldn't spot a variety on the page — is it listed anywhere, or do you know it?"
+- "No tasting notes were visible — what flavour descriptors does the roaster use?"
+- "The page doesn't mention altitude — do you know the elevation at \${farm or origin}?"
+
+NEVER ask about roast date (the user enters this via a dedicated date picker in the UI) or cupping score (optional, often unavailable — leave the field omitted if not printed). Return [] if every important field is already known.
+
+Return ONLY valid JSON, no markdown.
+
+Webpage text:
+${text}`,
         },
       ],
     });
@@ -96,8 +136,8 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "AI did not return text" }, { status: 500 });
     }
 
-    const extracted = parseClaudeJson(content.text, UrlExtractSchema);
-    if (!extracted) {
+    const parsed = parseClaudeJson(content.text, UrlExtractSchema);
+    if (!parsed) {
       return NextResponse.json(
         { error: "Could not extract coffee details from that page. Try entering manually." },
         { status: 422 }
@@ -109,10 +149,10 @@ export async function POST(req: Request) {
     // triggered the "I don't know X yet" Q&A even for well-known roasters
     // like Hoppenworth & Ploch.
     let roasterPrior: ReturnType<typeof toPriorSummary> | null = null;
-    if (extracted.roaster) {
+    if (parsed.extracted.roaster) {
       let prior: RoasterPrior | null = null;
       try {
-        const slug = canonicalRoasterSlug(extracted.roaster);
+        const slug = canonicalRoasterSlug(parsed.extracted.roaster);
         const direct = await db.select().from(roasters).where(eq(roasters.slug, slug)).limit(1);
         if (direct.length > 0) {
           prior = direct[0].data as RoasterPrior;
@@ -127,7 +167,7 @@ export async function POST(req: Request) {
       } catch {}
 
       if (!prior) {
-        const builtIn = getRoasterPrior(extracted.roaster);
+        const builtIn = getRoasterPrior(parsed.extracted.roaster);
         if (builtIn.confidence !== "fallback") prior = builtIn;
       }
 
@@ -135,8 +175,8 @@ export async function POST(req: Request) {
     }
 
     return NextResponse.json({
-      extracted,
-      clarifications: [],
+      extracted: parsed.extracted,
+      clarifications: parsed.clarifications ?? [],
       roasterPrior,
     });
   } catch (err) {

--- a/src/components/flow/LightStepScan.tsx
+++ b/src/components/flow/LightStepScan.tsx
@@ -312,14 +312,29 @@ export default function LightStepScan() {
         setUrlError(data.error || "Could not extract details from that page.");
         return;
       }
-      const { extracted, roasterPrior } = data as {
+      const { extracted, clarifications, roasterPrior } = data as {
         extracted: Record<string, unknown>;
+        clarifications?: string[];
         roasterPrior: RoasterPriorSummary | null;
       };
       const clean = Object.fromEntries(
         Object.entries(extracted).filter(([, v]) => v !== null && v !== undefined)
       ) as Parameters<typeof setCoffee>[0];
       setCoffee({ ...clean, aiExtracted: true });
+
+      // Mirror the photo-flow shape so the shared clarification handler
+      // (handleClarificationAnswer) can read clarifications and tick the
+      // index from a single source. confidence/isCoffeeBag are unused for
+      // URL but kept to satisfy the type contract.
+      const urlClarifications = clarifications ?? [];
+      setAnalysisResult({
+        extracted: clean as BagAnalysisResult["extracted"],
+        confidence: {},
+        clarifications: urlClarifications,
+        isCoffeeBag: true,
+        roasterPrior: roasterPrior ?? undefined,
+      });
+
       checkLibraryMatch(
         typeof extracted.name === "string" ? extracted.name : undefined,
         typeof extracted.roaster === "string" ? extracted.roaster : undefined
@@ -328,6 +343,17 @@ export default function LightStepScan() {
         setManualRoasterPrior(roasterPrior);
       } else if (extracted.roaster && typeof extracted.roaster === "string") {
         startRoasterQA(extracted.roaster);
+      }
+
+      // Surface the first clarification — chips for known categories
+      // (altitude/variety/notes), free-text fallback otherwise.
+      if (urlClarifications.length > 0) {
+        addClarificationMessage({
+          role: "assistant",
+          text: urlClarifications[0],
+          chips: getClarificationChips(urlClarifications[0]),
+        });
+        setClarificationIndex(0);
       }
     } catch {
       setUrlError("Network error — check your connection and try again.");
@@ -684,52 +710,6 @@ export default function LightStepScan() {
                   ))}
                 </div>
               )}
-              {/* Clarification chat */}
-              {clarificationMessages.length > 0 && (
-                <div className="space-y-3">
-                  {clarificationMessages.map((msg, i) => (
-                    <div key={i} className={`flex ${msg.role === "assistant" ? "justify-start" : "justify-end"}`}>
-                      {msg.role === "assistant" ? (
-                        <div className="max-w-[80%]">
-                          <div className="rounded-2xl rounded-tl-sm px-4 py-3" style={{ background: "var(--card)" }}>
-                            <p className="text-sm" style={{ color: "var(--foreground)" }}>{msg.text}</p>
-                          </div>
-                          {msg.chips && i === clarificationMessages.length - 1 && (
-                            <div className="mt-2 space-y-2">
-                              <div className="flex flex-wrap gap-2">
-                                {msg.chips.map(chip => (
-                                  <Chip key={chip} onClick={() => handleClarificationAnswer(chip)}>{chip}</Chip>
-                                ))}
-                                <Chip onClick={() => handleClarificationAnswer("Not sure")}>Not sure</Chip>
-                              </div>
-                              <div className="flex gap-2">
-                                <input type="text" value={freeText}
-                                  onChange={e => setFreeText(e.target.value)}
-                                  onKeyDown={e => e.key === "Enter" && freeText.trim() && handleClarificationAnswer(freeText.trim())}
-                                  placeholder="Or type your answer..."
-                                  className="flex-1 rounded-2xl px-3 py-2 text-base focus:outline-none"
-                                  style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--foreground)" }}
-                                />
-                                {freeText.trim() && (
-                                  <button onClick={() => handleClarificationAnswer(freeText.trim())}
-                                    className="px-3 py-2 rounded-xl text-sm font-medium active:scale-95 transition-all"
-                                    style={{ background: "var(--primary)", color: "var(--primary-foreground)" }}
-                                  >↵</button>
-                                )}
-                              </div>
-                            </div>
-                          )}
-                        </div>
-                      ) : (
-                        <div className="rounded-2xl rounded-tr-sm px-4 py-3 max-w-[60%]"
-                          style={{ background: "rgba(212,184,150,0.15)", border: "1px solid rgba(212,184,150,0.25)" }}>
-                          <p className="text-sm" style={{ color: "var(--foreground)" }}>{msg.text}</p>
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              )}
             </div>
           )}
 
@@ -903,6 +883,56 @@ export default function LightStepScan() {
             </div>
           )}
         </div>
+
+        {/* Clarification chat — shared between photo + URL flows so both
+            paths get the same follow-up Q&A treatment. Reads from the
+            flow-store clarificationMessages, which the photo and link
+            handlers both populate via addClarificationMessage. */}
+        {clarificationMessages.length > 0 && (
+          <div className="space-y-3">
+            {clarificationMessages.map((msg, i) => (
+              <div key={i} className={`flex ${msg.role === "assistant" ? "justify-start" : "justify-end"}`}>
+                {msg.role === "assistant" ? (
+                  <div className="max-w-[80%]">
+                    <div className="rounded-2xl rounded-tl-sm px-4 py-3" style={{ background: "var(--card)" }}>
+                      <p className="text-sm" style={{ color: "var(--foreground)" }}>{msg.text}</p>
+                    </div>
+                    {msg.chips && i === clarificationMessages.length - 1 && (
+                      <div className="mt-2 space-y-2">
+                        <div className="flex flex-wrap gap-2">
+                          {msg.chips.map(chip => (
+                            <Chip key={chip} onClick={() => handleClarificationAnswer(chip)}>{chip}</Chip>
+                          ))}
+                          <Chip onClick={() => handleClarificationAnswer("Not sure")}>Not sure</Chip>
+                        </div>
+                        <div className="flex gap-2">
+                          <input type="text" value={freeText}
+                            onChange={e => setFreeText(e.target.value)}
+                            onKeyDown={e => e.key === "Enter" && freeText.trim() && handleClarificationAnswer(freeText.trim())}
+                            placeholder="Or type your answer..."
+                            className="flex-1 rounded-2xl px-3 py-2 text-base focus:outline-none"
+                            style={{ background: "var(--card)", border: "1px solid var(--border)", color: "var(--foreground)" }}
+                          />
+                          {freeText.trim() && (
+                            <button onClick={() => handleClarificationAnswer(freeText.trim())}
+                              className="px-3 py-2 rounded-xl text-sm font-medium active:scale-95 transition-all"
+                              style={{ background: "var(--primary)", color: "var(--primary-foreground)" }}
+                            >↵</button>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div className="rounded-2xl rounded-tr-sm px-4 py-3 max-w-[60%]"
+                    style={{ background: "rgba(212,184,150,0.15)", border: "1px solid rgba(212,184,150,0.25)" }}>
+                    <p className="text-sm" style={{ color: "var(--foreground)" }}>{msg.text}</p>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
 
         {/* Library match notice — original Dark behaviour restored:
             navigates to /coffees/[id] so the user can read the prior

--- a/src/lib/types/session.ts
+++ b/src/lib/types/session.ts
@@ -6,11 +6,13 @@ export interface CoffeeIdentity {
   name: string;
   origin: string;
   region?: string;
+  farm?: string; // specific farm / estate, e.g. "Fazenda Passeio"
   variety?: string;
   process: string; // Natural | Washed | Honey | Anaerobic | Other
   fermentationStyle?: string; // e.g. "Spontaneous Anaerobic", "Starter-culture Natural", "Thermal-shock Washed"
   roastLevel: string; // Light | Medium-Light | Medium | Dark
   roastDate?: string; // ISO date string
+  altitudeMeters?: number; // grow elevation in metres above sea level
   cuppingScore?: number; // SCA / Q-grade, e.g. 87.5
   bagPhotoUrl?: string;
   bagPhotoPath?: string;


### PR DESCRIPTION
## Summary

Three coupled gaps Markus surfaced on the scan → detail pipeline:

1. **`CoffeeIdentity` dropped `farm` + `altitudeMeters`** from its type even though `analyze-bag` has been extracting them. The data was passing through to JSONB at runtime (spread keeps extras) but couldn't be typed-read. Added both as optional fields.
2. **Coffee Detail page hid most of the scan data.** Only Variety / Roast / Region / Roast date / Bag notes were rendered. Cupping Score, Process, Farm, Altitude, Fermentation style — all gathered, all silently buried. Added DetailRows for each.
3. **`/api/analyze-url` returned hardcoded `clarifications: []`** so the link flow never asked follow-up questions even when the page lacked altitude / variety / notes. Photo flow asks them; link flow didn't — asymmetric scan UX.

## Fix

- `farm` + `altitudeMeters` added to `CoffeeIdentity` as optional fields.
- Coffee Detail's "Coffee Details" section now renders Variety, Process, Fermentation, Roast, Region, Farm, Altitude, Cupping score, Roast date — each conditional on presence.
- `analyze-url` Haiku prompt updated to produce a `clarifications` array (max 2, same priority order as analyze-bag: variety → notes → altitude → region/farm).
- `LightStepScan.handleUrlAnalyze` sets `analysisResult` with the URL extraction shape so the existing `handleClarificationAnswer` + `/api/analyze-bag/clarify` pipeline works for both flows.
- Clarification chat JSX moved out of the photo-only block to a shared spot below both input methods — single source of truth.

## Behavioural-change flag

Per `CLAUDE.md` Hard Rule on AI behaviour changes: the `analyze-url` prompt was edited to also produce `clarifications`. **Markus to validate on the deployed PWA:** scan 2-3 real product URLs (Hoppenworth, Tanat, your usual sources), confirm clarifications come back sensible AND extraction quality is unchanged for the fields it already covered.

## Test plan

- [ ] Scan a fresh coffee via photo → answer clarifications → save. Coffee Detail shows everything you entered.
- [ ] Scan a coffee via URL (`https://tanat.coffee/…`) → if altitude / variety / notes missing, follow-up questions now appear. Answer them, save, verify Coffee Detail.
- [ ] Manual entry path: unchanged.
- [ ] Existing library: open an old coffee. Existing detail rows still render (variety, roast, region, etc.). New rows only show if those fields were captured.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_