### PR TITLE
fix(coach): use Light Chip primitive for the 3 card actions

### DIFF
--- a/src/app/(light)/taste/page.tsx
+++ b/src/app/(light)/taste/page.tsx
@@ -6,6 +6,7 @@ import { SCA_CATEGORIES, flavorCategory } from "@/lib/constants/scaFlavorWheel";
 import FlavorWheel from "@/components/ui/FlavorWheel";
 import CoffeeBeanGlow from "@/components/ui/light/CoffeeBeanGlow";
 import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
+import Chip from "@/components/ui/light/Chip";
 
 /**
  * Taste Profile — coach + always-visible consumption stats.
@@ -404,18 +405,13 @@ export default function TastePage() {
  * Coach insight card with the three-action workflow.
  *
  * Two text rows are intentional:
- *   - First row (observation): the data, with real counts. The "what
- *     the coach noticed."
- *   - Second row (suggestion): the next move or test question. The
- *     "what to do."
+ *   - First row (observation): the data, with real counts.
+ *   - Second row (suggestion): the next move or test question.
  * Different weight/opacity so the roles are visually distinct and
  * scannable.
  *
- * Actions (left to right, soft → hard):
- *   - Try it          → status = trying; reminder surfaces in
- *                       /brew/new Context for matching coffees
- *   - Confirmed       → status = confirmed; boosts /recommend weight
- *   - Doesn't apply   → status = doesnt-apply; soft-preserved
+ * Actions use the Light system's `Chip` primitive (small variant) so
+ * the visual language matches StepLog's sensory + flavor pickers.
  */
 function InsightCard({
   insight,
@@ -430,46 +426,18 @@ function InsightCard({
 }) {
   return (
     <div className="bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 rounded-2xl px-4 py-4">
-      {/* Observation — what the coach noticed (the data) */}
       <p className="text-light-foreground text-[15px] font-medium leading-relaxed">
         {insight.observation}
       </p>
-      {/* Suggestion — what to do (the next move) */}
       <p className="text-light-foreground/75 text-[14px] leading-relaxed mt-2">
         {insight.suggestion}
       </p>
-      {/* Action row — 3 buttons, soft → hard left to right */}
-      <div className="mt-4 pt-3 border-t border-light-foreground/10 flex gap-2">
-        <CardAction onClick={onTry} variant="primary">Try it</CardAction>
-        <CardAction onClick={onConfirm} variant="soft">Confirmed</CardAction>
-        <CardAction onClick={onDoesntApply} variant="muted">Doesn’t apply</CardAction>
+      <div className="mt-4 pt-3 border-t border-light-foreground/10 flex flex-wrap gap-2">
+        <Chip size="sm" onClick={onTry}>Try it</Chip>
+        <Chip size="sm" onClick={onConfirm}>Confirmed</Chip>
+        <Chip size="sm" onClick={onDoesntApply}>Doesn’t apply</Chip>
       </div>
     </div>
-  );
-}
-
-function CardAction({
-  onClick,
-  variant,
-  children,
-}: {
-  onClick: () => void;
-  variant: "primary" | "soft" | "muted";
-  children: React.ReactNode;
-}) {
-  // Three tonal weights so the visual hierarchy matches the action
-  // hierarchy: Try it is the encouraged path (anthracite), Confirmed is
-  // satisfaction (cream-glass), Doesn't apply is dismissal (muted text).
-  const classes =
-    variant === "primary"
-      ? "flex-1 h-9 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] text-[12px] font-semibold tracking-tight active:scale-[0.97] transition-transform"
-      : variant === "soft"
-        ? "flex-1 h-9 rounded-full bg-light-card-selected text-light-foreground text-[12px] font-semibold tracking-tight backdrop-blur-light-card backdrop-saturate-150 active:scale-[0.97] transition-transform"
-        : "flex-1 h-9 rounded-full text-light-muted-foreground text-[12px] tracking-tight active:text-light-foreground transition-colors";
-  return (
-    <button type="button" onClick={onClick} className={classes}>
-      {children}
-    </button>
   );
 }
 

--- a/src/components/coach/CoachCard.tsx
+++ b/src/components/coach/CoachCard.tsx
@@ -1,16 +1,16 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { ReactNode } from "react";
+import Chip from "@/components/ui/light/Chip";
 
 /**
  * Coach insight card — shared across /taste, /coffees/[id], and the
  * /brew/new Context reminder pill.
  *
  * The card itself is presentational. The three actions surface
- * Try it / Confirmed / Doesn't apply with a clean visual hierarchy:
- * anthracite for the encouraged path, cream-glass for satisfaction,
- * muted text for dismissal.
+ * Try it / Confirmed / Doesn't apply as the Light system's `Chip`
+ * primitive (small variant) — same primitive used in StepLog's
+ * sensory + flavor pickers, so the visual language is consistent.
  *
  * Two-line layout is intentional:
  *   - row 1 = observation (data with real counts)
@@ -56,40 +56,12 @@ export function CoachCard({
       <p className="text-light-foreground/75 text-[14px] leading-relaxed mt-2">
         {insight.suggestion}
       </p>
-      <div className="mt-4 pt-3 border-t border-light-foreground/10 flex gap-2">
-        <CardAction onClick={onTry} variant="primary">
-          Try it
-        </CardAction>
-        <CardAction onClick={onConfirm} variant="soft">
-          Confirmed
-        </CardAction>
-        <CardAction onClick={onDoesntApply} variant="muted">
-          Doesn’t apply
-        </CardAction>
+      <div className="mt-4 pt-3 border-t border-light-foreground/10 flex flex-wrap gap-2">
+        <Chip size="sm" onClick={onTry}>Try it</Chip>
+        <Chip size="sm" onClick={onConfirm}>Confirmed</Chip>
+        <Chip size="sm" onClick={onDoesntApply}>Doesn’t apply</Chip>
       </div>
     </div>
-  );
-}
-
-function CardAction({
-  onClick,
-  variant,
-  children,
-}: {
-  onClick: () => void;
-  variant: "primary" | "soft" | "muted";
-  children: ReactNode;
-}) {
-  const classes =
-    variant === "primary"
-      ? "flex-1 h-9 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] text-[12px] font-semibold tracking-tight active:scale-[0.97] transition-transform"
-      : variant === "soft"
-        ? "flex-1 h-9 rounded-full bg-light-card-selected text-light-foreground text-[12px] font-semibold tracking-tight backdrop-blur-light-card backdrop-saturate-150 active:scale-[0.97] transition-transform"
-        : "flex-1 h-9 rounded-full text-light-muted-foreground text-[12px] tracking-tight active:text-light-foreground transition-colors";
-  return (
-    <button type="button" onClick={onClick} className={classes}>
-      {children}
-    </button>
   );
 }
 


### PR DESCRIPTION
## Why

I shipped the coach card with bespoke buttons (h-9 pill, three custom tonal weights) instead of using the existing Light design system. That broke visual consistency with the rest of the app — StepLog's sensory and flavor pickers, the rotation chips on /coffees, etc., all use the documented `Chip` primitive.

## What

Both card surfaces (`CoachCard` in `/coffees/[id]` and `InsightCard` in `/taste`) now render their Try it / Confirmed / Doesn't apply row as three Chips at `size="sm"`. Drops the custom `CardAction` from both files (net -60 lines).

The previous three-tonal-weight hierarchy (anthracite primary, taupe soft, muted text) is gone — all three actions get the same Chip treatment. You distinguish them by label and position, the same as every other 3-option chip row in the app.

## Test plan

- [ ] Open any rotation coffee → three matching pills (cream-glass, 12px, backdrop-blur)
- [ ] Open /taste → same pills on each coach card

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5x8F1Ssu5UiQJJkQrJzre)_