### PR TITLE
fix(lessons): protect user edits + rotation-aware page

### DIFF
--- a/scripts/backfill-lessons.mjs
+++ b/scripts/backfill-lessons.mjs
@@ -210,7 +210,7 @@ Write the updated directive now via write_lesson.`;
       },
       body: JSON.stringify({
         model: "claude-haiku-4-5",
-        max_tokens: 600,
+        max_tokens: 1024,
         system: SYSTEM_PROMPT,
         tools: [WRITE_LESSON_TOOL],
         tool_choice: { type: "tool", name: "write_lesson" },
@@ -221,9 +221,29 @@ Write the updated directive now via write_lesson.`;
       console.error(`  ✗ haiku ${res.status}:`, await res.text());
       return null;
     }
-    const body = await res.json();
+    // Read as text first so we can dump the raw payload on JSON.parse
+    // failure — Anthropic occasionally returns responses our outer
+    // .json() couldn't parse, and without the body we can't tell whether
+    // the issue is truncation, an unescaped char, or something stranger.
+    const responseText = await res.text();
+    let body;
+    try {
+      body = JSON.parse(responseText);
+    } catch (parseErr) {
+      console.error(`  ✗ json parse: ${parseErr.message}`);
+      console.error(`     raw len=${responseText.length}`);
+      console.error(`     first 400: ${responseText.slice(0, 400)}`);
+      console.error(`     last 200:  ${responseText.slice(-200)}`);
+      return null;
+    }
+    if (body.stop_reason && body.stop_reason !== "tool_use" && body.stop_reason !== "end_turn") {
+      console.error(`  ⚠ stop_reason=${body.stop_reason}`);
+    }
     const toolBlock = body.content?.find((b) => b.type === "tool_use");
-    if (!toolBlock?.input) return null;
+    if (!toolBlock?.input) {
+      console.error(`  ✗ no tool_use block. content types: ${(body.content ?? []).map((b) => b.type).join(", ") || "none"}`);
+      return null;
+    }
     const content =
       typeof toolBlock.input.content === "string"
         ? toolBlock.input.content.trim()

--- a/scripts/backfill-lessons.mjs
+++ b/scripts/backfill-lessons.mjs
@@ -34,19 +34,36 @@ if (!ANTHROPIC_API_KEY) {
 
 const SYSTEM_PROMPT = `You are BTTS's memory writer. You distill a user's brew history into ONE durable directive — a single short paragraph that a recommendation prompt can quote verbatim months from now.
 
-Output exactly this JSON shape, nothing else:
-
-{
-  "content": "ONE paragraph, 1–3 short sentences. A concrete, actionable directive — what to prefer, what to avoid, what to remember. Reference real numbers (ratings, recipe names, methods). If two recipes diverge in outcome, name both. If freeNotes flag a meta-fact about the coffee/roaster (e.g. roasted for espresso, fermented hot, stale), surface it. Plain prose, no bullets, no JSON-in-JSON, no emojis. Metric units only.",
-  "confidence_n": <integer count of rated brews backing this lesson>
-}
+When you call write_lesson, pass:
+- content: ONE paragraph, 1–3 short sentences. A concrete, actionable directive — what to prefer, what to avoid, what to remember. Reference real numbers (ratings, recipe names, methods). If two recipes diverge in outcome, name both. If a freeNote flags a meta-fact about the coffee or roaster (e.g. roasted for espresso, fermented hot, stale), paraphrase it into the directive without using quotation marks. Plain prose, no bullets, no emojis. Metric units only. If you cannot write a concrete directive from the evidence, pass an empty string.
+- confidence_n: integer count of rated brews backing this lesson.
 
 Constraints:
-- One paragraph only. If you can't be concrete, return empty content "".
-- Prefer "Avoid X for this coffee" / "Prefer Y" over generic "experiment more".
-- Cite recipe NAMES (the title + based-on), not just methods, when distinguishing what worked.
-- Where freeNotes contain a meta-observation the user typed (e.g. "this is an espresso roast"), include it verbatim as a quoted phrase.
+- Prefer "Avoid X" / "Prefer Y" over generic "experiment more".
+- Cite recipe NAMES (the title plus the based-on), not just methods, when distinguishing what worked.
+- Do not use quotation marks anywhere in content — paraphrase rather than quote.
 - No hedging. The user wants a directive, not advice.`;
+
+const WRITE_LESSON_TOOL = {
+  name: "write_lesson",
+  description:
+    "Persist the distilled BTTS lesson for this (level, scope). Always call this tool exactly once.",
+  input_schema: {
+    type: "object",
+    properties: {
+      content: {
+        type: "string",
+        description:
+          "1–3 short sentences, plain prose, no quotation marks. Empty string if no concrete directive can be drawn from the evidence.",
+      },
+      confidence_n: {
+        type: "integer",
+        description: "Number of rated brews backing this lesson.",
+      },
+    },
+    required: ["content", "confidence_n"],
+  },
+};
 
 function resolveBrewedCandidate(session) {
   const rec = session.recommendation;
@@ -178,10 +195,10 @@ async function callHaiku(scopeLabel, level, sessionList, existingContent) {
   const userMessage = `Level: ${level}
 Scope: ${scopeLabel}
 
-${existingContent ? `Existing lesson (revise if the new evidence changes it; keep what still holds):\n"${existingContent}"\n\n` : ""}Brews backing this scope (most recent first, max 30):
+${existingContent ? `Existing lesson (revise if the new evidence changes it; keep what still holds): ${existingContent}\n\n` : ""}Brews backing this scope (most recent first, max 30):
 ${formatSessionsForPrompt(sessionList)}
 
-Write the updated directive now.`;
+Write the updated directive now via write_lesson.`;
 
   try {
     const res = await fetch("https://api.anthropic.com/v1/messages", {
@@ -193,8 +210,10 @@ Write the updated directive now.`;
       },
       body: JSON.stringify({
         model: "claude-haiku-4-5",
-        max_tokens: 400,
+        max_tokens: 600,
         system: SYSTEM_PROMPT,
+        tools: [WRITE_LESSON_TOOL],
+        tool_choice: { type: "tool", name: "write_lesson" },
         messages: [{ role: "user", content: userMessage }],
       }),
     });
@@ -203,15 +222,15 @@ Write the updated directive now.`;
       return null;
     }
     const body = await res.json();
-    const rawText = body.content?.[0]?.text?.trim();
-    if (!rawText) return null;
-    const jsonMatch = rawText.match(/\{[\s\S]*\}/);
-    const parsed = JSON.parse(jsonMatch ? jsonMatch[0] : rawText);
+    const toolBlock = body.content?.find((b) => b.type === "tool_use");
+    if (!toolBlock?.input) return null;
     const content =
-      typeof parsed.content === "string" ? parsed.content.trim() : "";
+      typeof toolBlock.input.content === "string"
+        ? toolBlock.input.content.trim()
+        : "";
     const confidenceN =
-      typeof parsed.confidence_n === "number"
-        ? Math.max(0, Math.floor(parsed.confidence_n))
+      typeof toolBlock.input.confidence_n === "number"
+        ? Math.max(0, Math.floor(toolBlock.input.confidence_n))
         : ratedCount;
     if (!content) return null;
     return { content, confidenceN };

--- a/src/app/(light)/lessons/page.tsx
+++ b/src/app/(light)/lessons/page.tsx
@@ -27,6 +27,12 @@ type Level = "coffee" | "roaster" | "method-style" | "process-roast";
 type Source = "auto" | "user-confirmed" | "user-edited" | "backfill";
 type Status = "active" | "dismissed";
 
+interface CoffeeMeta {
+  inRotation: boolean;
+  roaster: string;
+  name: string;
+}
+
 interface Lesson {
   id: string;
   level: Level;
@@ -39,6 +45,8 @@ interface Lesson {
   userNote: string | null;
   createdAt: string;
   updatedAt: string;
+  /** Present only for level='coffee'; null when the coffees row is missing. */
+  coffeeMeta?: CoffeeMeta | null;
 }
 
 const LEVEL_TITLES: Record<Level, string> = {
@@ -146,6 +154,18 @@ export default function LessonsPage() {
   };
   for (const l of active) groupedActive[l.level].push(l);
 
+  // Coffee level splits two ways: lessons for bags currently in rotation
+  // (front-and-centre) vs lessons for archived bags (out-of-rotation,
+  // collapsed into a drawer). Bags whose coffeeMeta couldn't be resolved
+  // (legacy / deleted coffee row) sit in the archived bucket so they
+  // don't crowd the main view — they can still be inspected.
+  const coffeeInRotation = groupedActive.coffee.filter(
+    (l) => l.coffeeMeta?.inRotation === true,
+  );
+  const coffeeArchived = groupedActive.coffee.filter(
+    (l) => l.coffeeMeta?.inRotation !== true,
+  );
+
   return (
     <div className="min-h-svh bg-transparent flex flex-col">
       {/* Header */}
@@ -201,16 +221,30 @@ export default function LessonsPage() {
         </div>
       ) : (
         <div className="flex-1 px-5 pb-20 space-y-10">
-          {LEVEL_ORDER.map((lvl) => (
-            <LevelSection
-              key={lvl}
-              level={lvl}
-              lessons={groupedActive[lvl]}
-              onDismiss={handleDismiss}
-              onConfirm={handleConfirm}
-              onSaveEdit={handleSaveEdit}
-            />
-          ))}
+          {LEVEL_ORDER.map((lvl) => {
+            if (lvl === "coffee") {
+              return (
+                <CoffeeLevelSection
+                  key={lvl}
+                  inRotation={coffeeInRotation}
+                  archived={coffeeArchived}
+                  onDismiss={handleDismiss}
+                  onConfirm={handleConfirm}
+                  onSaveEdit={handleSaveEdit}
+                />
+              );
+            }
+            return (
+              <LevelSection
+                key={lvl}
+                level={lvl}
+                lessons={groupedActive[lvl]}
+                onDismiss={handleDismiss}
+                onConfirm={handleConfirm}
+                onSaveEdit={handleSaveEdit}
+              />
+            );
+          })}
 
           {/* Dismissed drawer */}
           {dismissed.length > 0 && (
@@ -243,6 +277,80 @@ export default function LessonsPage() {
 
       <NavigationOverlay open={menuOpen} onClose={() => setMenuOpen(false)} />
     </div>
+  );
+}
+
+function CoffeeLevelSection({
+  inRotation,
+  archived,
+  onDismiss,
+  onConfirm,
+  onSaveEdit,
+}: {
+  inRotation: Lesson[];
+  archived: Lesson[];
+  onDismiss: (id: string) => void;
+  onConfirm: (id: string) => void;
+  onSaveEdit: (id: string, content: string) => void;
+}) {
+  const [showArchived, setShowArchived] = useState(false);
+  return (
+    <section>
+      <div className="flex items-baseline justify-between mb-2 px-1">
+        <p className="text-light-muted-foreground text-xs tracking-widest uppercase">
+          {LEVEL_TITLES.coffee}
+        </p>
+        <span className="text-light-muted-foreground/70 text-xs">
+          {inRotation.length}
+          {archived.length > 0 ? ` · ${archived.length} archived` : ""}
+        </span>
+      </div>
+      <p className="text-light-muted-foreground text-xs leading-relaxed mb-3 px-1">
+        {LEVEL_BLURBS.coffee} Only bags in rotation are shown by default —
+        archived bags sit in the drawer below.
+      </p>
+      {inRotation.length === 0 ? (
+        <p className="text-light-muted-foreground/70 text-sm italic px-1">
+          No lessons for bags currently in rotation.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {inRotation.map((l) => (
+            <LessonCard
+              key={l.id}
+              lesson={l}
+              onDismiss={onDismiss}
+              onConfirm={onConfirm}
+              onSaveEdit={onSaveEdit}
+            />
+          ))}
+        </div>
+      )}
+      {archived.length > 0 && (
+        <div className="mt-4">
+          <button
+            type="button"
+            onClick={() => setShowArchived((v) => !v)}
+            className="text-light-muted-foreground text-xs tracking-widest uppercase px-1"
+          >
+            Archived bags ({archived.length}) {showArchived ? "▾" : "▸"}
+          </button>
+          {showArchived && (
+            <div className="space-y-3 mt-3">
+              {archived.map((l) => (
+                <LessonCard
+                  key={l.id}
+                  lesson={l}
+                  onDismiss={onDismiss}
+                  onConfirm={onConfirm}
+                  onSaveEdit={onSaveEdit}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </section>
   );
 }
 
@@ -322,7 +430,12 @@ function LessonCard({
       }`}
     >
       <p className="text-light-muted-foreground text-xs mb-1.5 leading-tight">
-        {lesson.scope}
+        {/* Friendly display name for coffee-level rows when available;
+            falls back to the raw scope id (e.g. "ineffable_coffee_roasters__la_coipa"
+            for rows whose coffees-table join missed). */}
+        {lesson.coffeeMeta
+          ? `${lesson.coffeeMeta.roaster} — ${lesson.coffeeMeta.name}${lesson.coffeeMeta.inRotation ? "" : " · archived"}`
+          : lesson.scope}
       </p>
       {editing ? (
         <textarea

--- a/src/app/api/lessons/route.ts
+++ b/src/app/api/lessons/route.ts
@@ -6,14 +6,19 @@
  * "dismissed" affordance and the user can re-activate them; /recommend
  * filters dismissed separately (loadLessonsForRecommend).
  *
+ * For level='coffee' rows we also join the coffees table so the page
+ * can (a) hide out-of-rotation coffees under an "Archived" drawer by
+ * default and (b) show a friendly "Roaster — Coffee Name" label
+ * instead of the raw scope id (e.g. "ineffable_coffee_roasters__la_coipa").
+ *
  * Optional query params:
  *   - level: 'coffee' | 'roaster' | 'method-style' | 'process-roast'
  *   - includeDismissed: 'false' to hide dismissed rows (default: include)
  */
 import { NextRequest, NextResponse } from "next/server";
-import { desc, eq } from "drizzle-orm";
+import { desc, eq, inArray } from "drizzle-orm";
 import { db } from "@/lib/db/client";
-import { lessons } from "@/lib/db/schema";
+import { coffees, lessons } from "@/lib/db/schema";
 import type { LessonLevel } from "@/lib/db/schema";
 
 const VALID_LEVELS: LessonLevel[] = [
@@ -46,6 +51,37 @@ export async function GET(req: NextRequest) {
       ? rows
       : rows.filter((r) => r.status !== "dismissed");
 
+    // For coffee-level rows, attach rotation status + friendly display
+    // name by joining the coffees table. Single point-lookup query;
+    // no N+1.
+    const coffeeIds = Array.from(
+      new Set(
+        filtered.filter((r) => r.level === "coffee").map((r) => r.scope),
+      ),
+    );
+    const coffeeMeta = new Map<
+      string,
+      { inRotation: boolean; roaster: string; name: string }
+    >();
+    if (coffeeIds.length > 0) {
+      const coffeeRows = await db
+        .select({
+          id: coffees.id,
+          inRotation: coffees.inRotation,
+          roaster: coffees.roaster,
+          name: coffees.name,
+        })
+        .from(coffees)
+        .where(inArray(coffees.id, coffeeIds));
+      for (const c of coffeeRows) {
+        coffeeMeta.set(c.id, {
+          inRotation: c.inRotation,
+          roaster: c.roaster,
+          name: c.name,
+        });
+      }
+    }
+
     return NextResponse.json(
       filtered.map((r) => ({
         id: r.id,
@@ -59,6 +95,8 @@ export async function GET(req: NextRequest) {
         userNote: r.userNote,
         createdAt: r.createdAt.toISOString(),
         updatedAt: r.updatedAt.toISOString(),
+        coffeeMeta:
+          r.level === "coffee" ? coffeeMeta.get(r.scope) ?? null : null,
       })),
     );
   } catch (err) {

--- a/src/lib/claude/lessons.ts
+++ b/src/lib/claude/lessons.ts
@@ -132,18 +132,14 @@ export async function loadSessionsForScope(
 
 const SYSTEM_PROMPT = `You are BTTS's memory writer. You distill a user's brew history into ONE durable directive — a single short paragraph that a recommendation prompt can quote verbatim months from now.
 
-Output exactly this JSON shape, nothing else:
-
-{
-  "content": "ONE paragraph, 1–3 short sentences. A concrete, actionable directive — what to prefer, what to avoid, what to remember. Reference real numbers (ratings, recipe names, methods). If two recipes diverge in outcome, name both. If freeNotes flag a meta-fact about the coffee/roaster (e.g. roasted for espresso, fermented hot, stale), surface it. Plain prose, no bullets, no JSON-in-JSON, no emojis. Metric units only.",
-  "confidence_n": <integer count of rated brews backing this lesson>
-}
+When you call write_lesson, pass:
+- content: ONE paragraph, 1–3 short sentences. A concrete, actionable directive — what to prefer, what to avoid, what to remember. Reference real numbers (ratings, recipe names, methods). If two recipes diverge in outcome, name both. If a freeNote flags a meta-fact about the coffee or roaster (e.g. roasted for espresso, fermented hot, stale), paraphrase it into the directive without using quotation marks. Plain prose, no bullets, no emojis. Metric units only. If you cannot write a concrete directive from the evidence, pass an empty string.
+- confidence_n: integer count of rated brews backing this lesson.
 
 Constraints:
-- One paragraph only. If you can't be concrete, return empty content "".
-- Prefer "Avoid X for this coffee" / "Prefer Y" over generic "experiment more".
-- Cite recipe NAMES (the title + based-on), not just methods, when distinguishing what worked.
-- Where freeNotes contain a meta-observation the user typed (e.g. "this is an espresso roast"), include it verbatim as a quoted phrase.
+- Prefer "Avoid X" / "Prefer Y" over generic "experiment more".
+- Cite recipe NAMES (the title plus the based-on), not just methods, when distinguishing what worked.
+- Do not use quotation marks anywhere in content — paraphrase rather than quote.
 - No hedging. The user wants a directive, not advice.`;
 
 interface DistillResult {
@@ -200,26 +196,52 @@ async function callHaikuForDistillation(
   const userMessage = `Level: ${scope.level}
 Scope: ${scope.label}
 
-${existing?.content ? `Existing lesson (revise if the new evidence changes it; keep what still holds):\n"${existing.content}"\n\n` : ""}Brews backing this scope (most recent first, max 30):
+${existing?.content ? `Existing lesson (revise if the new evidence changes it; keep what still holds): ${existing.content}\n\n` : ""}Brews backing this scope (most recent first, max 30):
 ${formatSessionsForPrompt(sessionList)}
 
-Write the updated directive now.`;
+Write the updated directive now via write_lesson.`;
 
   try {
     const msg = await client.messages.create({
       model: "claude-haiku-4-5",
-      max_tokens: 400,
+      max_tokens: 600,
       system: SYSTEM_PROMPT,
+      tools: [
+        {
+          name: "write_lesson",
+          description:
+            "Persist the distilled BTTS lesson for this (level, scope). Always call this tool exactly once.",
+          input_schema: {
+            type: "object",
+            properties: {
+              content: {
+                type: "string",
+                description:
+                  "1–3 short sentences, plain prose, no quotation marks. Empty string if no concrete directive can be drawn from the evidence.",
+              },
+              confidence_n: {
+                type: "integer",
+                description: "Number of rated brews backing this lesson.",
+              },
+            },
+            required: ["content", "confidence_n"],
+          },
+        },
+      ],
+      tool_choice: { type: "tool", name: "write_lesson" },
       messages: [{ role: "user", content: userMessage }],
     });
-    const rawText = (msg.content[0] as { type: string; text: string })?.text?.trim();
-    if (!rawText) return null;
-    const jsonMatch = rawText.match(/\{[\s\S]*\}/);
-    const parsed = JSON.parse(jsonMatch ? jsonMatch[0] : rawText);
-    const content = typeof parsed.content === "string" ? parsed.content.trim() : "";
+
+    const toolBlock = msg.content.find(
+      (b): b is Anthropic.Messages.ToolUseBlock => b.type === "tool_use",
+    );
+    if (!toolBlock) return null;
+    const input = toolBlock.input as { content?: unknown; confidence_n?: unknown };
+    const content =
+      typeof input.content === "string" ? input.content.trim() : "";
     const confidence_n =
-      typeof parsed.confidence_n === "number"
-        ? Math.max(0, Math.floor(parsed.confidence_n))
+      typeof input.confidence_n === "number"
+        ? Math.max(0, Math.floor(input.confidence_n))
         : ratedCount;
     if (!content) return null;
     return { content, confidence_n };

--- a/src/lib/claude/lessons.ts
+++ b/src/lib/claude/lessons.ts
@@ -286,6 +286,12 @@ async function upsertLesson(
     });
   } else {
     const row = existing[0];
+    // User-edited rows are sacred — the user explicitly rewrote this
+    // lesson. Auto distillation MUST NOT overwrite their text. Skip
+    // entirely (no content update, no evidence update). Only an explicit
+    // user-edited source coming back in (the PATCH route) can change
+    // the row's content from here on.
+    if (row.source === "user-edited" && source !== "user-edited") return;
     await db
       .update(lessons)
       .set({
@@ -320,6 +326,9 @@ export async function distillLessonsForSession(session: Session): Promise<number
         .where(and(eq(lessons.level, scope.level), eq(lessons.scope, scope.scope)))
         .limit(1);
       const existing = existingRows[0] ?? null;
+      // User has explicitly rewritten this lesson — don't even call
+      // Haiku. Their text is the truth. Saves an API call too.
+      if (existing?.source === "user-edited") return false;
       const distillation = await callHaikuForDistillation(
         scope,
         sessionList,
@@ -352,6 +361,7 @@ export async function distillLessonForScope(
     .where(and(eq(lessons.level, scope.level), eq(lessons.scope, scope.scope)))
     .limit(1);
   const existing = existingRows[0] ?? null;
+  if (existing?.source === "user-edited") return false;
   const distillation = await callHaikuForDistillation(scope, sessionList, existing);
   if (!distillation) return false;
   await upsertLesson(scope, distillation, sessionList, source);


### PR DESCRIPTION
## Summary

Two surgical follow-ups after the live /lessons surface exposed real issues.

1. **User-edit overwrite bug (fix)** — when a row's source was `user-edited`, the next auto distillation was silently overwriting the user's text with new Haiku output while leaving the "you wrote this" pill in place. The user's correction was never reaching /recommend after the first auto run. Now `distillLessonsForSession` / `distillLessonForScope` / `upsertLesson` all bail before the Haiku call when the existing row is user-edited. Belt and braces.

2. **Rotation-aware /lessons page** — 30 coffee-level lessons rendered flat, half of them for bags long out of rotation. /recommend only reads a coffee-lesson for the bag being brewed RIGHT NOW, so out-of-rotation coffee lessons are pure visual noise on the page. `GET /api/lessons` now joins the coffees table for level='coffee' rows and returns `coffeeMeta {inRotation, roaster, name}`. The page splits the coffee section into "In rotation" (visible) + an expandable "Archived bags (N)" drawer. Friendlier display too: "Ineffable Coffee Roasters — La Coipa" instead of "ineffable_coffee_roasters__la_coipa".

## Deploy state

- No schema change. No backfill rerun needed.
- Pure code change — merge and the auto-deploy is enough.

## Test plan

- [ ] After deploy, `/lessons` opens with the coffee section showing only in-rotation bags by default.
- [ ] "Archived bags (N)" drawer reveals the rest.
- [ ] Coffee lesson labels now read "Roaster — Coffee Name" not "roaster_coffee_name".
- [ ] Edit a lesson, then log a strong-signal brew for the same scope (≤2★ or ≥4★ or with freeNotes). Verify the edited content is still there afterwards (no overwrite).

https://claude.ai/code/session_01N5x8F1Ssu5UiQJJkQrJzre

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5x8F1Ssu5UiQJJkQrJzre)_