### PR TITLE
feat(lessons): two-tool Haiku + answer endpoint (Step 2 of 3) [SAMPLE BEFORE MERGE]

### DIFF
--- a/scripts/backfill-lessons.mjs
+++ b/scripts/backfill-lessons.mjs
@@ -32,29 +32,38 @@ if (!ANTHROPIC_API_KEY) {
   process.exit(1);
 }
 
-const SYSTEM_PROMPT = `You are BTTS's memory writer. You distill a user's brew history into ONE durable directive — a single short paragraph that a recommendation prompt can quote verbatim months from now.
+const SYSTEM_PROMPT = `You are BTTS's memory writer. You distill a user's brew history into ONE durable directive per scope — a paragraph a recommendation prompt can quote verbatim months from now.
 
-When you call write_lesson, pass:
-- content: ONE paragraph, 1–3 short sentences. A concrete, actionable directive — what to prefer, what to avoid, what to remember. Reference real numbers (ratings, recipe names, methods). If two recipes diverge in outcome, name both. If a freeNote flags a meta-fact about the coffee or roaster (e.g. roasted for espresso, fermented hot, stale), paraphrase it into the directive without using quotation marks. Plain prose, no bullets, no emojis. Metric units only. If you cannot write a concrete directive from the evidence, pass an empty string.
-- confidence_n: integer count of rated brews backing this lesson.
+COFFEE IS MULTIVARIATE. Before assigning blame to a recipe, consider:
+- Bag age (<7d too fresh, 7–21d peak, 22–35d slightly past, 35–60d past peak, 60+ stale)
+- Recipe family (Hoffmann vs Hub vs Kasuya vs Wölfl — different physics, different cups)
+- Water source (clarity blend ~73 ppm vs filtered tap ~220 ppm — buffering differs)
+- Grind drift (Niche calibration shifts over months)
+- Pour technique (agitation level, pulse timing)
+- Roast inconsistency at source — some bags are uneven, not the user's fault
+- Palate fluctuation day to day
 
-Constraints:
-- Prefer "Avoid X" / "Prefer Y" over generic "experiment more".
-- Cite recipe NAMES (the title plus the based-on), not just methods, when distinguishing what worked.
-- Do not use quotation marks anywhere in content — paraphrase rather than quote.
-- No hedging. The user wants a directive, not advice.`;
+ONE TOOL PER TURN.
+
+Call write_lesson when the evidence is clean: 3+ rated brews, a consistent pattern, ONE variable clearly standing out. Be a coach, not a hedger. Reference recipe NAMES (title plus based-on). Paraphrase freeNotes; never quote them.
+
+Call ask_for_clarification when multiple plausible causes could explain the pattern and you need the user to disambiguate. The draft is your best guess as if you'd called write_lesson; the questions are how you'd want to be wrong. Questions must be SPECIFIC — reference the actual brews, the actual dates, the actual ambiguity. Options must be PLAUSIBLE — each one a real explanation the user might endorse, written in their voice. NO generic "Was it the recipe?" questions — name the recipes.
+
+Single bucket, 1 rated brew: usually ask_for_clarification (a single data point cannot support a directive). Use the draft to capture what the brew suggested; use the question to ask whether the user thinks this is a real pattern or a one-off.
+
+Metric units. No emojis. No quotation marks anywhere.`;
 
 const WRITE_LESSON_TOOL = {
   name: "write_lesson",
   description:
-    "Persist the distilled BTTS lesson for this (level, scope). Always call this tool exactly once.",
+    "Use when the evidence is clean: 3+ rated brews, consistent pattern, one variable clearly standing out as the cause. Be a coach issuing a directive. Never call this AND ask_for_clarification in the same turn.",
   input_schema: {
     type: "object",
     properties: {
       content: {
         type: "string",
         description:
-          "1–3 short sentences, plain prose, no quotation marks. Empty string if no concrete directive can be drawn from the evidence.",
+          "1–3 short sentences, plain prose, no quotation marks. A directive — prefer X / avoid Y / remember Z. Reference recipe NAMES (title plus based-on). Paraphrase freeNotes; never quote them.",
       },
       confidence_n: {
         type: "integer",
@@ -62,6 +71,51 @@ const WRITE_LESSON_TOOL = {
       },
     },
     required: ["content", "confidence_n"],
+  },
+};
+
+const ASK_FOR_CLARIFICATION_TOOL = {
+  name: "ask_for_clarification",
+  description:
+    "Use when multiple plausible causes could explain the pattern and you genuinely need the user's input to disambiguate. Examples: a single bad brew on a 42-day-old bag (recipe vs age?); a method change coinciding with a water source change; inconsistent ratings on the same recipe across weeks. Never call this AND write_lesson in the same turn.",
+  input_schema: {
+    type: "object",
+    properties: {
+      draft: {
+        type: "string",
+        description:
+          "Your tentative directive — what you'd commit if your best guess were correct. The user reads this alongside the questions. Same constraints as write_lesson.content.",
+      },
+      confidence_n: {
+        type: "integer",
+        description: "Number of rated brews backing this draft.",
+      },
+      questions: {
+        type: "array",
+        minItems: 1,
+        maxItems: 2,
+        items: {
+          type: "object",
+          properties: {
+            prompt: {
+              type: "string",
+              description:
+                "ONE concrete question naming the actual ambiguity. Reference the specific brews, recipe names, and dates. Not generic.",
+            },
+            options: {
+              type: "array",
+              minItems: 2,
+              maxItems: 4,
+              items: { type: "string" },
+              description:
+                "Plausible explanations the user can tap, written in the user's voice.",
+            },
+          },
+          required: ["prompt", "options"],
+        },
+      },
+    },
+    required: ["draft", "confidence_n", "questions"],
   },
 };
 
@@ -188,6 +242,12 @@ function formatSessionsForPrompt(sessionList) {
     .join("\n");
 }
 
+/**
+ * Two-tool Haiku call. Returns either:
+ *   { kind: 'confident', content, confidenceN }
+ *   { kind: 'uncertain', draft, confidenceN, questions: [{id, prompt, options}] }
+ * or null on failure.
+ */
 async function callHaiku(scopeLabel, level, sessionList, existingContent) {
   const ratedCount = sessionList.filter((s) => s.result?.rating != null).length;
   if (ratedCount === 0) return null;
@@ -198,7 +258,7 @@ Scope: ${scopeLabel}
 ${existingContent ? `Existing lesson (revise if the new evidence changes it; keep what still holds): ${existingContent}\n\n` : ""}Brews backing this scope (most recent first, max 30):
 ${formatSessionsForPrompt(sessionList)}
 
-Write the updated directive now via write_lesson.`;
+Choose ONE tool — write_lesson if the signal is clean, ask_for_clarification if it isn't.`;
 
   try {
     const res = await fetch("https://api.anthropic.com/v1/messages", {
@@ -212,8 +272,8 @@ Write the updated directive now via write_lesson.`;
         model: "claude-haiku-4-5",
         max_tokens: 1024,
         system: SYSTEM_PROMPT,
-        tools: [WRITE_LESSON_TOOL],
-        tool_choice: { type: "tool", name: "write_lesson" },
+        tools: [WRITE_LESSON_TOOL, ASK_FOR_CLARIFICATION_TOOL],
+        tool_choice: { type: "auto" },
         messages: [{ role: "user", content: userMessage }],
       }),
     });
@@ -221,10 +281,6 @@ Write the updated directive now via write_lesson.`;
       console.error(`  ✗ haiku ${res.status}:`, await res.text());
       return null;
     }
-    // Read as text first so we can dump the raw payload on JSON.parse
-    // failure — Anthropic occasionally returns responses our outer
-    // .json() couldn't parse, and without the body we can't tell whether
-    // the issue is truncation, an unescaped char, or something stranger.
     const responseText = await res.text();
     let body;
     try {
@@ -244,16 +300,49 @@ Write the updated directive now via write_lesson.`;
       console.error(`  ✗ no tool_use block. content types: ${(body.content ?? []).map((b) => b.type).join(", ") || "none"}`);
       return null;
     }
-    const content =
-      typeof toolBlock.input.content === "string"
-        ? toolBlock.input.content.trim()
-        : "";
-    const confidenceN =
-      typeof toolBlock.input.confidence_n === "number"
-        ? Math.max(0, Math.floor(toolBlock.input.confidence_n))
-        : ratedCount;
-    if (!content) return null;
-    return { content, confidenceN };
+
+    if (toolBlock.name === "write_lesson") {
+      const content =
+        typeof toolBlock.input.content === "string"
+          ? toolBlock.input.content.trim()
+          : "";
+      const confidenceN =
+        typeof toolBlock.input.confidence_n === "number"
+          ? Math.max(0, Math.floor(toolBlock.input.confidence_n))
+          : ratedCount;
+      if (!content) return null;
+      return { kind: "confident", content, confidenceN };
+    }
+
+    if (toolBlock.name === "ask_for_clarification") {
+      const draft =
+        typeof toolBlock.input.draft === "string"
+          ? toolBlock.input.draft.trim()
+          : "";
+      const confidenceN =
+        typeof toolBlock.input.confidence_n === "number"
+          ? Math.max(0, Math.floor(toolBlock.input.confidence_n))
+          : ratedCount;
+      const rawQs = Array.isArray(toolBlock.input.questions)
+        ? toolBlock.input.questions
+        : [];
+      const questions = rawQs.flatMap((q) => {
+        if (!q || typeof q !== "object") return [];
+        const prompt = typeof q.prompt === "string" ? q.prompt.trim() : "";
+        const options = Array.isArray(q.options)
+          ? q.options
+              .filter((o) => typeof o === "string" && o.trim().length > 0)
+              .map((o) => o.trim())
+              .slice(0, 4)
+          : [];
+        if (!prompt || options.length < 2) return [];
+        return [{ id: randomUUID(), prompt, options }];
+      });
+      if (!draft || questions.length === 0) return null;
+      return { kind: "uncertain", draft, confidenceN, questions };
+    }
+
+    return null;
   } catch (err) {
     console.error(`  ✗ haiku error:`, err.message);
     return null;
@@ -323,6 +412,11 @@ async function main() {
       skipped++;
       continue;
     }
+    if (existing && existing.status === "pending") {
+      console.log(`  ⏭  ${bucket.level}:${bucket.scope} (pending — awaiting user answer)`);
+      skipped++;
+      continue;
+    }
 
     const top = bucket.sessions
       .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
@@ -341,18 +435,36 @@ async function main() {
     }
     const evidence = top.slice(0, 12).map((s) => s.id);
     const now = new Date();
+    // Branch on Haiku's tool choice:
+    //   confident  -> status='active', content=content, questions=null
+    //   uncertain  -> status='pending', content=draft,  questions=[...]
+    const content =
+      distillation.kind === "confident"
+        ? distillation.content
+        : distillation.draft;
+    const status =
+      distillation.kind === "confident" ? "active" : "pending";
+    const questionsJson =
+      distillation.kind === "uncertain"
+        ? JSON.stringify(distillation.questions)
+        : null;
     if (existing) {
       // Preserve dismissed status; do not auto-revive a thumbs-down.
       await pool.query(
         `UPDATE lessons
             SET content = $1, confidence_n = $2, evidence_session_ids = $3::jsonb,
                 source = CASE WHEN source = 'user-edited' THEN source ELSE 'backfill' END,
-                updated_at = $4
-          WHERE id = $5`,
+                status = CASE WHEN status = 'dismissed' THEN status ELSE $4 END,
+                questions = $5::jsonb,
+                answers = NULL,
+                updated_at = $6
+          WHERE id = $7`,
         [
-          distillation.content,
+          content,
           distillation.confidenceN,
           JSON.stringify(evidence),
+          status,
+          questionsJson,
           now,
           existing.id,
         ],
@@ -360,20 +472,23 @@ async function main() {
     } else {
       await pool.query(
         `INSERT INTO lessons
-            (id, level, scope, content, confidence_n, evidence_session_ids, source, status, created_at, updated_at)
-          VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'backfill', 'active', $7, $7)`,
+            (id, level, scope, content, confidence_n, evidence_session_ids,
+             source, status, questions, answers, created_at, updated_at)
+          VALUES ($1, $2, $3, $4, $5, $6::jsonb, 'backfill', $7, $8::jsonb, NULL, $9, $9)`,
         [
           randomUUID(),
           bucket.level,
           bucket.scope,
-          distillation.content,
+          content,
           distillation.confidenceN,
           JSON.stringify(evidence),
+          status,
+          questionsJson,
           now,
         ],
       );
     }
-    console.log("✓");
+    console.log(distillation.kind === "uncertain" ? "✓ pending" : "✓");
     processed++;
   }
 

--- a/scripts/sample-lesson.mjs
+++ b/scripts/sample-lesson.mjs
@@ -1,0 +1,314 @@
+// Sample one lesson distillation against a real (level, scope) bucket
+// WITHOUT writing to the DB. Use for Hard-Rule validation: see what
+// Haiku produces under the new two-tool prompt before turning it loose
+// on the corpus.
+//
+// Usage on VPS:
+//   docker cp scripts brewlog-app-1:/app/
+//   docker compose exec app node scripts/sample-lesson.mjs <level> <scope>
+//
+// Examples:
+//   node scripts/sample-lesson.mjs coffee rvtc__el_congo_by_carlos_montero___don_eli
+//   node scripts/sample-lesson.mjs roaster "hoppenworth & ploch"
+//   node scripts/sample-lesson.mjs method-style "clever dripper · hub bloom-first clever"
+//   node scripts/sample-lesson.mjs process-roast "natural × light"
+//
+// Output: the Haiku tool call (write_lesson or ask_for_clarification)
+// pretty-printed to stdout. No DB writes. No row mutation. Safe to run
+// dozens of times.
+
+import pg from "pg";
+import { randomUUID } from "crypto";
+
+const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL });
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY;
+if (!ANTHROPIC_API_KEY) {
+  console.error("ANTHROPIC_API_KEY env var missing");
+  process.exit(1);
+}
+
+const [, , levelArg, ...scopeArgs] = process.argv;
+if (!levelArg || scopeArgs.length === 0) {
+  console.error("usage: node scripts/sample-lesson.mjs <level> <scope>");
+  console.error("       level = coffee | roaster | method-style | process-roast");
+  process.exit(1);
+}
+const scopeArg = scopeArgs.join(" ").toLowerCase().trim();
+
+// ─── prompt + tools (mirror of scripts/backfill-lessons.mjs) ────────────
+
+const SYSTEM_PROMPT = `You are BTTS's memory writer. You distill a user's brew history into ONE durable directive per scope — a paragraph a recommendation prompt can quote verbatim months from now.
+
+COFFEE IS MULTIVARIATE. Before assigning blame to a recipe, consider:
+- Bag age (<7d too fresh, 7–21d peak, 22–35d slightly past, 35–60d past peak, 60+ stale)
+- Recipe family (Hoffmann vs Hub vs Kasuya vs Wölfl — different physics, different cups)
+- Water source (clarity blend ~73 ppm vs filtered tap ~220 ppm — buffering differs)
+- Grind drift (Niche calibration shifts over months)
+- Pour technique (agitation level, pulse timing)
+- Roast inconsistency at source — some bags are uneven, not the user's fault
+- Palate fluctuation day to day
+
+ONE TOOL PER TURN.
+
+Call write_lesson when the evidence is clean: 3+ rated brews, a consistent pattern, ONE variable clearly standing out. Be a coach, not a hedger. Reference recipe NAMES (title plus based-on). Paraphrase freeNotes; never quote them.
+
+Call ask_for_clarification when multiple plausible causes could explain the pattern and you need the user to disambiguate. The draft is your best guess as if you'd called write_lesson; the questions are how you'd want to be wrong. Questions must be SPECIFIC — reference the actual brews, the actual dates, the actual ambiguity. Options must be PLAUSIBLE — each one a real explanation the user might endorse, written in their voice. NO generic "Was it the recipe?" questions — name the recipes.
+
+Single bucket, 1 rated brew: usually ask_for_clarification (a single data point cannot support a directive). Use the draft to capture what the brew suggested; use the question to ask whether the user thinks this is a real pattern or a one-off.
+
+Metric units. No emojis. No quotation marks anywhere.`;
+
+const WRITE_LESSON_TOOL = {
+  name: "write_lesson",
+  description:
+    "Use when the evidence is clean: 3+ rated brews, consistent pattern, one variable clearly standing out as the cause. Be a coach issuing a directive. Never call this AND ask_for_clarification in the same turn.",
+  input_schema: {
+    type: "object",
+    properties: {
+      content: { type: "string" },
+      confidence_n: { type: "integer" },
+    },
+    required: ["content", "confidence_n"],
+  },
+};
+
+const ASK_FOR_CLARIFICATION_TOOL = {
+  name: "ask_for_clarification",
+  description:
+    "Use when multiple plausible causes could explain the pattern and you genuinely need the user's input to disambiguate.",
+  input_schema: {
+    type: "object",
+    properties: {
+      draft: { type: "string" },
+      confidence_n: { type: "integer" },
+      questions: {
+        type: "array",
+        minItems: 1,
+        maxItems: 2,
+        items: {
+          type: "object",
+          properties: {
+            prompt: { type: "string" },
+            options: {
+              type: "array",
+              minItems: 2,
+              maxItems: 4,
+              items: { type: "string" },
+            },
+          },
+          required: ["prompt", "options"],
+        },
+      },
+    },
+    required: ["draft", "confidence_n", "questions"],
+  },
+};
+
+// ─── session helpers (mirror of backfill-lessons.mjs) ──────────────────
+
+function resolveBrewedCandidate(session) {
+  const rec = session.recommendation;
+  if (!rec || !Array.isArray(rec.candidates)) return null;
+  const idx = session.brew?.selectedCandidateIdx;
+  if (typeof idx === "number" && rec.candidates[idx]) return rec.candidates[idx];
+  const method = session.brew?.methodUsed;
+  if (method) {
+    const found = rec.candidates.find(
+      (c) => c.method?.toLowerCase() === method.toLowerCase(),
+    );
+    if (found) return found;
+  }
+  return rec.candidates[0] ?? null;
+}
+function brewedRecipe(session) {
+  const cand = resolveBrewedCandidate(session);
+  return cand?.recipe ?? session.recommendation?.primaryRecipe ?? null;
+}
+function brewedRecipeName(candidate) {
+  if (!candidate) return null;
+  const title = candidate.title;
+  const basedOn = candidate.basedOn;
+  if (title && basedOn && basedOn.toLowerCase() !== "own recipe") {
+    return `${title} (based on ${basedOn})`;
+  }
+  return title || null;
+}
+function scopesForSession(session) {
+  const out = [];
+  const coffee = session.coffee;
+  const result = session.result;
+  if (!coffee || !result) return out;
+  const coffeeKey =
+    coffee.coffeeId ??
+    (coffee.roaster && coffee.name
+      ? `${coffee.roaster}__${coffee.name}`.toLowerCase().replace(/[^a-z0-9]/g, "_")
+      : null);
+  if (coffeeKey) out.push({ level: "coffee", scope: coffeeKey, label: `${coffee.roaster} — ${coffee.name}` });
+  if (coffee.roaster) out.push({ level: "roaster", scope: coffee.roaster.toLowerCase().trim(), label: coffee.roaster });
+  const candidate = resolveBrewedCandidate(session);
+  const basedOn = candidate?.basedOn?.trim();
+  const usedMethod = (session.brew?.methodUsed || candidate?.method || "").trim();
+  if (usedMethod && basedOn && basedOn.toLowerCase() !== "own recipe") {
+    out.push({
+      level: "method-style",
+      scope: `${usedMethod} · ${basedOn}`.toLowerCase(),
+      label: `${usedMethod} · ${basedOn}`,
+    });
+  }
+  if (coffee.process && coffee.roastLevel) {
+    out.push({
+      level: "process-roast",
+      scope: `${coffee.process} × ${coffee.roastLevel}`.toLowerCase().trim(),
+      label: `${coffee.process} × ${coffee.roastLevel}`,
+    });
+  }
+  return out;
+}
+function formatSessionsForPrompt(sessionList) {
+  return sessionList
+    .map((s) => {
+      const candidate = resolveBrewedCandidate(s);
+      const recipe = brewedRecipe(s);
+      const method =
+        s.brew?.methodUsed ||
+        candidate?.method ||
+        s.recommendation?.primaryMethod ||
+        "?";
+      const recipeName = brewedRecipeName(candidate);
+      const date = new Date(s.createdAt).toLocaleDateString("en-GB", {
+        day: "numeric",
+        month: "short",
+        year: "numeric",
+      });
+      const rating = s.result?.rating != null ? `${s.result.rating}★` : "unrated";
+      const dose = s.brew?.doseGrams ?? recipe?.doseGrams;
+      const water = s.brew?.waterGrams ?? recipe?.waterGrams;
+      const grind = s.brew?.grindSettingUsed ?? recipe?.grindSize;
+      const temp = s.brew?.actualTempC ?? recipe?.waterTempC;
+      const flavors = s.result?.flavorNotes?.slice(0, 4).join(", ") || "";
+      const free = s.result?.freeNotes
+        ? ` freeNote=${s.result.freeNotes.replace(/\n/g, " ").slice(0, 400)}`
+        : "";
+      const attr = s.result?.attribution ? ` attribution=${s.result.attribution}` : "";
+      const fit = s.result?.fit ? ` fit=${s.result.fit}` : "";
+      const recipeLine = recipeName ? `${method} ${recipeName}` : method;
+      const parts = [];
+      if (dose != null) parts.push(`${dose}g`);
+      if (water != null) parts.push(`${water}g`);
+      if (grind != null && grind !== "") parts.push(typeof grind === "number" ? `${grind}°` : `${grind}`);
+      if (temp != null) parts.push(`${temp}°C`);
+      return `- ${date} · ${rating} · ${recipeLine} · ${parts.join("/")} · [${flavors}]${free}${attr}${fit}`;
+    })
+    .join("\n");
+}
+
+// ─── main ──────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log(`Sampling distillation for ${levelArg}:${scopeArg}\n`);
+
+  // Pull every session that contributes to this (level, scope).
+  const sessRes = await pool.query(
+    `SELECT id, type, mode, created_at, coffee, place, context, recommendation, brew, result
+       FROM sessions
+      ORDER BY created_at_ms DESC`,
+  );
+  const sessions = sessRes.rows
+    .map((r) => ({
+      id: r.id,
+      type: r.type,
+      mode: r.mode,
+      createdAt: r.created_at.toISOString(),
+      coffee: r.coffee,
+      place: r.place ?? undefined,
+      context: r.context ?? undefined,
+      recommendation: r.recommendation ?? undefined,
+      brew: r.brew ?? undefined,
+      result: r.result ?? undefined,
+    }))
+    .filter((s) => s.result);
+
+  const matched = sessions.filter((s) =>
+    scopesForSession(s).some(
+      (x) => x.level === levelArg && x.scope === scopeArg,
+    ),
+  );
+  if (matched.length === 0) {
+    console.error(`✗ no sessions match (${levelArg}, ${scopeArg})`);
+    await pool.end();
+    process.exit(1);
+  }
+  console.log(`Matched ${matched.length} sessions.`);
+
+  // Pull existing lesson for this scope (so Haiku sees it as context).
+  const existingRes = await pool.query(
+    `SELECT content, source, status FROM lessons WHERE level = $1 AND scope = $2 LIMIT 1`,
+    [levelArg, scopeArg],
+  );
+  const existing = existingRes.rows[0];
+  if (existing) {
+    console.log(`Existing lesson (source=${existing.source}, status=${existing.status}):`);
+    console.log(`  ${existing.content}\n`);
+  } else {
+    console.log("No existing lesson for this scope.\n");
+  }
+
+  // Build the user message.
+  const top = matched.slice(0, 30);
+  const userMessage = `Level: ${levelArg}
+Scope: ${scopeArg}
+
+${existing?.content ? `Existing lesson (revise if the new evidence changes it; keep what still holds): ${existing.content}\n\n` : ""}Brews backing this scope (most recent first, max 30):
+${formatSessionsForPrompt(top)}
+
+Choose ONE tool — write_lesson if the signal is clean, ask_for_clarification if it isn't.`;
+
+  console.log("─".repeat(60));
+  console.log("CALLING HAIKU…\n");
+
+  const res = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "x-api-key": ANTHROPIC_API_KEY,
+      "anthropic-version": "2023-06-01",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "claude-haiku-4-5",
+      max_tokens: 1024,
+      system: SYSTEM_PROMPT,
+      tools: [WRITE_LESSON_TOOL, ASK_FOR_CLARIFICATION_TOOL],
+      tool_choice: { type: "auto" },
+      messages: [{ role: "user", content: userMessage }],
+    }),
+  });
+
+  if (!res.ok) {
+    console.error(`✗ haiku ${res.status}: ${await res.text()}`);
+    await pool.end();
+    process.exit(1);
+  }
+  const body = await res.json();
+  const toolBlock = body.content?.find((b) => b.type === "tool_use");
+  if (!toolBlock) {
+    console.error("✗ no tool_use block");
+    console.error(JSON.stringify(body, null, 2));
+    await pool.end();
+    process.exit(1);
+  }
+
+  console.log(`TOOL CALLED: ${toolBlock.name}\n`);
+  console.log("INPUT:");
+  console.log(JSON.stringify(toolBlock.input, null, 2));
+  console.log("");
+  console.log(`stop_reason=${body.stop_reason} · input_tokens=${body.usage?.input_tokens} · output_tokens=${body.usage?.output_tokens}`);
+  console.log("");
+  console.log("NO DB WRITE. Done.");
+
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error("sample failed:", err);
+  process.exit(1);
+});

--- a/src/app/api/lessons/[id]/answer/route.ts
+++ b/src/app/api/lessons/[id]/answer/route.ts
@@ -1,0 +1,83 @@
+/**
+ * POST /api/lessons/[id]/answer
+ *
+ * The user has answered a pending lesson's clarifying questions on the
+ * /lessons page. Body shape:
+ *
+ *   { answers: [{ questionId, selected | null, freeText | null }, ...] }
+ *
+ * Triggers finaliseLessonWithAnswers() — a second Haiku turn that folds
+ * the answers into the draft and commits the final directive. The row
+ * flips from status='pending' to 'active' and the answers are persisted
+ * for audit.
+ *
+ * The endpoint is synchronous (the user is waiting for confirmation,
+ * unlike the fire-and-forget post-brew distillation). Total turn-around
+ * is ~1–2 s for the Haiku call.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { finaliseLessonWithAnswers } from "@/lib/claude/lessons";
+
+const AnswerSchema = z.object({
+  answers: z
+    .array(
+      z.object({
+        questionId: z.string().min(1),
+        selected: z.string().min(1).nullable(),
+        freeText: z.string().max(500).nullable(),
+      }),
+    )
+    .min(1)
+    .max(4),
+});
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const body = await req.json();
+    const parsed = AnswerSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Invalid answer body", details: parsed.error.flatten() },
+        { status: 400 },
+      );
+    }
+    const updated = await finaliseLessonWithAnswers(
+      params.id,
+      parsed.data.answers,
+    );
+    if (!updated) {
+      return NextResponse.json(
+        { error: "Lesson not found, not pending, or Haiku could not finalise." },
+        { status: 409 },
+      );
+    }
+    return NextResponse.json({
+      id: updated.id,
+      level: updated.level,
+      scope: updated.scope,
+      content: updated.content,
+      confidenceN: updated.confidenceN,
+      evidenceSessionIds: updated.evidenceSessionIds,
+      source: updated.source,
+      status: updated.status,
+      userNote: updated.userNote,
+      questions: updated.questions,
+      answers: updated.answers,
+      createdAt: updated.createdAt.toISOString(),
+      updatedAt: updated.updatedAt.toISOString(),
+    });
+  } catch (err) {
+    console.error("lessons answer error:", err);
+    return NextResponse.json(
+      { error: "Failed to finalise lesson" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/lessons/route.ts
+++ b/src/app/api/lessons/route.ts
@@ -93,6 +93,11 @@ export async function GET(req: NextRequest) {
         source: r.source,
         status: r.status,
         userNote: r.userNote,
+        // Migration 0013 — pending lessons carry questions; answered
+        // ones carry answers alongside the questions (preserved for
+        // audit). Both null for legacy 'active' or 'dismissed' rows.
+        questions: r.questions,
+        answers: r.answers,
         createdAt: r.createdAt.toISOString(),
         updatedAt: r.updatedAt.toISOString(),
         coffeeMeta:

--- a/src/lib/claude/lessons.ts
+++ b/src/lib/claude/lessons.ts
@@ -24,7 +24,13 @@ import { and, eq, inArray } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import { lessons, sessions } from "@/lib/db/schema";
 import { rowToSession } from "@/lib/db/helpers";
-import type { LessonLevel, LessonRow, LessonSource } from "@/lib/db/schema";
+import type {
+  LessonAnswer,
+  LessonLevel,
+  LessonQuestion,
+  LessonRow,
+  LessonSource,
+} from "@/lib/db/schema";
 import type { Session } from "@/lib/types/session";
 import { resolveBrewedRecipe, brewedRecipeName } from "@/lib/utils/resolveRecipe";
 
@@ -130,17 +136,38 @@ export async function loadSessionsForScope(
   return filtered.slice(0, limit);
 }
 
-const SYSTEM_PROMPT = `You are BTTS's memory writer. You distill a user's brew history into ONE durable directive — a single short paragraph that a recommendation prompt can quote verbatim months from now.
+const SYSTEM_PROMPT = `You are BTTS's memory writer. You distill a user's brew history into ONE durable directive per scope — a paragraph a recommendation prompt can quote verbatim months from now.
 
-When you call write_lesson, pass:
-- content: ONE paragraph, 1–3 short sentences. A concrete, actionable directive — what to prefer, what to avoid, what to remember. Reference real numbers (ratings, recipe names, methods). If two recipes diverge in outcome, name both. If a freeNote flags a meta-fact about the coffee or roaster (e.g. roasted for espresso, fermented hot, stale), paraphrase it into the directive without using quotation marks. Plain prose, no bullets, no emojis. Metric units only. If you cannot write a concrete directive from the evidence, pass an empty string.
-- confidence_n: integer count of rated brews backing this lesson.
+COFFEE IS MULTIVARIATE. Before assigning blame to a recipe, consider:
+- Bag age (<7d too fresh, 7–21d peak, 22–35d slightly past, 35–60d past peak, 60+ stale)
+- Recipe family (Hoffmann vs Hub vs Kasuya vs Wölfl — different physics, different cups)
+- Water source (clarity blend ~73 ppm vs filtered tap ~220 ppm — buffering differs)
+- Grind drift (Niche calibration shifts over months)
+- Pour technique (agitation level, pulse timing)
+- Roast inconsistency at source — some bags are uneven, not the user's fault
+- Palate fluctuation day to day
 
-Constraints:
-- Prefer "Avoid X" / "Prefer Y" over generic "experiment more".
-- Cite recipe NAMES (the title plus the based-on), not just methods, when distinguishing what worked.
-- Do not use quotation marks anywhere in content — paraphrase rather than quote.
-- No hedging. The user wants a directive, not advice.`;
+ONE TOOL PER TURN.
+
+Call write_lesson when the evidence is clean: 3+ rated brews, a consistent pattern, ONE variable clearly standing out. Be a coach, not a hedger. Reference recipe NAMES (title plus based-on). Paraphrase freeNotes; never quote them.
+
+Call ask_for_clarification when multiple plausible causes could explain the pattern and you need the user to disambiguate. The draft is your best guess as if you'd called write_lesson; the questions are how you'd want to be wrong. Questions must be SPECIFIC — reference the actual brews, the actual dates, the actual ambiguity. Options must be PLAUSIBLE — each one a real explanation the user might endorse, written in their voice. NO generic "Was it the recipe?" questions — name the recipes.
+
+Single bucket, 1 rated brew: usually ask_for_clarification (a single data point cannot support a directive). Use the draft to capture what the brew suggested; use the question to ask whether the user thinks this is a real pattern or a one-off.
+
+Metric units. No emojis. No quotation marks anywhere.`;
+
+const FINALISE_PROMPT = `You previously drafted a lesson and asked the user clarifying questions about this scope. The user has now answered. Incorporate their answers and commit the final directive via write_lesson.
+
+Preserve what was right in the draft. Adjust what the answers contradict. If their answer fundamentally changes your diagnosis (you blamed the recipe but they blame the age), rewrite cleanly to match their understanding — their answer is ground truth.
+
+Same constraints as before: 1–3 short sentences, plain prose, no quotation marks, no emojis, metric units only, reference recipe NAMES.`;
+
+/** Live distiller output: either a confident lesson or an uncertain
+ * draft that needs clarification. upsertLesson() branches on `kind`. */
+export type DistillOutput =
+  | { kind: "confident"; content: string; confidenceN: number }
+  | { kind: "uncertain"; draft: string; confidenceN: number; questions: LessonQuestion[] };
 
 interface DistillResult {
   content: string;
@@ -185,11 +212,80 @@ function formatSessionsForPrompt(sessionList: Session[]): string {
     .join("\n");
 }
 
+/** The two-tool array passed to the Haiku distillation call. Shared with
+ * the backfill script (mirrored there in JS — keep in sync). */
+const DISTILL_TOOLS: Anthropic.Messages.Tool[] = [
+  {
+    name: "write_lesson",
+    description:
+      "Use when the evidence is clean: 3+ rated brews, consistent pattern, one variable clearly standing out as the cause. Be a coach issuing a directive. Never call this AND ask_for_clarification in the same turn.",
+    input_schema: {
+      type: "object",
+      properties: {
+        content: {
+          type: "string",
+          description:
+            "1–3 short sentences, plain prose, no quotation marks. A directive — prefer X / avoid Y / remember Z. Reference recipe NAMES (title plus based-on). Paraphrase freeNotes; never quote them.",
+        },
+        confidence_n: {
+          type: "integer",
+          description: "Number of rated brews backing this lesson.",
+        },
+      },
+      required: ["content", "confidence_n"],
+    },
+  },
+  {
+    name: "ask_for_clarification",
+    description:
+      "Use when multiple plausible causes could explain the pattern and you genuinely need the user's input to disambiguate. Examples: a single bad brew on a 42-day-old bag (recipe vs age?); a method change coinciding with a water source change; inconsistent ratings on the same recipe across weeks. Never call this AND write_lesson in the same turn.",
+    input_schema: {
+      type: "object",
+      properties: {
+        draft: {
+          type: "string",
+          description:
+            "Your tentative directive — what you'd commit if your best guess were correct. The user reads this alongside the questions. Same constraints as write_lesson.content.",
+        },
+        confidence_n: {
+          type: "integer",
+          description: "Number of rated brews backing this draft.",
+        },
+        questions: {
+          type: "array",
+          minItems: 1,
+          maxItems: 2,
+          items: {
+            type: "object",
+            properties: {
+              prompt: {
+                type: "string",
+                description:
+                  "ONE concrete question naming the actual ambiguity. Reference the specific brews, recipe names, and dates. Not generic.",
+              },
+              options: {
+                type: "array",
+                minItems: 2,
+                maxItems: 4,
+                items: { type: "string" },
+                description:
+                  "Plausible explanations the user can tap, written in the user's voice. Each option is a real candidate explanation, not a hedge.",
+              },
+            },
+            required: ["prompt", "options"],
+          },
+        },
+      },
+      required: ["draft", "confidence_n", "questions"],
+    },
+  },
+];
+
 async function callHaikuForDistillation(
   scope: DistillScope,
   sessionList: Session[],
   existing: LessonRow | null,
-): Promise<DistillResult | null> {
+): Promise<DistillOutput | null> {
   const ratedCount = sessionList.filter((s) => s.result?.rating != null).length;
   if (ratedCount === 0) return null;
 
@@ -199,39 +295,118 @@ Scope: ${scope.label}
 ${existing?.content ? `Existing lesson (revise if the new evidence changes it; keep what still holds): ${existing.content}\n\n` : ""}Brews backing this scope (most recent first, max 30):
 ${formatSessionsForPrompt(sessionList)}
 
-Write the updated directive now via write_lesson.`;
+Choose ONE tool — write_lesson if the signal is clean, ask_for_clarification if it isn't.`;
+
+  try {
+    const msg = await client.messages.create({
+      model: "claude-haiku-4-5",
+      max_tokens: 1024,
+      system: SYSTEM_PROMPT,
+      tools: DISTILL_TOOLS,
+      tool_choice: { type: "auto" },
+      messages: [{ role: "user", content: userMessage }],
+    });
+
+    const toolBlock = msg.content.find(
+      (b): b is Anthropic.Messages.ToolUseBlock => b.type === "tool_use",
+    );
+    if (!toolBlock) return null;
+
+    if (toolBlock.name === "write_lesson") {
+      const input = toolBlock.input as {
+        content?: unknown;
+        confidence_n?: unknown;
+      };
+      const content =
+        typeof input.content === "string" ? input.content.trim() : "";
+      const confidenceN =
+        typeof input.confidence_n === "number"
+          ? Math.max(0, Math.floor(input.confidence_n))
+          : ratedCount;
+      if (!content) return null;
+      return { kind: "confident", content, confidenceN };
+    }
+
+    if (toolBlock.name === "ask_for_clarification") {
+      const input = toolBlock.input as {
+        draft?: unknown;
+        confidence_n?: unknown;
+        questions?: unknown;
+      };
+      const draft = typeof input.draft === "string" ? input.draft.trim() : "";
+      const confidenceN =
+        typeof input.confidence_n === "number"
+          ? Math.max(0, Math.floor(input.confidence_n))
+          : ratedCount;
+      const rawQs = Array.isArray(input.questions) ? input.questions : [];
+      const questions: LessonQuestion[] = rawQs.flatMap((q): LessonQuestion[] => {
+        if (!q || typeof q !== "object") return [];
+        const obj = q as { prompt?: unknown; options?: unknown };
+        const prompt = typeof obj.prompt === "string" ? obj.prompt.trim() : "";
+        const options = Array.isArray(obj.options)
+          ? obj.options
+              .filter((o): o is string => typeof o === "string" && o.trim().length > 0)
+              .map((o) => o.trim())
+              .slice(0, 4)
+          : [];
+        if (!prompt || options.length < 2) return [];
+        const lq: LessonQuestion = { id: randomUUID(), prompt, options };
+        return [lq];
+      });
+      if (!draft || questions.length === 0) return null;
+      return { kind: "uncertain", draft, confidenceN, questions };
+    }
+
+    return null;
+  } catch (err) {
+    console.error(`distillLesson(${scope.level}:${scope.scope}) error:`, err);
+    return null;
+  }
+}
+
+/** Second-turn Haiku call: given a pending draft + the user's answers,
+ * finalise the lesson via write_lesson. Used by POST /api/lessons/[id]/answer. */
+async function callHaikuToFinalise(
+  scope: DistillScope,
+  sessionList: Session[],
+  draft: string,
+  questions: LessonQuestion[],
+  answers: LessonAnswer[],
+): Promise<DistillResult | null> {
+  const ratedCount = sessionList.filter((s) => s.result?.rating != null).length;
+
+  const qAndA = questions
+    .map((q) => {
+      const a = answers.find((ans) => ans.questionId === q.id);
+      const answerText = a
+        ? [a.selected, a.freeText].filter(Boolean).join(" — ")
+        : "(no answer)";
+      return `Q: ${q.prompt}\nA: ${answerText}`;
+    })
+    .join("\n\n");
+
+  const userMessage = `Level: ${scope.level}
+Scope: ${scope.label}
+
+Draft you wrote earlier: ${draft}
+
+Brews backing this scope (most recent first, max 30):
+${formatSessionsForPrompt(sessionList)}
+
+User's answers to your clarifying questions:
+${qAndA}
+
+Now commit the final directive via write_lesson.`;
 
   try {
     const msg = await client.messages.create({
       model: "claude-haiku-4-5",
       max_tokens: 600,
-      system: SYSTEM_PROMPT,
-      tools: [
-        {
-          name: "write_lesson",
-          description:
-            "Persist the distilled BTTS lesson for this (level, scope). Always call this tool exactly once.",
-          input_schema: {
-            type: "object",
-            properties: {
-              content: {
-                type: "string",
-                description:
-                  "1–3 short sentences, plain prose, no quotation marks. Empty string if no concrete directive can be drawn from the evidence.",
-              },
-              confidence_n: {
-                type: "integer",
-                description: "Number of rated brews backing this lesson.",
-              },
-            },
-            required: ["content", "confidence_n"],
-          },
-        },
-      ],
+      system: FINALISE_PROMPT,
+      tools: [DISTILL_TOOLS[0]],
       tool_choice: { type: "tool", name: "write_lesson" },
       messages: [{ role: "user", content: userMessage }],
     });
-
     const toolBlock = msg.content.find(
       (b): b is Anthropic.Messages.ToolUseBlock => b.type === "tool_use",
     );
@@ -246,7 +421,7 @@ Write the updated directive now via write_lesson.`;
     if (!content) return null;
     return { content, confidence_n };
   } catch (err) {
-    console.error(`distillLesson(${scope.level}:${scope.scope}) error:`, err);
+    console.error(`finaliseLesson(${scope.level}:${scope.scope}) error:`, err);
     return null;
   }
 }
@@ -260,7 +435,7 @@ Write the updated directive now via write_lesson.`;
  */
 async function upsertLesson(
   scope: DistillScope,
-  result: DistillResult,
+  output: DistillOutput,
   sessionList: Session[],
   source: LessonSource = "auto",
 ): Promise<void> {
@@ -271,45 +446,70 @@ async function upsertLesson(
     .where(and(eq(lessons.level, scope.level), eq(lessons.scope, scope.scope)))
     .limit(1);
   const now = new Date();
+
+  // Decide what content/status to write based on which tool Haiku chose.
+  const content =
+    output.kind === "confident" ? output.content : output.draft;
+  const status: "active" | "pending" =
+    output.kind === "confident" ? "active" : "pending";
+  const questions: LessonQuestion[] | null =
+    output.kind === "uncertain" ? output.questions : null;
+
   if (existing.length === 0) {
     await db.insert(lessons).values({
       id: randomUUID(),
       level: scope.level,
       scope: scope.scope,
-      content: result.content,
-      confidenceN: result.confidence_n,
+      content,
+      confidenceN: output.confidenceN,
       evidenceSessionIds: evidence,
       source,
-      status: "active",
+      status,
+      questions,
+      answers: null,
       createdAt: now,
       updatedAt: now,
     });
-  } else {
-    const row = existing[0];
-    // User-edited rows are sacred — the user explicitly rewrote this
-    // lesson. Auto distillation MUST NOT overwrite their text. Skip
-    // entirely (no content update, no evidence update). Only an explicit
-    // user-edited source coming back in (the PATCH route) can change
-    // the row's content from here on.
-    if (row.source === "user-edited" && source !== "user-edited") return;
-    await db
-      .update(lessons)
-      .set({
-        content: result.content,
-        confidenceN: result.confidence_n,
-        evidenceSessionIds: evidence,
-        // Only escalate source on explicit user edits — leave auto-on-auto alone.
-        source: row.source === "user-edited" ? row.source : source,
-        updatedAt: now,
-      })
-      .where(eq(lessons.id, row.id));
+    return;
   }
+
+  const row = existing[0];
+  // User-edited rows are sacred — the user explicitly rewrote this
+  // lesson. Auto distillation MUST NOT overwrite their text. Skip
+  // entirely. Only an explicit user-edited source coming back in
+  // (the PATCH route) can change the row's content from here on.
+  if (row.source === "user-edited" && source !== "user-edited") return;
+
+  await db
+    .update(lessons)
+    .set({
+      content,
+      confidenceN: output.confidenceN,
+      evidenceSessionIds: evidence,
+      // Only escalate source on explicit user edits — leave auto-on-auto alone.
+      source: row.source === "user-edited" ? row.source : source,
+      status,
+      questions,
+      // Going from pending → confident means the answers are now stale —
+      // null them out. Going confident → confident keeps answers as null.
+      // Going pending → pending replaces with new questions, so old
+      // answers are invalid: null them out too.
+      answers: null,
+      updatedAt: now,
+    })
+    .where(eq(lessons.id, row.id));
 }
 
 /**
  * Distill all four scopes for a single session. Called from POST
  * /api/sessions in a fire-and-forget after the response is sent — never
  * blocks the save. Returns the number of lessons upserted.
+ *
+ * Skips:
+ *   - low-signal brews (isHighSignal gate)
+ *   - user-edited rows (the user's text is the truth)
+ *   - pending rows (the user is mid-answer; don't yank the questions
+ *     out from under them with a new auto run)
  */
 export async function distillLessonsForSession(session: Session): Promise<number> {
   if (!isHighSignal(session)) return 0;
@@ -326,9 +526,8 @@ export async function distillLessonsForSession(session: Session): Promise<number
         .where(and(eq(lessons.level, scope.level), eq(lessons.scope, scope.scope)))
         .limit(1);
       const existing = existingRows[0] ?? null;
-      // User has explicitly rewritten this lesson — don't even call
-      // Haiku. Their text is the truth. Saves an API call too.
       if (existing?.source === "user-edited") return false;
+      if (existing?.status === "pending") return false;
       const distillation = await callHaikuForDistillation(
         scope,
         sessionList,
@@ -362,10 +561,78 @@ export async function distillLessonForScope(
     .limit(1);
   const existing = existingRows[0] ?? null;
   if (existing?.source === "user-edited") return false;
+  if (existing?.status === "pending") return false;
   const distillation = await callHaikuForDistillation(scope, sessionList, existing);
   if (!distillation) return false;
   await upsertLesson(scope, distillation, sessionList, source);
   return true;
+}
+
+/**
+ * Finalise a pending lesson now that the user has answered the
+ * clarifying questions. Called from POST /api/lessons/[id]/answer.
+ *
+ * Runs a second Haiku turn (single-tool, write_lesson forced) with the
+ * draft + questions + user's answers. Updates the row in place:
+ *   - content = final directive from the second turn
+ *   - status  = 'active'
+ *   - answers = stored (kept for audit, surfaced on the page)
+ *   - questions kept (so the page can show "you answered X to Y")
+ *
+ * Returns the updated row, or null if Haiku couldn't produce a final
+ * content (caller can re-prompt or surface the error).
+ */
+export async function finaliseLessonWithAnswers(
+  lessonId: string,
+  answers: LessonAnswer[],
+): Promise<LessonRow | null> {
+  const existingRows = await db
+    .select()
+    .from(lessons)
+    .where(eq(lessons.id, lessonId))
+    .limit(1);
+  const row = existingRows[0];
+  if (!row) return null;
+  if (row.status !== "pending") return null;
+  if (!row.questions || row.questions.length === 0) return null;
+
+  const scope: DistillScope = {
+    level: row.level,
+    scope: row.scope,
+    label: row.scope, // best we can do without re-resolving — Haiku still sees full session detail
+  };
+  const sessionList = await loadSessionsForScope(scope);
+
+  const finalised = await callHaikuToFinalise(
+    scope,
+    sessionList,
+    row.content,
+    row.questions,
+    answers,
+  );
+  if (!finalised) return null;
+
+  const now = new Date();
+  await db
+    .update(lessons)
+    .set({
+      content: finalised.content,
+      confidenceN: finalised.confidence_n,
+      status: "active",
+      answers,
+      // questions preserved for audit. source stays whatever it was
+      // (typically 'auto' or 'backfill'); the user didn't write the
+      // content themselves, they just answered.
+      updatedAt: now,
+    })
+    .where(eq(lessons.id, lessonId));
+
+  const refreshed = await db
+    .select()
+    .from(lessons)
+    .where(eq(lessons.id, lessonId))
+    .limit(1);
+  return refreshed[0] ?? null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Step 2 of 3 for the ask-before-rating lessons flow. **Behavioural change** — Haiku now picks per-scope between writing a confident directive and asking the user clarifying questions BEFORE committing. The /lessons page UI is unchanged in this PR (Step 3 adds the Pending section); `/recommend` already filters to `status='active'` so pending lessons are auto-excluded from recommendations.

## ⚠️ DO NOT MERGE WITHOUT SAMPLING

Per the validate-before-changing-AI-behavior Hard Rule in `CLAUDE.md`: this is a meaningful prompt rewrite. Sample 2–3 buckets first using `scripts/sample-lesson.mjs` (no DB writes), look at the output, then decide whether to merge.

## What changes

**Distillation prompt rewrite** — now leads with the COFFEE IS MULTIVARIATE block (bag age curve, recipe-family physics, water source buffering, grind drift, pour technique, roast inconsistency, palate fluctuation). Single-brew buckets are explicitly steered toward `ask_for_clarification` because one data point cannot support a directive.

**Two-tool pattern** (`tool_choice: { type: "auto" }`):
- `write_lesson` — content + confidence_n, unchanged shape
- `ask_for_clarification` — draft + confidence_n + questions[1..2], each with prompt + options[2..4]. Question ids generated server-side.

**Persistence** — `upsertLesson` branches:
- confident → `status='active'`, content=content, questions=null
- uncertain → `status='pending'`, content=draft, questions=[…]
- User-edited rows still bail before the Haiku call (sacred).
- Pending rows ALSO bail — don't yank questions out from under the user mid-answer.

**`finaliseLessonWithAnswers()`** — second Haiku turn (single tool, `write_lesson` forced) with draft + questions + user answers. Commits the final directive, flips status to `'active'`, persists the answers for audit.

**New endpoint** `POST /api/lessons/[id]/answer` — Zod-validated, synchronous, 60s timeout.

**`GET /api/lessons` response** now includes `questions` + `answers` so Step 3 can render the pending state.

**Backfill script** mirrors the two-tool pattern. Pending buckets are skipped on re-runs (same gate as live).

**`scripts/sample-lesson.mjs`** — preview the new prompt on real buckets WITHOUT writing to DB. Hard-Rule discipline.

## How to sample

```bash
cd /opt/brewlog && git fetch origin claude/lessons-questions-haiku-v2
git show origin/claude/lessons-questions-haiku-v2:scripts/sample-lesson.mjs > /tmp/sample-lesson.mjs
docker cp /tmp/sample-lesson.mjs brewlog-app-1:/app/scripts/sample-lesson.mjs

# Three representative buckets:
docker compose exec app node scripts/sample-lesson.mjs coffee rvtc__el_congo_by_carlos_montero___don_eli
docker compose exec app node scripts/sample-lesson.mjs roaster "hoppenworth & ploch"
docker compose exec app node scripts/sample-lesson.mjs process-roast "honey × light"
```

Each call prints:
- which tool was called (`write_lesson` confident vs `ask_for_clarification` uncertain)
- the full input shape (content / draft / questions / options)
- token usage

Paste the output back and we look at it together. **If the question quality is good (specific, names recipes, plausible options) we merge. If it's generic mush, I tune the prompt.**

## What's untouched

- `/recommend` — pending lessons already excluded via `status='active'` filter; no change.
- `/lessons` page UI — still doesn't render the Pending section; Step 3.
- Existing 51 lessons on prod — unchanged (re-distillation only happens on new strong-signal brews; backfill rerun is a separate step you can decide on after Step 3).

## Test plan

- [ ] `sample-lesson.mjs` runs without error against 3 buckets.
- [ ] Output quality reviewed before merge.
- [ ] After merge + deploy, log a 1★ brew with freeNotes — confirm a pending lesson is created (or a confident one, if Haiku decides the signal is clean).
- [ ] After Step 3 ships and the Pending UI is live, answer a pending question; confirm the row transitions to `'active'` with finalised content.

https://claude.ai/code/session_01N5x8F1Ssu5UiQJJkQrJzre

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5x8F1Ssu5UiQJJkQrJzre)_