### PR TITLE
fix(recommend): both candidates must hit user's custom volume (±30ml)

### DIFF
--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -560,7 +560,7 @@ export async function generateRecommendation(
     batch:
       "target ~750g water — Moccamaster ONLY; scale dose to ~50g.",
     custom: context.customWaterMl
-      ? `target exactly ${context.customWaterMl}ml — the user typed this exact number, NEVER alter it. Dose at 1:15. Capacity tensions with the chosen method are handled separately (see HARD CAPACITY CONSTRAINT / USER OVERRIDE block below). When the user has locked a method that's near or past the vessel's comfortable max for this volume, honor BOTH the method and the ml — flag the trade-off in reasoning, do not silently clamp the water.`
+      ? `target exactly ${context.customWaterMl}ml for BOTH candidates — tolerance is ±30ml, never more. The user typed this exact number. Reference recipes from the corpus (Kasuya 4:6, Hoffmann Better 1 Cup, Wölfl Orea Fast, etc.) supply the TECHNIQUE and ratio, NOT absolute numbers — scale the dose proportionally so waterGrams lands within 30ml of ${context.customWaterMl}. Default ratio 1:15 (so ${Math.round((context.customWaterMl ?? 350) / 15)}g dose / ${context.customWaterMl}g water). If a specific reference recipe calls for a different ratio (e.g. 1:14 for Wölfl, 1:16 for Medina), use its ratio but still scale to ~${context.customWaterMl}ml. Capacity tensions with the chosen method are handled separately (see HARD CAPACITY CONSTRAINT / USER OVERRIDE block). When the user has locked a method that's near or past the vessel's comfortable max for this volume, honor BOTH the method and the ml — flag the trade-off in reasoning, do not silently clamp the water.`
       : "target ~350g water / 23g dose",
     surprise:
       "SURPRISE MODE: full creative freedom on method and recipe — hard capacity limits still apply. Be adventurous.",


### PR DESCRIPTION
## Summary

After PR #165 the locked method respected the user's custom volume, but the **contrast** candidate (the free-choice one) still pulled reference recipes from the corpus at their published numbers. Markus' case: typed 450ml + locked Clever → locked recipe scaled to 450g ✓, contrast V60 came back as Kasuya 4:6 at the corpus default 20g/300g ✗.

## Fix

Tightened the `amountGuide.custom` block:
- BOTH candidates must land within **±30ml** of the typed volume.
- Reference recipes from the corpus (Kasuya 4:6, Hoffmann Better 1 Cup, Wölfl Orea Fast, etc.) supply the TECHNIQUE + ratio, NOT absolute numbers.
- Default ratio 1:15 (so 450ml → 30g dose / 450g water).
- Recipes that explicitly call for a different ratio (Wölfl 1:14, Medina 1:16, etc.) keep their ratio but still scale to the user's target volume.

## Behavioural-change flag

Per `CLAUDE.md` Hard Rule on AI behaviour changes: this is a prompt edit to `/api/recommend`. **Markus to validate on the deployed PWA:**
- Clever + 450ml custom → both candidates within 450 ± 30 g water. Locked Clever uses 450g; contrast (Kasuya / Wölfl / whatever) is scaled to ~450g, not the corpus default.
- Open method + 350ml "small" preset → unchanged, scaling note doesn't kick in.

If the contrast candidate still ignores the volume, escalate — there may be a third layer of the prompt that needs reinforcement.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_