### PR TITLE
fix(taste): vertically center "Taste Profile" headline with burger menu

### DIFF
--- a/src/app/(light)/taste/page.tsx
+++ b/src/app/(light)/taste/page.tsx
@@ -322,7 +322,7 @@ export default function TastePage() {
 
 function Header({ onMenu }: { onMenu: () => void }) {
   return (
-    <div className="px-5 pb-4 flex items-start justify-between gap-3" style={{ paddingTop: 'calc(env(safe-area-inset-top) + 1.25rem)' }}>
+    <div className="px-5 pb-4 flex items-center justify-between gap-3" style={{ paddingTop: 'calc(env(safe-area-inset-top) + 1.25rem)' }}>
       <div>
         <h1 className="font-fraunces text-3xl text-light-foreground leading-none">Taste Profile</h1>
       </div>


### PR DESCRIPTION
## Summary

Header row on Taste Profile used `items-start`, so the burger button was top-aligned with the h1 box. Because Fraunces sits a bit lower inside its line box, the burger visually floated above the title's actual centre. Markus on Safari: "headline is too high".

Switched to `items-center` to match the other one-line library headers (Café Library, Coffee Library) which already use it.

## Test plan

- [ ] `/taste` on Safari + PWA: "Taste Profile" h1 and burger circle share the same vertical centre line.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_