### PR TITLE
Offline re-brew of known coffees with sync-on-reconnect

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -46,6 +46,12 @@ export default withPWA({
   aggressiveFrontEndNavCaching: true,
   reloadOnOnline: true,
   disable: process.env.NODE_ENV === "development",
+  // Offline document fallback — an uncached navigation while offline lands
+  // on /offline instead of a browser error page. The brew shell (/coffees,
+  // /brew/new) is precached via cacheOnFrontEndNav, so this is a safety net.
+  fallbacks: {
+    document: "/offline",
+  },
   workboxOptions: {
     disableDevLogs: true,
   },

--- a/src/app/(light)/coffees/[id]/page.tsx
+++ b/src/app/(light)/coffees/[id]/page.tsx
@@ -9,9 +9,16 @@ import StarRating from "@/components/ui/light/StarRating";
 import CoffeeBeanGlow from "@/components/ui/light/CoffeeBeanGlow";
 import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
 import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
-import { useFlowStore } from "@/store/flowStore";
 import { useFieldConfig } from "@/lib/field/FieldContext";
 import { rememberSessionField } from "@/lib/field/cache";
+import { useOnline } from "@/hooks/useOnline";
+import { startBrewAgain, startBrewAgainOffline } from "@/lib/flow/brewAgain";
+import {
+  cacheBrewableCoffee,
+  getBrewableCoffee,
+  type BrewableCoffee,
+  type BrewableRecipe,
+} from "@/lib/storage/offlineLibrary";
 
 interface RoasterInfo {
   region?: string;
@@ -27,8 +34,9 @@ export default function CoffeeDetailPage() {
   const [roasterInfo, setRoasterInfo] = useState<RoasterInfo | null>(null);
   const [roasterGenerating, setRoasterGenerating] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [offlineCoffee, setOfflineCoffee] = useState<BrewableCoffee | null>(null);
   const router = useRouter();
-  const { reset, setCoffee: setFlowCoffee, setStep, setMode, setSkipScan, setFieldZones } = useFlowStore();
+  const online = useOnline();
 
   // Personal notes state
   const [editingNotes, setEditingNotes] = useState(false);
@@ -39,6 +47,13 @@ export default function CoffeeDetailPage() {
 
   useEffect(() => {
     async function load() {
+      // Offline — render this coffee from the local re-brew cache.
+      if (typeof navigator !== "undefined" && !navigator.onLine) {
+        const cached = await getBrewableCoffee(id);
+        setOfflineCoffee(cached);
+        setLoading(false);
+        return;
+      }
       try {
         const coffeeRes = await fetch(`/api/coffees/${id}`, { cache: "no-store" });
         if (!coffeeRes.ok) { setLoading(false); return; }
@@ -97,6 +112,8 @@ export default function CoffeeDetailPage() {
                   if (found.fieldZones) {
                     coffeeSessions.forEach(s => rememberSessionField(s.id, found.fieldZones));
                   }
+                  // Warm the offline re-brew cache for this coffee.
+                  void cacheBrewableCoffee(found, coffeeSessions);
                 })
                 .catch(() => {})
             : Promise.resolve(),
@@ -108,12 +125,13 @@ export default function CoffeeDetailPage() {
       }
     }
     load();
-  }, [id]);
+  }, [id, online]);
 
   // Adopt this coffee's Field composition so the page paints in its
   // cup-specific colours, matching the brew-session detail and the
-  // brew flow's "Brew Again" path.
-  useFieldConfig(coffee?.fieldZones ? { fieldZones: coffee.fieldZones, rotation: 0 } : null);
+  // brew flow's "Brew Again" path. Offline, lift it from the cache.
+  const activeFieldZones = coffee?.fieldZones ?? offlineCoffee?.fieldZones ?? null;
+  useFieldConfig(activeFieldZones ? { fieldZones: activeFieldZones, rotation: 0 } : null);
 
   if (loading) {
     return (
@@ -126,6 +144,12 @@ export default function CoffeeDetailPage() {
         </div>
       </div>
     );
+  }
+
+  // Offline — slim detail with the re-brew recipe picker (the network
+  // sections like roaster info and notes editing aren't available).
+  if (!coffee && offlineCoffee) {
+    return <OfflineCoffeeDetail coffee={offlineCoffee} router={router} />;
   }
 
   if (!coffee) {
@@ -156,26 +180,20 @@ export default function CoffeeDetailPage() {
     // Prefer the most-recent scanned CoffeeIdentity (has variety, tasting notes,
     // roast level). Fall back to the aggregate if the coffee somehow has no
     // sessions yet — defaults match the user's profile (light roast).
-    const identity: CoffeeIdentity = latestCoffee ?? {
-      roaster: coffee.roaster,
-      name: coffee.name,
-      origin: coffee.origin,
-      process: coffee.process,
-      roastLevel: "Light",
-      roastDate: coffee.latestRoastDate,
-      bagPhotoUrl: coffee.bagPhotoUrl,
-      aiExtracted: false,
-      coffeeId: coffee.id,
-    };
-    reset();
-    setFlowCoffee({ ...identity, coffeeId: coffee.id });
-    // Generative Field v1.1 — Brew Again path: lift the persisted
-    // composition so the flow paints in this coffee's colours rather
-    // than the Default fallback.
-    setFieldZones(coffee.fieldZones ?? null);
-    setMode("home");
-    setSkipScan(true);
-    setStep("context");
+    const identity: CoffeeIdentity = latestCoffee
+      ? { ...latestCoffee, coffeeId: coffee.id }
+      : {
+          roaster: coffee.roaster,
+          name: coffee.name,
+          origin: coffee.origin,
+          process: coffee.process,
+          roastLevel: "Light",
+          roastDate: coffee.latestRoastDate,
+          bagPhotoUrl: coffee.bagPhotoUrl,
+          aiExtracted: false,
+          coffeeId: coffee.id,
+        };
+    startBrewAgain(identity, coffee.fieldZones ?? null);
     router.push("/brew/new");
   };
 
@@ -494,6 +512,102 @@ function DetailRow({ label, value }: { label: string; value: string }) {
     <div className="flex items-baseline justify-between gap-4">
       <span className="text-light-muted-foreground text-sm shrink-0">{label}</span>
       <span className="text-light-foreground/80 text-sm text-right">{value}</span>
+    </div>
+  );
+}
+
+/**
+ * Offline coffee detail — the re-brew recipe picker. Shows up to the two
+ * best-rated cached recipes; tapping one seeds the flow store and jumps
+ * straight to the brew timer (skipping the AI recommend step).
+ */
+function OfflineCoffeeDetail({
+  coffee,
+  router,
+}: {
+  coffee: BrewableCoffee;
+  router: { push: (href: string) => void };
+}) {
+  const { identity, fieldZones, recipes } = coffee;
+  const origin = identity.origin;
+
+  const start = (recipe: BrewableRecipe) => {
+    startBrewAgainOffline(identity, fieldZones, recipe);
+    router.push("/brew/new");
+  };
+
+  return (
+    <div className="min-h-svh bg-transparent flex flex-col">
+      <div className="relative">
+        {identity.bagPhotoUrl ? (
+          <div className="relative h-72">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={identity.bagPhotoUrl} alt={identity.name} className="w-full h-full object-cover" />
+            <div
+              aria-hidden
+              className="absolute inset-0 pointer-events-none"
+              style={{
+                background:
+                  "linear-gradient(to top, hsl(30 60% 92% / 0.95) 0%, hsl(30 60% 92% / 0.45) 45%, transparent 80%)",
+              }}
+            />
+          </div>
+        ) : (
+          <div className="h-40 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150" />
+        )}
+
+        <button
+          onClick={() => router.push("/coffees")}
+          aria-label="Back to library"
+          className="absolute left-4 w-10 h-10 rounded-full bg-light-card-default/85 backdrop-blur-light-card backdrop-blur-sm flex items-center justify-center text-light-foreground"
+          style={{ top: "calc(env(safe-area-inset-top) + 1rem)" }}
+        >
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+
+        <div className={`${identity.bagPhotoUrl ? "absolute bottom-0 left-0 right-0" : ""} p-5`}>
+          {identity.process && (
+            <p className="text-light-foreground/50 text-xs tracking-widest uppercase mb-1">{identity.process}</p>
+          )}
+          <h1 className="font-fraunces text-3xl text-light-foreground">{identity.name}</h1>
+          <p className="text-light-foreground/60 text-sm mt-1">
+            {identity.roaster}{origin ? ` · ${origin}` : ""}
+          </p>
+        </div>
+      </div>
+
+      <div className="px-5 pt-5 pb-8 space-y-3">
+        <p className="text-light-muted-foreground text-xs uppercase tracking-widest">
+          {recipes.length > 1 ? "Brew again — pick a recipe" : "Brew again"}
+        </p>
+        {recipes.length === 0 ? (
+          <p className="text-light-muted-foreground text-sm">No saved recipe to brew offline.</p>
+        ) : (
+          recipes.map((r, i) => (
+            <button
+              key={i}
+              type="button"
+              onClick={() => start(r)}
+              className="w-full text-left rounded-2xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 p-4 active:scale-[0.99] transition-transform"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2 min-w-0">
+                  <BrewMethodIcon method={r.method} className="w-4 h-4 shrink-0 text-light-foreground" />
+                  <span className="text-light-foreground text-sm font-medium truncate">{r.method}</span>
+                </div>
+                {typeof r.rating === "number" && r.rating > 0 && (
+                  <StarRating value={r.rating} readonly size="sm" />
+                )}
+              </div>
+              <p className="text-light-muted-foreground text-xs mt-1.5">
+                {r.recipe.doseGrams}g / {r.recipe.waterGrams}g · {r.recipe.waterTempC}°C
+              </p>
+            </button>
+          ))
+        )}
+      </div>
     </div>
   );
 }

--- a/src/app/(light)/coffees/page.tsx
+++ b/src/app/(light)/coffees/page.tsx
@@ -3,12 +3,45 @@ import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Menu } from "lucide-react";
 import type { Coffee } from "@/lib/types/coffee";
-import type { CoffeeIdentity } from "@/lib/types/session";
+import type { CoffeeIdentity, Session } from "@/lib/types/session";
 import StarRating from "@/components/ui/light/StarRating";
 import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
-import { useFlowStore } from "@/store/flowStore";
+import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
+import { useOnline } from "@/hooks/useOnline";
+import { startBrewAgain, startBrewAgainOffline } from "@/lib/flow/brewAgain";
+import {
+  cacheBrewableLibrary,
+  getBrewableLibrary,
+  type BrewableCoffee,
+  type BrewableRecipe,
+} from "@/lib/storage/offlineLibrary";
 
 type Filter = "recent" | "favorites" | "roaster";
+
+/** Map a cached brewable coffee to the Coffee shape the list renders, so
+ * the offline view reuses the same card markup. avgRating is derived from
+ * the cached recipes' ratings; inRotation stays false offline (the quick
+ * "Brew" button is online-only — offline you pick a recipe on the detail
+ * page). */
+function brewableToCoffee(b: BrewableCoffee): Coffee {
+  const ratings = b.recipes.map((r) => r.rating).filter((n): n is number => typeof n === "number");
+  const avgRating = ratings.length ? ratings.reduce((s, n) => s + n, 0) / ratings.length : undefined;
+  return {
+    id: b.id,
+    roaster: b.identity.roaster,
+    name: b.identity.name,
+    origin: b.identity.origin,
+    process: b.identity.process,
+    firstSeenAt: "",
+    sessionCount: b.sessionCount,
+    sessionIds: [],
+    avgRating,
+    bagPhotoUrl: b.identity.bagPhotoUrl,
+    latestRoastDate: b.identity.roastDate,
+    fieldZones: b.fieldZones,
+    inRotation: false,
+  };
+}
 
 export default function CoffeesPage() {
   const [coffees, setCoffees] = useState<Coffee[]>([]);
@@ -19,13 +52,21 @@ export default function CoffeesPage() {
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<Filter>("recent");
   const [menuOpen, setMenuOpen] = useState(false);
+  // Offline: raw cache (with recipes) kept alongside the mapped list, plus
+  // the id of the coffee whose re-brew picker is open. Navigating to the
+  // detail route offline is unreliable (its RSC payload may be uncached),
+  // so the picker opens inline on the list — which is reliably precached.
+  const [offlineLib, setOfflineLib] = useState<BrewableCoffee[]>([]);
+  const [pickerId, setPickerId] = useState<string | null>(null);
   const router = useRouter();
-  const { reset, setCoffee, setStep, setMode, setSkipScan, setFieldZones } = useFlowStore();
+  const online = useOnline();
 
+  // Online "Brew" shortcut — synthesize a CoffeeIdentity from the aggregate
+  // (roastLevel isn't on the Coffee row, default "Light" per the user's
+  // profile) and start the AI flow at Step "context". Offline this button
+  // doesn't render (inRotation is false); you pick a recipe on the detail
+  // page instead.
   const brewThis = (coffee: Coffee) => {
-    // Synthesize a CoffeeIdentity from the aggregate. roastLevel isn't stored
-    // on the Coffee row — default to "Light" (matches the user's profile).
-    // Downstream /recommend gets the rest from preferences + history.
     const identity: CoffeeIdentity = {
       roaster: coffee.roaster,
       name: coffee.name,
@@ -37,34 +78,58 @@ export default function CoffeesPage() {
       aiExtracted: false,
       coffeeId: coffee.id,
     };
-    reset();
-    setCoffee(identity);
-    // Generative Field v1.1 — lift this coffee's persisted Field
-    // composition for the Brew Again flow.
-    setFieldZones(coffee.fieldZones ?? null);
-    setMode("home");
-    setSkipScan(true);
-    setStep("context");
+    startBrewAgain(identity, coffee.fieldZones ?? null);
     router.push("/brew/new");
   };
 
   useEffect(() => {
+    let cancelled = false;
     setLoading(true);
     setError(false);
+
+    // Offline — render the locally cached library (only coffees that have a
+    // re-brewable recipe).
+    if (typeof navigator !== "undefined" && !navigator.onLine) {
+      getBrewableLibrary().then((lib) => {
+        if (cancelled) return;
+        const brewable = lib.filter((b) => b.recipes.length > 0);
+        setOfflineLib(brewable);
+        setCoffees(brewable.map(brewableToCoffee));
+        setLoading(false);
+      });
+      return () => { cancelled = true; };
+    }
+
+    const coffeesP = fetch("/api/coffees", { cache: "no-store" })
+      .then((r) => { if (!r.ok) throw new Error(); return r.json() as Promise<Coffee[]>; });
+
+    // Render the list as soon as coffees load — don't block on the cache warm.
+    coffeesP
+      .then((data) => {
+        if (cancelled) return;
+        setCoffees([...data].sort((a, b) => (b.firstSeenAt || "").localeCompare(a.firstSeenAt || "")));
+      })
+      .catch(() => { if (!cancelled) setError(true); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+
+    fetch("/api/sessions?count=true&mode=home", { cache: "no-store" })
+      .then((r) => (r.ok ? (r.json() as Promise<{ total: number } | null>) : null))
+      .then((count) => { if (!cancelled && count?.total != null) setTotalSessions(count.total); })
+      .catch(() => {});
+
+    // Warm the offline re-brew cache in the background (full feed → top-2
+    // recipes per coffee). Never blocks the visible list.
     Promise.all([
-      fetch("/api/coffees", { cache: "no-store" })
-        .then(r => { if (!r.ok) throw new Error(); return r.json(); })
-        .then((data: Coffee[]) => {
-          const sorted = [...data].sort((a, b) => (b.firstSeenAt || "").localeCompare(a.firstSeenAt || ""));
-          setCoffees(sorted);
-        })
-        .catch(() => setError(true)),
-      fetch("/api/sessions?count=true&mode=home", { cache: "no-store" })
-        .then(r => r.ok ? r.json() : null)
-        .then((d: { total: number } | null) => { if (d?.total != null) setTotalSessions(d.total); })
-        .catch(() => {}),
-    ]).finally(() => setLoading(false));
-  }, [retryCount]);
+      coffeesP,
+      fetch("/api/sessions?limit=300", { cache: "no-store" })
+        .then((r) => (r.ok ? (r.json() as Promise<Session[]>) : []))
+        .catch((): Session[] => []),
+    ])
+      .then(([data, sessions]) => cacheBrewableLibrary(data, sessions))
+      .catch(() => {});
+
+    return () => { cancelled = true; };
+  }, [retryCount, online]);
 
   const sessionTotal = totalSessions ?? coffees.reduce((s, c) => s + c.sessionCount, 0);
   const roasterCount = useMemo(() => new Set(coffees.map(c => c.roaster).filter(Boolean)).size, [coffees]);
@@ -211,7 +276,7 @@ export default function CoffeesPage() {
                       flush with the card border, no padding gap. */}
                   <button
                     type="button"
-                    onClick={() => router.push(`/coffees/${coffee.id}`)}
+                    onClick={() => (online ? router.push(`/coffees/${coffee.id}`) : setPickerId(coffee.id))}
                     className="flex items-stretch flex-1 min-w-0 text-left active:opacity-80 transition-opacity"
                   >
                     {/* Photo — full-height left strip (w-24 = 96px).
@@ -299,6 +364,77 @@ export default function CoffeesPage() {
       </div>
 
       <NavigationOverlay open={menuOpen} onClose={() => setMenuOpen(false)} />
+
+      {pickerId && (
+        <OfflineRecipePicker
+          coffee={offlineLib.find((b) => b.id === pickerId) ?? null}
+          onClose={() => setPickerId(null)}
+          onPick={(b, r) => {
+            startBrewAgainOffline(b.identity, b.fieldZones, r);
+            router.push("/brew/new");
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Offline re-brew picker — a bottom sheet that opens from the library list
+ * when offline (the detail route may not be cached). Shows the up-to-two
+ * best-rated cached recipes; picking one seeds the flow and jumps to brew.
+ */
+function OfflineRecipePicker({
+  coffee,
+  onClose,
+  onPick,
+}: {
+  coffee: BrewableCoffee | null;
+  onClose: () => void;
+  onPick: (coffee: BrewableCoffee, recipe: BrewableRecipe) => void;
+}) {
+  if (!coffee) return null;
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Pick a recipe"
+      className="fixed inset-0 z-[2100] flex items-end justify-center bg-light-foreground/20 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="w-full max-w-md m-3 rounded-3xl bg-light-card-default backdrop-blur-[20px] backdrop-saturate-150 border border-light-foreground/15 p-5"
+        style={{ paddingBottom: "max(1.25rem, env(safe-area-inset-bottom))" }}
+      >
+        <p className="font-fraunces text-xl text-light-foreground leading-tight">{coffee.identity.name}</p>
+        <p className="text-light-muted-foreground text-xs mb-4">
+          {coffee.recipes.length > 1 ? "Pick a recipe to brew" : "Brew again"}
+        </p>
+        <div className="space-y-2.5">
+          {coffee.recipes.map((r, i) => (
+            <button
+              key={i}
+              type="button"
+              onClick={() => onPick(coffee, r)}
+              className="w-full text-left rounded-2xl bg-light-card-default border border-light-foreground/15 p-3.5 active:scale-[0.99] transition-transform"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="flex items-center gap-2 min-w-0">
+                  <BrewMethodIcon method={r.method} className="w-4 h-4 shrink-0 text-light-foreground" />
+                  <span className="text-light-foreground text-sm font-medium truncate">{r.method}</span>
+                </div>
+                {typeof r.rating === "number" && r.rating > 0 && (
+                  <StarRating value={r.rating} readonly size="sm" />
+                )}
+              </div>
+              <p className="text-light-muted-foreground text-xs mt-1.5">
+                {r.recipe.doseGrams}g / {r.recipe.waterGrams}g · {r.recipe.waterTempC}°C
+              </p>
+            </button>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/(light)/offline/page.tsx
+++ b/src/app/(light)/offline/page.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+export const dynamic = "force-static";
+
+/**
+ * Service-worker document fallback (next.config.mjs `fallbacks.document`).
+ * Shown when an uncached route is navigated to while offline. The core
+ * offline path — re-brewing a known coffee — lives under the precached
+ * /coffees + /brew/new shell, so this is a safety net, not the main door.
+ */
+export default function OfflinePage() {
+  return (
+    <div className="min-h-svh bg-transparent flex flex-col items-center justify-center gap-5 px-8 text-center">
+      <h1 className="font-fraunces text-3xl text-light-foreground">You&apos;re offline</h1>
+      <p className="text-light-muted-foreground text-sm leading-relaxed max-w-xs">
+        This page isn&apos;t available offline. You can still re-brew a coffee you&apos;ve logged
+        before from your library.
+      </p>
+      <Link
+        href="/coffees"
+        className="h-12 px-6 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] text-sm font-semibold flex items-center active:scale-[0.98] transition-transform"
+      >
+        Open your library
+      </Link>
+    </div>
+  );
+}

--- a/src/components/flow/LightStepSummary.tsx
+++ b/src/components/flow/LightStepSummary.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useFlowStore } from "@/store/flowStore";
 import { useRouter } from "next/navigation";
+import { enqueueSession } from "@/lib/storage/saveQueue";
 import LightFlowShell from "@/components/ui/light/LightFlowShell";
 import LightStarRating from "@/components/ui/light/StarRating";
 import CoffeeBeanGlow from "@/components/ui/light/CoffeeBeanGlow";
@@ -37,6 +38,7 @@ export default function LightStepSummary() {
   const { draft, reset } = useFlowStore();
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
+  const [savedOffline, setSavedOffline] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [terrain, setTerrain] = useState<string | null>(null);
   const [adjustment, setAdjustment] = useState<string | null>(null);
@@ -61,41 +63,72 @@ export default function LightStepSummary() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const finishSaved = (offline: boolean) => {
+    setSavedOffline(offline);
+    setSaved(true);
+    setTimeout(() => {
+      reset();
+      router.push("/");
+    }, 1500);
+  };
+
   const handleSave = async () => {
     setSaving(true);
     setSaveError(null);
+    const body = {
+      ...draft,
+      fieldZones: useFlowStore.getState().fieldZones,
+      type: "coffee" as const,
+      createdAt: new Date().toISOString(),
+    };
+
+    // Offline → queue immediately and sync on reconnect (LightShell flushes).
+    if (typeof navigator !== "undefined" && !navigator.onLine) {
+      try {
+        await enqueueSession(body);
+        finishSaved(true);
+      } catch (err) {
+        console.error("Offline queue error:", err);
+        setSaveError("Couldn't save offline — please try again");
+      } finally {
+        setSaving(false);
+      }
+      return;
+    }
+
     try {
       const res = await fetch("/api/sessions", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          ...draft,
-          fieldZones: useFlowStore.getState().fieldZones,
-          type: "coffee",
-          createdAt: new Date().toISOString(),
-        }),
+        body: JSON.stringify(body),
       });
-      if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as {
+      if (res.ok) {
+        finishSaved(false);
+      } else {
+        // Server rejected the save while online — surface it, allow retry.
+        const errBody = (await res.json().catch(() => ({}))) as {
           error?: string;
           details?: { fieldErrors?: Record<string, string[]>; formErrors?: string[] };
         };
-        const fieldErrors = body.details?.fieldErrors ?? {};
+        const fieldErrors = errBody.details?.fieldErrors ?? {};
         const firstField = Object.entries(fieldErrors).find(([, msgs]) => msgs && msgs.length > 0);
         const detailMsg = firstField
           ? `${firstField[0]}: ${firstField[1][0]}`
-          : body.details?.formErrors?.[0];
-        const baseMsg = body.error || `Save failed (${res.status})`;
-        throw new Error(detailMsg ? `${baseMsg} — ${detailMsg}` : baseMsg);
+          : errBody.details?.formErrors?.[0];
+        const baseMsg = errBody.error || `Save failed (${res.status})`;
+        setSaveError(detailMsg ? `${baseMsg} — ${detailMsg}` : baseMsg);
       }
-      setSaved(true);
-      setTimeout(() => {
-        reset();
-        router.push("/");
-      }, 1500);
     } catch (err) {
-      console.error("Session save error:", err);
-      setSaveError(err instanceof Error ? err.message : "Failed to save — please try again");
+      // Network failure (dropped connection mid-save) → queue rather than
+      // lose the brew.
+      console.error("Session save network error:", err);
+      try {
+        await enqueueSession(body);
+        finishSaved(true);
+      } catch (queueErr) {
+        console.error("Offline queue error:", queueErr);
+        setSaveError("Failed to save — please try again");
+      }
     } finally {
       setSaving(false);
     }
@@ -134,7 +167,9 @@ export default function LightStepSummary() {
         </div>
         <div className="text-center">
           <p className="font-fraunces text-[32px] leading-tight text-light-foreground">Logged</p>
-          <p className="text-[13px] text-light-muted-foreground mt-1">Session saved to your diary</p>
+          <p className="text-[13px] text-light-muted-foreground mt-1">
+            {savedOffline ? "Saved offline — will sync when you're back online" : "Session saved to your diary"}
+          </p>
         </div>
       </div>
     );

--- a/src/components/ui/light/ActionPill.tsx
+++ b/src/components/ui/light/ActionPill.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation";
 import { Coffee, MapPin, User, Crosshair, Globe, BookOpen, RotateCcw } from "lucide-react";
 import type { NavAction } from "@/app/api/explore-agent/route";
-import { useFlowStore } from "@/store/flowStore";
+import { startBrewAgain } from "@/lib/flow/brewAgain";
 import type { CoffeeIdentity } from "@/lib/types/session";
 
 /**
@@ -91,7 +91,6 @@ function ActionPillIcon({ destination }: { destination: NavAction["destination"]
 
 export default function ActionPill({ action }: { action: NavAction }) {
   const router = useRouter();
-  const { reset, setCoffee, setMode, setSkipScan, setStep, setFieldZones } = useFlowStore();
 
   const handleClick = async () => {
     if (action.destination === "brew_again" && action.id) {
@@ -113,15 +112,10 @@ export default function ActionPill({ action }: { action: NavAction }) {
               aiExtracted: false,
               coffeeId: row.id,
             };
-            reset();
-            setCoffee(identity);
             // Generative Field v1.1 — Brew Again from Home: lift the
             // persisted Field composition. The /api/coffees/[id]
             // response now carries fieldZones via rowToCoffee.
-            setFieldZones(row.fieldZones ?? null);
-            setMode("home");
-            setSkipScan(true);
-            setStep("context");
+            startBrewAgain(identity, row.fieldZones ?? null);
           }
         }
       } catch {

--- a/src/components/ui/light/LightShell.tsx
+++ b/src/components/ui/light/LightShell.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 import { FieldProvider } from "@/lib/field/FieldContext";
 import Field from "./Field";
+import { useOnline } from "@/hooks/useOnline";
+import { flushQueue } from "@/lib/storage/saveQueue";
 
 /**
  * Light System v1.0 + v1.1 — route-scoped shell.
@@ -27,10 +29,28 @@ import Field from "./Field";
  * they update the context.
  */
 export default function LightShell({ children }: { children: ReactNode }) {
+  const online = useOnline();
+
+  // Drain any brews queued while offline once a connection is available
+  // (also runs once on mount, catching saves from a previous visit).
+  useEffect(() => {
+    if (online) void flushQueue();
+  }, [online]);
+
   return (
     <FieldProvider>
       <div data-light-scope="true" className="font-chivo text-light-foreground min-h-dvh">
         <Field />
+        {!online && (
+          <div
+            className="fixed inset-x-0 z-[60] flex justify-center pointer-events-none"
+            style={{ top: "calc(env(safe-area-inset-top) + 0.5rem)" }}
+          >
+            <div className="pointer-events-auto rounded-full bg-light-foreground/90 px-3.5 py-1.5 text-[11px] font-medium text-[hsl(36_55%_96%)] shadow-sm backdrop-blur">
+              Offline
+            </div>
+          </div>
+        )}
         {children}
       </div>
     </FieldProvider>

--- a/src/components/ui/light/NavigationOverlay.tsx
+++ b/src/components/ui/light/NavigationOverlay.tsx
@@ -2,6 +2,7 @@
 
 import { X } from "lucide-react";
 import Link from "next/link";
+import { useFlowStore } from "@/store/flowStore";
 
 /**
  * BTTS Navigation Overlay (specs/home.md §7).
@@ -86,7 +87,13 @@ export default function NavigationOverlay({ open, onClose }: NavigationOverlayPr
             <Link
               key={item.label}
               href={item.href}
-              onClick={onClose}
+              onClick={() => {
+                // "New Session" must always start fresh — the flow store
+                // is persisted (localStorage), so without a reset this
+                // would resume a stale interrupted draft.
+                if (item.href === "/brew/new") useFlowStore.getState().reset();
+                onClose();
+              }}
               className="font-chivo text-[24px] font-medium text-light-foreground"
             >
               {item.label}

--- a/src/hooks/useOnline.ts
+++ b/src/hooks/useOnline.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Tracks connectivity via navigator.onLine + the online/offline events.
+ * Seeds `true` so the offline UI never flashes during hydration; the real
+ * value is read on mount.
+ */
+export function useOnline(): boolean {
+  const [online, setOnline] = useState(true);
+
+  useEffect(() => {
+    const update = () => setOnline(navigator.onLine);
+    update();
+    window.addEventListener("online", update);
+    window.addEventListener("offline", update);
+    return () => {
+      window.removeEventListener("online", update);
+      window.removeEventListener("offline", update);
+    };
+  }, []);
+
+  return online;
+}

--- a/src/lib/flow/brewAgain.ts
+++ b/src/lib/flow/brewAgain.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared "Brew Again" entry — hydrates the flow store and positions it at
+ * the right step. Used by the coffee library list, the coffee detail page
+ * and the home Action Pill so the entry pattern lives in one place.
+ *
+ *   - online  → land on Step "context" (the AI generates a fresh recipe)
+ *   - offline → seed a cached recipe and skip straight to Step "brew"
+ *
+ * Both call reset() first, so a stale in-flight draft never leaks in.
+ */
+
+import { useFlowStore } from "@/store/flowStore";
+import type { CoffeeIdentity } from "@/lib/types/session";
+import type { FieldZones } from "@/lib/field/types";
+import type { BrewableRecipe } from "@/lib/storage/offlineLibrary";
+
+export function startBrewAgain(identity: CoffeeIdentity, fieldZones: FieldZones | null): void {
+  const s = useFlowStore.getState();
+  s.reset();
+  s.setCoffee(identity);
+  s.setFieldZones(fieldZones);
+  s.setMode("home");
+  s.setSkipScan(true);
+  s.setStep("context");
+}
+
+export function startBrewAgainOffline(
+  identity: CoffeeIdentity,
+  fieldZones: FieldZones | null,
+  recipe: BrewableRecipe,
+): void {
+  const s = useFlowStore.getState();
+  s.reset();
+  s.setCoffee(identity);
+  s.setFieldZones(fieldZones);
+  s.setMode("home");
+  s.setSkipScan(true);
+  s.setRecommendation(recipe.recommendation);
+  s.setBrew({ methodUsed: recipe.method });
+  s.setStep("brew");
+}

--- a/src/lib/storage/idb.ts
+++ b/src/lib/storage/idb.ts
@@ -1,0 +1,88 @@
+/**
+ * Minimal promise-based IndexedDB wrapper for the offline brew feature.
+ *
+ * One database, two object stores:
+ *   - `brewable`        — cached coffees + their re-brewable recipes (offlineLibrary.ts)
+ *   - `pendingSessions` — brew saves queued while offline (saveQueue.ts)
+ *
+ * No external dependency — the surface we need is tiny. All reads fail
+ * soft (callers wrap in try/catch) because IndexedDB is unavailable in
+ * SSR and can be blocked by private-mode quirks.
+ */
+
+const DB_NAME = "brewlog-offline";
+const DB_VERSION = 1;
+
+export const STORE_BREWABLE = "brewable";
+export const STORE_QUEUE = "pendingSessions";
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function openDB(): Promise<IDBDatabase> {
+  if (typeof indexedDB === "undefined") {
+    return Promise.reject(new Error("IndexedDB unavailable"));
+  }
+  if (!dbPromise) {
+    dbPromise = new Promise<IDBDatabase>((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, DB_VERSION);
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains(STORE_BREWABLE)) {
+          db.createObjectStore(STORE_BREWABLE, { keyPath: "id" });
+        }
+        if (!db.objectStoreNames.contains(STORE_QUEUE)) {
+          db.createObjectStore(STORE_QUEUE, { keyPath: "clientId" });
+        }
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => reject(req.error);
+    });
+  }
+  return dbPromise;
+}
+
+function request<T>(
+  store: string,
+  mode: IDBTransactionMode,
+  fn: (s: IDBObjectStore) => IDBRequest,
+): Promise<T> {
+  return openDB().then(
+    (db) =>
+      new Promise<T>((resolve, reject) => {
+        const tx = db.transaction(store, mode);
+        const req = fn(tx.objectStore(store));
+        req.onsuccess = () => resolve(req.result as T);
+        req.onerror = () => reject(req.error);
+      }),
+  );
+}
+
+export function idbGetAll<T>(store: string): Promise<T[]> {
+  return request<T[]>(store, "readonly", (s) => s.getAll());
+}
+
+export function idbGet<T>(store: string, key: IDBValidKey): Promise<T | undefined> {
+  return request<T | undefined>(store, "readonly", (s) => s.get(key));
+}
+
+export function idbPut<T>(store: string, value: T): Promise<void> {
+  return request<void>(store, "readwrite", (s) => s.put(value as unknown as Record<string, unknown>));
+}
+
+export function idbDelete(store: string, key: IDBValidKey): Promise<void> {
+  return request<void>(store, "readwrite", (s) => s.delete(key));
+}
+
+/** Replace the entire contents of a store in a single transaction. */
+export async function idbReplaceAll<T>(store: string, values: T[]): Promise<void> {
+  const db = await openDB();
+  await new Promise<void>((resolve, reject) => {
+    const tx = db.transaction(store, "readwrite");
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+    const os = tx.objectStore(store);
+    os.clear();
+    for (const v of values) os.put(v as unknown as Record<string, unknown>);
+  });
+}

--- a/src/lib/storage/offlineLibrary.ts
+++ b/src/lib/storage/offlineLibrary.ts
@@ -1,0 +1,160 @@
+/**
+ * Offline brew library — caches coffees and their re-brewable recipes in
+ * IndexedDB so a known coffee can be brewed again without a network.
+ *
+ * Source of truth stays the server. We mirror, per coffee, its richest
+ * identity and the *two best-rated* past recipes (deduplicated), derived
+ * from the session feed the library pages already load while online. The
+ * cache is refreshed on every successful online library load, so it is as
+ * fresh as the last time the user opened the library with a connection.
+ */
+
+import type { Coffee } from "@/lib/types/coffee";
+import type { Session, CoffeeIdentity, Recommendation, BrewRecipe } from "@/lib/types/session";
+import type { FieldZones } from "@/lib/field/types";
+import { STORE_BREWABLE, idbGetAll, idbGet, idbPut, idbReplaceAll } from "./idb";
+
+export interface BrewableRecipe {
+  method: string;
+  recipe: BrewRecipe;
+  /** Normalized Recommendation whose primaryMethod/primaryRecipe equal
+   * the used recipe — set straight into the flow store so LightStepBrew
+   * and LightStepSummary read the right numbers. */
+  recommendation: Recommendation;
+  brewedAt: string; // ISO
+  rating?: number;
+}
+
+export interface BrewableCoffee {
+  id: string;
+  identity: CoffeeIdentity;
+  fieldZones: FieldZones | null;
+  sessionCount: number;
+  recipes: BrewableRecipe[]; // up to 2, best first
+  cachedAt: number;
+}
+
+function recipeSignature(r: BrewableRecipe): string {
+  const x = r.recipe;
+  return [r.method, x.doseGrams, x.waterGrams, x.waterTempC, x.targetTimeSec, x.pourSequence ?? ""].join("|");
+}
+
+/** The recipe that was actually brewed in a session, normalized so the
+ * chosen method's recipe is the primary one. Null when the session has no
+ * usable recommendation. */
+function usedRecipe(session: Session): BrewableRecipe | null {
+  const rec = session.recommendation;
+  if (!rec) return null;
+  const method = session.brew?.methodUsed || rec.primaryMethod;
+  if (!method) return null;
+  const recipe = rec.candidates?.find((c) => c.method === method)?.recipe ?? rec.primaryRecipe;
+  if (!recipe) return null;
+  return {
+    method,
+    recipe,
+    recommendation: { ...rec, primaryMethod: method, primaryRecipe: recipe },
+    brewedAt: session.createdAt,
+    rating: session.result?.rating,
+  };
+}
+
+/** Up to 2 distinct recipes, best rating first (recency breaks ties and
+ * orders unrated brews). */
+function topTwoRecipes(sessions: Session[]): BrewableRecipe[] {
+  const recipes = sessions
+    .map(usedRecipe)
+    .filter((r): r is BrewableRecipe => r !== null)
+    .sort((a, b) => {
+      const ra = a.rating ?? -1;
+      const rb = b.rating ?? -1;
+      if (rb !== ra) return rb - ra;
+      return b.brewedAt.localeCompare(a.brewedAt);
+    });
+
+  const seen = new Set<string>();
+  const distinct: BrewableRecipe[] = [];
+  for (const r of recipes) {
+    const sig = recipeSignature(r);
+    if (seen.has(sig)) continue;
+    seen.add(sig);
+    distinct.push(r);
+    if (distinct.length === 2) break;
+  }
+  return distinct;
+}
+
+function synthesizeIdentity(coffee: Coffee): CoffeeIdentity {
+  return {
+    roaster: coffee.roaster,
+    name: coffee.name,
+    origin: coffee.origin,
+    process: coffee.process,
+    roastLevel: "Light",
+    roastDate: coffee.latestRoastDate,
+    bagPhotoUrl: coffee.bagPhotoUrl,
+    aiExtracted: false,
+    coffeeId: coffee.id,
+  };
+}
+
+function buildBrewableCoffee(coffee: Coffee, coffeeSessions: Session[]): BrewableCoffee {
+  // The most recent session's coffee identity is richest (variety, roast
+  // level, tasting notes); fall back to a synthesized identity.
+  const newest = [...coffeeSessions].sort((a, b) => b.createdAt.localeCompare(a.createdAt))[0];
+  const identity: CoffeeIdentity = newest?.coffee
+    ? { ...newest.coffee, coffeeId: coffee.id }
+    : synthesizeIdentity(coffee);
+
+  return {
+    id: coffee.id,
+    identity,
+    fieldZones: coffee.fieldZones ?? null,
+    sessionCount: coffee.sessionCount,
+    recipes: topTwoRecipes(coffeeSessions),
+    cachedAt: Date.now(),
+  };
+}
+
+/** Comprehensive warm — replaces the whole cache from the full library +
+ * session feed. Called on the coffee-library page while online. */
+export async function cacheBrewableLibrary(coffees: Coffee[], sessions: Session[]): Promise<void> {
+  try {
+    const byId = new Map(sessions.map((s) => [s.id, s]));
+    const records = coffees.map((c) => {
+      const cs = (c.sessionIds ?? [])
+        .map((id) => byId.get(id))
+        .filter((s): s is Session => Boolean(s));
+      return buildBrewableCoffee(c, cs);
+    });
+    await idbReplaceAll(STORE_BREWABLE, records);
+  } catch {
+    // Best-effort — a failed warm just leaves the previous cache in place.
+  }
+}
+
+/** Single-coffee upsert — called on the coffee detail page while online so
+ * a freshly-opened coffee's recipes stay current. */
+export async function cacheBrewableCoffee(coffee: Coffee, coffeeSessions: Session[]): Promise<void> {
+  try {
+    await idbPut(STORE_BREWABLE, buildBrewableCoffee(coffee, coffeeSessions));
+  } catch {
+    // ignore
+  }
+}
+
+export async function getBrewableLibrary(): Promise<BrewableCoffee[]> {
+  try {
+    const all = await idbGetAll<BrewableCoffee>(STORE_BREWABLE);
+    return all.sort((a, b) => (a.identity.name || "").localeCompare(b.identity.name || ""));
+  } catch {
+    return [];
+  }
+}
+
+export async function getBrewableCoffee(id: string): Promise<BrewableCoffee | null> {
+  try {
+    return (await idbGet<BrewableCoffee>(STORE_BREWABLE, id)) ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/storage/saveQueue.ts
+++ b/src/lib/storage/saveQueue.ts
@@ -1,0 +1,79 @@
+/**
+ * Offline save queue — when a brew is saved without a network, the POST
+ * body is parked in IndexedDB and flushed to /api/sessions once the device
+ * is back online (driven by an `online` listener in LightShell).
+ *
+ * Background Sync is intentionally NOT used — iOS Safari PWAs don't support
+ * it reliably. A `flushing` guard coalesces concurrent flushes so a queued
+ * save isn't POSTed twice.
+ */
+
+import { STORE_QUEUE, idbGetAll, idbPut, idbDelete } from "./idb";
+
+export interface PendingSession {
+  clientId: string;
+  body: unknown; // exact /api/sessions POST body
+  queuedAt: number;
+}
+
+function newClientId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+export async function enqueueSession(body: unknown): Promise<void> {
+  const entry: PendingSession = { clientId: newClientId(), body, queuedAt: Date.now() };
+  await idbPut(STORE_QUEUE, entry);
+}
+
+export async function getPendingSessions(): Promise<PendingSession[]> {
+  try {
+    return await idbGetAll<PendingSession>(STORE_QUEUE);
+  } catch {
+    return [];
+  }
+}
+
+export async function pendingCount(): Promise<number> {
+  return (await getPendingSessions()).length;
+}
+
+let flushing = false;
+
+/** POST every queued session. Returns how many were successfully flushed.
+ * Leaves entries in the queue on network/5xx errors for a later retry;
+ * drops entries the server rejects as invalid (4xx) so they can't wedge
+ * the queue forever. */
+export async function flushQueue(): Promise<number> {
+  if (flushing) return 0;
+  flushing = true;
+  try {
+    const pending = await getPendingSessions();
+    let flushed = 0;
+    for (const item of pending) {
+      try {
+        const res = await fetch("/api/sessions", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(item.body),
+        });
+        if (res.ok) {
+          await idbDelete(STORE_QUEUE, item.clientId);
+          flushed++;
+        } else if (res.status >= 400 && res.status < 500) {
+          // Permanently rejected — drop it so the queue can drain.
+          await idbDelete(STORE_QUEUE, item.clientId);
+        }
+        // 5xx: leave queued, try again next flush.
+      } catch {
+        // Network error — stop; we're likely offline again.
+        break;
+      }
+    }
+    return flushed;
+  } finally {
+    flushing = false;
+  }
+}

--- a/src/store/flowStore.ts
+++ b/src/store/flowStore.ts
@@ -90,8 +90,12 @@ export const useFlowStore = create<FlowState>()(
         set({ step: "scan", draft: initialDraft, fieldZones: null, skipScan: false, isAnalyzing: false, isRecommending: false, recommendError: null, clarificationMessages: [] }),
     }),
     {
+      // localStorage (not sessionStorage) so an in-flight brew survives a
+      // reload — critical offline, where an interrupted brew would
+      // otherwise be lost. "New Session" calls reset() so it never resumes
+      // a stale draft.
       name: "brew-flow",
-      storage: createJSONStorage(() => sessionStorage),
+      storage: createJSONStorage(() => localStorage),
     }
   )
 );


### PR DESCRIPTION
## Summary

A reduced offline mode for the brew process. The timer, pour guide and tasting log were already client-only; this fills the gaps around them so a **known coffee can be brewed without a network**.

- **Cache** the library + each coffee's **two best-rated** recipes in IndexedDB, warmed in the background on online library loads (never blocks the visible list).
- **Offline entry:** the library reads from cache and a recipe picker opens **inline on the list** — `/coffees/[id]` is server-rendered, so it can't be relied on offline, whereas the list and `/brew/new` are precached. Picking a recipe seeds the flow and jumps straight to the brew timer, skipping the AI recommend step.
- **Save queue:** session saves are queued in IndexedDB when offline and flushed on reconnect from `LightShell`. Summary shows "saved offline — will sync".
- **Durability:** the flow store persists to `localStorage` so an interrupted brew survives a reload; "New Session" resets so it never resumes a stale draft.
- **Service worker** `/offline` document fallback for uncached navigations.

No AI behaviour changes — offline reuses previously-generated recipes verbatim (no prompt/model/schema edits).

## Test plan

Verified locally: `tsc --noEmit` clean, production build passes, SW generates the `/offline` fallback, `pourSequence` tests green (17/17).

On the deployed iPhone PWA (the only valid env per project rules):
- [ ] Online: open `/coffees` + a few detail pages → IndexedDB `brewable` populates.
- [ ] Airplane mode → library renders from cache; brew a coffee with **one** recipe (picker auto-uses it) → timer + pour guide run → log → "saved offline — will sync".
- [ ] Brew a coffee with **two** recipes → picker shows both best-rated → pick one → brew runs with exactly that recipe.
- [ ] Airplane mode off → queue flushes; session appears in history + taste stats.
- [ ] Reload mid-brew offline → draft survives, no redirect to `/login`.
- [ ] Offline coffee with no cached recipe → no active brew action, no crash.

https://claude.ai/code/session_01PFTByY9gZq2i11dsBU4NgK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFTByY9gZq2i11dsBU4NgK)_