### PR TITLE
fix(recommend): Orea candidates must name the specific bottom

### DIFF
--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -335,6 +335,16 @@ ORIGAMI DRIPPER — dedicated rules:
    - Big (22g:330g): Bloom 45g → 135g → 235g → 330g | ~3:20 (targetTimeSec: 200)
 6. Max practical volume: 500 ml. Minimum: 200 ml.
 
+OREA V4 — dedicated rules:
+1. One brewer body, four interchangeable bottom plates that change flow rate dramatically.
+   Slowest → fastest: Apex → Classic → Fast → Open.
+   - Orea Apex (most restricted, slowest): clarity / maximum contact time. Delicate light-medium lots.
+   - Orea Classic (medium, default): versatile, sweetness-forward. The general-purpose bottom.
+   - Orea Fast (fast, turbulent): the Wölfl 2024 WAC bottom. Clean cup on naturals via short bed-contact + turbulent pours.
+   - Orea Open (fastest, open bed): maximum bypass / lightest body, or a forgiving target for very fine grinds.
+2. The candidate's method field MUST name the specific bottom — use exactly "Orea Fast", "Orea Classic", "Orea Apex", or "Orea Open". NEVER return the generic "Orea V4 Wide" or bare "Orea": the user owns all four bottoms and needs to know which one to fit. A recipe whose name references a bottom (e.g. "Wölfl-adapted Orea Fast") MUST set method to that exact bottom ("Orea Fast").
+3. Niche° + agitation per bottom: see the NICHE° GRIND REFERENCE and AGITATION RULES blocks above.
+
 NICHE° GRIND REFERENCE:
 V60: 396–406° | Orea: 401–411° | Origami Air M: 401–408°
 Origami (cone): 398–408° | Origami (wave): 398–406°


### PR DESCRIPTION
## Summary

Markus: a recommended "Wölfl-adapted Orea Fast" recipe displayed its brewer as the generic **"Orea V4 Wide"** — no indication of which of the four bottoms (Apex / Classic / Fast / Open) to actually fit. Since PR #144 split the bottoms into distinct methods + icons, the recipe needs to name one.

## Fix

The recommend prompt had an Origami (cone)/(wave) disambiguation rule but no Orea equivalent. Added an **OREA V4 — dedicated rules** block:
- Describes each bottom's flow character (slowest → fastest: Apex → Classic → Fast → Open).
- Demands the candidate's `method` field name the exact bottom — `"Orea Fast"`, `"Orea Classic"`, `"Orea Apex"`, or `"Orea Open"` — never the generic `"Orea V4 Wide"` or bare `"Orea"`.
- A recipe whose name references a bottom (Wölfl → Fast) must set method to that bottom.

Side effect: `BrewMethodIcon` already routes "Orea Fast" etc. to their specific SVGs (PR #144), so the icon will be correct too instead of falling back to Classic.

## Behavioural-change flag

Per `CLAUDE.md` Hard Rule: prompt edit to `/api/recommend`. **Markus to validate on the deployed PWA:**
- A recommended Orea recipe shows a specific bottom — never "Orea V4 Wide".
- Bottom matches the recipe's character (Wölfl → Fast, clarity-probe → Apex, sweetness → Classic).

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_