### PR TITLE
fix(past-conversations): title-case the headline

### DIFF
--- a/src/app/(light)/past-conversations/page.tsx
+++ b/src/app/(light)/past-conversations/page.tsx
@@ -72,7 +72,7 @@ export default function PastConversationsPage() {
           style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.25rem)" }}
         >
           <h1 className="font-fraunces text-3xl leading-none text-light-foreground">
-            Past conversations
+            Past Conversations
           </h1>
           <button
             type="button"


### PR DESCRIPTION
## Summary

"Past conversations" was the only Light page title with a lowercase second word. Every other title is title-cased (Coffee Library, Café Library, Taste Profile, Nearby). Capitalised to "Past Conversations".

## Test plan

- [ ] `/past-conversations` header reads "Past Conversations".
- [ ] NavigationOverlay menu item already reads "Past Conversations" — now consistent with the page title.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_