### PR TITLE
fix: ban Drip Assist from /recommend + lock greeting time-of-day to Europe/Berlin

### DIFF
--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -156,7 +156,11 @@ export default function HomePage() {
     // a tod boundary (morning → midday → afternoon → evening →
     // late-night). Old `brewlog.starter.v{2..6}.<date>` entries are
     // orphaned in localStorage — harmless.
-    const key = `brewlog.starter.v8.${todayKey()}.${timeBucket()}`;
+    // v9 bumps for the Europe/Berlin timezone fix on the server — prior
+    // cached "Late night" greetings generated at 06:00 CEST (because
+    // the server read UTC 04:00) need to be discarded so the morning
+    // bucket regenerates from scratch.
+    const key = `brewlog.starter.v9.${todayKey()}.${timeBucket()}`;
     try {
       const cached = window.localStorage.getItem(key);
       if (cached) {

--- a/src/app/api/greeting/route.ts
+++ b/src/app/api/greeting/route.ts
@@ -163,9 +163,21 @@ export async function POST(req: NextRequest) {
       rowToSession(row as Parameters<typeof rowToSession>[0])
     );
 
+    // The server runs in UTC; the user is in Europe/Berlin. Without
+    // explicitly converting, at 06:48 CEST we computed UTC 04:48 and
+    // returned "late-night" — Haiku then opened the haiku with
+    // "Late night —" at 6:48 in the morning. Lock the wall-clock
+    // read to Europe/Berlin so the bucket matches what the user
+    // actually sees on their phone.
     const now = new Date();
-    const hour = now.getHours();
-    const minute = now.getMinutes();
+    const berlinParts = new Intl.DateTimeFormat("en-GB", {
+      timeZone: "Europe/Berlin",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    }).formatToParts(now);
+    const hour = Number(berlinParts.find((p) => p.type === "hour")?.value ?? "0");
+    const minute = Number(berlinParts.find((p) => p.type === "minute")?.value ?? "0");
     const timeOfDay =
       hour < 5 ? "late-night"
       : hour < 11 ? "morning"

--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -723,16 +723,18 @@ export async function generateRecommendation(
     ? `\nLOCKED METHOD: "${context.preferredMethod}" — the user has explicitly locked this brewer. BOTH candidates MUST use ${context.preferredMethod}. Do NOT swap to a different vessel for the second candidate. The two candidates contrast through substantially different RECIPE PHYSICS on the same brewer — different pour pattern (e.g. 4:6 vs Rao thirds vs single continuous), different ratio (e.g. 1:15 vs 1:17), different temperature (e.g. flat 95°C vs staged 80→95°C), different agitation profile, inverted vs upright (AeroPress), bypass vs no-bypass, immersion-then-drain vs full-percolation, etc. Both candidates equal — neither is primary. Override the lock only if genuinely incompatible with the coffee chemistry (rare). Capacity tensions are NOT a valid reason to override — those are handled via the USER OVERRIDE block above.`
     : "";
 
-  // Drip Assist emergency-only routing — when the user has explicitly
-  // locked V60 + Drip Assist (the perforated-disc accessory used only
-  // when no gooseneck is around, e.g. travelling), the disc adds flow
-  // resistance and the recipe needs to grind ~5° coarser than the bare
-  // V60 baseline to keep drawdown in the same window. The disc is NOT
-  // recommended proactively — only honor the user's explicit lock.
-  const dripAssistNote =
-    context.preferredMethod && /drip\s*-?\s*assist/i.test(context.preferredMethod)
-      ? `\nDRIP ASSIST GRIND OFFSET: The locked V60 + Drip Assist recipe MUST grind ~5° coarser than the V60 baseline in the NICHE° GRIND REFERENCE (use the "V60 + Drip Assist" range, not the bare V60 range). The disc smooths pour distribution but reduces free flow area; coarsen to compensate so total brew time matches a bare V60. Mention in reasoning that this is the disc-on emergency dial-in, not the user's preferred bare-V60 setup.`
-      : "";
+  // Drip Assist routing — the disc is the user's emergency / travel
+  // backup, used only when no gooseneck kettle is around. It is NEVER
+  // recommended proactively. When the user has explicitly locked
+  // "V60 + Drip Assist", honor it with the coarser-grind instruction;
+  // otherwise, ban it outright so Opus doesn't surface it as an
+  // exploratory candidate (the "Drip Assist Slow-Flow Probe" failure
+  // mode where it picked the disc on its own).
+  const dripAssistLocked =
+    context.preferredMethod && /drip\s*-?\s*assist/i.test(context.preferredMethod);
+  const dripAssistNote = dripAssistLocked
+    ? `\nDRIP ASSIST GRIND OFFSET: The locked V60 + Drip Assist recipe MUST grind ~5° coarser than the V60 baseline in the NICHE° GRIND REFERENCE (use the "V60 + Drip Assist" range, not the bare V60 range). The disc smooths pour distribution but reduces free flow area; coarsen to compensate so total brew time matches a bare V60. Mention in reasoning that this is the disc-on emergency dial-in, not the user's preferred bare-V60 setup.`
+    : `\nDRIP ASSIST IS BANNED: Do NOT suggest "V60 + Drip Assist" as a candidate's primaryMethod. The Hario Drip Assist disc is the user's emergency/travel backup (used only when no gooseneck kettle is available). It is NEVER a proactive recommendation. If the user wanted it, they would have locked it as preferredMethod — they did not. Pick a bare V60 or any other brewer the user owns instead.`;
 
   const goal = context.intent || "balanced";
   const goalNote = `\nGOAL: "${goal}" — the user's stated taste direction for this brew. The only user-stated bias allowed; everything else is science. See GOAL VOCABULARY in LAYER 1 for what this means and how it interacts with process defaults.`;


### PR DESCRIPTION
## Two bugs, both surfaced this morning

### 1. /recommend was suggesting Drip Assist
The exploratory candidate came back as "Drip Assist Slow-Flow Probe / V60 + Drip Assist". The disc is your emergency-only travel backup — should never be proactive.

The prompt already had a Drip Assist note, but it only fired when you had explicitly LOCKED the disc as `preferredMethod`. With no lock, nothing told Opus the disc was off-limits, and it picked it as "exploratory."

**Fix:** inverted the branch. When the disc is NOT locked, emit a hard `DRIP ASSIST IS BANNED` rule in the user message telling Opus not to use it as a candidate's primaryMethod. When it IS locked, the existing coarser-grind offset note fires as before.

### 2. Welcome haiku read "Late night" at 06:48 in the morning
Server runs in UTC; you're in CEST. Bare `new Date().getHours()` returned 4 → bucket = `late-night` → haiku opens with "Late night —". Wrong all morning.

**Fix:** lock the wall-clock read to `Europe/Berlin` via `Intl.DateTimeFormat`. The bucket now matches what your phone clock says.

Bumped the client-side greeting cache key `v8 → v9` so any "Late night" haikus already cached this morning get discarded and the morning bucket regenerates from scratch.

## Test plan

- [ ] Next /recommend run with no locked method → no candidate suggests V60 + Drip Assist
- [ ] Lock V60 + Drip Assist in the flow → still works (the existing coarser-grind offset fires)
- [ ] Open home screen after deploy → greeting reads "Morning" / "Midday" / etc. matching local time
- [ ] Tomorrow morning at 06:48 CEST → no more "Late night"

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5x8F1Ssu5UiQJJkQrJzre)_