### PR TITLE
Fix offline-save sync: flush queue on app foreground

### DIFF
--- a/src/components/ui/light/ConnectionStatus.tsx
+++ b/src/components/ui/light/ConnectionStatus.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { flushQueue, pendingCount } from "@/lib/storage/saveQueue";
+
+/**
+ * Single top-of-screen indicator for connectivity + offline-save sync.
+ *
+ * Why this owns the flush (not a `online`-event effect): iOS Safari PWAs
+ * fire the `online`/`offline` events unreliably, so a reconnect often
+ * doesn't wake any listener. We therefore re-check `navigator.onLine`
+ * (which IS accurate when read) on mount AND on every foreground
+ * (`visibilitychange`) — reopening or returning to the app reliably
+ * drains the queue. The `online` event is kept as a bonus trigger.
+ *
+ * Queued brews are never dropped, so a stuck save stays visible with a
+ * tap-to-retry that also surfaces the server's error.
+ */
+export default function ConnectionStatus() {
+  const [online, setOnline] = useState(true);
+  const [pending, setPending] = useState(0);
+  const [syncing, setSyncing] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const syncingRef = useRef(false);
+
+  const tick = useCallback(async () => {
+    const isOnline = typeof navigator === "undefined" ? true : navigator.onLine;
+    setOnline(isOnline);
+    const count = await pendingCount();
+    setPending(count);
+    if (isOnline && count > 0 && !syncingRef.current) {
+      syncingRef.current = true;
+      setSyncing(true);
+      setFailed(false);
+      const res = await flushQueue();
+      syncingRef.current = false;
+      setSyncing(false);
+      setPending(res.remaining);
+      setFailed(res.remaining > 0);
+      if (res.lastError) console.warn("Offline sync incomplete:", res.lastError);
+    }
+  }, []);
+
+  useEffect(() => {
+    void tick();
+    const onOnline = () => void tick();
+    const onOffline = () => setOnline(false);
+    const onVisible = () => { if (document.visibilityState === "visible") void tick(); };
+    window.addEventListener("online", onOnline);
+    window.addEventListener("offline", onOffline);
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      window.removeEventListener("online", onOnline);
+      window.removeEventListener("offline", onOffline);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [tick]);
+
+  const plural = pending === 1 ? "" : "s";
+  let label: string | null = null;
+  let tappable = false;
+  if (syncing) {
+    label = "Syncing brew…";
+  } else if (online && pending > 0 && failed) {
+    label = `${pending} brew${plural} didn't sync — tap to retry`;
+    tappable = true;
+  } else if (online && pending > 0) {
+    label = "Syncing brew…";
+  } else if (!online) {
+    label = "Offline";
+  }
+
+  if (!label) return null;
+
+  return (
+    <div
+      className="fixed inset-x-0 z-[60] flex justify-center pointer-events-none"
+      style={{ top: "calc(env(safe-area-inset-top) + 0.5rem)" }}
+    >
+      <button
+        type="button"
+        disabled={!tappable}
+        onClick={() => { if (tappable) void tick(); }}
+        className="pointer-events-auto rounded-full bg-light-foreground/90 px-3.5 py-1.5 text-[11px] font-medium text-[hsl(36_55%_96%)] shadow-sm backdrop-blur disabled:cursor-default"
+      >
+        {label}
+      </button>
+    </div>
+  );
+}

--- a/src/components/ui/light/LightShell.tsx
+++ b/src/components/ui/light/LightShell.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { useEffect, type ReactNode } from "react";
+import type { ReactNode } from "react";
 import { FieldProvider } from "@/lib/field/FieldContext";
 import Field from "./Field";
-import { useOnline } from "@/hooks/useOnline";
-import { flushQueue } from "@/lib/storage/saveQueue";
+import ConnectionStatus from "./ConnectionStatus";
 
 /**
  * Light System v1.0 + v1.1 — route-scoped shell.
@@ -23,34 +22,14 @@ import { flushQueue } from "@/lib/storage/saveQueue";
  * "use client" here scopes that React state to the (light) tree;
  * Dark routes outside this group keep their server-render path.
  *
- * Field placement: rendered inside the FieldProvider but at the
- * same DOM level as children, so the fixed -z-10 sandwich paints
- * behind every (light) view. Pages don't render their own Field —
- * they update the context.
+ * ConnectionStatus owns the offline indicator + offline-save sync.
  */
 export default function LightShell({ children }: { children: ReactNode }) {
-  const online = useOnline();
-
-  // Drain any brews queued while offline once a connection is available
-  // (also runs once on mount, catching saves from a previous visit).
-  useEffect(() => {
-    if (online) void flushQueue();
-  }, [online]);
-
   return (
     <FieldProvider>
       <div data-light-scope="true" className="font-chivo text-light-foreground min-h-dvh">
         <Field />
-        {!online && (
-          <div
-            className="fixed inset-x-0 z-[60] flex justify-center pointer-events-none"
-            style={{ top: "calc(env(safe-area-inset-top) + 0.5rem)" }}
-          >
-            <div className="pointer-events-auto rounded-full bg-light-foreground/90 px-3.5 py-1.5 text-[11px] font-medium text-[hsl(36_55%_96%)] shadow-sm backdrop-blur">
-              Offline
-            </div>
-          </div>
-        )}
+        <ConnectionStatus />
         {children}
       </div>
     </FieldProvider>

--- a/src/lib/storage/saveQueue.ts
+++ b/src/lib/storage/saveQueue.ts
@@ -42,16 +42,23 @@ export async function pendingCount(): Promise<number> {
 
 let flushing = false;
 
-/** POST every queued session. Returns how many were successfully flushed.
- * Leaves entries in the queue on network/5xx errors for a later retry;
- * drops entries the server rejects as invalid (4xx) so they can't wedge
- * the queue forever. */
-export async function flushQueue(): Promise<number> {
-  if (flushing) return 0;
+export interface FlushResult {
+  flushed: number;
+  remaining: number;
+  /** Reason the queue still has entries, for surfacing in the UI. */
+  lastError?: string;
+}
+
+/** POST every queued session. Stops at the first failure (network or
+ * non-2xx) and leaves the rest queued — a brew is never silently dropped,
+ * so a stuck item stays visible and retryable rather than vanishing. */
+export async function flushQueue(): Promise<FlushResult> {
+  if (flushing) return { flushed: 0, remaining: await pendingCount() };
   flushing = true;
+  let flushed = 0;
+  let lastError: string | undefined;
   try {
     const pending = await getPendingSessions();
-    let flushed = 0;
     for (const item of pending) {
       try {
         const res = await fetch("/api/sessions", {
@@ -62,18 +69,18 @@ export async function flushQueue(): Promise<number> {
         if (res.ok) {
           await idbDelete(STORE_QUEUE, item.clientId);
           flushed++;
-        } else if (res.status >= 400 && res.status < 500) {
-          // Permanently rejected — drop it so the queue can drain.
-          await idbDelete(STORE_QUEUE, item.clientId);
+        } else {
+          const text = await res.text().catch(() => "");
+          lastError = `HTTP ${res.status}${text ? `: ${text.slice(0, 200)}` : ""}`;
+          break;
         }
-        // 5xx: leave queued, try again next flush.
-      } catch {
-        // Network error — stop; we're likely offline again.
+      } catch (e) {
+        lastError = e instanceof Error ? e.message : "network error";
         break;
       }
     }
-    return flushed;
   } finally {
     flushing = false;
   }
+  return { flushed, remaining: await pendingCount(), lastError };
 }


### PR DESCRIPTION
## Summary

Follow-up to #184. Offline brewing worked, but a brew **saved offline never synced** on reconnect.

**Root cause:** iOS Safari PWAs fire the `online`/`offline` events unreliably, and the flush was only triggered off the React `online` state (which depends on that flaky event). On reconnect, nothing kicked the queue.

**Fix:**
- Re-check `navigator.onLine` (accurate when read) on **mount** and on every **foreground** (`visibilitychange`) — which reliably fires when the app is reopened/returned to — and flush then. The `online` event stays as a bonus trigger.
- New single `ConnectionStatus` indicator: shows `Offline` / `Syncing brew…` / `N brews didn't sync — tap to retry`. Queued brews are **never dropped** on a failed POST, so a stuck save stays visible and manually retryable, and surfaces the server error.

## Test plan

`tsc` clean, production build passes.

On the deployed iPhone PWA:
- [ ] Brew a coffee in airplane mode → "saved offline" → indicator shows a pending brew.
- [ ] Turn airplane mode off and bring the app to foreground → "Syncing brew…" → indicator clears → session appears in history + taste stats.
- [ ] If it still doesn't sync, the pill shows the error — tap to retry and report what it says.

https://claude.ai/code/session_01PFTByY9gZq2i11dsBU4NgK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFTByY9gZq2i11dsBU4NgK)_