### PR TITLE
fix(explore-agent): chat knows what the app knows — Orea bottoms + full recipe corpus

### DIFF
--- a/src/app/api/explore-agent/route.ts
+++ b/src/app/api/explore-agent/route.ts
@@ -11,6 +11,7 @@ import {
   formatVarietyPriorForPrompt,
 } from "@/lib/knowledge/varieties";
 import { TECHNIQUES } from "@/lib/knowledge/techniques";
+import { ALL_RECIPES, formatRecipeForPrompt } from "@/lib/knowledge/recipes";
 import { db } from "@/lib/db/client";
 import { places } from "@/lib/db/schema";
 import type { Session } from "@/lib/types/session";
@@ -99,6 +100,14 @@ When browsing a roaster's product listing:
 ## Filter Brewing Expertise
 
 V60 (Hario, Orea V4), AeroPress, Clever Dripper, Kalita Wave, Chemex, Moccamaster, Drip Assist. Deep understanding of percolation vs. immersion.
+
+**Orea V4 bottoms (four interchangeable flow plates — slowest → fastest):**
+- **Apex** — 8 inward-pointing triangular teeth. Most restricted flow, slowest drawdown of the four. Use for maximum contact time, body, and sweetness development on light-medium roasts. Light stir at bloom ONLY; no post-bloom agitation (clarity focus).
+- **Classic** — central plate with a cross of 4 flow slots. Medium flow, the default Orea bottom. Versatile baseline, slightly slower than a V60 size 02. Gentle swirl at bloom and after final pour. Strong pick for sweetness-forward brews.
+- **Fast** — 8 short radial bars between inner and outer ring. Faster than V60. The Wölfl 2024 WAC bottom: turbulent, fast-flowing, paradoxically delivers clarity on naturals because total bed-contact time stays short. Light stir at bloom; no post-bloom agitation.
+- **Open** — clean donut hole, no plate restriction. Fastest possible flow, essentially open-bottomed dripper behaviour. Use when you want maximum bypass / lightest body, or a forgiving target for very fine grinds where you need flow to compensate. Gentle swirl at bloom only.
+
+Flow ranking head-to-head: **Apex (slowest) → Classic → Fast → Open (fastest)**. Pair the bottom to the brewing goal, not the other way round. All four are part of the user's kit — never tell them to "check the site" or ask which is slowest.
 
 Championship recipes: Kasuya 4:6, Peng Jiajun 2025 WBC temp-staging, Wölfl 2024 Orea FAST.
 
@@ -520,6 +529,16 @@ export async function POST(req: NextRequest) {
         TECHNIQUES.map(
           (t) => `- ${t.id} (${t.attribution.person}): ${t.description}`
         ).join("\n")
+    );
+
+    // Reference recipe corpus — the same 20 championship + reference
+    // recipes /api/recommend uses, in full. Injected as-is so the chat
+    // can speak with authority about Kasuya 4:6, Wölfl 2024 Orea Fast,
+    // Hoffmann Better 1 Cup, etc. — no more "let me check online" when
+    // the user asks about a recipe that's already baked into the app.
+    contextParts.push(
+      `\n## Reference Recipe Library (full corpus — championship + named-expert recipes documented in the app; cite by name when you draw from one)\n\n` +
+        ALL_RECIPES.map(formatRecipeForPrompt).join("\n\n")
     );
 
     const dynamicContext = contextParts.join("");


### PR DESCRIPTION
## Summary

Markus: the BTTS chat said "I don't have access to Orea bottom specs, this is a gap in what's been built into me" — and his broader point: **the chat should fundamentally know what the app knows.**

Two prompts (`/recommend` and `/explore-agent`) had drifted: `/recommend` had a deep knowledge layer (Orea bottoms, championship recipes with full pour mechanics) while `/explore-agent` had only roaster priors + variety priors + techniques. The chat couldn't speak with authority about gear or recipes already baked into the app.

## Fix

Two additions to `/api/explore-agent`:

1. **Orea V4 bottom block** in the static "Filter Brewing Expertise" section. Names each bottom, ranks them slowest → fastest (**Apex → Classic → Fast → Open**), describes when to use each, and spells out the bloom/agitation per bottom. Mirrors the guidance already in `/api/recommend`.
2. **Full reference recipe corpus** injected into per-turn dynamic context — all 20 championship + named-expert recipes, formatted via `formatRecipeForPrompt`. The chat can now speak about Kasuya 4:6, Wölfl 2024 Orea Fast, Hoffmann Better 1 Cup, Stanica WAC, etc. with the same authority `/recommend` does.

## Behavioural-change flag

Per `CLAUDE.md` Hard Rule on AI behaviour changes: prompt edit to `/api/explore-agent`. **Markus to validate on the deployed PWA:**
- "What's the difference between the Orea bottoms?" → direct answer with slowest→fastest ranking, no "let me check online".
- "Give me Kasuya 4:6 for this coffee" → reproduces 20g:300g, 92°C, 411–421°, 3:30 total, 4:6 pour pattern without hesitation.
- Open-ended chat unchanged — roaster priors / variety priors / techniques / user profile still present.

Tradeoff: per-turn prompt is bigger now (~5-7 KB more). Prompt caching covers most of the cost; if latency becomes an issue, we can condense to just recipe names + headline params instead of full pour sequences.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_