### PR TITLE
feat(coach): 3-action workflow + per-coffee card + /taste always-visible stats + brew detail 2×2

### DIFF
--- a/src/app/(light)/brew/[id]/page.tsx
+++ b/src/app/(light)/brew/[id]/page.tsx
@@ -185,25 +185,26 @@ export default function SessionDetailPage() {
         </div>
       )}
 
-      {/* Recipe */}
+      {/* Recipe — 2×2 stat grid (Dose | Grind on row 1, Water | Temp on
+          row 2). When grind is missing the cell stays empty rather than
+          collapsing the layout. Iced brews get an additional 2-up row
+          underneath for Ice + Final cup. */}
       {recipe && (
         <Section title="Recipe">
-          <div className="grid grid-cols-3 gap-3">
-            <Stat label="Dose" value={`${recipe.doseGrams}g`} />
-            <Stat label={recipe.iceGrams ? "Hot Water" : "Water"} value={`${recipe.waterGrams}g`} />
-            <Stat label="Temp" value={`${recipe.waterTempC}°C`} />
-          </div>
           {(() => {
             const grind = brew?.grindSettingUsed ?? recipe.grindSize;
             const grindLabel = grind
               ? typeof grind === "number"
                 ? `${grind}°`
                 : grind
-              : null;
-            if (!grindLabel) return null;
+              : "—";
+            const waterLabel = recipe.iceGrams ? "Hot Water" : "Water";
             return (
-              <div className="grid grid-cols-1 gap-3 mt-3">
+              <div className="grid grid-cols-2 gap-3">
+                <Stat label="Dose" value={`${recipe.doseGrams}g`} />
                 <Stat label="Grind" value={grindLabel} />
+                <Stat label={waterLabel} value={`${recipe.waterGrams}g`} />
+                <Stat label="Temp" value={`${recipe.waterTempC}°C`} />
               </div>
             );
           })()}

--- a/src/app/(light)/coffees/[id]/page.tsx
+++ b/src/app/(light)/coffees/[id]/page.tsx
@@ -9,6 +9,7 @@ import StarRating from "@/components/ui/light/StarRating";
 import CoffeeBeanGlow from "@/components/ui/light/CoffeeBeanGlow";
 import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
 import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
+import { CoffeeCoachCard } from "@/components/coach/CoachCard";
 import { useFieldConfig } from "@/lib/field/FieldContext";
 import { rememberSessionField } from "@/lib/field/cache";
 import { useOnline } from "@/hooks/useOnline";
@@ -401,6 +402,19 @@ export default function CoffeeDetailPage() {
           ) : null}
         </div>
       )}
+
+      {/* Coach card — single most-relevant insight for this coffee.
+          Rotation-only: out-of-rotation pages stay clean. Filters by
+          attribute overlap (variety / process / origin / roast / method)
+          and prefers 'trying' over 'new' rows. */}
+      <CoffeeCoachCard
+        inRotation={!!coffee.inRotation}
+        variety={variety}
+        process={process}
+        origin={origin}
+        roastLevel={roastLevel}
+        method={coffee.bestMethod}
+      />
 
       {/* Personal notes */}
       <div className="px-5 py-4 border-b border-light-foreground/15">

--- a/src/app/(light)/taste/page.tsx
+++ b/src/app/(light)/taste/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
-import { Menu, ChevronDown } from "lucide-react";
+import { Menu } from "lucide-react";
 import type { Session } from "@/lib/types/session";
 import { SCA_CATEGORIES, flavorCategory } from "@/lib/constants/scaFlavorWheel";
 import FlavorWheel from "@/components/ui/FlavorWheel";
@@ -8,23 +8,26 @@ import CoffeeBeanGlow from "@/components/ui/light/CoffeeBeanGlow";
 import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
 
 /**
- * Taste Profile — coach-first edition.
+ * Taste Profile — coach + always-visible consumption stats.
  *
- * Replaces the previous narrative paragraph + consumption-stat layout
- * with a multivariate coach pass over the full corpus. The consumption
- * stats (origin / process / method rankings, body / acidity distros,
- * flavour wheel, rating trend) are retained but demoted into a single
- * collapsible "What you brew" section below the coach panel. The
- * insights themselves come from /api/insights — a cached Opus pass
- * driven by lib/claude/insights.ts.
+ * Layout (top to bottom):
+ *   1. Avg rating + rated brews header
+ *   2. Coach insights (top 3 with `status: 'new'`, 3-action workflow:
+ *      Try it / Confirmed / Doesn't apply). When a card is processed
+ *      (Confirmed or Doesn't apply), the next from the back slides in.
+ *      Trying cards stay in the queue until later resolved.
+ *   3. What you brew — Flavor wheel, top flavors, rating trend, body /
+ *      acidity, best origins / processes / methods. ALWAYS VISIBLE.
  */
+
+type InsightStatus = "new" | "trying" | "confirmed" | "doesnt-apply";
 
 interface InsightItem {
   id: string;
   observation: string;
   suggestion: string;
   citationFields: string[];
-  dismissed: boolean;
+  status: InsightStatus;
   source: string;
 }
 
@@ -138,10 +141,13 @@ export default function TastePage() {
   const [stats, setStats] = useState<TasteStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [menuOpen, setMenuOpen] = useState(false);
+  // All non-doesnt-apply insights returned by the server. Local state
+  // splits them by status: only `new` shows in the queue; `trying` rows
+  // live elsewhere (the /brew/new Context step). `confirmed` rows fade
+  // out here and weight /recommend prompts.
   const [insights, setInsights] = useState<InsightItem[]>([]);
   const [insightsLoading, setInsightsLoading] = useState(true);
   const [insightsError, setInsightsError] = useState<string | null>(null);
-  const [statsOpen, setStatsOpen] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -168,7 +174,9 @@ export default function TastePage() {
     fetch("/api/insights", { cache: "no-store", signal: controller.signal })
       .then(r => r.json())
       .then((d) => {
-        const items: InsightItem[] = (d.insights ?? []).filter((it: InsightItem) => !it.dismissed);
+        const items: InsightItem[] = (d.insights ?? []).filter(
+          (it: InsightItem) => it.status !== "doesnt-apply",
+        );
         setInsights(items);
         if (items.length === 0 && (d.corpusSize ?? 0) < 4) {
           setInsightsError("Log and rate a few more brews — the coach needs at least four rated sessions to spot a cross-axis pattern.");
@@ -182,19 +190,40 @@ export default function TastePage() {
     return () => { clearTimeout(timer); controller.abort(); };
   }, []);
 
-  const dismissInsight = async (id: string) => {
-    setInsights((prev) => prev.filter((i) => i.id !== id));
+  /**
+   * Optimistic state update + PATCH. Used by all three card actions:
+   *   - "Try it"      → status = trying  (card leaves /taste queue; surfaces in /brew/new Context)
+   *   - "Confirmed"   → status = confirmed (server also bumps source = user-confirmed for /recommend weighting)
+   *   - "Doesn't apply" → status = doesnt-apply (soft-preserved across regens)
+   * Cards in the new queue are always the visible top 3 with status='new';
+   * the moment one is acted on, the next 'new' row in the local list
+   * slides into its place.
+   */
+  const updateInsight = async (id: string, status: InsightStatus) => {
+    setInsights((prev) =>
+      prev
+        .map((i) => (i.id === id ? { ...i, status } : i))
+        // Drop fully-resolved entries from local state so they don't
+        // crowd downstream rendering. `trying` stays so the user sees
+        // it move off the queue but knows it's still alive (reminder).
+        .filter((i) => i.status !== "doesnt-apply" && i.status !== "confirmed"),
+    );
     try {
       await fetch("/api/insights", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id, dismissed: true }),
+        body: JSON.stringify({ id, status }),
       });
     } catch {
-      // dismissal is optimistic — if the PATCH fails it'll come back
-      // next regeneration; not worth surfacing to the user
+      // Optimistic — if the PATCH fails the row re-appears on the next
+      // regeneration. Not worth surfacing to the user.
     }
   };
+
+  // Active queue = status='new' only, top 3 visible. As the user acts on
+  // them, the next 'new' card slides in. 'trying' cards are NOT here —
+  // they live in the /brew/new Context reminder.
+  const queue = insights.filter((i) => i.status === "new").slice(0, 3);
 
   if (loading) {
     return (
@@ -246,13 +275,12 @@ export default function TastePage() {
           <p className="text-light-muted-foreground/60 text-xs ml-auto self-end">All time</p>
         </div>
 
-        {/* ─── COACH INSIGHTS ─────────────────────────────────────
-            Replaces the old "What you love, over time" narrative
-            summary. Each card = one multivariate observation + one
-            suggestion / question. No labels, no chapters — the
-            terminology lives in the writing. Generated by Opus over the
-            full session corpus (lib/claude/insights.ts), cached
-            server-side until a new brew lands. */}
+        {/* ─── COACH ─────────────────────────────────────────────
+            Top 3 active observations (status='new'), each with the
+            three-action workflow. When the user processes one
+            (Confirmed / Doesn't apply), the next 'new' row from the
+            back slides in. 'Try it' moves the card off this queue but
+            keeps it alive as a /brew/new reminder. */}
         <Section title="Coach">
           {insightsLoading ? (
             <div className="space-y-3">
@@ -264,116 +292,106 @@ export default function TastePage() {
                 </div>
               ))}
             </div>
-          ) : insights.length === 0 ? (
+          ) : queue.length === 0 ? (
             <div className="bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-2xl px-4 py-4">
               <p className="text-light-foreground/85 text-sm leading-relaxed">
-                {insightsError ?? "No cross-axis patterns are clear yet — keep logging and the coach will surface concrete observations once enough variation is on the record."}
+                {insightsError ?? "All clear. Coach is watching for the next pattern."}
               </p>
             </div>
           ) : (
             <div className="space-y-3">
-              {insights.map((insight) => (
+              {queue.map((insight) => (
                 <InsightCard
                   key={insight.id}
                   insight={insight}
-                  onDismiss={() => dismissInsight(insight.id)}
+                  onTry={() => updateInsight(insight.id, "trying")}
+                  onConfirm={() => updateInsight(insight.id, "confirmed")}
+                  onDoesntApply={() => updateInsight(insight.id, "doesnt-apply")}
                 />
               ))}
             </div>
           )}
         </Section>
 
-        {/* ─── WHAT YOU BREW (collapsed) ────────────────────────
-            All the consumption stats demoted into one place. Still here
-            for the user who wants the at-a-glance distributions, but no
-            longer the headline. */}
-        <div>
-          <button
-            type="button"
-            onClick={() => setStatsOpen((v) => !v)}
-            className="w-full flex items-center justify-between gap-2 px-1 py-1 text-light-muted-foreground"
-          >
-            <span className="text-xs uppercase tracking-widest">What you brew</span>
-            <ChevronDown className={`h-4 w-4 transition-transform ${statsOpen ? "rotate-180" : ""}`} />
-          </button>
-          <div className={`overflow-hidden transition-all duration-300 ${statsOpen ? "max-h-[4000px] opacity-100 mt-4" : "max-h-0 opacity-0"}`}>
-            <div className="flex flex-col gap-8">
-              <Section title="Flavor Profile">
-                <div className="w-full">
-                  <FlavorWheel mode="profile" profileData={stats.radarData} size={320} />
-                </div>
-              </Section>
-
-              {stats.topFlavors.length > 0 && (
-                <Section title="Top Flavors">
-                  <div className="space-y-2">
-                    {stats.topFlavors.map(f => (
-                      <div key={f.name} className="flex items-center gap-3">
-                        <span className="text-light-foreground text-sm w-28 shrink-0 capitalize">{f.name}</span>
-                        <div className="flex-1 h-1.5 bg-light-foreground/10 rounded-full overflow-hidden">
-                          <div
-                            className="h-full bg-light-foreground rounded-full transition-all"
-                            style={{ width: `${(f.count / maxFlavor) * 100}%` }}
-                          />
-                        </div>
-                        <span className="text-light-muted-foreground text-xs w-5 text-right">{f.count}</span>
-                      </div>
-                    ))}
-                  </div>
-                </Section>
-              )}
-
-              {stats.ratingTrend.length > 1 && (
-                <Section title="Rating Over Time">
-                  <div className="flex items-end gap-2 h-24">
-                    {stats.ratingTrend.map(t => (
-                      <div key={t.label} className="flex-1 flex flex-col items-center gap-1">
-                        <span className="text-light-muted-foreground text-xs">{t.avg}</span>
-                        <div className="w-full bg-light-foreground/10 rounded-t-lg overflow-hidden" style={{ height: "60px" }}>
-                          <div
-                            className="w-full bg-light-foreground rounded-t-lg transition-all"
-                            style={{ height: `${(t.avg / trendMax) * 60}px`, marginTop: `${60 - (t.avg / trendMax) * 60}px` }}
-                          />
-                        </div>
-                        <span className="text-light-muted-foreground text-xs">{t.label}</span>
-                      </div>
-                    ))}
-                  </div>
-                </Section>
-              )}
-
-              <div className="grid grid-cols-2 gap-4">
-                {Object.keys(stats.bodyDist).length > 0 && (
-                  <Section title="Body">
-                    <DistBar data={stats.bodyDist} total={stats.totalSessions} />
-                  </Section>
-                )}
-                {Object.keys(stats.acidityDist).length > 0 && (
-                  <Section title="Acidity">
-                    <DistBar data={stats.acidityDist} total={stats.totalSessions} />
-                  </Section>
-                )}
-              </div>
-
-              {stats.topOrigins.length > 0 && (
-                <Section title="Best Origins">
-                  <RankedList items={stats.topOrigins} />
-                </Section>
-              )}
-
-              {stats.topProcesses.length > 0 && (
-                <Section title="Best Processes">
-                  <RankedList items={stats.topProcesses} />
-                </Section>
-              )}
-
-              {stats.topMethods.length > 0 && (
-                <Section title="Best Methods">
-                  <RankedList items={stats.topMethods} />
-                </Section>
-              )}
+        {/* ─── WHAT YOU BREW (always visible) ────────────────────
+            Flavor wheel + top flavors + trend + distributions + best
+            origins / processes / methods. The visual identity of /taste
+            — never hidden. */}
+        <div className="flex flex-col gap-8">
+          <Section title="Flavor Profile">
+            <div className="w-full">
+              <FlavorWheel mode="profile" profileData={stats.radarData} size={320} />
             </div>
+          </Section>
+
+          {stats.topFlavors.length > 0 && (
+            <Section title="Top Flavors">
+              <div className="space-y-2">
+                {stats.topFlavors.map(f => (
+                  <div key={f.name} className="flex items-center gap-3">
+                    <span className="text-light-foreground text-sm w-28 shrink-0 capitalize">{f.name}</span>
+                    <div className="flex-1 h-1.5 bg-light-foreground/10 rounded-full overflow-hidden">
+                      <div
+                        className="h-full bg-light-foreground rounded-full transition-all"
+                        style={{ width: `${(f.count / maxFlavor) * 100}%` }}
+                      />
+                    </div>
+                    <span className="text-light-muted-foreground text-xs w-5 text-right">{f.count}</span>
+                  </div>
+                ))}
+              </div>
+            </Section>
+          )}
+
+          {stats.ratingTrend.length > 1 && (
+            <Section title="Rating Over Time">
+              <div className="flex items-end gap-2 h-24">
+                {stats.ratingTrend.map(t => (
+                  <div key={t.label} className="flex-1 flex flex-col items-center gap-1">
+                    <span className="text-light-muted-foreground text-xs">{t.avg}</span>
+                    <div className="w-full bg-light-foreground/10 rounded-t-lg overflow-hidden" style={{ height: "60px" }}>
+                      <div
+                        className="w-full bg-light-foreground rounded-t-lg transition-all"
+                        style={{ height: `${(t.avg / trendMax) * 60}px`, marginTop: `${60 - (t.avg / trendMax) * 60}px` }}
+                      />
+                    </div>
+                    <span className="text-light-muted-foreground text-xs">{t.label}</span>
+                  </div>
+                ))}
+              </div>
+            </Section>
+          )}
+
+          <div className="grid grid-cols-2 gap-4">
+            {Object.keys(stats.bodyDist).length > 0 && (
+              <Section title="Body">
+                <DistBar data={stats.bodyDist} total={stats.totalSessions} />
+              </Section>
+            )}
+            {Object.keys(stats.acidityDist).length > 0 && (
+              <Section title="Acidity">
+                <DistBar data={stats.acidityDist} total={stats.totalSessions} />
+              </Section>
+            )}
           </div>
+
+          {stats.topOrigins.length > 0 && (
+            <Section title="Best Origins">
+              <RankedList items={stats.topOrigins} />
+            </Section>
+          )}
+
+          {stats.topProcesses.length > 0 && (
+            <Section title="Best Processes">
+              <RankedList items={stats.topProcesses} />
+            </Section>
+          )}
+
+          {stats.topMethods.length > 0 && (
+            <Section title="Best Methods">
+              <RankedList items={stats.topMethods} />
+            </Section>
+          )}
         </div>
       </div>
 
@@ -382,22 +400,76 @@ export default function TastePage() {
   );
 }
 
-function InsightCard({ insight, onDismiss }: { insight: InsightItem; onDismiss: () => void }) {
+/**
+ * Coach insight card with the three-action workflow.
+ *
+ * Two text rows are intentional:
+ *   - First row (observation): the data, with real counts. The "what
+ *     the coach noticed."
+ *   - Second row (suggestion): the next move or test question. The
+ *     "what to do."
+ * Different weight/opacity so the roles are visually distinct and
+ * scannable.
+ *
+ * Actions (left to right, soft → hard):
+ *   - Try it          → status = trying; reminder surfaces in
+ *                       /brew/new Context for matching coffees
+ *   - Confirmed       → status = confirmed; boosts /recommend weight
+ *   - Doesn't apply   → status = doesnt-apply; soft-preserved
+ */
+function InsightCard({
+  insight,
+  onTry,
+  onConfirm,
+  onDoesntApply,
+}: {
+  insight: InsightItem;
+  onTry: () => void;
+  onConfirm: () => void;
+  onDoesntApply: () => void;
+}) {
   return (
     <div className="bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-2xl px-4 py-4">
-      <p className="text-light-foreground text-[15px] leading-relaxed">{insight.observation}</p>
-      <p className="text-light-foreground/80 text-[14px] leading-relaxed mt-2">{insight.suggestion}</p>
-      <div className="mt-3 pt-3 border-t border-light-foreground/10 flex justify-end">
-        <button
-          type="button"
-          onClick={onDismiss}
-          aria-label="Dismiss insight"
-          className="text-light-muted-foreground text-[11px] uppercase tracking-widest active:text-light-foreground transition-colors"
-        >
-          Not for me
-        </button>
+      {/* Observation — what the coach noticed (the data) */}
+      <p className="text-light-foreground text-[15px] font-medium leading-relaxed">
+        {insight.observation}
+      </p>
+      {/* Suggestion — what to do (the next move) */}
+      <p className="text-light-foreground/75 text-[14px] leading-relaxed mt-2">
+        {insight.suggestion}
+      </p>
+      {/* Action row — 3 buttons, soft → hard left to right */}
+      <div className="mt-4 pt-3 border-t border-light-foreground/10 flex gap-2">
+        <CardAction onClick={onTry} variant="primary">Try it</CardAction>
+        <CardAction onClick={onConfirm} variant="soft">Confirmed</CardAction>
+        <CardAction onClick={onDoesntApply} variant="muted">Doesn’t apply</CardAction>
       </div>
     </div>
+  );
+}
+
+function CardAction({
+  onClick,
+  variant,
+  children,
+}: {
+  onClick: () => void;
+  variant: "primary" | "soft" | "muted";
+  children: React.ReactNode;
+}) {
+  // Three tonal weights so the visual hierarchy matches the action
+  // hierarchy: Try it is the encouraged path (anthracite), Confirmed is
+  // satisfaction (cream-glass), Doesn't apply is dismissal (muted text).
+  const classes =
+    variant === "primary"
+      ? "flex-1 h-9 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] text-[12px] font-semibold tracking-tight active:scale-[0.97] transition-transform"
+      : variant === "soft"
+        ? "flex-1 h-9 rounded-full bg-light-card-selected text-light-foreground text-[12px] font-semibold tracking-tight backdrop-blur-light-card backdrop-saturate-150 active:scale-[0.97] transition-transform"
+        : "flex-1 h-9 rounded-full text-light-muted-foreground text-[12px] tracking-tight active:text-light-foreground transition-colors";
+  return (
+    <button type="button" onClick={onClick} className={classes}>
+      {children}
+    </button>
   );
 }
 

--- a/src/app/api/greeting/route.ts
+++ b/src/app/api/greeting/route.ts
@@ -5,7 +5,7 @@ import { loadCoffeeLibraryCompact, formatLibraryForPrompt } from "@/lib/claude/c
 import { loadUserProfile } from "@/lib/claude/userProfile";
 import { db } from "@/lib/db/client";
 import { sessions, insights as insightsTable } from "@/lib/db/schema";
-import { desc, isNull } from "drizzle-orm";
+import { desc, ne } from "drizzle-orm";
 import { rowToSession } from "@/lib/db/helpers";
 
 export const dynamic = "force-dynamic";
@@ -154,7 +154,7 @@ export async function POST(req: NextRequest) {
       db
         .select()
         .from(insightsTable)
-        .where(isNull(insightsTable.dismissedAt))
+        .where(ne(insightsTable.status, "doesnt-apply"))
         .orderBy(desc(insightsTable.latestSessionMs))
         .limit(8)
         .catch(() => []),

--- a/src/app/api/insights/route.ts
+++ b/src/app/api/insights/route.ts
@@ -1,22 +1,64 @@
 import { NextRequest, NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import { insights } from "@/lib/db/schema";
+import type { InsightStatus } from "@/lib/db/schema";
 import { getOrGenerateInsights } from "@/lib/claude/insights";
 import { z } from "zod";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 60;
 
+const STATUS_VALUES: readonly InsightStatus[] = ["new", "trying", "confirmed", "doesnt-apply"] as const;
+
 /**
- * GET — Returns the active coach insights for the Taste Profile page.
- * Idempotent. Calls Opus only when the corpus has advanced past the
- * cached set's latestSessionMs (or the cache is empty). The Taste
- * Profile page mounts → calls this → renders. No client cache needed:
- * the cache is at the data layer.
+ * GET — Returns coach insights.
+ *
+ * Default (no query): runs the Opus regeneration check (cache-aware) and
+ * returns all rows. The /taste page filters client-side by status.
+ *
+ * ?status=trying (etc.): returns only rows matching that status. Used by
+ * /coffees/[id] and /brew/new Context step to pull active reminders for
+ * a specific coffee context — they filter further by attribute overlap
+ * client-side.
+ *
+ * ?status=trying,new: comma-separated list also accepted for surfaces
+ * that want both 'new' and 'trying' candidates (the coffee detail
+ * coach card prefers 'trying' but falls back to 'new').
  */
-export async function GET() {
+export async function GET(req: NextRequest) {
   try {
+    const url = new URL(req.url);
+    const statusParam = url.searchParams.get("status");
+
+    // Status-filtered read: skip the Opus regeneration check entirely —
+    // this is a lightweight lookup, not a full /taste page mount.
+    if (statusParam) {
+      const requested = statusParam
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s): s is InsightStatus => (STATUS_VALUES as readonly string[]).includes(s));
+      if (requested.length === 0) {
+        return NextResponse.json({ insights: [] });
+      }
+      const rows = await db
+        .select()
+        .from(insights)
+        .where(inArray(insights.status, requested));
+      return NextResponse.json({
+        insights: rows.map((row) => ({
+          id: row.id,
+          observation: row.observation,
+          suggestion: row.suggestion,
+          citationFields: row.citationFields ?? [],
+          status: row.status,
+          source: row.source,
+        })),
+      });
+    }
+
+    // Default path — /taste page mount. Runs the full cache-aware
+    // generation, returns everything for client-side filtering.
     const result = await getOrGenerateInsights();
     return NextResponse.json({
       insights: result.insights.map((row) => ({
@@ -24,7 +66,7 @@ export async function GET() {
         observation: row.observation,
         suggestion: row.suggestion,
         citationFields: row.citationFields ?? [],
-        dismissed: !!row.dismissedAt,
+        status: row.status,
         source: row.source,
       })),
       generated: result.generated,
@@ -41,13 +83,19 @@ export async function GET() {
 
 const PatchSchema = z.object({
   id: z.string().min(1),
-  dismissed: z.boolean(),
+  status: z.enum(["new", "trying", "confirmed", "doesnt-apply"]),
 });
 
 /**
- * PATCH — Toggle dismissed on a single insight row. Dismissed insights
- * stay out of /recommend and the Taste Profile page until re-enabled.
- * Survives regeneration (similar-text matching in replaceInsights).
+ * PATCH — Update an insight's workflow status.
+ *
+ *   new           → fresh, in the /taste queue
+ *   trying        → user is testing it; surfaces in /brew/new Context
+ *   confirmed     → user saw the pattern hold; weights /recommend higher
+ *   doesnt-apply  → user rejects it; soft-preserved across regens
+ *
+ * Status survives Opus regeneration (see replaceInsights in
+ * lib/claude/insights.ts) — only 'new' rows get replaced.
  */
 export async function PATCH(req: NextRequest) {
   try {
@@ -57,13 +105,20 @@ export async function PATCH(req: NextRequest) {
       return NextResponse.json({ error: "Invalid body" }, { status: 400 });
     }
     const now = new Date();
+    const { id, status } = parsed.data;
     await db
       .update(insights)
       .set({
-        dismissedAt: parsed.data.dismissed ? now : null,
+        status,
+        // Mirror dismissedAt for legacy code paths that still read it
+        // (e.g. the GET cache check). 'doesnt-apply' is the spiritual
+        // successor of dismissed.
+        dismissedAt: status === "doesnt-apply" ? now : null,
+        // Confirmation also bumps source so /recommend can weight it.
+        source: status === "confirmed" ? "user-confirmed" : "opus",
         updatedAt: now,
       })
-      .where(eq(insights.id, parsed.data.id));
+      .where(eq(insights.id, id));
     return NextResponse.json({ ok: true });
   } catch (err) {
     console.error("insights PATCH error:", err);

--- a/src/app/api/recommend/route.ts
+++ b/src/app/api/recommend/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, ne, sql } from "drizzle-orm";
 import { generateRecommendation, type RecommendInsight } from "@/lib/claude/recommend";
 import { buildEscherTerrain } from "@/lib/claude/escher";
 import { db } from "@/lib/db/client";
@@ -119,12 +119,13 @@ export async function POST(req: NextRequest) {
         ? buildEscherTerrain(sessions, coffee).catch(() => "")
         : Promise.resolve(""),
       loadCoffeeHistory(coffee?.coffeeId, coffee?.roaster, coffee?.name),
-      // Coach insights — filter out dismissed at the query layer so the
-      // prompt never sees them.
+      // Coach insights — exclude only doesnt-apply at the query layer.
+      // new / trying / confirmed all feed the prompt, with confirmed
+      // ranked higher in the recommend prompt block builder.
       db
         .select()
         .from(insightsTable)
-        .where(isNull(insightsTable.dismissedAt))
+        .where(ne(insightsTable.status, "doesnt-apply"))
         .limit(20)
         .catch(() => []),
     ]);

--- a/src/components/coach/CoachCard.tsx
+++ b/src/components/coach/CoachCard.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
+
+/**
+ * Coach insight card — shared across /taste, /coffees/[id], and the
+ * /brew/new Context reminder pill.
+ *
+ * The card itself is presentational. The three actions surface
+ * Try it / Confirmed / Doesn't apply with a clean visual hierarchy:
+ * anthracite for the encouraged path, cream-glass for satisfaction,
+ * muted text for dismissal.
+ *
+ * Two-line layout is intentional:
+ *   - row 1 = observation (data with real counts)
+ *   - row 2 = suggestion (next move)
+ * Visually distinct weights so the roles are scannable.
+ */
+
+export type InsightStatus = "new" | "trying" | "confirmed" | "doesnt-apply";
+
+export interface CoachInsight {
+  id: string;
+  observation: string;
+  suggestion: string;
+  citationFields: string[];
+  status: InsightStatus;
+  source: string;
+}
+
+export function CoachCard({
+  insight,
+  onTry,
+  onConfirm,
+  onDoesntApply,
+  eyebrow,
+}: {
+  insight: CoachInsight;
+  onTry: () => void;
+  onConfirm: () => void;
+  onDoesntApply: () => void;
+  /** Optional small label above the card ("Coach", "Reminder", etc.). */
+  eyebrow?: string;
+}) {
+  return (
+    <div className="bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-2xl px-4 py-4">
+      {eyebrow && (
+        <p className="text-light-muted-foreground text-[11px] uppercase tracking-widest mb-2">
+          {eyebrow}
+        </p>
+      )}
+      <p className="text-light-foreground text-[15px] font-medium leading-relaxed">
+        {insight.observation}
+      </p>
+      <p className="text-light-foreground/75 text-[14px] leading-relaxed mt-2">
+        {insight.suggestion}
+      </p>
+      <div className="mt-4 pt-3 border-t border-light-foreground/10 flex gap-2">
+        <CardAction onClick={onTry} variant="primary">
+          Try it
+        </CardAction>
+        <CardAction onClick={onConfirm} variant="soft">
+          Confirmed
+        </CardAction>
+        <CardAction onClick={onDoesntApply} variant="muted">
+          Doesn’t apply
+        </CardAction>
+      </div>
+    </div>
+  );
+}
+
+function CardAction({
+  onClick,
+  variant,
+  children,
+}: {
+  onClick: () => void;
+  variant: "primary" | "soft" | "muted";
+  children: ReactNode;
+}) {
+  const classes =
+    variant === "primary"
+      ? "flex-1 h-9 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] text-[12px] font-semibold tracking-tight active:scale-[0.97] transition-transform"
+      : variant === "soft"
+        ? "flex-1 h-9 rounded-full bg-light-card-selected text-light-foreground text-[12px] font-semibold tracking-tight backdrop-blur-light-card backdrop-saturate-150 active:scale-[0.97] transition-transform"
+        : "flex-1 h-9 rounded-full text-light-muted-foreground text-[12px] tracking-tight active:text-light-foreground transition-colors";
+  return (
+    <button type="button" onClick={onClick} className={classes}>
+      {children}
+    </button>
+  );
+}
+
+/**
+ * Lightweight wrapper for /coffees/[id]: fetches insights filtered to
+ * `new` + `trying`, scores by attribute overlap with the given coffee,
+ * renders the single best match. No render when the coffee isn't in
+ * rotation, or when nothing matches.
+ *
+ * Filter precedence: prefers status='trying' (active reminder) then
+ * status='new'. Never renders confirmed or doesnt-apply.
+ */
+export function CoffeeCoachCard({
+  inRotation,
+  variety,
+  process,
+  origin,
+  roastLevel,
+  method,
+}: {
+  inRotation: boolean;
+  variety?: string | null;
+  process?: string | null;
+  origin?: string | null;
+  roastLevel?: string | null;
+  /** Optional brew method history hint — boosts insights citing 'method'. */
+  method?: string | null;
+}) {
+  const [pick, setPick] = useState<CoachInsight | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!inRotation) {
+      setLoading(false);
+      return;
+    }
+    const controller = new AbortController();
+    fetch("/api/insights?status=trying,new", {
+      cache: "no-store",
+      signal: controller.signal,
+    })
+      .then((r) => r.json())
+      .then((d) => {
+        const all: CoachInsight[] = Array.isArray(d.insights) ? d.insights : [];
+        setPick(selectBestMatch(all, { variety, process, origin, roastLevel, method }));
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+    return () => controller.abort();
+  }, [inRotation, variety, process, origin, roastLevel, method]);
+
+  if (!inRotation || loading || !pick) return null;
+
+  const patchStatus = async (status: InsightStatus) => {
+    setPick(null);
+    try {
+      await fetch("/api/insights", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: pick.id, status }),
+      });
+    } catch {
+      /* optimistic */
+    }
+  };
+
+  return (
+    <div className="px-5 py-4 border-b border-light-foreground/15">
+      <CoachCard
+        insight={pick}
+        eyebrow="Coach"
+        onTry={() => patchStatus("trying")}
+        onConfirm={() => patchStatus("confirmed")}
+        onDoesntApply={() => patchStatus("doesnt-apply")}
+      />
+    </div>
+  );
+}
+
+/**
+ * Score insights by `citationFields` overlap with the coffee's
+ * attributes. Trying status wins all ties (it's already an active
+ * reminder; surface it on the page where the user is about to brew).
+ */
+function selectBestMatch(
+  insights: CoachInsight[],
+  ctx: {
+    variety?: string | null;
+    process?: string | null;
+    origin?: string | null;
+    roastLevel?: string | null;
+    method?: string | null;
+  },
+): CoachInsight | null {
+  if (insights.length === 0) return null;
+
+  const want = new Set<string>();
+  if (ctx.variety) want.add("variety");
+  if (ctx.process) want.add("process");
+  if (ctx.origin) want.add("origin");
+  if (ctx.roastLevel) want.add("roast");
+  if (ctx.method) want.add("method");
+
+  const score = (i: CoachInsight) => {
+    const overlap = i.citationFields.reduce(
+      (acc, f) => acc + (want.has(f.toLowerCase()) ? 1 : 0),
+      0,
+    );
+    // Trying tier beats new tier regardless of overlap.
+    const tier = i.status === "trying" ? 100 : 0;
+    return tier + overlap;
+  };
+
+  const best = [...insights].sort((a, b) => score(b) - score(a))[0];
+  // Require at least one field overlap OR a 'trying' status to bother
+  // surfacing — otherwise the card is just generic noise on this page.
+  if (best.status !== "trying" && score(best) === 0) return null;
+  return best;
+}

--- a/src/components/flow/LightStepContext.tsx
+++ b/src/components/flow/LightStepContext.tsx
@@ -10,6 +10,7 @@ import Card, { CardTitle, CardSubText, CardIcon } from "@/components/ui/light/Ca
 import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
 import { Brain, FlaskConical, Moon, Users, CupSoda } from "lucide-react";
 import type { Session, SessionContext } from "@/lib/types/session";
+import type { CoachInsight } from "@/components/coach/CoachCard";
 
 /**
  * Light System fork of /components/flow/StepContext.tsx.
@@ -173,6 +174,10 @@ export default function LightStepContext() {
   const [approach, setApproach] = useState<ApproachId | null>(null);
   const [grinderId, setGrinderId] = useState<string | null>(ctx.grinder ?? null);
   const [coffeeMemory, setCoffeeMemory] = useState<CoffeeMemory | null>(null);
+  // Single 'trying' insight matching this coffee — surfaces as a quiet
+  // reminder above the Context selectors. The user's earlier "Try it"
+  // tap on /taste lands here when they reach for the same coffee.
+  const [tryingReminder, setTryingReminder] = useState<CoachInsight | null>(null);
 
   // Sync local grinder selection with whatever lands in ctx (rehydrate
   // from store when the page is re-entered mid-session).
@@ -200,6 +205,44 @@ export default function LightStepContext() {
       cancelled = true;
     };
   }, [draft.coffee?.coffeeId]);
+
+  // Fetch any 'trying' insight that matches this coffee's attributes.
+  // citationFields overlap with variety / process / origin / roast.
+  useEffect(() => {
+    const c = draft.coffee;
+    if (!c) return;
+    const want = new Set<string>(
+      [
+        c.variety && "variety",
+        c.process && "process",
+        c.origin && "origin",
+        c.roastLevel && "roast",
+      ].filter(Boolean) as string[],
+    );
+    if (want.size === 0) return;
+    let cancelled = false;
+    fetch("/api/insights?status=trying", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : { insights: [] }))
+      .then((d) => {
+        if (cancelled) return;
+        const items: CoachInsight[] = Array.isArray(d.insights) ? d.insights : [];
+        const scored = items
+          .map((i) => ({
+            insight: i,
+            overlap: i.citationFields.reduce(
+              (acc, f) => acc + (want.has(f.toLowerCase()) ? 1 : 0),
+              0,
+            ),
+          }))
+          .filter((x) => x.overlap > 0)
+          .sort((a, b) => b.overlap - a.overlap);
+        setTryingReminder(scored[0]?.insight ?? null);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [draft.coffee]);
 
   const updateCtx = (patch: Partial<SessionContext>) => {
     setContext({ ...ctx, ...patch } as SessionContext);
@@ -278,6 +321,18 @@ export default function LightStepContext() {
               </p>
             </div>
           )}
+        </div>
+      )}
+
+      {tryingReminder && (
+        <div className="mb-10 rounded-3xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 p-4">
+          <p className="label-eyebrow mb-1.5">Coach reminder · trying</p>
+          <p className="text-[14px] leading-relaxed text-light-foreground">
+            {tryingReminder.observation}
+          </p>
+          <p className="text-[13px] leading-relaxed text-light-foreground/70 mt-1.5">
+            {tryingReminder.suggestion}
+          </p>
         </div>
       )}
 

--- a/src/lib/claude/insights.ts
+++ b/src/lib/claude/insights.ts
@@ -26,7 +26,7 @@
  */
 import Anthropic from "@anthropic-ai/sdk";
 import { randomUUID } from "crypto";
-import { desc, gte } from "drizzle-orm";
+import { desc, eq, gte } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import { insights, sessions } from "@/lib/db/schema";
 import { rowToSession } from "@/lib/db/helpers";
@@ -395,26 +395,28 @@ async function callOpusForInsights(userMessage: string): Promise<InsightItem[] |
 }
 
 async function replaceInsights(items: InsightItem[], latestMs: number): Promise<void> {
-  // Preserve dismissals across regenerations by remembering the
-  // dismissed observations' first 80 chars. Anything Opus re-emits that
-  // looks similar inherits the dismissal.
+  // Three-tier preservation across regenerations:
+  //   - status != 'new'  → keep the row entirely (user has acted on it)
+  //   - status == 'new'  → delete and replace with the fresh Opus pass
+  // For doesnt-apply rows in particular: also remember the observation
+  // text so a re-emitted similar observation inherits the doesnt-apply
+  // status instead of popping back as 'new'.
   const old = await db.select().from(insights);
-  const dismissed = new Map<string, { dismissedAt: Date | null; userNote: string | null }>();
-  for (const row of old) {
-    if (row.dismissedAt) {
-      dismissed.set(row.observation.slice(0, 80).toLowerCase(), {
-        dismissedAt: row.dismissedAt,
-        userNote: row.userNote,
-      });
-    }
+  const acted = old.filter((r) => r.status !== "new");
+  const actedTextIndex = new Map<string, typeof acted[number]>();
+  for (const row of acted) {
+    actedTextIndex.set(row.observation.slice(0, 80).toLowerCase(), row);
   }
 
-  await db.delete(insights);
+  await db.delete(insights).where(eq(insights.status, "new"));
 
   const now = new Date();
   for (const item of items) {
     const key = item.observation.slice(0, 80).toLowerCase();
-    const carry = dismissed.get(key);
+    const existingActed = actedTextIndex.get(key);
+    // If Opus re-emitted an observation the user already acted on, skip
+    // — the existing row (kept above) carries the user's status forward.
+    if (existingActed) continue;
     await db.insert(insights).values({
       id: randomUUID(),
       observation: item.observation,
@@ -422,8 +424,9 @@ async function replaceInsights(items: InsightItem[], latestMs: number): Promise<
       citationFields: item.citationFields ?? [],
       latestSessionMs: latestMs,
       source: "opus",
-      dismissedAt: carry?.dismissedAt ?? null,
-      userNote: carry?.userNote ?? null,
+      status: "new",
+      dismissedAt: null,
+      userNote: null,
       createdAt: now,
       updatedAt: now,
     });

--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -304,13 +304,15 @@ What makes a strong portfolio:
 - brewingLesson should explain the WHY, in Hoffmann-style plain language: the physics, the chemistry,
   what it predicts the brewer will taste and why. Not "Perger says more agitation." Say what Perger's
   thesis actually predicts for this specific coffee at this specific extraction stage.
-- The reasoning field is the coach's opening: ONE sentence, ≤30 words. What does this coffee demand
-  today and what is the single thing to watch across both candidates. Direct address to the user. No
-  preamble, no recap of history — the candidates carry their own per-field detail (whyChosen,
-  hypothesis, predictedCupProfile, whatToObserve). reasoning is the headline only.
+- The reasoning field is the coach's opening: ONE substantive sentence, 40–60 words. State the coffee's
+  defining tension or demand today, ground it in a named coffee-science principle or expert
+  (Hoffmann, Kasuya, Rao, Perger, Wölfl, Peng, Hsu, Gagné, etc.), and name the one thing to watch
+  across both candidates. Direct address to the user. NOT a headline fragment; NOT 4–6 sentences
+  either — one sentence with content. Per-candidate fields (whyChosen, hypothesis, predictedCupProfile,
+  whatToObserve) carry the per-recipe detail; reasoning sets the brain behind the portfolio.
 - Freshness call-out: when the coffee is ≥22 days past roast (slightly past peak, past peak, or stale),
-  the freshness reality MUST appear somewhere in the candidate fields (whyChosen or hypothesis), but
-  NOT in the one-sentence reasoning unless it IS the headline tension.
+  the freshness reality goes either in the reasoning sentence (if it IS the headline tension) or in the
+  per-candidate fields. Don't bury it.
 
 What to avoid:
 - Category rules disguised as hypotheses: "AeroPress is always good for X" — say what THIS recipe tests
@@ -531,10 +533,10 @@ Return valid JSON only. No markdown. No explanation outside the JSON.
       "brewingLesson": "3–4 sentences. Teach the extraction science behind this candidate in Hoffmann-style plain language. What physical or chemical mechanism is being tested? What does that mechanism predict the brewer will taste? What should they notice at each stage of the brew? No jargon without explanation."
     }
   ],
-  "reasoning": "ONE sentence, ≤30 words. The coach's headline only — what does this coffee demand today and what is the single thing to watch across the candidates. No preamble, no history recap, no per-candidate detail — that lives in whyChosen / hypothesis / predictedCupProfile / whatToObserve / brewingLesson on each candidate."
+  "reasoning": "ONE substantive sentence, 40–60 words. The coach's opening: state this coffee's defining tension or demand today, ground it in a named coffee-science principle or expert (Hoffmann, Kasuya, Rao, Perger, Wölfl, Peng, Hsu, Gagné, …), and name the single thing to watch across both candidates. Direct address. NOT a headline fragment; NOT 4–6 sentences. One sentence WITH content."
 }
 
-BREVITY: recipe values stay exact numbers. whyChosen, hypothesis, predictedCupProfile, whatToObserve, learningValue: 1 short sentence each (hard cap). reasoning: ONE sentence, ≤30 words. brewingLesson, sessionObjective, coffeeAssessment: 2–4 sentences — these are the teaching fields and can breathe.
+BREVITY: recipe values stay exact numbers. whyChosen, hypothesis, predictedCupProfile, whatToObserve, learningValue: 1 short sentence each (hard cap). reasoning: one substantive 40–60 word sentence (expertise required, see above). brewingLesson, sessionObjective, coffeeAssessment: 2–4 sentences — these are the teaching fields and can breathe.
 
 LANGUAGE: Always respond in English. All text fields must be in English only.
 GRIND SIZE: Must be a single Niche° value (e.g. "406°") or single Comandante click count (e.g. "26"). Never a range.`;

--- a/src/lib/db/migrations/0014_add_insight_status.sql
+++ b/src/lib/db/migrations/0014_add_insight_status.sql
@@ -1,0 +1,35 @@
+-- 0014 — Insight status workflow
+--
+-- The original insights table (0013) had only `dismissed_at`. The user
+-- found that affordance confusing on /taste (only "Not for me" with no
+-- feedback). This migration adds a richer workflow:
+--
+--   status = 'new'         → just generated, visible in /taste queue
+--   status = 'trying'      → user tapped "Try it"; surfaces as a quiet
+--                            reminder in /brew/new Context step
+--   status = 'confirmed'   → user tapped "Confirmed"; carries higher
+--                            weight in /recommend + /greeting prompts
+--   status = 'doesnt-apply'→ user tapped "Doesn't apply"; soft-dismissed
+--                            and inherited across regenerations so the
+--                            same observation isn't re-pitched
+--
+-- Replaces dismissed_at semantically. The column is kept for back-compat
+-- but new rows default to status='new' and the orchestrator preserves
+-- non-'new' rows across Opus regenerations.
+--
+-- Run with:
+--   cat src/lib/db/migrations/0014_add_insight_status.sql \
+--     | docker compose exec -T postgres psql -U brewlog -d brewlog
+
+ALTER TABLE insights
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'new'
+    CHECK (status IN ('new', 'trying', 'confirmed', 'doesnt-apply'));
+
+-- Back-fill any existing dismissed_at rows so the user's previous
+-- dismissals don't pop back as 'new'.
+UPDATE insights
+  SET status = 'doesnt-apply'
+  WHERE dismissed_at IS NOT NULL
+    AND status = 'new';
+
+CREATE INDEX IF NOT EXISTS insights_status_idx ON insights (status);

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -202,6 +202,9 @@ export const conversationMessages = pgTable(
 // Multivariate coach memory — replaces the lessons table for the
 // surfaces that need cross-axis observations. See migration 0013.
 export type InsightSource = "opus" | "user-confirmed";
+// Migration 0014 adds a card-workflow state machine. See
+// 0014_add_insight_status.sql for the semantics of each value.
+export type InsightStatus = "new" | "trying" | "confirmed" | "doesnt-apply";
 
 export const insights = pgTable(
   "insights",
@@ -212,6 +215,7 @@ export const insights = pgTable(
     citationFields: jsonb("citation_fields").$type<string[]>().notNull().default([]),
     latestSessionMs: bigint("latest_session_ms", { mode: "number" }).notNull(),
     source: text("source").$type<InsightSource>().notNull().default("opus"),
+    status: text("status").$type<InsightStatus>().notNull().default("new"),
     dismissedAt: timestamp("dismissed_at", { withTimezone: true }),
     userNote: text("user_note"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
@@ -220,6 +224,7 @@ export const insights = pgTable(
   (t) => ({
     latestSessionMsIdx: index("insights_latest_session_ms_idx").on(t.latestSessionMs.desc()),
     dismissedAtIdx: index("insights_dismissed_at_idx").on(t.dismissedAt),
+    statusIdx: index("insights_status_idx").on(t.status),
     createdAtIdx: index("insights_created_at_idx").on(t.createdAt.desc()),
   })
 );


### PR DESCRIPTION
## Summary

Replaces the single "Not for me" dismiss with a three-action workflow, surfaces insights where the user is about to act on them, fixes the /taste layout (coach on top, "What you brew" always visible — no collapsible), tightens the brew detail grid, and widens the recipe intro back to one substantive sentence with expertise.

## Workflow

New `status` column on `insights`: `new | trying | confirmed | doesnt-apply` (migration 0014).

| Action | Server-side | What user sees |
|---|---|---|
| **Try it** | `status = 'trying'` | Card leaves /taste queue. Surfaces as a quiet reminder pill in /brew/new Context step when brewing a coffee matching this insight's `citationFields`. |
| **Confirmed** | `status = 'confirmed'`, `source = 'user-confirmed'` | Card leaves /taste queue. Higher weight in /recommend + /greeting. |
| **Doesn't apply** | `status = 'doesnt-apply'` | Card disappears. Soft-preserved across regenerations (similar-text matching). |

Orchestrator only replaces `status='new'` rows on regeneration — user-acted rows are preserved. Re-emitted similar observations inherit the existing user action.

## /taste layout

- **Coach** at top: top 3 cards with `status='new'`, three actions each. Queue slides in from the back (when an `'new'` is processed, the next one becomes visible).
- **What you brew** below, **always visible**: flavor wheel, top flavors, rating trend, body / acidity, best origins / processes / methods. No collapsible.
- Two-paragraph card layout intentional: row 1 = observation (data, real counts), row 2 = suggestion (next move). Different weights so roles scan.

## /coffees/[id]

Single coach card between Roaster and Notes. **Rotation-only.** Filters by `citationFields` overlap with this coffee's attributes (variety / process / origin / roast / best method). Prefers `status='trying'` then `'new'`. Same three actions.

## /brew/new Context step

Quiet card above the context selectors, shown only when a `'trying'` insight matches the chosen coffee. Read-only — the user already chose Try it; this just reminds them when they reach for that coffee.

## /brew/[id] Brew Session Detail

2×2 stat grid: Dose | Grind on row 1, Water | Temp on row 2. Was 3-up + Grind underneath. Same Stat primitive.

## Recipe intro widened

`recommend.ts` prompt: `reasoning` is one substantive sentence (40–60 words) with a named coffee-science principle. Not a headline fragment, not a 6-sentence wall.

## Deploy

```bash
cat src/lib/db/migrations/0014_add_insight_status.sql \
  | docker compose exec -T postgres psql -U brewlog -d brewlog
```

Run on the VPS BEFORE merging — `/api/recommend` and `/api/insights` query the new `status` column, the `.catch` keeps them from 500-ing if the column doesn't exist yet but the workflow won't work.

## Test plan

- [ ] /taste mounts → wheel + top flavors visible. Coach shows up to 3 cards. Each card has Try it / Confirmed / Doesn't apply.
- [ ] Tap "Try it" → card leaves queue. Open /brew/new on the matching coffee → reminder pill appears on Context step.
- [ ] Tap "Confirmed" → card leaves queue. Next /recommend run weights this insight higher (visible in the reasoning quality).
- [ ] Tap "Doesn't apply" → card leaves queue. Trigger insights regeneration → similar observation doesn't pop back.
- [ ] /coffees/[id] for a rotation coffee → ONE coach card between Roaster and Notes. For a non-rotation coffee → no card.
- [ ] /brew/[id] → Dose | Grind on row 1, Water | Temp on row 2.
- [ ] /brew/new → recipe intro reads as a full sentence with expertise, not a headline.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5x8F1Ssu5UiQJJkQrJzre)_