### PR TITLE
Security, performance & flow hardening

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -7,7 +7,11 @@ import { createSession, setSessionCookie } from "@/lib/auth/session";
 
 export const dynamic = "force-dynamic";
 
-const pinAttempts = new Map<string, { count: number; lockedUntil: number }>();
+// Single-user app: a global PIN lockout instead of a per-IP one. The previous
+// per-IP key used x-forwarded-for, which a client can spoof to rotate keys and
+// sidestep the limit entirely. One owner means one counter is both simpler and
+// not bypassable.
+let pinAttempts: { count: number; lockedUntil: number } = { count: 0, lockedUntil: 0 };
 const PIN_MAX_ATTEMPTS = 5;
 const PIN_LOCKOUT_MS = 60_000;
 const CHALLENGE_KEY = "default";
@@ -18,11 +22,9 @@ export async function POST(req: NextRequest) {
     const body = await req.json();
 
     if (body.type === "pin") {
-      const ip = req.headers.get("x-forwarded-for") ?? req.headers.get("x-real-ip") ?? "unknown";
       const now = Date.now();
-      const record = pinAttempts.get(ip);
 
-      if (record && record.lockedUntil > now) {
+      if (pinAttempts.lockedUntil > now) {
         return NextResponse.json({ error: "Too many attempts. Try again in 60 seconds." }, { status: 429 });
       }
 
@@ -30,16 +32,15 @@ export async function POST(req: NextRequest) {
       if (!expected) return NextResponse.json({ error: "PIN not configured" }, { status: 400 });
 
       if (body.pin !== expected) {
-        const attempts = record && record.lockedUntil <= now ? record.count + 1 : 1;
-        if (attempts >= PIN_MAX_ATTEMPTS) {
-          pinAttempts.set(ip, { count: attempts, lockedUntil: now + PIN_LOCKOUT_MS });
-        } else {
-          pinAttempts.set(ip, { count: attempts, lockedUntil: 0 });
-        }
+        const attempts = pinAttempts.count + 1;
+        pinAttempts = {
+          count: attempts,
+          lockedUntil: attempts >= PIN_MAX_ATTEMPTS ? now + PIN_LOCKOUT_MS : 0,
+        };
         return NextResponse.json({ error: "Wrong PIN" }, { status: 401 });
       }
 
-      pinAttempts.delete(ip);
+      pinAttempts = { count: 0, lockedUntil: 0 };
       const token = await createSession();
       setSessionCookie(token);
       return NextResponse.json({ verified: true });

--- a/src/app/api/coffees/route.ts
+++ b/src/app/api/coffees/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
+import { inArray } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import { coffees, roasters } from "@/lib/db/schema";
 import { rowToCoffee } from "@/lib/db/helpers";
@@ -27,10 +27,19 @@ export async function GET(req: NextRequest) {
       const roasterNames = Array.from(new Set(all.map(c => c.roaster).filter(Boolean)));
       const summaries: Record<string, RoasterSummary> = {};
 
+      // Load every matching roaster row in a single query (was one query per
+      // roaster — an N+1 that grew with the library).
+      const slugByName = new Map(
+        roasterNames.map(name => [name, name.toLowerCase().trim().replace(/\s+/g, "-")])
+      );
+      const slugs = Array.from(new Set(slugByName.values()));
+      const savedRows = slugs.length > 0
+        ? await db.select().from(roasters).where(inArray(roasters.slug, slugs))
+        : [];
+      const savedBySlug = new Map(savedRows.map(r => [r.slug, r]));
+
       for (const name of roasterNames) {
-        const slug = name.toLowerCase().trim().replace(/\s+/g, "-");
-        const roasterRows = await db.select().from(roasters).where(eq(roasters.slug, slug)).limit(1);
-        const saved = roasterRows[0];
+        const saved = savedBySlug.get(slugByName.get(name)!);
         if (saved) {
           summaries[name] = {
             region: saved.region ?? undefined,

--- a/src/app/api/explore-agent/route.ts
+++ b/src/app/api/explore-agent/route.ts
@@ -14,6 +14,7 @@ import { TECHNIQUES } from "@/lib/knowledge/techniques";
 import { ALL_RECIPES, formatRecipeForPrompt } from "@/lib/knowledge/recipes";
 import { db } from "@/lib/db/client";
 import { places } from "@/lib/db/schema";
+import { assertSafeHttpsUrl } from "@/lib/utils/safeFetch";
 import type { Session } from "@/lib/types/session";
 
 export const dynamic = "force-dynamic";
@@ -233,6 +234,9 @@ const TOOLS: Anthropic.Tool[] = [
 // ── Tool implementations ─────────────────────────────────────────────────────
 
 async function fetchPage(url: string): Promise<string> {
+  const safe = await assertSafeHttpsUrl(url);
+  if (!safe.ok) return safe.error ?? "URL blocked";
+
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 12000);
 
@@ -319,6 +323,9 @@ async function fetchPage(url: string): Promise<string> {
 async function fetchImageAsBase64(
   url: string
 ): Promise<{ data: string; mediaType: "image/jpeg" | "image/png" | "image/gif" | "image/webp" }> {
+  const safe = await assertSafeHttpsUrl(url);
+  if (!safe.ok) throw new Error(safe.error ?? "URL blocked");
+
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 15000);
   try {

--- a/src/app/api/places/route.ts
+++ b/src/app/api/places/route.ts
@@ -54,6 +54,28 @@ function buildQueries(name: string, address: string | null, city: string): strin
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
+
+  // Nearby mode (map locate-me): nearest resolved places to a lat,lng pair,
+  // ranked by great-circle distance in SQL. The client no longer needs the
+  // whole table to work out what's close.
+  const near = searchParams.get("near");
+  if (near) {
+    const [latStr, lngStr] = near.split(",");
+    const lat = parseFloat(latStr);
+    const lng = parseFloat(lngStr);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return Response.json([]);
+    const rows = await db
+      .select()
+      .from(places)
+      .where(sql`${places.lat} IS NOT NULL AND ${places.lng} IS NOT NULL`)
+      .orderBy(
+        // LEAST(1, …) guards acos against float drift past 1.0 (→ NaN).
+        sql`6371 * acos(LEAST(1, cos(radians(${lat})) * cos(radians(${places.lat})) * cos(radians(${places.lng}) - radians(${lng})) + sin(radians(${lat})) * sin(radians(${places.lat}))))`,
+      )
+      .limit(50);
+    return Response.json(rows);
+  }
+
   const q = searchParams.get("q")?.trim() ?? "";
 
   // Split on whitespace so a search like "Kolo Berlin" requires BOTH "Kolo"
@@ -61,30 +83,32 @@ export async function GET(req: Request) {
   // looking for the literal string "Kolo Berlin" in a single column.
   const tokens = q.split(/\s+/).filter(Boolean);
 
-  const rows = tokens.length > 0
-    ? await db.select().from(places).where(
-        sql.join(
-          tokens.map((t) => {
-            const pat = `%${t}%`;
-            return sql`(${places.name} ILIKE ${pat} OR ${places.city} ILIKE ${pat} OR ${places.address} ILIKE ${pat})`;
-          }),
-          sql` AND `,
-        ),
-      ).orderBy(asc(places.city), asc(places.name))
-    : await db.select().from(places).orderBy(asc(places.city), asc(places.name));
+  // No query and no near → empty. The map loads on demand (search or
+  // locate-me); the old no-arg branch returned all 6k rows as multi-MB JSON
+  // that nothing rendered until the user interacted.
+  if (tokens.length === 0) return Response.json([]);
+
+  const rows = await db.select().from(places).where(
+    sql.join(
+      tokens.map((t) => {
+        const pat = `%${t}%`;
+        return sql`(${places.name} ILIKE ${pat} OR ${places.city} ILIKE ${pat} OR ${places.address} ILIKE ${pat})`;
+      }),
+      sql` AND `,
+    ),
+  ).orderBy(asc(places.city), asc(places.name));
   const unresolved = rows.filter(p => p.lat == null || p.lng == null);
 
-  // Geocode any unresolved places in the background — newest IDs first so
-  // recently-added cities get coords on the next load without delaying this response.
-  // Previously this was synchronous (5 × 1.1s = 5.5s+ delay), which meant
-  // locate-me fired before places were loaded and showed "No cafés in this area".
+  // Geocode matched-but-unresolved places in the background — newest IDs first
+  // so a freshly-added café gets coords on a later search without delaying
+  // this response.
   if (unresolved.length > 0) {
     const toGeocode = [...unresolved].sort((a, b) => b.id - a.id).slice(0, 5);
     (async () => {
       for (const place of toGeocode) {
         let coords: { lat: number; lng: number } | null = null;
-        for (const q of buildQueries(place.name, place.address, place.city)) {
-          coords = await nominatim(q);
+        for (const query of buildQueries(place.name, place.address, place.city)) {
+          coords = await nominatim(query);
           if (coords) break;
         }
         if (coords) {

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -120,6 +120,20 @@ export async function POST(req: NextRequest) {
     const createdAtMs = Date.now();
     const createdAt = new Date(data.createdAt);
 
+    // Idempotency for the offline save queue: if a reconnect re-POSTs a brew
+    // whose insert already succeeded (the response was lost on a flaky link),
+    // the body carries the same client-set createdAt. Return the existing row
+    // instead of inserting a duplicate. A single user never logs two real
+    // brews on the same millisecond, so createdAt is a safe dedup key.
+    const dupe = await db
+      .select({ id: sessions.id })
+      .from(sessions)
+      .where(eq(sessions.createdAt, createdAt))
+      .limit(1);
+    if (dupe[0]) {
+      return NextResponse.json({ id: dupe[0].id });
+    }
+
     await db.insert(sessions).values({
       id: sessionId,
       type: data.type,

--- a/src/components/cafes/CafeMap.tsx
+++ b/src/components/cafes/CafeMap.tsx
@@ -109,9 +109,6 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
   const [selected, setSelected] = useState<CafeSummary | null>(null);
   const [placeSelected, setPlaceSelected] = useState<Place | null>(null);
   const [places, setPlaces] = useState<Place[]>([]);
-  // Always-current places ref so locate-me (inside [] effect) can read latest places
-  const placesRef = useRef(places);
-  placesRef.current = places;
   const [search, setSearch] = useState(initialSearch ?? "");
   const [debouncedSearch, setDebouncedSearch] = useState(initialSearch ?? "");
   const [mapReady, setMapReady] = useState(false);
@@ -144,16 +141,13 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
   }, [search]);
 
   const filteredPlaces = useMemo(() => {
+    // `places` is already the server-matched set (by ?q= or ?near=), so we
+    // only drop rows still missing coords — re-filtering by substring here
+    // would wrongly exclude cross-field token matches like "Kolo Berlin".
     if (nearbyIds != null)
       return places.filter(p => nearbyIds.has(p.id) && p.lat != null && p.lng != null);
-    if (debouncedSearch.trim()) {
-      const q = debouncedSearch.toLowerCase();
-      return places.filter(p =>
-        p.name.toLowerCase().includes(q) ||
-        p.city.toLowerCase().includes(q) ||
-        (p.address ?? "").toLowerCase().includes(q)
-      );
-    }
+    if (debouncedSearch.trim())
+      return places.filter(p => p.lat != null && p.lng != null);
     return [];
   }, [places, debouncedSearch, nearbyIds]);
 
@@ -162,13 +156,20 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
     [filteredPlaces]
   );
 
-  // Fetch curated places
+  // Fetch curated places on demand — by search term, never the whole table.
+  // Locate-me owns `places` while in nearby mode, so skip the search fetch
+  // there to avoid clobbering its results.
   useEffect(() => {
-    fetch("/api/places")
+    if (nearbyIds != null) return;
+    const term = debouncedSearch.trim();
+    if (!term) { setPlaces([]); return; }
+    let cancelled = false;
+    fetch(`/api/places?q=${encodeURIComponent(term)}`)
       .then(r => r.json())
-      .then((data: Place[]) => setPlaces(data))
+      .then((data: Place[]) => { if (!cancelled) setPlaces(data); })
       .catch(() => {});
-  }, []);
+    return () => { cancelled = true; };
+  }, [debouncedSearch, nearbyIds]);
 
   // Initialize Leaflet + visited café pins — runs once on mount.
   // Cafes data is read from cafesRef so this effect doesn't need cafes as a dep
@@ -206,15 +207,23 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
       locateMeFnRef.current = () => {
         setLocatingUser(true);
         navigator.geolocation.getCurrentPosition(
-          (pos) => {
+          async (pos) => {
             const { latitude: lat, longitude: lng } = pos.coords;
 
             userMarkerRef.current?.remove();
             userMarkerRef.current = L.marker([lat, lng], { icon: youAreHereIcon, zIndexOffset: 1000 }).addTo(map);
 
-            const allPlaces = placesRef.current.filter(p => p.lat != null && p.lng != null);
+            // Ask the server for the nearest resolved places — no full-table
+            // download, the distance ranking happens in SQL.
+            let nearby: Place[] = [];
+            try {
+              const res = await fetch(`/api/places?near=${lat},${lng}`);
+              nearby = await res.json();
+            } catch { /* network error — treated as no results below */ }
 
-            if (allPlaces.length === 0) {
+            const resolved = nearby.filter(p => p.lat != null && p.lng != null);
+
+            if (resolved.length === 0) {
               map.flyTo([lat, lng], 15);
               setLocateError("No cafés in database for this area yet");
               setTimeout(() => setLocateError(null), 3000);
@@ -222,14 +231,12 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
               return;
             }
 
-            // Sort all curated places by distance from user
-            const sorted = allPlaces
+            // Small city mode: nearest place <50 km away and whole city fits in 25 → show all
+            const sorted = resolved
               .map(p => ({ p, dist: haversineKm(lat, lng, p.lat!, p.lng!) }))
               .sort((a, b) => a.dist - b.dist);
-
-            // Small city mode: nearest place <50 km away and whole city fits in 25 → show all
             const nearestCity = sorted[0].p.city;
-            const cityPlaces = allPlaces.filter(
+            const cityPlaces = resolved.filter(
               p => p.city.toLowerCase() === nearestCity.toLowerCase()
             );
             const toShow =
@@ -237,6 +244,7 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
                 ? cityPlaces
                 : sorted.slice(0, 25).map(x => x.p);
 
+            setPlaces(resolved);
             setNearbyIds(new Set(toShow.map(p => p.id)));
 
             // Fit map to user location + all nearby spots


### PR DESCRIPTION
## Summary

Outcome of a Security / Performance / Flow audit. The app was already solid for a single-user PWA — these are the genuinely actionable findings (verified in code, several agent-reported "criticals" were already handled and are not touched here).

**Security**
- **Block SSRF in the chat agent** — `explore-agent`'s `fetch_page` and `analyze_image` tools fetched arbitrary URLs without validation. They now run through `assertSafeHttpsUrl` (the same guard `analyze-url` already uses), so the agent can't be steered into internal/metadata addresses (`169.254.169.254`, `localhost`, private ranges).
- **Harden the PIN lockout** — the brute-force lockout was keyed on the client-controllable `x-forwarded-for` header, so rotating it bypassed the 5-attempt limit. Replaced with a single global counter (single-user app → one counter is simpler and not bypassable).

**Data integrity**
- **Stop offline double-saves** — if the offline save queue re-POSTs a brew whose insert already landed (response lost on a flaky link), the server now returns the existing row instead of inserting a duplicate. Dedup is on the client-set `createdAt`, which is stable across retries — migration-free, online path unchanged.

**Performance**
- **Roaster-summary N+1 → one query** — `GET /api/coffees?roasterSummaries=true` ran one `roasters` query per roaster; now a single `inArray` query. Response unchanged.
- **Map loads on demand** — `CafeMap` dumped the whole `places` table (~6.2k rows, multi-MB) on mount. Now demand-driven: `?q=` for search (server token-AND filter) and a new `?near=lat,lng` endpoint ranking the nearest 50 by great-circle distance in SQL.

**Deliberately not changed:** 30-day session TTL (no frequent re-login — intentional UX), AI prompts/models (no behavioral change → no validation required), AI rate-limiting (unnecessary for a single authenticated user).

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Chat agent refuses to fetch an internal/localhost URL
- [ ] Save a brew offline, toggle airplane mode to sync → exactly one session appears
- [ ] 6 wrong PINs (varying `X-Forwarded-For`) → 429 from the 5th
- [ ] `GET /api/coffees?roasterSummaries=true` returns identical summaries
- [ ] `/cafes/map`: no full-table payload in the network tab; search, locate-me, pin select, and "I've been here" all work

https://claude.ai/code/session_012fN5Lq9axfskzhVYnux1To

---
_Generated by [Claude Code](https://claude.ai/code/session_012fN5Lq9axfskzhVYnux1To)_