### PR TITLE
feat(conversations): 1-week TTL on archived past-conversations

### DIFF
--- a/deploy/ofelia.ini
+++ b/deploy/ofelia.ini
@@ -12,3 +12,12 @@ schedule = 0 3 * * 1
 container = brewlog-app-1
 command = curl -sf -X POST http://localhost:3000/api/coffees/compact -H "Authorization: Bearer ${CRON_SECRET}"
 no-overlap = true
+
+# Daily at 04:00 — delete archived conversations older than 7 days.
+# Active (non-archived) conversations are NEVER touched. See
+# src/app/api/conversations/cleanup/route.ts for the 7-day rationale.
+[job-exec "conversations-cleanup"]
+schedule = 0 4 * * *
+container = brewlog-app-1
+command = curl -sf -X POST http://localhost:3000/api/conversations/cleanup -H "Authorization: Bearer ${CRON_SECRET}"
+no-overlap = true

--- a/src/app/api/conversations/cleanup/route.ts
+++ b/src/app/api/conversations/cleanup/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+import { and, isNotNull, lt } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { conversations } from "@/lib/db/schema";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Daily cleanup cron — deletes archived conversations older than 7
+ * days. Conversation messages cascade-delete via the foreign key on
+ * conversation_messages.conversation_id (onDelete: cascade in
+ * src/lib/db/schema.ts).
+ *
+ * NEVER touches the active conversation (archivedAt IS NULL) — that's
+ * the live thread on /home; auto-deleting it after a quiet week would
+ * surprise the user. Only archived past-conversations get the TTL.
+ *
+ * Triggered by Ofelia daily (see deploy/ofelia.ini). Auth via
+ * CRON_SECRET bearer token, same pattern as /api/research and
+ * /api/coffees/compact.
+ */
+export async function POST(req: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  const auth = req.headers.get("authorization");
+  if (!secret || auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const cutoff = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+    const result = await db
+      .delete(conversations)
+      .where(
+        and(
+          isNotNull(conversations.archivedAt),
+          lt(conversations.archivedAt, cutoff),
+        ),
+      )
+      .returning({ id: conversations.id });
+
+    return NextResponse.json({
+      deleted: result.length,
+      cutoff: cutoff.toISOString(),
+    });
+  } catch (err) {
+    console.error("conversations/cleanup error:", err);
+    return NextResponse.json({ error: "Cleanup failed" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary

Adds a 1-week TTL on archived past-conversations. Active (non-archived) conversations are NEVER auto-deleted — that's the live thread on /home, and a quiet week shouldn't nuke it.

## Implementation

- **`POST /api/conversations/cleanup`** — deletes rows from `conversations` WHERE `archivedAt IS NOT NULL AND archivedAt < now() - 7 days`. Messages cascade-delete via the existing FK (`conversation_messages.conversation_id` has `onDelete: cascade` in `src/lib/db/schema.ts`).
- **Ofelia job** in `deploy/ofelia.ini` — daily at 04:00, same `CRON_SECRET` bearer pattern as `/api/research` and `/api/coffees/compact`.

## Deploy

Ofelia reads `./deploy/ofelia.ini` via the existing volume mount and reloads on a container cycle. After merge + auto-deploy:

```bash
cd /opt/brewlog
docker compose up -d ofelia
# Verify the new job is registered:
docker compose exec ofelia ofelia validate --config /etc/ofelia/config.ini
```

The first cleanup run is the next scheduled tick (04:00 UTC). To trigger immediately:

```bash
curl -sf -X POST http://localhost:3000/api/conversations/cleanup \
  -H "Authorization: Bearer ${CRON_SECRET}"
# → { "deleted": N, "cutoff": "..." }
```

## Test plan

- [ ] Archive an old conversation manually (set `archivedAt` to >7 days ago via psql on a test row).
- [ ] Hit the endpoint with the cron secret → row is deleted, response shows `deleted: 1`.
- [ ] Verify the active conversation (`archivedAt IS NULL`) is untouched.
- [ ] Verify `conversation_messages` rows for the deleted conversation are gone (cascade).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5x8F1Ssu5UiQJJkQrJzre)_