### PR TITLE
feat(lessons): schema for ask-before-rating flow (Step 1 of 3)

### DIFF
--- a/src/lib/db/migrations/0013_add_lesson_questions.sql
+++ b/src/lib/db/migrations/0013_add_lesson_questions.sql
@@ -1,0 +1,35 @@
+-- 0013 — Lessons: questions + answers for the "ask before rating" flow
+--
+-- When the live distiller (src/lib/claude/lessons.ts) decides it cannot
+-- write a confident lesson from the brew evidence alone — multiple
+-- plausible causes (recipe vs bag age vs water source vs technique
+-- drift) — it now stores a DRAFT plus a small set of clarifying
+-- questions and flips status='pending'. The user answers on the
+-- /lessons page; a second Haiku turn folds the answers in and the row
+-- moves back to status='active'.
+--
+-- Two new nullable JSONB columns:
+--   - questions LessonQuestion[]  | null  — populated while status='pending'
+--   - answers   LessonAnswer[]    | null  — populated once the user has answered
+--
+-- Status CHECK is extended to allow 'pending' alongside the existing
+-- 'active' / 'dismissed'. DROP IF EXISTS guards the rename so the
+-- migration is safe to apply on systems where the auto-named
+-- constraint differs from the default lessons_status_check.
+--
+-- Run on VPS:
+--   cat src/lib/db/migrations/0013_add_lesson_questions.sql \
+--     | docker compose exec -T postgres psql -U brewlog -d brewlog
+
+ALTER TABLE lessons
+  ADD COLUMN IF NOT EXISTS questions jsonb;
+
+ALTER TABLE lessons
+  ADD COLUMN IF NOT EXISTS answers jsonb;
+
+ALTER TABLE lessons
+  DROP CONSTRAINT IF EXISTS lessons_status_check;
+
+ALTER TABLE lessons
+  ADD CONSTRAINT lessons_status_check
+  CHECK (status IN ('active', 'dismissed', 'pending'));

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -196,13 +196,35 @@ export const conversationMessages = pgTable(
 
 // BTTS distilled memory — promoted from raw sessions into per-level
 // directives by src/lib/claude/lessons.ts. See migration 0012.
+// Migration 0013 adds questions + answers and the 'pending' status for
+// the "ask before committing a verdict" flow.
 export type LessonLevel =
   | "coffee"
   | "roaster"
   | "method-style"
   | "process-roast";
 export type LessonSource = "auto" | "user-confirmed" | "user-edited" | "backfill";
-export type LessonStatus = "active" | "dismissed";
+export type LessonStatus = "active" | "dismissed" | "pending";
+
+/** A single clarifying question Haiku asks before committing a lesson.
+ * Persisted as part of lessons.questions while the row is pending.
+ * The user picks one option, or types into freeText for an "Other" path. */
+export interface LessonQuestion {
+  id: string;
+  prompt: string;
+  /** 2–4 prefab choices. The card renders these as buttons + one extra
+   * "Other…" affordance that expands a free-text input. */
+  options: string[];
+}
+
+/** The user's answer to a LessonQuestion. selected is one of the
+ * options (or null if they only typed in freeText). freeText is
+ * optional supplementary detail. */
+export interface LessonAnswer {
+  questionId: string;
+  selected: string | null;
+  freeText: string | null;
+}
 
 export const lessons = pgTable(
   "lessons",
@@ -216,6 +238,12 @@ export const lessons = pgTable(
     source: text("source").$type<LessonSource>().notNull().default("auto"),
     status: text("status").$type<LessonStatus>().notNull().default("active"),
     userNote: text("user_note"),
+    // Migration 0013 — populated when status='pending' (draft + questions
+    // awaiting user clarification). Null otherwise.
+    questions: jsonb("questions").$type<LessonQuestion[] | null>(),
+    // Migration 0013 — the user's answers, written by PATCH
+    // /api/lessons/[id]/answer. Null until the user responds.
+    answers: jsonb("answers").$type<LessonAnswer[] | null>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },


### PR DESCRIPTION
## Summary

Step 1 of 3 for the ask-before-rating lessons flow. **Pure schema change, no behaviour change.** The existing distiller still writes only confident lessons via `write_lesson`; this commit just opens the room for Step 2.

## What changes

- `0013_add_lesson_questions.sql` migration:
  - `ADD COLUMN questions jsonb` (nullable)
  - `ADD COLUMN answers jsonb` (nullable)
  - extend the `status` CHECK to allow `'pending'` alongside `'active'` / `'dismissed'`. `DROP CONSTRAINT IF EXISTS` first so it works whether the existing constraint is auto-named or explicit.
- Drizzle: `LessonStatus` gains `"pending"`. New `LessonQuestion` / `LessonAnswer` interfaces. Two jsonb columns on the lessons table.

## JSONB shapes

```ts
LessonQuestion = { id, prompt, options: string[2..4] }
LessonAnswer   = { questionId, selected | null, freeText | null }
```

## Deploy order — **migration first**

```bash
cd /opt/brewlog && cat src/lib/db/migrations/0013_add_lesson_questions.sql \
  | docker compose exec -T postgres psql -U brewlog -d brewlog
```

Then merge.

The columns are nullable and additive, the CHECK adds a value (doesn't remove one), so this is a no-risk migration. Existing rows untouched. /lessons + /recommend behave identically after merge — they don't read the new columns yet.

## What's next

- **Step 2** — Haiku two-tool pattern (`write_lesson` confident vs `ask_for_clarification` uncertain), knowledge-layer injection so questions are coffee-literate, `/api/lessons/[id]/answer` endpoint. Behavioural change — I'll sample outputs against 2–3 real buckets before merging this one (proper Hard Rule discipline).
- **Step 3** — Pending section on `/lessons`, prefab-button UI.

https://claude.ai/code/session_01N5x8F1Ssu5UiQJJkQrJzre

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5x8F1Ssu5UiQJJkQrJzre)_