### PR TITLE
fix(scan): roast date defaults to current year + SQL repair for Friedhats Gesha

### DIFF
--- a/scripts/fix-friedhats-gesha-date.sql
+++ b/scripts/fix-friedhats-gesha-date.sql
@@ -1,0 +1,57 @@
+-- One-shot data fix for the Friedhats Colombia Gesha record whose
+-- roast date was extracted as 2025-MM-DD instead of 2026-MM-DD by the
+-- bag scanner (defaulted to last year on an ambiguous month/day stamp).
+--
+-- This script runs in three parts. Inspect each SELECT before running
+-- the UPDATE that follows it.
+--
+-- Run with:
+--   cat scripts/fix-friedhats-gesha-date.sql \
+--     | docker compose exec -T postgres psql -U brewlog -d brewlog
+
+-- ──────────────────────────────────────────────────────────────────
+-- 1. INSPECT: find the affected row in coffees
+-- ──────────────────────────────────────────────────────────────────
+SELECT id, roaster, name, latest_roast_date, in_rotation
+  FROM coffees
+ WHERE roaster ILIKE '%Friedhats%'
+   AND (name ILIKE '%Gesha%' OR name ILIKE '%Geisha%')
+   AND latest_roast_date LIKE '2025-%';
+
+-- ──────────────────────────────────────────────────────────────────
+-- 2. UPDATE: bump the year on coffees.latest_roast_date.
+-- Comment this out if the SELECT above didn't return what you expected.
+-- ──────────────────────────────────────────────────────────────────
+UPDATE coffees
+   SET latest_roast_date = '2026' || substring(latest_roast_date FROM 5)
+ WHERE roaster ILIKE '%Friedhats%'
+   AND (name ILIKE '%Gesha%' OR name ILIKE '%Geisha%')
+   AND latest_roast_date LIKE '2025-%';
+
+-- ──────────────────────────────────────────────────────────────────
+-- 3. UPDATE: fix the same date inside each session's coffee JSONB.
+-- The recommend / greeting / extractor read from sessions.coffee, not
+-- coffees.latest_roast_date, so this update is just as important.
+-- ──────────────────────────────────────────────────────────────────
+UPDATE sessions
+   SET coffee = jsonb_set(
+         coffee,
+         '{roastDate}',
+         to_jsonb('2026' || substring(coffee->>'roastDate' FROM 5))
+       )
+ WHERE coffee->>'roaster' ILIKE '%Friedhats%'
+   AND (coffee->>'name' ILIKE '%Gesha%' OR coffee->>'name' ILIKE '%Geisha%')
+   AND coffee->>'roastDate' LIKE '2025-%';
+
+-- ──────────────────────────────────────────────────────────────────
+-- 4. VERIFY
+-- ──────────────────────────────────────────────────────────────────
+SELECT id, roaster, name, latest_roast_date
+  FROM coffees
+ WHERE roaster ILIKE '%Friedhats%'
+   AND (name ILIKE '%Gesha%' OR name ILIKE '%Geisha%');
+
+SELECT id, coffee->>'roaster', coffee->>'name', coffee->>'roastDate'
+  FROM sessions
+ WHERE coffee->>'roaster' ILIKE '%Friedhats%'
+   AND (coffee->>'name' ILIKE '%Gesha%' OR coffee->>'name' ILIKE '%Geisha%');

--- a/src/lib/claude/analyzeBag.ts
+++ b/src/lib/claude/analyzeBag.ts
@@ -28,7 +28,28 @@ const BagAnalysisSchema = z.object({
 
 const SYSTEM_PROMPT = `You are an expert specialty coffee analyst with deep knowledge of coffee producers, origins, processing methods, and roasters worldwide. When given a photo of a coffee bag or label, extract all visible information AND supplement with your knowledge to fill in gaps the bag doesn't explicitly state. Return structured JSON only.`;
 
-const USER_PROMPT = `Analyze this coffee bag photo and return a JSON object. Extract what's visible on the bag, then use your knowledge to supplement missing details (mark these as "researched"). For completely unknown fields, use null.
+function buildUserPrompt(): string {
+  // Today's date is injected so the model can resolve ambiguous roast
+  // dates (e.g. "Mar 4" with no year) against reality — every bag the
+  // user scans is roasted in the recent past, never the future, and
+  // almost always in the current calendar year. Without this anchor,
+  // Claude consistently defaulted to the previous year on
+  // month-and-day-only stamps.
+  const today = new Date();
+  const todayIso = today.toISOString().slice(0, 10);
+  const currentYear = today.getUTCFullYear();
+  const previousYear = currentYear - 1;
+
+  return `Analyze this coffee bag photo and return a JSON object. Extract what's visible on the bag, then use your knowledge to supplement missing details (mark these as "researched"). For completely unknown fields, use null.
+
+TODAY IS ${todayIso}.
+
+ROAST DATE RULES (non-negotiable):
+- If the bag shows a FULL date (month + day + year), use it verbatim.
+- If the bag shows ONLY month + day (e.g. "Roasted 03/04", "Roasted Mar 4", "EU 04.03"), assume the CURRENT year (${currentYear}). The only exception: that combination of month + day would put the date in the FUTURE relative to today — only then drop back to ${previousYear}. Specialty coffee is roasted in the recent past, never tomorrow.
+- If the bag shows a "best before" or "consume by" date (typically 6–12 months after roast), DO NOT use it as roastDate. Set roastDate to null in that case.
+- If no date is visible at all, set roastDate to null.
+- Always return ISO format: YYYY-MM-DD. Never DD/MM/YY or MM-DD.
 
 Return this exact JSON structure:
 {
@@ -67,9 +88,10 @@ clarifications: list up to 2 natural-language questions about the most important
 - "I didn't spot a variety — is it listed anywhere on the bag, or do you know it?"
 - "No tasting notes were visible — what flavour descriptors does the roaster use?"
 
-NEVER ask about roast date (the user enters this via a dedicated date picker in the UI) or cupping/Q score (optional, often unavailable — leave null if not printed on the bag).
+NEVER ask about roast date (the user can correct it via the UI's date picker if needed) or cupping/Q score (optional, often unavailable — leave null if not printed on the bag).
 
 Return ONLY valid JSON with no markdown or explanation.`;
+}
 
 export interface RoasterPriorSummary {
   name: string;
@@ -123,7 +145,7 @@ export async function analyzeBagImage(imageBase64: string, mimeType: string): Pr
             type: "image",
             source: { type: "base64", media_type: mimeType as "image/jpeg" | "image/png" | "image/webp", data: imageBase64 },
           },
-          { type: "text", text: USER_PROMPT },
+          { type: "text", text: buildUserPrompt() },
         ],
       },
     ],
@@ -136,6 +158,21 @@ export async function analyzeBagImage(imageBase64: string, mimeType: string): Pr
     const cleanExtracted = Object.fromEntries(
       Object.entries(parsed.extracted).filter(([, v]) => v !== null && v !== undefined)
     );
+
+    // Defensive year guard: even with the prompt instruction, Claude
+    // occasionally returns last year's date for an ambiguous "Mar 4"
+    // stamp. If the date sits more than 11 months in the past AND
+    // bumping the year by one lands within the last 11 months, take
+    // the bump — that's the path the prompt was already asking for.
+    // Don't touch dates that are within 11 months (legit fresh bag)
+    // or further than 23 months back (clearly wasn't extracted from a
+    // YY-stamp).
+    const rd = (cleanExtracted as { roastDate?: string }).roastDate;
+    if (typeof rd === "string" && /^\d{4}-\d{2}-\d{2}/.test(rd)) {
+      const cleaned = guardRoastYear(rd);
+      if (cleaned !== rd) (cleanExtracted as { roastDate?: string }).roastDate = cleaned;
+    }
+
     return {
       result: {
         extracted: cleanExtracted as BagAnalysisResult["extracted"],
@@ -150,4 +187,27 @@ export async function analyzeBagImage(imageBase64: string, mimeType: string): Pr
     result: { extracted: {}, confidence: {}, clarifications: [], isCoffeeBag: false },
     usage: response.usage,
   };
+}
+
+/**
+ * Defensive year adjustment for ambiguous month+day-only roast dates.
+ * If the parsed date is >11 months in the past AND shifting it forward
+ * by one year lands within the "fresh bag" window (i.e. not in the
+ * future), use that. Otherwise return the original.
+ */
+function guardRoastYear(iso: string): string {
+  const parsed = new Date(`${iso.slice(0, 10)}T00:00:00Z`);
+  if (isNaN(parsed.getTime())) return iso;
+  const now = new Date();
+  const elevenMonthsMs = 11 * 30 * 24 * 60 * 60 * 1000;
+  const ageMs = now.getTime() - parsed.getTime();
+  if (ageMs < elevenMonthsMs) return iso;
+
+  const bumped = new Date(parsed);
+  bumped.setUTCFullYear(bumped.getUTCFullYear() + 1);
+  // Bumped must not be in the future and must be more reasonable.
+  if (bumped.getTime() > now.getTime()) return iso;
+  const newAgeMs = now.getTime() - bumped.getTime();
+  if (newAgeMs >= elevenMonthsMs) return iso;
+  return bumped.toISOString().slice(0, 10);
 }


### PR DESCRIPTION
## Summary

The bag scanner consistently parsed month-and-day-only roast stamps as last year instead of the current year — your Friedhats Colombia Gesha (2 weeks old) was logged as 14 months old, which cascaded through the welcome haiku, /recommend's freshness handling, and the freshness zone classifier.

## Fix — code

Two layers, defence in depth:

1. **Prompt rule.** `analyzeBag.ts` now builds the user prompt fresh per call so today's date can be injected. Explicit ROAST DATE RULES section forces the model to use the current year on ambiguous month/day stamps, only drop back a year if that would otherwise put the date in the future, never use a "best before" date as roastDate, and always return ISO `YYYY-MM-DD`.

2. **Defensive post-process.** `guardRoastYear()` — if the returned date is more than 11 months in the past AND shifting it forward by one year lands within the fresh-bag window (without going into the future), take the bump. Catches the case where the model still gets it wrong despite the prompt rule.

## Fix — data

`scripts/fix-friedhats-gesha-date.sql` — bumps the Friedhats Colombia Gesha row from `2025-MM-DD` to `2026-MM-DD` on the production DB, in both `coffees.latest_roast_date` and inside the per-session `coffee.roastDate` JSONB. Inspect-then-update structure (SELECT first, UPDATE after) so you can verify the affected row before mutating.

Run on the VPS:

```bash
cd /opt/brewlog
git fetch origin claude/bag-date-current-year
git show origin/claude/bag-date-current-year:scripts/fix-friedhats-gesha-date.sql \
  | docker compose exec -T postgres psql -U brewlog -d brewlog
```

## Test plan

- [ ] After merge + deploy + SQL run: open Friedhats Colombia Gesha → roast date reads 2026, freshness shows ~2 weeks not ~14 months.
- [ ] Next scan of a bag with only month/day stamp → roast date defaults to 2026 (current year), not 2025.
- [ ] Welcome haiku stops calling fresh bags "stale" / "past peak" when they're actually in peak.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5x8F1Ssu5UiQJJkQrJzre)_