### PR TITLE
feat(lessons): Pending UI — answer the clarifying questions inline

### DIFF
--- a/src/app/(light)/lessons/page.tsx
+++ b/src/app/(light)/lessons/page.tsx
@@ -25,12 +25,24 @@ import CoffeeBeanGlow from "@/components/ui/light/CoffeeBeanGlow";
 
 type Level = "coffee" | "roaster" | "method-style" | "process-roast";
 type Source = "auto" | "user-confirmed" | "user-edited" | "backfill";
-type Status = "active" | "dismissed";
+type Status = "active" | "dismissed" | "pending";
 
 interface CoffeeMeta {
   inRotation: boolean;
   roaster: string;
   name: string;
+}
+
+interface LessonQuestion {
+  id: string;
+  prompt: string;
+  options: string[];
+}
+
+interface LessonAnswer {
+  questionId: string;
+  selected: string | null;
+  freeText: string | null;
 }
 
 interface Lesson {
@@ -47,6 +59,10 @@ interface Lesson {
   updatedAt: string;
   /** Present only for level='coffee'; null when the coffees row is missing. */
   coffeeMeta?: CoffeeMeta | null;
+  /** Populated when status='pending' — Haiku's clarifying questions. */
+  questions?: LessonQuestion[] | null;
+  /** Populated once finalised — preserved for audit. */
+  answers?: LessonAnswer[] | null;
 }
 
 const LEVEL_TITLES: Record<Level, string> = {
@@ -144,7 +160,45 @@ export default function LessonsPage() {
     }
   };
 
-  const active = (lessons ?? []).filter((l) => l.status !== "dismissed");
+  /**
+   * Answer a pending lesson — POST to the finalisation endpoint which
+   * runs a second Haiku turn folding the answers into the draft and
+   * flipping status pending → active. The response is the finalised
+   * row; we replace the local lesson with it so the card transitions
+   * out of the Pending section into the relevant level section.
+   *
+   * Returns true on success so the card can clear its local state.
+   */
+  const handleAnswer = async (
+    id: string,
+    answers: LessonAnswer[],
+  ): Promise<boolean> => {
+    try {
+      const res = await fetch(`/api/lessons/${id}/answer`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ answers }),
+      });
+      if (!res.ok) return false;
+      const updated: Lesson = await res.json();
+      // The API returns the row without the coffeeMeta join; preserve
+      // ours so coffee-level cards keep their friendly name + rotation
+      // status after answering.
+      setLessons((prev) =>
+        prev?.map((l) =>
+          l.id === id ? { ...updated, coffeeMeta: l.coffeeMeta } : l,
+        ) ?? prev,
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  const pending = (lessons ?? []).filter((l) => l.status === "pending");
+  const active = (lessons ?? []).filter(
+    (l) => l.status !== "dismissed" && l.status !== "pending",
+  );
   const dismissed = (lessons ?? []).filter((l) => l.status === "dismissed");
   const groupedActive: Record<Level, Lesson[]> = {
     coffee: [],
@@ -221,6 +275,19 @@ export default function LessonsPage() {
         </div>
       ) : (
         <div className="flex-1 px-5 pb-20 space-y-10">
+          {/* Pending section — pinned to the top. Visually distinct
+              (dashed border on the cards) so the user knows BTTS is
+              waiting on their input. Skipped entirely when empty so
+              the page doesn't show a hollow "Awaiting your input (0)"
+              header. */}
+          {pending.length > 0 && (
+            <PendingSection
+              lessons={pending}
+              onAnswer={handleAnswer}
+              onDismiss={handleDismiss}
+            />
+          )}
+
           {LEVEL_ORDER.map((lvl) => {
             if (lvl === "coffee") {
               return (
@@ -529,4 +596,220 @@ function SourcePill({ source }: { source: Source }) {
           ? "from history"
           : "auto";
   return <span className="text-[11px] text-light-muted-foreground">{label}</span>;
+}
+
+function PendingSection({
+  lessons,
+  onAnswer,
+  onDismiss,
+}: {
+  lessons: Lesson[];
+  onAnswer: (id: string, answers: LessonAnswer[]) => Promise<boolean>;
+  onDismiss: (id: string) => void;
+}) {
+  return (
+    <section>
+      <div className="flex items-baseline justify-between mb-2 px-1">
+        <p className="text-light-muted-foreground text-xs tracking-widest uppercase">
+          Awaiting your input
+        </p>
+        <span className="text-light-muted-foreground/70 text-xs">
+          {lessons.length}
+        </span>
+      </div>
+      <p className="text-light-muted-foreground text-xs leading-relaxed mb-3 px-1">
+        BTTS drafted these but couldn&rsquo;t commit them on its own. Your
+        answer becomes the lesson and ships into /recommend.
+      </p>
+      <div className="space-y-3">
+        {lessons.map((l) => (
+          <PendingLessonCard
+            key={l.id}
+            lesson={l}
+            onAnswer={onAnswer}
+            onDismiss={onDismiss}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/** A single picked answer in the card's local state. selected holds the
+ * chosen prefab option; useFreeText flips to true when the user taps
+ * "Other…" and starts typing. On submit one of the two is converted to
+ * the API's selected / freeText fields. */
+interface LocalPick {
+  selected: string | null;
+  freeText: string;
+  useFreeText: boolean;
+}
+
+function PendingLessonCard({
+  lesson,
+  onAnswer,
+  onDismiss,
+}: {
+  lesson: Lesson;
+  onAnswer: (id: string, answers: LessonAnswer[]) => Promise<boolean>;
+  onDismiss: (id: string) => void;
+}) {
+  const questions = lesson.questions ?? [];
+  const [picks, setPicks] = useState<Record<string, LocalPick>>(() =>
+    Object.fromEntries(
+      questions.map((q) => [
+        q.id,
+        { selected: null, freeText: "", useFreeText: false },
+      ]),
+    ),
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(false);
+
+  const setPick = (qid: string, patch: Partial<LocalPick>) =>
+    setPicks((prev) => ({ ...prev, [qid]: { ...prev[qid], ...patch } }));
+
+  const allAnswered = questions.every((q) => {
+    const p = picks[q.id];
+    if (!p) return false;
+    return p.useFreeText ? p.freeText.trim().length > 0 : p.selected != null;
+  });
+
+  const handleSubmit = async () => {
+    if (!allAnswered || submitting) return;
+    setSubmitting(true);
+    setError(false);
+    const answers: LessonAnswer[] = questions.map((q) => {
+      const p = picks[q.id];
+      return {
+        questionId: q.id,
+        selected: p.useFreeText ? null : p.selected,
+        freeText: p.useFreeText ? p.freeText.trim() : null,
+      };
+    });
+    const ok = await onAnswer(lesson.id, answers);
+    if (!ok) {
+      setSubmitting(false);
+      setError(true);
+    }
+    // On success the parent replaces this lesson in state, so this
+    // component unmounts — no need to clear submitting locally.
+  };
+
+  return (
+    <div className="rounded-2xl border border-dashed border-light-foreground/40 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 px-4 py-3.5">
+      <p className="text-light-muted-foreground text-xs mb-1.5 leading-tight">
+        {lesson.coffeeMeta
+          ? `${lesson.coffeeMeta.roaster} — ${lesson.coffeeMeta.name}${lesson.coffeeMeta.inRotation ? "" : " · archived"}`
+          : lesson.scope}
+      </p>
+
+      {/* Draft — italic + muted so it reads as provisional. */}
+      <p className="text-light-foreground/75 text-sm leading-relaxed italic mb-3">
+        Draft: {lesson.content}
+      </p>
+
+      {/* Questions stack. Each renders prompt + prefab buttons + Other
+          affordance. Submit enables when every question has an answer. */}
+      <div className="space-y-4">
+        {questions.map((q) => {
+          const p = picks[q.id];
+          return (
+            <div key={q.id}>
+              <p className="text-light-foreground text-sm leading-snug mb-2">
+                {q.prompt}
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {q.options.map((opt) => {
+                  const isSelected = !p?.useFreeText && p?.selected === opt;
+                  return (
+                    <button
+                      key={opt}
+                      type="button"
+                      onClick={() =>
+                        setPick(q.id, {
+                          selected: opt,
+                          useFreeText: false,
+                          freeText: "",
+                        })
+                      }
+                      className={`inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight backdrop-blur-light-card backdrop-saturate-150 border transition-all ${
+                        isSelected
+                          ? "bg-light-foreground text-[hsl(36_55%_96%)] border-light-foreground"
+                          : "bg-light-card-default text-light-foreground border-light-foreground/15"
+                      }`}
+                    >
+                      {opt}
+                    </button>
+                  );
+                })}
+                {p?.useFreeText ? (
+                  <input
+                    type="text"
+                    value={p.freeText}
+                    onChange={(e) =>
+                      setPick(q.id, { freeText: e.target.value })
+                    }
+                    onBlur={() => {
+                      // Treat an empty Other field as "I changed my mind" —
+                      // collapse back to button row so allAnswered re-checks.
+                      if (p.freeText.trim() === "") {
+                        setPick(q.id, { useFreeText: false });
+                      }
+                    }}
+                    placeholder="Tell BTTS in your own words…"
+                    autoFocus
+                    className="flex-1 min-w-[180px] rounded-full border border-light-foreground/30 bg-transparent text-light-foreground text-[12px] px-3 py-1.5 focus:outline-none focus:border-light-foreground/60"
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setPick(q.id, { useFreeText: true, selected: null })
+                    }
+                    className="inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight border border-dashed border-light-foreground/40 text-light-muted-foreground"
+                  >
+                    Other…
+                  </button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center justify-between gap-3 mt-4">
+        <div className="flex items-center gap-2 flex-wrap text-[11px] text-light-muted-foreground">
+          <span>n={lesson.confidenceN}</span>
+          <span aria-hidden>·</span>
+          <span>awaiting answer</span>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => onDismiss(lesson.id)}
+            disabled={submitting}
+            className="text-light-muted-foreground text-xs hover:text-[hsl(12_70%_45%)] transition-colors disabled:opacity-50"
+          >
+            Dismiss
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!allAnswered || submitting}
+            className="rounded-full bg-light-foreground text-[hsl(36_55%_96%)] text-xs font-medium px-3 py-1.5 active:scale-[0.98] transition-transform disabled:opacity-40"
+          >
+            {submitting ? "Working…" : "Submit"}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <p className="text-[11px] text-[hsl(12_70%_45%)] mt-2">
+          Couldn&rsquo;t finalise. Tap Submit to retry.
+        </p>
+      )}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

Step 3 of 3 — closes the question loop. The user can now SEE BTTS's draft + clarifying questions inline on `/lessons` and answer them in two taps.

## What changes

**`PendingSection`** — new section pinned to the top of `/lessons` (only renders when there are pending lessons). "Awaiting your input" eyebrow + one-line blurb. Sits ABOVE the four level sections so drafts + questions are the first thing the user sees.

**`PendingLessonCard`** — visually distinct from `LessonCard` by a dashed border (signals "not committed yet"). Renders:

- Scope label (uses `coffeeMeta` friendly name when available)
- Draft (italic + muted, prefixed "Draft:") — Haiku's tentative directive
- Question stack — per question:
  - Prompt
  - 2–4 prefab option chips. Selected = inverted anthracite; unselected = cream-glass.
  - **"Other…"** dashed chip that expands to a full-width text input. Blur-with-empty collapses back to chips.
- Footer: `n=X · awaiting answer` on the left; **Dismiss** + **Submit** on the right. Submit disabled until every question has an answer.

**Submit flow:**

1. `handleAnswer` POSTs to `/api/lessons/[id]/answer` with `LessonAnswer[]`.
2. The endpoint (already shipped Step 2) runs Haiku's finalisation turn and returns the updated row.
3. The page replaces the lesson in local state (preserving `coffeeMeta` since the answer endpoint doesn't re-join the coffees table).
4. The card unmounts from `PendingSection` and re-mounts in the matching level section as a normal active card.

**Failure path:** error surface "Couldn't finalise. Tap Submit to retry." The user's picks are preserved.

## No schema / no API change

The `/api/lessons/[id]/answer` endpoint and the `GET /api/lessons` questions/answers response shape were already shipped in Step 2. This PR is purely the UI catching up.

## Test plan

- [ ] Log a high-signal brew that Haiku decides to ask about (≤2★ or ≥4★ with multiple plausible causes). Confirm a pending card appears at the top of `/lessons` with a dashed border.
- [ ] Tap an option for each question. Confirm Submit becomes active only when ALL questions are answered.
- [ ] Tap "Other…" — confirm the input appears, focused. Type, then submit.
- [ ] Submit. Confirm: the card disappears from Pending and a new active card appears in the matching level section with Haiku's finalised content.
- [ ] On a pending card, tap Dismiss. Confirm it moves to the Dismissed drawer.
- [ ] Force a network failure on submit (offline mode). Confirm the "Couldn't finalise" error appears and the picks are preserved for retry.

https://claude.ai/code/session_01N5x8F1Ssu5UiQJJkQrJzre

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5x8F1Ssu5UiQJJkQrJzre)_