### PR TITLE
fix(lessons): pattern thresholds per level, not single-rating triggers

### DIFF
--- a/scripts/backfill-lessons.mjs
+++ b/scripts/backfill-lessons.mjs
@@ -395,10 +395,39 @@ async function main() {
   let errors = 0;
 
   for (const bucket of buckets.values()) {
-    const ratedCount = bucket.sessions.filter((s) => s.result?.rating != null).length;
-    if (ratedCount === 0) {
+    const rated = bucket.sessions.filter((s) => typeof s.result?.rating === "number");
+
+    // Pattern threshold gate — mirror of meetsPatternThreshold() in
+    // src/lib/claude/lessons.ts. Keep in sync if the live gate moves.
+    //   coffee         ≥3 rated brews
+    //   roaster        ≥3 rated brews AND ≥2 different coffees
+    //   method-style   ≥3 rated brews
+    //   process-roast  ≥3 rated brews AND ≥2 different coffees
+    if (rated.length < 3) {
+      console.log(`  ⏭  ${bucket.level}:${bucket.scope} (${rated.length} brews — below threshold)`);
       skipped++;
       continue;
+    }
+    if (bucket.level === "roaster" || bucket.level === "process-roast") {
+      const uniqueCoffees = new Set(
+        rated
+          .map((s) => {
+            const c = s.coffee;
+            if (!c) return null;
+            return (
+              c.coffeeId ??
+              (c.roaster && c.name
+                ? `${c.roaster}__${c.name}`.toLowerCase()
+                : null)
+            );
+          })
+          .filter((x) => x !== null),
+      );
+      if (uniqueCoffees.size < 2) {
+        console.log(`  ⏭  ${bucket.level}:${bucket.scope} (only ${uniqueCoffees.size} coffee${uniqueCoffees.size === 1 ? "" : "s"} — need ≥2 for ${bucket.level})`);
+        skipped++;
+        continue;
+      }
     }
 
     // Pull existing row to feed Haiku and to honour user-edited rows.

--- a/src/lib/claude/lessons.ts
+++ b/src/lib/claude/lessons.ts
@@ -116,16 +116,53 @@ export function scopesForSession(session: Session): DistillScope[] {
 }
 
 /**
- * High-signal heuristic. Only brews carrying useful information move the
- * lessons forward — running Haiku on every neutral 3★ no-note brew is
- * waste.
+ * Pattern gate. Different from the old isHighSignal — we no longer
+ * trigger on individual extreme ratings. Lessons emerge only when
+ * there's enough DATA in a scope to see a pattern, not when one brew
+ * was hot or cold.
+ *
+ * Per-level thresholds:
+ *   coffee         ≥3 rated brews of this bag
+ *   roaster        ≥3 rated brews AND ≥2 different coffees from this roaster
+ *   method-style   ≥3 rated brews using this recipe family
+ *   process-roast  ≥3 rated brews AND ≥2 different coffees
+ *
+ * Below the gate: no lesson, no questions, nothing. A single brew of a
+ * new roaster does NOT generate a roaster-level lesson. Two brews of
+ * one coffee from a new roaster do NOT generate a roaster-level lesson
+ * either — that's pattern-matching one bag's quirks onto a whole
+ * brand. The threshold protects against that.
+ *
+ * All ratings count (3, 3.5, etc.) — the gate is sample size, not
+ * extremity. A coffee that consistently lands at 3.5 IS a pattern
+ * worth noting once we have ≥3 brews of it.
  */
-export function isHighSignal(session: Session): boolean {
-  const r = session.result;
-  if (!r) return false;
-  if (typeof r.rating === "number" && (r.rating <= 2 || r.rating >= 4)) return true;
-  if (r.freeNotes && r.freeNotes.trim().length > 8) return true;
-  return false;
+export function meetsPatternThreshold(
+  scope: DistillScope,
+  sessionList: Session[],
+): boolean {
+  const rated = sessionList.filter((s) => typeof s.result?.rating === "number");
+  if (rated.length < 3) return false;
+
+  if (scope.level === "roaster" || scope.level === "process-roast") {
+    const uniqueCoffees = new Set(
+      rated
+        .map((s) => {
+          const c = s.coffee;
+          if (!c) return null;
+          return (
+            c.coffeeId ??
+            (c.roaster && c.name
+              ? `${c.roaster}__${c.name}`.toLowerCase()
+              : null)
+          );
+        })
+        .filter((x): x is string => x !== null),
+    );
+    if (uniqueCoffees.size < 2) return false;
+  }
+
+  return true;
 }
 
 /**
@@ -171,7 +208,7 @@ write_lesson when the evidence is clean: 3+ rated brews, a consistent pattern, O
 
 ask_for_clarification when multiple plausible causes could explain the pattern. Draft = your best guess as if you'd called write_lesson; questions = how you'd want to be wrong. Questions must be SPECIFIC — name the brews, the dates, the recipes, the candidate causes. Options must be PLAUSIBLE — each one a real explanation written in the user's voice, not a placeholder. NO generic "Was it the recipe?" — name the recipes. NO generic "Was it the age?" — name the day count and what shifts in that window per the freshness curve above.
 
-Single bucket, 1 rated brew: usually ask_for_clarification. One data point cannot support a directive. Use the draft to record what the brew suggested; use the question to ask whether this is a pattern or a one-off.
+Every scope you see has already passed a sample-size gate (≥3 brews, and ≥2 different coffees for roaster / process-roast). Below-threshold scopes never reach you. So you do NOT need to caveat that a single brew is too small to call — by the time you're asked, the data is there.
 
 Metric units. No emojis. No quotation marks anywhere in your output. Output prose, not bullet lists.`;
 
@@ -657,21 +694,25 @@ async function upsertLesson(
  * /api/sessions in a fire-and-forget after the response is sent — never
  * blocks the save. Returns the number of lessons upserted.
  *
- * Skips:
- *   - low-signal brews (isHighSignal gate)
+ * Skips per scope:
+ *   - below the pattern threshold (see meetsPatternThreshold)
  *   - user-edited rows (the user's text is the truth)
  *   - pending rows (the user is mid-answer; don't yank the questions
  *     out from under them with a new auto run)
+ *
+ * The OLD per-session "is this rating extreme enough to count" gate is
+ * gone. Lessons emerge from sample-size now, not from any single brew
+ * being hot or cold. A 3.5★ brew counts the same as a 5★ once the
+ * threshold is met.
  */
 export async function distillLessonsForSession(session: Session): Promise<number> {
-  if (!isHighSignal(session)) return 0;
   const scopes = scopesForSession(session);
   if (scopes.length === 0) return 0;
 
   const results = await Promise.allSettled(
     scopes.map(async (scope) => {
       const sessionList = await loadSessionsForScope(scope);
-      if (sessionList.length === 0) return false;
+      if (!meetsPatternThreshold(scope, sessionList)) return false;
       const existingRows = await db
         .select()
         .from(lessons)
@@ -705,7 +746,7 @@ export async function distillLessonForScope(
   source: LessonSource = "backfill",
 ): Promise<boolean> {
   const sessionList = await loadSessionsForScope(scope);
-  if (sessionList.length === 0) return false;
+  if (!meetsPatternThreshold(scope, sessionList)) return false;
   const existingRows = await db
     .select()
     .from(lessons)


### PR DESCRIPTION
## Summary

Two fixes to stop the lessons-from-noise problem:

1. **3.5★ now counts.** The old gate only fired on ≤2★ or ≥4★. A consistent 3.5★ coffee was invisible — even though "this coffee always lands at 3.5★" IS a pattern. Gone.
2. **No more roaster-level lessons from a single coffee.** Previously, 2 brews of one bag from a new roaster triggered a roaster-level directive — pattern-matching one bag's quirks onto the whole brand.

## New gate: pattern-size, not rating extremity

| Level | Threshold |
|---|---|
| Coffee | ≥3 rated brews of this bag |
| Roaster | ≥3 rated brews **AND** ≥2 different coffees from this roaster |
| Recipe family | ≥3 rated brews using this recipe family |
| Process × roast | ≥3 rated brews **AND** ≥2 different coffees |

Below threshold → no lesson, no questions, nothing. `isHighSignal` is replaced by `meetsPatternThreshold(scope, sessionList)`. Applied at both entry points (`distillLessonsForSession` + `distillLessonForScope`) and mirrored in `scripts/backfill-lessons.mjs`.

`SYSTEM_PROMPT` updated — Haiku no longer needs to caveat about small N, because every scope it sees has already passed the gate.

## Required after merge — wipe the stale lessons

The existing 51 lessons include some from coffees not brewed in 2+ months, plus roaster-level rows that wouldn't pass the new gate. Drop them so the new system starts clean and `/recommend` stops citing stale patterns.

On the VPS, per the Hard Rule (count first, then delete):

```bash
cd /opt/brewlog
echo "SELECT count(*) FROM lessons;" | docker compose exec -T postgres psql -U brewlog -d brewlog
# should print ~51 — confirm before next step
echo "DELETE FROM lessons;"            | docker compose exec -T postgres psql -U brewlog -d brewlog
```

After that, `/lessons` is empty. The page shows the "No lessons yet…" empty state. Next strong-data brew that crosses a threshold writes the first new one.

## Test plan

- [ ] After wipe + deploy: `/lessons` shows empty state.
- [ ] Log a brew on a coffee with 0 existing rated brews → no lesson appears.
- [ ] Log a 2nd brew → still no coffee-level lesson.
- [ ] Log a 3rd → coffee-level lesson appears.
- [ ] Log 3 brews of 1 coffee from a new roaster → coffee-level lesson appears, but NO roaster-level lesson (only 1 unique coffee).
- [ ] Log a brew of a 2nd coffee from the same roaster (now ≥3 brews total + ≥2 coffees) → roaster-level lesson appears.

https://claude.ai/code/session_01N5x8F1Ssu5UiQJJkQrJzre

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5x8F1Ssu5UiQJJkQrJzre)_