### PR TITLE
docs: document offline brew mode + sync fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ The single remaining Dark route is `cafes/map/page.tsx` and that's intentional (
 | `(light)/taste/page.tsx` | Light | Taste profile — Avg rating + rated count + AI summary + FlavorWheel (profile mode) + top flavors / rating trend / body / acidity / origins / processes / methods |
 | `(light)/login/page.tsx` | Light | Passkey (WebAuthn) login UI + PIN fallback + reset path |
 | `(light)/onboarding/page.tsx` | Light | First-run equipment + grinder wizard (uses the Chip primitive) |
+| `(light)/offline/page.tsx` | Light | Service-worker document fallback (`next.config.mjs` `fallbacks.document`). Shown when an uncached route is opened offline; links to `/coffees`. Safety net — the real offline path lives in the precached `/coffees` + `/brew/new` shell. |
 | `layout.tsx` | — | Root layout: PWA meta tags, font preloads, `<ScrollContainer>` wrapper |
 | `loading.tsx` | Light | Global loading state — Light CoffeeBeanGlow on inline cream bg (renders before LightShell mounts) |
 | `cafes/map/page.tsx` | Dark *(intentional)* | Nearby — full-screen Leaflet map (CartoCDN dark tiles); needs `h-dvh flex flex-col` + `flex-1 min-h-0` so Leaflet gets a non-zero container |
@@ -121,7 +122,7 @@ All Light. The Dark `Step*.tsx` files (`FlowShell`, `StepMode`, `StepScan`, `Ste
 | `LightStepSummary.tsx` | Review + save session |
 
 **Light UI primitives (`src/components/ui/light/`):**
-`LightShell` (wraps `(light)` group, sets `[data-light-scope]`), `LightFlowShell` (drives `useFieldConfig` per step, scrolls top on step change), `Field` (reads FieldContext → renders `composeFieldGradient(zones, rotation)` fixed -z-10), `Card`, `Section`, `Footnote`, `Chip`, `Hero` (eyebrow + Fraunces 40px question), `CTA` (anthracite button + cream text), `CTAWarmth`, `ActionPill` (Brew-Again candidates on home), `ChatInput`, `ChatThread`, `AttachmentSheet`, `NavigationOverlay` (full-screen menu — Home / Past Conversations / New Session / Coffee Library / Nearby / Café Library / Taste Profile), `ReferenceCoffeePicker`, `StarRating` (rotation toggle + log rating), `CircularTimer` (Light fork — anchored to Date.now, visibility-snap), `CoffeeBeanGlow` (anthracite stroke fork).
+`LightShell` (wraps `(light)` group, sets `[data-light-scope]`), `LightFlowShell` (drives `useFieldConfig` per step, scrolls top on step change), `Field` (reads FieldContext → renders `composeFieldGradient(zones, rotation)` fixed -z-10), `Card`, `Section`, `Footnote`, `Chip`, `Hero` (eyebrow + Fraunces 40px question), `CTA` (anthracite button + cream text), `CTAWarmth`, `ActionPill` (Brew-Again candidates on home), `ChatInput`, `ChatThread`, `AttachmentSheet`, `NavigationOverlay` (full-screen menu — Home / Past Conversations / New Session / Coffee Library / Nearby / Café Library / Taste Profile), `ReferenceCoffeePicker`, `StarRating` (rotation toggle + log rating), `CircularTimer` (Light fork — anchored to Date.now, visibility-snap), `CoffeeBeanGlow` (anthracite stroke fork), `ConnectionStatus` (top-center pill rendered by `LightShell` — shows Offline / Syncing / "didn't sync — tap to retry"; owns the offline-save flush, re-checking `navigator.onLine` on mount + `visibilitychange` rather than the unreliable iOS online event).
 
 **Shared / Dark-era UI primitives (`src/components/ui/`):**
 `Button`, `CoffeeBeanGlow` (kept for `PhotoUpload`; CSS shim `[data-light-scope] { filter: brightness(0) }` inverts it to anthracite at the consumer), `FlavorWheel` (now Light palette in place — canvas transparent, cream-glass panels, anthracite text/icons), `BrewMethodIcon` (inverted via the same shim), `NumberStepper`, `PhotoUpload`, `PlaceSearch`, `ProgressDots`, `StarRating` (still consumed by `CafeMap` only), `ThinkingDots`, `WaveformBars`.
@@ -204,7 +205,13 @@ lib/
 │   └── grindSettings.ts    # ★ Single source of Niche Zero degrees — replaces hardcoded copies in CLAUDE.md / docs / prompts
 ├── theme/
 │   └── gradients.ts        # Shared gradient tokens (CSS strings) used across pages
-├── storage/s3.ts           # Hetzner Object Storage (S3-compatible)
+├── storage/
+│   ├── s3.ts               # Hetzner Object Storage (S3-compatible)
+│   ├── idb.ts              # ★ Tiny promise-based IndexedDB wrapper — DB `brewlog-offline`, two stores (brewable, pendingSessions). Backs the offline brew feature.
+│   ├── offlineLibrary.ts   # ★ Caches coffees + their TOP-2 best-rated recipes (deduped) for offline re-brew. Warmed in background on online /coffees loads.
+│   └── saveQueue.ts        # ★ Offline save queue — parks the /api/sessions POST body in IDB; flushQueue() drains it (never drops a brew on failure).
+├── flow/
+│   └── brewAgain.ts        # ★ Shared "Brew Again" entry — startBrewAgain() (online → Step "context") + startBrewAgainOffline() (seed cached recipe → Step "brew"). Used by /coffees list, /coffees/[id], ActionPill.
 └── utils/
     ├── cn.ts / safeFetch.ts / formatTime.ts / pourSequence.ts
     └── pourSequence.test.mjs  # node --test suite for pour math
@@ -214,7 +221,8 @@ lib/
 
 | File | Purpose |
 |------|---------|
-| `src/store/flowStore.ts` | ★ Zustand brew flow state (sessionStorage-persisted) |
+| `src/store/flowStore.ts` | ★ Zustand brew flow state (**localStorage**-persisted since the offline work — survives a mid-brew reload; "New Session" in `NavigationOverlay` calls `reset()` so it never resumes a stale draft) |
+| `src/hooks/useOnline.ts` | Connectivity boolean (seeds `true` for SSR, then `navigator.onLine` + online/offline events). Used by the `/coffees` pages for the offline read path. |
 | `src/hooks/useWakeLock.ts` | Keep screen on during active brew |
 | `src/hooks/useVoiceCapture.ts` | Mic recording + level metering for inline-chat voice input (BTTS Home) |
 | `src/hooks/useVoicePlayback.ts` | Streaming TTS playback for inline-chat voice output (BTTS Home) |
@@ -264,6 +272,17 @@ All migrations applied manually on the VPS — see migration NOTE above.
 ## Current Status — Snapshot May 2026
 
 ### ✅ Done
+**Offline Brew Mode — re-brew a known coffee without a network (PR #184 + #185)**
+- The brew process itself was already client-only (timer, pour guide, tasting log — no network; pour math is local). The two gaps were getting a recipe (the `/api/recommend` Opus gate) and saving (`/api/sessions` POST). Offline mode closes both by **reusing a previously-brewed recipe** and **queuing the save**.
+- **Scope:** offline you open a coffee from the locally-cached library, pick one of its **two best-rated** past recipes (auto-used if there's only one), brew with the full timer + pour guide, log, and the save is buffered + auto-synced on reconnect. NO offline AI, NO offline bag scan, NO brand-new coffees offline. Online flow is **unchanged** (KI still generates fresh recipes) — the recipe picker is offline-only, so the validated Opus path is untouched.
+- **Cache (`src/lib/storage/offlineLibrary.ts`, IndexedDB):** per coffee, its richest identity + Field zones + up to 2 deduped best-rated recipes, derived from the session feed. Warmed in the background on every online `/coffees` load (full-feed fetch → top-2 per coffee) and refreshed per-coffee on `/coffees/[id]`. Never blocks the visible list.
+- **Offline entry:** `/coffees` reads from cache when offline; tapping a coffee opens an **inline recipe-picker sheet on the list** (NOT the detail route — `/coffees/[id]` is server-rendered, so its RSC isn't reliably cached offline, whereas `/coffees` + `/brew/new` are precached). Picking seeds the flow via `startBrewAgainOffline()` and jumps straight to Step "brew", skipping context + recommend. `/coffees/[id]` also has an offline slim view (picker) for the case it IS cached.
+- **Save queue (`src/lib/storage/saveQueue.ts`):** `LightStepSummary` enqueues the exact POST body when offline (or on a network throw); success screen says "saved offline — will sync". `flushQueue()` drains it and **never drops a brew** on failure (a stuck save stays visible + retryable).
+- **Sync trigger (`ConnectionStatus`, the fix in #185):** iOS Safari PWAs fire the `online`/`offline` events unreliably (so does next-pwa's `reloadOnOnline`), so flushing is driven off `navigator.onLine` re-checked on **mount + `visibilitychange`** (reopening / foregrounding the app reliably fires) — the `online` event is a bonus trigger only. The pill surfaces Offline / Syncing / "didn't sync — tap to retry".
+- **Durability:** `flowStore` persists to `localStorage` (was `sessionStorage`) so a mid-brew reload doesn't lose the draft. `NavigationOverlay`'s "New Session" calls `reset()` so a fresh session never resumes a stale draft.
+- **PWA:** `next.config.mjs` `fallbacks.document: "/offline"` catches uncached offline navigations. App shell (`/`, `/coffees`, `/brew/new`) precached via the existing `cacheOnFrontEndNav`.
+- **Cache caveat:** the offline cache only contains coffees whose library/detail you opened online at least once. A coffee never seen online won't be brewable offline (list empty-state / `/offline` handle it gracefully).
+
 **BTTS Light migration — complete (PR #65 → #137)**
 - Every visited surface lives in the `(light)` route group with the BTTS Light theme — Cream background, Fraunces 40 px hero, Chivo body, anthracite foreground, generative Field background.
 - Light primitives stack: `LightShell`, `LightFlowShell`, `Field`, `Card`, `Section`, `Footnote`, `Chip`, `Hero`, `CTA`, `CTAWarmth`, `ActionPill`, `ChatInput`, `ChatThread`, `NavigationOverlay`, `StarRating`, `CircularTimer` (fork), `CoffeeBeanGlow` (fork).
@@ -347,7 +366,7 @@ All migrations applied manually on the VPS — see migration NOTE above.
 - Session GET: single indexed query on `createdAtMs DESC`
 - Coffee library with detail pages (rating history, brew signatures, notes)
 - Roaster profiles with AI-generated style summaries
-- Zustand flow store with sessionStorage persistence
+- Zustand flow store with localStorage persistence (survives a mid-brew reload — see Offline Brew Mode)
 
 **AI features**
 - Brew recipe generation: 2–4 candidates with reasoning (`recommend.ts`)

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -4,6 +4,26 @@
 
 ---
 
+## Latest — Offline Brew Mode (PR #184 → #185, 2026-05-24) ✅ shipped + verified on device
+
+Re-brew a **known** coffee with no network. The brew process was already client-only (timer, pour guide, tasting log; pour math is local); the only offline-breaking pieces were fetching a recipe (`/api/recommend`) and saving (`/api/sessions`). Both closed by reusing a past recipe + queuing the save.
+
+- **#184** — the feature:
+  - `src/lib/storage/idb.ts` — tiny IndexedDB wrapper, DB `brewlog-offline`, stores `brewable` + `pendingSessions`.
+  - `src/lib/storage/offlineLibrary.ts` — caches each coffee's identity + Field zones + **top-2 best-rated** deduped recipes. Warmed in the background on online `/coffees` loads (full-feed fetch) and per-coffee on `/coffees/[id]`.
+  - `src/lib/storage/saveQueue.ts` — parks the POST body when offline; flush drains it and **never drops a brew** on a failed POST.
+  - `src/lib/flow/brewAgain.ts` — shared entry: `startBrewAgain()` (online → Step "context") / `startBrewAgainOffline()` (seed cached recipe → Step "brew"). Now used by `/coffees`, `/coffees/[id]`, `ActionPill`.
+  - `src/hooks/useOnline.ts`, `src/app/(light)/offline/page.tsx` (SW document fallback), `next.config.mjs` `fallbacks.document`.
+  - `flowStore` → **localStorage** (was sessionStorage) so a mid-brew reload survives. `NavigationOverlay` "New Session" now calls `reset()`.
+  - Offline recipe picker opens **inline on the `/coffees` list** (a sheet), NOT via `/coffees/[id]` — that route is server-rendered (ƒ in the build), so its RSC isn't reliably cached offline; `/coffees` + `/brew/new` are precached.
+- **#185** — the sync fix (first cut didn't sync): iOS PWAs fire the `online` event unreliably (so does next-pwa `reloadOnOnline`). New `ConnectionStatus` component (rendered by `LightShell`) drives the flush off `navigator.onLine` re-checked on **mount + `visibilitychange`**, and surfaces Offline / Syncing / "didn't sync — tap to retry".
+
+**Markus verified on the deployed PWA:** offline brew works, and after #185 the save syncs on reconnect. ("Funktioniert.")
+
+**Caveat:** the cache only holds coffees opened online at least once. Open the Coffee Library online once after any fresh install to populate it.
+
+---
+
 ## Top priority for next session
 
 **`/cafes/map` polish + integration with "I've been here".** The map page is the single sore thumb left: it still renders dark CartoCDN tiles with default Leaflet blue markers while everything around it is Light cream + anthracite. Two coupled jobs:
@@ -107,6 +127,8 @@ conversations + conversation_messages → BTTS chat history
 
 - **Docker name conflict on parallel `up -d`.** Manual `docker compose up -d app` while a GitHub Action is running the same command races. Resolution: `docker rm -f brewlog-app-1 && docker compose up -d app`. Future deploys should harden the workflow (open item #6).
 - **iOS PWA caches `apple-mobile-web-app-status-bar-style` at install time.** Changing the meta tag does not update an already-installed PWA on iPhone. User has to delete the PWA from the home screen AND clear Safari → Advanced → Website Data for the domain, then re-install.
+- **iOS PWA `online`/`offline` events are unreliable.** A reconnect frequently never fires `online`, so anything waiting on that event (a React `online` state, next-pwa `reloadOnOnline`) silently doesn't run. This cost a round-trip on the offline-sync feature (#184's flush didn't fire → #185). Fix pattern: re-check `navigator.onLine` (accurate when READ) on `visibilitychange` / app foreground and on mount — don't rely on the event alone. See `ConnectionStatus.tsx`.
+- **App Router dynamic routes aren't reliably available offline.** A `[id]` route is server-rendered (ƒ in the build output), so its RSC payload is only SW-cached for ids visited online — navigating to an unvisited id offline falls to the `/offline` fallback. Keep offline entry points on precached static routes (`/coffees`, `/brew/new`); that's why the offline recipe picker is an inline sheet on the list, not a detail-page navigation.
 - **Tailwind only scans `src/{app,components,pages}`.** `src/lib/**` is NOT in `tailwind.config.ts` `content`. Utility classes that live only in lib are silently never generated. If you need a shared visual constant in lib, export it as a raw CSS value and apply via inline `style={{ background: ... }}` at the call site.
 - **html canvas default.** `html { background-color: #F3E5DC }` (cream). `body { background-color: #0E0B0A }` by default, dropped to `transparent` only when `body:has([data-light-scope="true"])` matches. Light routes therefore show the cream canvas behind the Field; the legacy Dark `cafes/map` keeps its dark body. `loading.tsx` explicitly sets `background: #F3E5DC` inline because it renders BEFORE LightShell mounts.
 - **Next.js standalone Docker image** does NOT expose `@anthropic-ai/sdk` as `node_modules/@anthropic-ai`. Backfill script started failing with `ERR_MODULE_NOT_FOUND` until rewritten to call the Messages API over plain `fetch`. `pg` IS in standalone deps (traced via Drizzle).
@@ -142,6 +164,7 @@ src/
 │   │   ├── taste/page.tsx
 │   │   ├── login/page.tsx      ← Fraunces 3xl wordmark + pill CTAs
 │   │   ├── onboarding/page.tsx
+│   │   ├── offline/page.tsx     ← NEW — SW document fallback (#184)
 │   │   └── past-conversations/
 │   ├── cafes/map/page.tsx      ← Only Dark route left (next session's target)
 │   ├── api/
@@ -154,7 +177,7 @@ src/
 ├── components/
 │   ├── flow/                   ← LightStep*.tsx (seven brew steps)
 │   ├── ui/
-│   │   ├── light/              ← Light primitives
+│   │   ├── light/              ← Light primitives (+ ConnectionStatus.tsx, NEW #185 — offline/sync pill)
 │   │   ├── FlavorWheel.tsx     ← Light palette in place
 │   │   ├── BrewMethodIcon.tsx  ← Routes Orea variants to specific SVGs
 │   │   ├── PhotoUpload.tsx     ← Uses Dark CoffeeBeanGlow + CSS-shim invert
@@ -168,13 +191,17 @@ src/
 ├── lib/
 │   ├── field/                  ← v1.1 zones + cache.ts (coffee↔brew Field carry)
 │   ├── claude/                 ← recommend.ts, analyzeBag.ts, …
+│   ├── storage/                ← s3.ts + idb.ts / offlineLibrary.ts / saveQueue.ts (NEW — offline brew, #184)
+│   ├── flow/brewAgain.ts       ← NEW — shared Brew-Again entry (online + offline)
 │   ├── db/
 │   │   ├── schema.ts           ← + cafeVisits table
 │   │   ├── helpers.ts
 │   │   └── migrations/         ← 0000..0011 (0010 + 0011 applied 2026-05)
 │   └── types/                  ← + CafeVisit, CafeVisitRating in cafes.ts
+├── hooks/
+│   └── useOnline.ts            ← NEW — connectivity boolean
 └── store/
-    └── flowStore.ts
+    └── flowStore.ts            ← localStorage-persisted (was sessionStorage, #184)
 public/brew-icons/
 ├── orea-classic.svg            ← NEW (#144)
 ├── orea-open.svg                ← NEW


### PR DESCRIPTION
## Summary

Docs-only. Records the offline brew feature (#184) and the sync fix (#185).

- **CLAUDE.md** — `lib/storage/` (idb, offlineLibrary, saveQueue) + `lib/flow/brewAgain.ts` in the tree, `useOnline` hook, `/offline` route, `ConnectionStatus` primitive, `flowStore` localStorage note, and a new "Offline Brew Mode" entry in the Done snapshot.
- **HANDOVER.md** — dated shipped section, two new pitfalls (iOS `online` event unreliability; App Router dynamic routes not reliably available offline), and the new files in the tree.

No code changes.

https://claude.ai/code/session_01PFTByY9gZq2i11dsBU4NgK

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFTByY9gZq2i11dsBU4NgK)_