### PR TITLE
fix(chat): wrap long URLs in input + research unknown roasters

### DIFF
--- a/src/app/api/explore-agent/route.ts
+++ b/src/app/api/explore-agent/route.ts
@@ -97,6 +97,17 @@ When browsing a roaster's product listing:
 4. Return the requested number of picks with clear reasoning
 5. For an "exploration" pick: something that gently stretches their palate — different origin or process, not a flavour bomb they dislike
 
+## Unknown Roaster Protocol (do NOT skip)
+
+When the user asks about a roaster — by name or by URL — that is NOT in the **Roaster Style Priors** block injected below:
+
+1. **Always call fetch_page first** before answering. Either on the URL they shared, or on the roaster's own site (try \`<roaster-slug>.com\` or \`<roaster-slug>.coffee\` first; if the user shared a URL, use it directly).
+2. From the fetched page, extract: location/country, roast level, process/origin focus, varieties carried, price range, tasting-note vocabulary, founding year if visible, any awards or competition history.
+3. Synthesise a one-paragraph style read on the roaster — same shape as the curated priors below (roast tendency, clarity-vs-sweetness bias, agitation tolerance, recommended temp/ratio range, methodAffinities).
+4. **Flag clearly that this is an "inferred" read, not a curated profile** — quote the source URL once, and note that it's based on what's currently visible on their site.
+
+Do NOT hand-wave with reputation talk ("the sourcing choices and note vocabulary are positive signals…") when you haven't actually fetched their page. If \`fetch_page\` fails or returns nothing usable, say so explicitly: "I tried to fetch [URL] and got [error/empty]. Without that I can't give you a real read on them."
+
 ## Filter Brewing Expertise
 
 V60 (Hario, Orea V4), AeroPress, Clever Dripper, Kalita Wave, Chemex, Moccamaster. Deep understanding of percolation vs. immersion.

--- a/src/components/ui/light/ChatInput.tsx
+++ b/src/components/ui/light/ChatInput.tsx
@@ -379,7 +379,7 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
                 </div>
               )}
               <div className="flex items-end gap-1">
-                <div className="relative min-h-8 flex-1">
+                <div className="relative min-h-8 min-w-0 flex-1">
                   <div
                     ref={editorRef}
                     contentEditable
@@ -390,6 +390,10 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
                     onInput={handleInput}
                     onFocus={handleFocus}
                     onPaste={handlePaste}
+                    // overflow-wrap: anywhere → unbreakable strings (long
+                    // URLs, no-space tokens) wrap inside the pill instead
+                    // of pushing the editor wider than its container.
+                    style={{ overflowWrap: "anywhere" }}
                     className="block min-h-8 w-full whitespace-pre-wrap break-words font-chivo text-[16px] font-normal leading-[2rem] text-light-foreground focus:outline-none"
                   />
                   {!hasText && (


### PR DESCRIPTION
## Summary

Two issues Markus surfaced from the same screenshot:

### 1. UI — long URL widens the chat input pill

When he pasted a long roaster URL (`https://ineffablecoffee.com/en/pages/de-cafe-de-especialidad`), the contentEditable editor pushed the pill past the screen edge. Tailwind's `break-words` only breaks at word boundaries, so an unbroken URL stretched the parent flex container.

**Fix:** added `min-w-0` to the editor's parent `flex-1` wrapper so flex-shrink propagates, plus inline `overflow-wrap: anywhere` on the editor so URLs wrap at any character.

### 2. Behaviour — chat hand-waves instead of researching unknown roasters

When the user asks about a roaster not in our curated `getRoasterPrior` priors, the chat returned a "the sourcing choices and note vocabulary are positive signals…" non-answer instead of calling `fetch_page`. The tool description already said "call this whenever the user shares a URL", but Sonnet didn't consistently follow through.

**Fix:** added a dedicated **Unknown Roaster Protocol** section to `AGENT_SYSTEM_PROMPT` that explicitly:
1. Demands `fetch_page` first — either on the URL the user shared, or on `<roaster-slug>.com / .coffee`.
2. Specifies what to extract (location, roast level, process focus, varieties, tasting-note vocabulary, year, awards).
3. Demands a synthesised one-paragraph style read in the same shape as the curated priors.
4. Demands the read be flagged as "inferred" with the source URL quoted.
5. Explicitly forbids reputation hand-waving without fetching.
6. Tells the agent how to fail honestly when `fetch_page` returns nothing.

## Behavioural-change flag

Per `CLAUDE.md` Hard Rule on AI behaviour changes: prompt edit to `/api/explore-agent`. **Markus to validate on the deployed PWA:**
- Ask the chat about a roaster you know isn't in the priors (e.g. Ineffable Coffee). Should call `fetch_page`, return a structured one-paragraph read, quote the source URL, and flag it as "inferred". Should NOT say "positive signals" or similar reputation talk.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_