### PR TITLE
chore(greeting): default weather location to Düsseldorf

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,10 +10,10 @@ USER_LOCATION=Your City
 # ── Weather (daily greeting) ──────────────────────────────────────────────────
 # Coordinates for the daily home greeting's optional weather angle
 # (Open-Meteo, free, no API key). A hot day steers the suggestion toward
-# iced coffee; on an ordinary day weather is ignored. Defaults to Cologne
-# (50.9375, 6.9603) if unset — override with your home coordinates.
-WEATHER_LATITUDE=50.9375
-WEATHER_LONGITUDE=6.9603
+# iced coffee; on an ordinary day weather is ignored. Defaults to
+# Düsseldorf (51.2277, 6.7735) if unset — override with your coordinates.
+WEATHER_LATITUDE=51.2277
+WEATHER_LONGITUDE=6.7735
 
 # ── Anthropic ─────────────────────────────────────────────────────────────────
 ANTHROPIC_API_KEY=sk-ant-...

--- a/src/app/api/greeting/route.ts
+++ b/src/app/api/greeting/route.ts
@@ -34,8 +34,8 @@ const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
  * is strictly optional context and must never block the greeting.
  */
 async function fetchWeather(): Promise<string | null> {
-  const lat = process.env.WEATHER_LATITUDE ?? "50.9375";
-  const lon = process.env.WEATHER_LONGITUDE ?? "6.9603";
+  const lat = process.env.WEATHER_LATITUDE ?? "51.2277";
+  const lon = process.env.WEATHER_LONGITUDE ?? "6.7735";
   try {
     const url =
       `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}` +


### PR DESCRIPTION
## Summary

Markus is in Düsseldorf, not Cologne. Single-user app, so the simplest fix is to change the hardcoded default weather coordinates rather than make him set env vars on the VPS.

- Default coordinates → Düsseldorf (51.2277, 6.7735).
- `WEATHER_LATITUDE` / `WEATHER_LONGITUDE` env override still works if he travels and wants to repoint it.
- `.env.example` updated.

No action needed on the VPS — the greeting will use Düsseldorf weather automatically after deploy.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_