### PR TITLE
feat(greeting): live weather (Open-Meteo) — surfaced only when it matters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,14 @@ USER_DISPLAY_NAME=Your Name
 # Your city/location — optional, used for context in the Explore chat
 USER_LOCATION=Your City
 
+# ── Weather (daily greeting) ──────────────────────────────────────────────────
+# Coordinates for the daily home greeting's optional weather angle
+# (Open-Meteo, free, no API key). A hot day steers the suggestion toward
+# iced coffee; on an ordinary day weather is ignored. Defaults to Cologne
+# (50.9375, 6.9603) if unset — override with your home coordinates.
+WEATHER_LATITUDE=50.9375
+WEATHER_LONGITUDE=6.9603
+
 # ── Anthropic ─────────────────────────────────────────────────────────────────
 ANTHROPIC_API_KEY=sk-ant-...
 

--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -150,13 +150,13 @@ export default function HomePage() {
   useEffect(() => {
     // Cache version bumped on every greeting-prompt change so stale
     // cached lines from the previous rule don't show up next morning.
-    // v5 = science-grounded brewing recommendation (bag + method +
-    // reason) instead of a plain time/rotation greeting. Time-of-day
+    // v6 = science-grounded recommendation + optional live weather
+    // (Open-Meteo) so a hot day can steer toward iced. Time-of-day
     // bucket appended so the starter regenerates when the user crosses
     // a tod boundary (morning → midday → afternoon → evening →
-    // late-night). Old `brewlog.starter.v{2,3,4}.<date>` entries are
+    // late-night). Old `brewlog.starter.v{2..5}.<date>` entries are
     // orphaned in localStorage — harmless.
-    const key = `brewlog.starter.v5.${todayKey()}.${timeBucket()}`;
+    const key = `brewlog.starter.v6.${todayKey()}.${timeBucket()}`;
     try {
       const cached = window.localStorage.getItem(key);
       if (cached) {

--- a/src/app/api/greeting/route.ts
+++ b/src/app/api/greeting/route.ts
@@ -26,6 +26,50 @@ export const maxDuration = 30;
 
 const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
+/**
+ * Fetch today's weather for the user's location via Open-Meteo (free,
+ * keyless). Coordinates come from WEATHER_LATITUDE / WEATHER_LONGITUDE
+ * env vars, defaulting to Cologne (the app's home region). Returns a
+ * short prompt-ready line, or null on any failure / timeout — weather
+ * is strictly optional context and must never block the greeting.
+ */
+async function fetchWeather(): Promise<string | null> {
+  const lat = process.env.WEATHER_LATITUDE ?? "50.9375";
+  const lon = process.env.WEATHER_LONGITUDE ?? "6.9603";
+  try {
+    const url =
+      `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}` +
+      `&current=temperature_2m,weather_code&daily=temperature_2m_max,temperature_2m_min` +
+      `&timezone=auto&forecast_days=1`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(4000) });
+    if (!res.ok) return null;
+    const data = await res.json();
+    const nowC = data?.current?.temperature_2m;
+    const maxC = data?.daily?.temperature_2m_max?.[0];
+    const code = data?.current?.weather_code;
+    if (nowC == null) return null;
+    const cond = describeWeatherCode(code);
+    const parts = [`currently ${Math.round(nowC)}°C${cond ? `, ${cond}` : ""}`];
+    if (maxC != null) parts.push(`today's high ${Math.round(maxC)}°C`);
+    return parts.join(", ");
+  } catch {
+    return null;
+  }
+}
+
+/** Coarse WMO weather-code → label. Only what's useful for a coffee line. */
+function describeWeatherCode(code: unknown): string {
+  const c = typeof code === "number" ? code : -1;
+  if (c === 0) return "clear";
+  if (c <= 3) return "partly cloudy";
+  if (c <= 48) return "foggy";
+  if (c <= 67) return "rainy";
+  if (c <= 77) return "snowy";
+  if (c <= 82) return "showers";
+  if (c <= 99) return "stormy";
+  return "";
+}
+
 const SYSTEM_PROMPT = `You are writing the opening line of a personal coffee app each morning. ONE short, warm sentence that makes a smart, specific brewing suggestion for today — a real recommendation a knowledgeable barista friend would text you, grounded in coffee science. Not a status report, not a generic greeting.
 
 THE SHAPE (this is the whole point)
@@ -85,7 +129,7 @@ export async function POST(req: NextRequest) {
     // payloads, so a malformed body doesn't 400 here.
     await req.json().catch(() => ({} as RequestBody));
 
-    const [library, recentRows, profile] = await Promise.all([
+    const [library, recentRows, profile, weather] = await Promise.all([
       // Only the last few bags in active rotation — the line biases
       // toward what the user is brewing right now, not their full
       // historical library.
@@ -97,6 +141,7 @@ export async function POST(req: NextRequest) {
         .limit(5)
         .catch(() => []),
       loadUserProfile().catch(() => null),
+      fetchWeather(),
     ]);
     const recentSessions = (recentRows as unknown[]).map((row) =>
       rowToSession(row as Parameters<typeof rowToSession>[0])
@@ -138,6 +183,9 @@ export async function POST(req: NextRequest) {
 
     const userBlock = [
       `Time of day: ${timeOfDay} (local clock ${localHHMM}). Use this label exactly, or omit time entirely.`,
+      weather
+        ? `Weather (${weather}). OPTIONAL — use only if it genuinely changes the smart call (notably warm ≥26°C → iced is the move; otherwise ignore weather entirely and don't mention it).`
+        : "Weather: unavailable — recommend on bean/method/science alone.",
       `Brewers the user owns (only suggest from these): ${equipment}.`,
       recentLines.length > 0
         ? `Recent brews:\n${recentLines.join("\n")}`


### PR DESCRIPTION
## Summary

Markus: weather shouldn't always show — only when meaningful ("Tuesday it'll hit 31°" → iced is the smart call). And he's right: the app just needs the location and can look up the weather itself.

## Changes to `/api/greeting`

- **`fetchWeather()`** — Open-Meteo forecast (free, no API key): current temp + condition + today's high. Coordinates from `WEATHER_LATITUDE` / `WEATHER_LONGITUDE` env vars, defaulting to Cologne (the app's home region). 4s timeout, fully fail-safe — returns `null` on any error and the greeting proceeds without weather.
- **Injected as OPTIONAL context:** the prompt uses weather only when it genuinely changes the call (≥26°C → iced); on an ordinary day it's ignored and never mentioned. No forced weather chatter.
- **`.env.example`** documents `WEATHER_LATITUDE` / `LONGITUDE`. Markus overrides the default with his home coordinates on the VPS.
- **Cache** bumped `v5` → `v6`.

## How "smartness" works now

The greeting endpoint pulls: rotation bags (origin/process), owned equipment, time of day, AND live weather. The prompt decides whether each signal is worth using. A 31° afternoon → "take the La Coipa over ice with a Japanese iced V60". A mild morning → weather silent, recommends on bean + method + science.

## Behavioural-change flag

Per `CLAUDE.md` Hard Rule: prompt + context change to `/api/greeting` (model unchanged — Haiku 4.5). **Markus to validate on the deployed PWA:**
- Warm day → may suggest iced and cite the temp.
- Mild/cold/ordinary day → weather NOT mentioned.
- If Open-Meteo is unreachable → greeting still generates without weather.

**Action for Markus:** set `WEATHER_LATITUDE` / `WEATHER_LONGITUDE` on the VPS to your actual home coordinates if Cologne (50.9375, 6.9603) isn't right.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_