### PR TITLE
feat(coach): per-coffee Opus insight (drop library-wide field-overlap matching)

### DIFF
--- a/src/app/(light)/coffees/[id]/page.tsx
+++ b/src/app/(light)/coffees/[id]/page.tsx
@@ -403,18 +403,9 @@ export default function CoffeeDetailPage() {
         </div>
       )}
 
-      {/* Coach card — single most-relevant insight for this coffee.
-          Rotation-only: out-of-rotation pages stay clean. Filters by
-          attribute overlap (variety / process / origin / roast / method)
-          and prefers 'trying' over 'new' rows. */}
-      <CoffeeCoachCard
-        inRotation={!!coffee.inRotation}
-        variety={variety}
-        process={process}
-        origin={origin}
-        roastLevel={roastLevel}
-        method={coffee.bestMethod}
-      />
+      {/* Coach card — per-coffee Opus insight (its own brew history +
+          roaster prior + variety prior). Rotation-only. */}
+      <CoffeeCoachCard coffeeId={coffee.id} inRotation={!!coffee.inRotation} />
 
       {/* Personal notes */}
       <div className="px-5 py-4 border-b border-light-foreground/15">

--- a/src/app/api/coffees/[id]/insight/route.ts
+++ b/src/app/api/coffees/[id]/insight/route.ts
@@ -1,0 +1,141 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq, desc, sql } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "@/lib/db/client";
+import { coffees, sessions } from "@/lib/db/schema";
+import type { CoffeeCoachInsight } from "@/lib/db/schema";
+import { rowToCoffee, rowToSession } from "@/lib/db/helpers";
+import { generateCoffeeInsight } from "@/lib/claude/coffeeInsight";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+interface RouteParams {
+  params: { id: string };
+}
+
+/**
+ * GET — Per-coffee coach insight.
+ *
+ * Returns the cached insight if it's still fresh against this coffee's
+ * latest session. Regenerates via Opus when:
+ *   - the cache is missing, OR
+ *   - the cache is older than the latest session of THIS coffee,
+ *     AND the cache status is 'new' or 'doesnt-apply' (statuses
+ *     'trying' / 'confirmed' mean the user is mid-act-on-it; don't
+ *     change the card under them)
+ *
+ * 404 if the coffee doesn't exist.
+ */
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  try {
+    const coffeeRow = await db
+      .select()
+      .from(coffees)
+      .where(eq(coffees.id, params.id))
+      .limit(1);
+    if (coffeeRow.length === 0) {
+      return NextResponse.json({ error: "Coffee not found" }, { status: 404 });
+    }
+
+    const coffee = rowToCoffee(coffeeRow[0]);
+    // jsonb column — Drizzle returns it untyped; we know the shape we wrote.
+    const cached = (coffeeRow[0].coachInsight ?? null) as CoffeeCoachInsight | null;
+
+    // Latest session for THIS coffee = cache key.
+    const latestSessionRow = await db
+      .select({ ms: sessions.createdAtMs })
+      .from(sessions)
+      .where(sql`${sessions.coffee}->>'coffeeId' = ${params.id}`)
+      .orderBy(desc(sessions.createdAtMs))
+      .limit(1);
+    const latestSessionMs = latestSessionRow[0]?.ms ?? 0;
+
+    const userInMidFlight =
+      cached?.status === "trying" || cached?.status === "confirmed";
+    const cacheIsFresh =
+      cached != null && cached.generatedAtSessionMs >= latestSessionMs;
+
+    if (cached && (cacheIsFresh || userInMidFlight)) {
+      return NextResponse.json({ insight: cached });
+    }
+
+    // Regenerate.
+    const sessionRows = await db
+      .select()
+      .from(sessions)
+      .where(sql`${sessions.coffee}->>'coffeeId' = ${params.id}`)
+      .orderBy(desc(sessions.createdAtMs))
+      .limit(30);
+    const sessionList = sessionRows.map(rowToSession);
+
+    const generated = await generateCoffeeInsight(coffee, sessionList);
+    if (!generated) {
+      // Opus call failed — return whatever we have (might be null).
+      return NextResponse.json({ insight: cached });
+    }
+
+    const next: CoffeeCoachInsight = {
+      observation: generated.observation,
+      suggestion: generated.suggestion,
+      status: "new",
+      generatedAtSessionMs: latestSessionMs,
+      generatedAt: new Date().toISOString(),
+    };
+
+    await db
+      .update(coffees)
+      .set({ coachInsight: next })
+      .where(eq(coffees.id, params.id));
+
+    return NextResponse.json({ insight: next });
+  } catch (err) {
+    console.error("coffee insight GET error:", err);
+    return NextResponse.json({ error: "Failed to load insight" }, { status: 500 });
+  }
+}
+
+const PatchSchema = z.object({
+  status: z.enum(["new", "trying", "confirmed", "doesnt-apply"]),
+});
+
+/**
+ * PATCH — Update the per-coffee insight's workflow status.
+ *
+ *   trying        → quiet reminder pill in /brew/new Context when the
+ *                   user opens this coffee in the brew flow.
+ *   confirmed     → preserved across regenerations until user dismisses.
+ *   doesnt-apply  → soft-dismiss; next regeneration replaces it.
+ *
+ * If there's no cached insight to update, returns 404.
+ */
+export async function PATCH(req: NextRequest, { params }: RouteParams) {
+  try {
+    const body = await req.json();
+    const parsed = PatchSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid body" }, { status: 400 });
+    }
+    const row = await db
+      .select()
+      .from(coffees)
+      .where(eq(coffees.id, params.id))
+      .limit(1);
+    if (row.length === 0) {
+      return NextResponse.json({ error: "Coffee not found" }, { status: 404 });
+    }
+    const current = (row[0].coachInsight ?? null) as CoffeeCoachInsight | null;
+    if (!current) {
+      return NextResponse.json({ error: "No insight to update" }, { status: 404 });
+    }
+    const next: CoffeeCoachInsight = { ...current, status: parsed.data.status };
+    await db
+      .update(coffees)
+      .set({ coachInsight: next })
+      .where(eq(coffees.id, params.id));
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("coffee insight PATCH error:", err);
+    return NextResponse.json({ error: "Failed to update insight" }, { status: 500 });
+  }
+}

--- a/src/components/coach/CoachCard.tsx
+++ b/src/components/coach/CoachCard.tsx
@@ -94,29 +94,28 @@ function CardAction({
 }
 
 /**
- * Lightweight wrapper for /coffees/[id]: fetches insights filtered to
- * `new` + `trying`, scores by attribute overlap with the given coffee,
- * renders the single best match. No render when the coffee isn't in
- * rotation, or when nothing matches.
+ * Per-coffee coach card. Fetches an Opus-generated insight that is
+ * specifically about THIS coffee — its brew history, its roaster
+ * prior, its variety prior — from /api/coffees/[id]/insight.
  *
- * Filter precedence: prefers status='trying' (active reminder) then
- * status='new'. Never renders confirmed or doesnt-apply.
+ * Rotation-only: out-of-rotation pages stay clean.
+ *
+ * Status actions are local to this coffee (not the global /taste queue):
+ *   - Try it → status='trying'; surfaces as a /brew/new Context reminder
+ *     when this same coffee is selected for the next brew.
+ *   - Confirmed → status='confirmed'; preserved across regenerations
+ *     until the user explicitly dismisses or replaces.
+ *   - Doesn't apply → status='doesnt-apply'; next regeneration replaces.
+ *
+ * Replaces the earlier library-wide citation-field matcher that was
+ * surfacing wrong insights on the wrong coffees.
  */
 export function CoffeeCoachCard({
+  coffeeId,
   inRotation,
-  variety,
-  process,
-  origin,
-  roastLevel,
-  method,
 }: {
+  coffeeId: string;
   inRotation: boolean;
-  variety?: string | null;
-  process?: string | null;
-  origin?: string | null;
-  roastLevel?: string | null;
-  /** Optional brew method history hint — boosts insights citing 'method'. */
-  method?: string | null;
 }) {
   const [pick, setPick] = useState<CoachInsight | null>(null);
   const [loading, setLoading] = useState(true);
@@ -127,29 +126,49 @@ export function CoffeeCoachCard({
       return;
     }
     const controller = new AbortController();
-    fetch("/api/insights?status=trying,new", {
+    fetch(`/api/coffees/${coffeeId}/insight`, {
       cache: "no-store",
       signal: controller.signal,
     })
-      .then((r) => r.json())
+      .then((r) => (r.ok ? r.json() : { insight: null }))
       .then((d) => {
-        const all: CoachInsight[] = Array.isArray(d.insights) ? d.insights : [];
-        setPick(selectBestMatch(all, { variety, process, origin, roastLevel, method }));
+        const raw = d.insight;
+        if (!raw) {
+          setPick(null);
+          return;
+        }
+        // Hide confirmed + doesnt-apply from this view — the user has
+        // already acted on them. (The regeneration logic preserves
+        // confirmed rows specifically so the suggestion stays alive
+        // for /recommend prompts; on the coffee page itself, a
+        // resolved card just clutters.)
+        if (raw.status === "confirmed" || raw.status === "doesnt-apply") {
+          setPick(null);
+          return;
+        }
+        setPick({
+          id: coffeeId,
+          observation: raw.observation,
+          suggestion: raw.suggestion,
+          citationFields: [],
+          status: raw.status,
+          source: "per-coffee",
+        });
       })
       .catch(() => {})
       .finally(() => setLoading(false));
     return () => controller.abort();
-  }, [inRotation, variety, process, origin, roastLevel, method]);
+  }, [inRotation, coffeeId]);
 
   if (!inRotation || loading || !pick) return null;
 
   const patchStatus = async (status: InsightStatus) => {
     setPick(null);
     try {
-      await fetch("/api/insights", {
+      await fetch(`/api/coffees/${coffeeId}/insight`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ id: pick.id, status }),
+        body: JSON.stringify({ status }),
       });
     } catch {
       /* optimistic */
@@ -167,45 +186,4 @@ export function CoffeeCoachCard({
       />
     </div>
   );
-}
-
-/**
- * Score insights by `citationFields` overlap with the coffee's
- * attributes. Trying status wins all ties (it's already an active
- * reminder; surface it on the page where the user is about to brew).
- */
-function selectBestMatch(
-  insights: CoachInsight[],
-  ctx: {
-    variety?: string | null;
-    process?: string | null;
-    origin?: string | null;
-    roastLevel?: string | null;
-    method?: string | null;
-  },
-): CoachInsight | null {
-  if (insights.length === 0) return null;
-
-  const want = new Set<string>();
-  if (ctx.variety) want.add("variety");
-  if (ctx.process) want.add("process");
-  if (ctx.origin) want.add("origin");
-  if (ctx.roastLevel) want.add("roast");
-  if (ctx.method) want.add("method");
-
-  const score = (i: CoachInsight) => {
-    const overlap = i.citationFields.reduce(
-      (acc, f) => acc + (want.has(f.toLowerCase()) ? 1 : 0),
-      0,
-    );
-    // Trying tier beats new tier regardless of overlap.
-    const tier = i.status === "trying" ? 100 : 0;
-    return tier + overlap;
-  };
-
-  const best = [...insights].sort((a, b) => score(b) - score(a))[0];
-  // Require at least one field overlap OR a 'trying' status to bother
-  // surfacing — otherwise the card is just generic noise on this page.
-  if (best.status !== "trying" && score(best) === 0) return null;
-  return best;
 }

--- a/src/components/flow/LightStepContext.tsx
+++ b/src/components/flow/LightStepContext.tsx
@@ -206,43 +206,37 @@ export default function LightStepContext() {
     };
   }, [draft.coffee?.coffeeId]);
 
-  // Fetch any 'trying' insight that matches this coffee's attributes.
-  // citationFields overlap with variety / process / origin / roast.
+  // Fetch THIS coffee's per-coffee insight; surface it as a quiet
+  // reminder pill only when its status is 'trying' (the user already
+  // tapped "Try it" on the /coffees/[id] coach card and we're now in
+  // the flow that should remind them).
   useEffect(() => {
-    const c = draft.coffee;
-    if (!c) return;
-    const want = new Set<string>(
-      [
-        c.variety && "variety",
-        c.process && "process",
-        c.origin && "origin",
-        c.roastLevel && "roast",
-      ].filter(Boolean) as string[],
-    );
-    if (want.size === 0) return;
+    const coffeeId = draft.coffee?.coffeeId;
+    if (!coffeeId) return;
     let cancelled = false;
-    fetch("/api/insights?status=trying", { cache: "no-store" })
-      .then((r) => (r.ok ? r.json() : { insights: [] }))
+    fetch(`/api/coffees/${coffeeId}/insight`, { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : { insight: null }))
       .then((d) => {
         if (cancelled) return;
-        const items: CoachInsight[] = Array.isArray(d.insights) ? d.insights : [];
-        const scored = items
-          .map((i) => ({
-            insight: i,
-            overlap: i.citationFields.reduce(
-              (acc, f) => acc + (want.has(f.toLowerCase()) ? 1 : 0),
-              0,
-            ),
-          }))
-          .filter((x) => x.overlap > 0)
-          .sort((a, b) => b.overlap - a.overlap);
-        setTryingReminder(scored[0]?.insight ?? null);
+        const raw = d.insight;
+        if (!raw || raw.status !== "trying") {
+          setTryingReminder(null);
+          return;
+        }
+        setTryingReminder({
+          id: coffeeId,
+          observation: raw.observation,
+          suggestion: raw.suggestion,
+          citationFields: [],
+          status: raw.status,
+          source: "per-coffee",
+        });
       })
       .catch(() => {});
     return () => {
       cancelled = true;
     };
-  }, [draft.coffee]);
+  }, [draft.coffee?.coffeeId]);
 
   const updateCtx = (patch: Partial<SessionContext>) => {
     setContext({ ...ctx, ...patch } as SessionContext);

--- a/src/lib/claude/coffeeInsight.ts
+++ b/src/lib/claude/coffeeInsight.ts
@@ -1,0 +1,186 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { z } from "zod";
+import { parseClaudeJson } from "./parseJson";
+import type { Coffee } from "@/lib/types/coffee";
+import type { Session } from "@/lib/types/session";
+import { resolveBrewedRecipe } from "@/lib/utils/resolveRecipe";
+import { getRoasterPrior, formatRoasterPriorForPrompt } from "@/lib/roasters/priors";
+import { getVarietyPriorsForBag } from "@/lib/knowledge/varieties";
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+/**
+ * Per-coffee coach insight.
+ *
+ * Generates ONE observation + ONE suggestion specific to THIS coffee.
+ * Draws on:
+ *   - This coffee's attributes (variety, process, origin, roast, tasting
+ *     notes from the bag, the user's recorded common notes)
+ *   - This coffee's brew history (every session with the actually-brewed
+ *     recipe, rating, flavor notes, body, acidity)
+ *   - Roaster prior (Friedhats, SEY, April, … — clarity bias, temp bias,
+ *     method affinities)
+ *   - Variety prior (Gesha, SL28, Pink Bourbon … — aromatic ceiling,
+ *     acidity / body shape)
+ *
+ * Output is a two-paragraph card matching the existing CoachCard UX.
+ *
+ * Cache key is `(coffeeId, latestSessionMs)`. The orchestrator
+ * regenerates when a newer session lands, EXCEPT when the user is
+ * mid-`trying` or `confirmed` — don't change the card under them.
+ */
+
+const InsightSchema = z.object({
+  observation: z.string().min(20).max(600),
+  suggestion: z.string().min(20).max(400),
+});
+
+export interface GeneratedCoffeeInsight {
+  observation: string;
+  suggestion: string;
+}
+
+const SYSTEM_PROMPT = `You are a coffee expert writing a single, grounded coach note about ONE specific bag of coffee the user owns. Not their library, not coffees in general — THIS bag.
+
+Output is two short paragraphs:
+
+1. OBSERVATION — what their data on THIS coffee says, citing real numbers from THEIR brew history of THIS coffee when they have one (dose, water, temperature, grind degree, rating, the flavor notes they recorded). When there's no brew history yet, ground in the bag's attributes + named roaster and variety priors (e.g. "Friedhats roasts on the lighter side and biases toward clarity"; "Gesha lots reward 92–94°C and minimal agitation").
+
+2. SUGGESTION — ONE concrete next move, expressed for the next brew. A specific dial change (cooler by 2 °C, coarser by 5°, 1:16 → 1:17, swirl-not-stir), or one specific thing to watch (whether the floral lifts on cooling, whether the dry finish softens at 92 °C vs 96 °C). Not generic.
+
+NON-NEGOTIABLES:
+- Mention THIS coffee by roaster + name in the observation when relevant. The card lives on the coffee detail page; the user already knows which coffee it's about, so name it sparingly — once is plenty.
+- If there are zero brews of THIS coffee, say so plainly ("First time brewing this bag — here's what to anchor on"). Don't invent history.
+- If there are 1+ brews, cite the actual numbers from the brew history given to you. Don't invent or round.
+- Direct address ("you"), no preamble.
+- 40–80 words for observation, 25–50 for suggestion.
+
+Return JSON only: { "observation": string, "suggestion": string }`;
+
+/**
+ * Build the per-coffee user prompt. All numeric history comes from
+ * resolveBrewedRecipe (the actually-brewed candidate, not primaryRecipe)
+ * so we never quote a recipe the user didn't actually use.
+ */
+function buildUserPrompt(coffee: Coffee, sessionsForCoffee: Session[]): string {
+  const lines: string[] = [];
+
+  // 1. The coffee itself.
+  lines.push("THIS COFFEE:");
+  lines.push(`- Roaster: ${coffee.roaster}`);
+  lines.push(`- Name: ${coffee.name}`);
+  lines.push(`- Origin: ${coffee.origin}`);
+  lines.push(`- Process: ${coffee.process}`);
+  // Attribute fallback from the latest scanned session — coffee row only
+  // carries roaster/name/origin/process; variety + roast + region come
+  // from the per-session CoffeeIdentity (most recent first).
+  const latest = sessionsForCoffee[0]?.coffee;
+  if (latest?.variety) lines.push(`- Variety: ${latest.variety}`);
+  if (latest?.roastLevel) lines.push(`- Roast: ${latest.roastLevel}`);
+  if (latest?.region) lines.push(`- Region: ${latest.region}`);
+  if (latest?.farm) lines.push(`- Farm: ${latest.farm}`);
+  if (latest?.altitudeMeters) lines.push(`- Altitude: ${latest.altitudeMeters} m`);
+  if (latest?.fermentationStyle) lines.push(`- Fermentation: ${latest.fermentationStyle}`);
+  if (latest?.tastingNotesFromBag?.length) {
+    lines.push(`- Tasting notes from bag: ${latest.tastingNotesFromBag.join(", ")}`);
+  }
+  if (coffee.commonNotes?.length) {
+    lines.push(`- Notes you consistently taste: ${coffee.commonNotes.join(", ")}`);
+  }
+  if (coffee.latestRoastDate) {
+    const ageDays = Math.round(
+      (Date.now() - new Date(coffee.latestRoastDate).getTime()) / (1000 * 60 * 60 * 24),
+    );
+    lines.push(`- Roast date: ${coffee.latestRoastDate} (~${ageDays} days ago)`);
+  }
+  if (coffee.personalNotes) {
+    lines.push(`- Your own notes on this bag: ${coffee.personalNotes}`);
+  }
+  lines.push("");
+
+  // 2. Brew history with this bag.
+  const rated = sessionsForCoffee.filter((s) => s.result?.rating != null);
+  lines.push(`BREW HISTORY (${sessionsForCoffee.length} brews, ${rated.length} rated):`);
+  if (sessionsForCoffee.length === 0) {
+    lines.push("- None yet. This is the user's first encounter with this bag.");
+  } else {
+    // Most recent 8 — keeps the prompt tight and weights recent.
+    const recent = sessionsForCoffee.slice(0, 8);
+    for (const s of recent) {
+      const { recipe, candidate, method } = resolveBrewedRecipe(s);
+      if (!recipe) continue;
+      const date = s.createdAt
+        ? new Date(s.createdAt).toISOString().slice(0, 10)
+        : "?";
+      const grind = s.brew?.grindSettingUsed ?? recipe.grindSize ?? "?";
+      const actualTime = s.brew?.actualTimeSec
+        ? `${Math.floor(s.brew.actualTimeSec / 60)}:${String(s.brew.actualTimeSec % 60).padStart(2, "0")}`
+        : "?";
+      const rating = s.result?.rating != null ? `${s.result.rating}★` : "unrated";
+      const flavors = s.result?.flavorNotes?.length
+        ? ` "${s.result.flavorNotes.join(", ")}"`
+        : "";
+      const body = s.result?.body ? ` body=${s.result.body}` : "";
+      const acidity = s.result?.acidity ? ` acidity=${s.result.acidity}` : "";
+      const recipeName = candidate?.title || method || "unknown recipe";
+      lines.push(
+        `- ${date} ${method ?? "?"} ${recipe.doseGrams}g/${recipe.waterGrams}g ${recipe.waterTempC}°C grind=${grind} ${actualTime} → ${rating}${body}${acidity}${flavors} [${recipeName}]`,
+      );
+    }
+  }
+  lines.push("");
+
+  // 3. Roaster prior (only when curated — fallback returns noise).
+  const roasterPrior = getRoasterPrior(coffee.roaster);
+  if (roasterPrior.confidence !== "fallback") {
+    lines.push("ROASTER PRIOR:");
+    lines.push(formatRoasterPriorForPrompt(roasterPrior));
+    lines.push("");
+  }
+
+  // 4. Variety prior (only when the variety string maps to a known one).
+  if (latest?.variety) {
+    const varietyPriors = getVarietyPriorsForBag(latest.variety);
+    if (varietyPriors.length > 0) {
+      lines.push("VARIETY PRIOR:");
+      for (const v of varietyPriors) {
+        lines.push(`- ${v.name}: ${v.cupSignature} (acidity ${v.acidity}/body ${v.body}/aromatics ${v.aromatics})`);
+        if (v.brewingTendencies) lines.push(`  Brewing: ${v.brewingTendencies}`);
+      }
+      lines.push("");
+    }
+  }
+
+  lines.push(
+    "Write the coach note now. JSON only. ONE observation + ONE suggestion, both specific to THIS bag.",
+  );
+
+  return lines.join("\n");
+}
+
+export async function generateCoffeeInsight(
+  coffee: Coffee,
+  sessionsForCoffee: Session[],
+): Promise<GeneratedCoffeeInsight | null> {
+  try {
+    const userMessage = buildUserPrompt(coffee, sessionsForCoffee);
+    const response = await client.messages.create({
+      model: "claude-opus-4-7",
+      max_tokens: 1200,
+      system: [
+        { type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } },
+      ],
+      messages: [{ role: "user", content: userMessage }],
+    });
+    const text = response.content
+      .filter(
+        (b): b is Anthropic.Messages.TextBlock => b.type === "text",
+      )
+      .map((b) => b.text)
+      .join("\n");
+    return parseClaudeJson(text, InsightSchema);
+  } catch (err) {
+    console.error("coffeeInsight generation failed:", err);
+    return null;
+  }
+}

--- a/src/lib/db/migrations/0015_add_coffee_coach_insight.sql
+++ b/src/lib/db/migrations/0015_add_coffee_coach_insight.sql
@@ -1,0 +1,27 @@
+-- 0015 — Per-coffee coach insight
+--
+-- Adds a jsonb column on `coffees` to hold an Opus-generated insight
+-- specifically about THIS coffee. Replaces the library-wide
+-- citation-field overlap matching that was showing wrong insights on
+-- the wrong coffees (Friedhats Gesha was getting a "honey vs natural
+-- light roasts" card that was about other bags entirely).
+--
+-- Shape of the column:
+--   {
+--     "observation": string,
+--     "suggestion": string,
+--     "status": "new" | "trying" | "confirmed" | "doesnt-apply",
+--     "generatedAtSessionMs": number,
+--     "generatedAt": "ISO string"
+--   }
+--
+-- The orchestrator regenerates when generatedAtSessionMs is older than
+-- this coffee's latest session, EXCEPT when status is "confirmed" or
+-- "trying" (user is mid-act-on-it; don't change the card under them).
+--
+-- Run with:
+--   cat src/lib/db/migrations/0015_add_coffee_coach_insight.sql \
+--     | docker compose exec -T postgres psql -U brewlog -d brewlog
+
+ALTER TABLE coffees
+  ADD COLUMN IF NOT EXISTS coach_insight jsonb;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -83,7 +83,24 @@ export const coffees = pgTable("coffees", {
   // /api/greeting library snapshot so the daily Haiku starter
   // prioritises rotation bags. Toggled from /coffees/[id].
   inRotation: boolean("in_rotation").notNull().default(false),
+  // Per-coffee coach insight (migration 0015). Single Opus-generated
+  // observation+suggestion specific to THIS coffee, drawing on its
+  // brew history, roaster prior, and variety prior. Shape:
+  // { observation, suggestion, status, generatedAtSessionMs, generatedAt }.
+  coachInsight: jsonb("coach_insight").$type<CoffeeCoachInsight | null>(),
 });
+
+export interface CoffeeCoachInsight {
+  observation: string;
+  suggestion: string;
+  // Same state machine as library-wide insights (see InsightStatus).
+  status: "new" | "trying" | "confirmed" | "doesnt-apply";
+  // Latest sessionMs of THIS coffee at generation time. Stale when
+  // the coffee gets a newer session — triggers a regeneration unless
+  // the user is in the middle of `trying` or `confirmed`.
+  generatedAtSessionMs: number;
+  generatedAt: string;
+}
 
 // "I've been here" — visit-only café record without a brew session.
 // rating is intentionally binary ('come-back' | 'wont-return') since


### PR DESCRIPTION
## What you actually wanted

A coach card on a coffee detail page that says something about THAT coffee — not a library-wide insight that scored a false-positive on field-name overlap. Your Friedhats Colombian Gesha and SEY's washed Ethiopian were both getting a "honey vs natural light roasts" card that was about neither.

This PR builds the real thing.

## Per-coffee insight pipeline

`GET /api/coffees/[id]/insight` runs an Opus call that produces ONE observation + ONE suggestion specific to this coffee. Inputs:

- This coffee's full attribute set (variety, process, origin, roast, region, farm, altitude, tasting notes from bag, your common notes, personal notes, days-since-roast)
- This coffee's brew history (up to 30 sessions, each with the actually-brewed candidate via `resolveBrewedRecipe` — dose, water, temp, grind, actual time, rating, body, acidity, flavor notes, recipe name)
- Roaster prior (curated only — Friedhats, SEY, April, …)
- Variety prior (Gesha, SL28, Pink Bourbon — from the WCR-grounded catalog)

When there are 0 brews, the card opens with priors only ("First time brewing this bag — here's what to anchor on"). When there are 1+, it cites your actual numbers.

## Cache + workflow

`coffees.coach_insight jsonb` column (migration 0015) holds one record per coffee. Regenerates when the coffee gets a newer session, EXCEPT when status is `trying` or `confirmed` — don't change the card while you're mid-act on it. The three actions (Try it / Confirmed / Doesn't apply) still apply but they're per-coffee, not the global /taste queue.

## Where it surfaces

- **`/coffees/[id]`** — single card between Roaster and Notes, rotation-only.
- **`/brew/new` Context step** — quiet reminder pill when this coffee's per-coffee insight is `status='trying'`. Replaces the previous library-wide reminder.
- **`/taste`** — unchanged. That queue is library-wide on purpose (multivariate patterns across the corpus).

## Deploy

```bash
cat src/lib/db/migrations/0015_add_coffee_coach_insight.sql \
  | docker compose exec -T postgres psql -U brewlog -d brewlog
```

VPS migration must run BEFORE the deploy.

## Test plan

- [ ] Open Friedhats Colombian Gesha → card mentions Gesha + Colombia + cites your actual brew numbers from this bag
- [ ] Open SEY's washed Ethiopian → completely different card, specific to SEY
- [ ] Open a bag with 0 brews → card based on roaster/variety priors only, says so plainly
- [ ] Tap "Try it" → card disappears from this page; open `/brew/new` on that coffee → reminder pill appears with the same text
- [ ] Tap "Confirmed" → card disappears; status is preserved across regenerations
- [ ] Brew a new session of this coffee → card regenerates (unless status was trying/confirmed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5x8F1Ssu5UiQJJkQrJzre)_