### PR TITLE
fix(context): restore the old Morning Ritual sunrise icon exactly

### DIFF
--- a/src/components/flow/LightStepContext.tsx
+++ b/src/components/flow/LightStepContext.tsx
@@ -66,7 +66,7 @@ async function getRecentSessions(limit: number): Promise<Session[]> {
 function SunriseNoArrow({ className }: { className?: string }) {
   return (
     <svg
-      viewBox="0 0 24 24"
+      viewBox="2 6 20 20"
       fill="none"
       stroke="currentColor"
       strokeWidth={1.5}
@@ -75,7 +75,7 @@ function SunriseNoArrow({ className }: { className?: string }) {
       aria-hidden
       className={className}
     >
-      <path d="M12 2v8" />
+      <path d="M12 8v2" />
       <path d="m4.93 10.93 1.41 1.41" />
       <path d="M2 18h2" />
       <path d="M20 18h2" />


### PR DESCRIPTION
## Summary

The Morning Ritual occasion icon (`SunriseNoArrow` in `LightStepContext`) kept lucide Sunrise's long centre beam `M12 2v8` — an antenna sticking out the top, because the chevron arrow was removed but the shaft wasn't.

The pre-Light Dark `StepContext` (commit `a21e184`) had already solved this exactly: the middle beam shortened to `M12 8v2` (~2 units, matching the side beams) and the viewBox cropped to `2 6 20 20` so the icon fills its box like the other lucide occasion icons.

Restored those two exact values. Everything else (rays, ground line, sun dome, currentColor, strokeWidth 1.5) unchanged — so it renders in the current Light style but with the old, clean geometry Markus asked for.

## Test plan

- [ ] `/brew/new` → Context step → Occasion section: "Morning Ritual" card shows a clean sunrise (short top ray, no antenna), matching the side rays.

https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC

---
_Generated by [Claude Code](https://claude.ai/code/session_016zRB3Q9dVfuafvcR6dZQdC)_