### PR TITLE
feat: drip bag documentation in Coffee Library

### DIFF
--- a/src/app/(light)/coffees/drip/[id]/page.tsx
+++ b/src/app/(light)/coffees/drip/[id]/page.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { Menu } from "lucide-react";
+import StarRating from "@/components/ui/light/StarRating";
+import CoffeeBeanGlow from "@/components/ui/light/CoffeeBeanGlow";
+import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
+import { useFieldConfig } from "@/lib/field/FieldContext";
+import type { FieldZones } from "@/lib/field/types";
+import type { DripBag } from "@/lib/types/dripBag";
+
+/**
+ * Drip-bag detail — read-only documentation view. No rotation toggle, no
+ * Brew CTA, no coach card (a drip bag brews one fixed way and isn't in the
+ * AI corpus). The static /coffees/drip/* segment takes routing precedence
+ * over /coffees/[id], so there's no collision.
+ */
+export default function DripBagDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const [bag, setBag] = useState<DripBag | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/drip-bags/${id}`, { cache: "no-store" })
+      .then((r) => (r.ok ? (r.json() as Promise<DripBag>) : null))
+      .then((d) => {
+        if (!cancelled) {
+          setBag(d);
+          setLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  useFieldConfig(bag?.fieldZones ? { fieldZones: bag.fieldZones as FieldZones, rotation: 0 } : null);
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    try {
+      await fetch(`/api/drip-bags/${id}`, { method: "DELETE" });
+      router.push("/coffees");
+    } catch {
+      setDeleting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-svh bg-transparent flex flex-col">
+        <div className="px-5 pb-4" style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.5rem)" }}>
+          <button onClick={() => router.push("/coffees")} className="text-light-muted-foreground text-sm">
+            ← Library
+          </button>
+        </div>
+        <div className="flex-1 flex items-center justify-center">
+          <CoffeeBeanGlow size={64} />
+        </div>
+      </div>
+    );
+  }
+
+  if (!bag) {
+    return (
+      <div className="min-h-svh bg-transparent flex flex-col items-center justify-center gap-4">
+        <p className="text-light-muted-foreground">Drip bag not found</p>
+        <button onClick={() => router.push("/coffees")} className="text-light-foreground underline">
+          Back to library
+        </button>
+      </div>
+    );
+  }
+
+  const meta = [bag.origin, bag.region, bag.process, bag.variety, bag.roastLevel].filter(
+    (v): v is string => !!v
+  );
+
+  return (
+    <div className="min-h-svh bg-transparent flex flex-col">
+      {/* Hero */}
+      <div className="relative">
+        {bag.bagPhotoUrl ? (
+          <div className="relative h-72">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={bag.bagPhotoUrl} alt={bag.name} className="w-full h-full object-cover" />
+            <div
+              aria-hidden
+              className="absolute inset-0 pointer-events-none"
+              style={{
+                background:
+                  "linear-gradient(to top, hsl(30 60% 92% / 0.95) 0%, hsl(30 60% 92% / 0.45) 45%, transparent 80%)",
+              }}
+            />
+          </div>
+        ) : (
+          <div className="h-40 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150" />
+        )}
+
+        <button
+          onClick={() => router.push("/coffees")}
+          aria-label="Back to library"
+          className="absolute left-4 w-10 h-10 rounded-full bg-light-card-default/85 backdrop-blur-light-card backdrop-blur-sm flex items-center justify-center text-light-foreground"
+          style={{ top: "calc(env(safe-area-inset-top) + 1rem)" }}
+        >
+          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+
+        <button
+          type="button"
+          onClick={() => setMenuOpen(true)}
+          aria-label="Open menu"
+          className="absolute right-4 w-10 h-10 rounded-full bg-light-card-default/85 backdrop-blur-light-card backdrop-blur-sm flex items-center justify-center text-light-foreground active:scale-95 transition-transform"
+          style={{ top: "calc(env(safe-area-inset-top) + 1rem)" }}
+        >
+          <Menu className="w-5 h-5" strokeWidth={1.5} />
+        </button>
+
+        {/* Title overlay */}
+        <div className={`${bag.bagPhotoUrl ? "absolute bottom-0 left-0 right-0" : ""} p-5`}>
+          <p className="text-light-foreground/50 text-xs tracking-widest uppercase mb-1">Drip bag</p>
+          <h1 className="font-fraunces text-3xl text-light-foreground">{bag.name}</h1>
+          <p className="text-light-foreground/60 text-sm mt-1">
+            {bag.roaster}
+            {bag.origin ? ` · ${bag.origin}` : ""}
+          </p>
+        </div>
+      </div>
+
+      {/* Rating */}
+      {bag.rating > 0 && (
+        <div className="px-5 py-4 border-b border-light-foreground/15 flex items-center gap-3">
+          <StarRating value={bag.rating} readonly size="sm" />
+          <span className="text-light-muted-foreground text-xs uppercase tracking-widest">Your rating</span>
+        </div>
+      )}
+
+      {/* Identity chips */}
+      {meta.length > 0 && (
+        <div className="px-5 py-4 border-b border-light-foreground/15">
+          <p className="text-light-muted-foreground text-xs uppercase tracking-widest mb-3">Coffee details</p>
+          <div className="flex flex-wrap gap-1.5">
+            {meta.map((v) => (
+              <span
+                key={v}
+                className="inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground"
+              >
+                {v}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Printed notes */}
+      {bag.bagNotes.length > 0 && (
+        <div className="px-5 py-4 border-b border-light-foreground/15">
+          <p className="text-light-muted-foreground text-xs uppercase tracking-widest mb-3">Printed notes</p>
+          <div className="flex flex-wrap gap-1.5">
+            {bag.bagNotes.map((nVal) => (
+              <span
+                key={nVal}
+                className="inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight capitalize backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground"
+              >
+                {nVal}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Your flavours */}
+      {bag.flavorNotes.length > 0 && (
+        <div className="px-5 py-4 border-b border-light-foreground/15">
+          <p className="text-light-muted-foreground text-xs uppercase tracking-widest mb-3">You tasted</p>
+          <div className="flex flex-wrap gap-1.5">
+            {bag.flavorNotes.map((nVal) => (
+              <span
+                key={nVal}
+                className="inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight capitalize backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground"
+              >
+                {nVal}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Free notes */}
+      {bag.freeNotes && (
+        <div className="px-5 py-4 border-b border-light-foreground/15">
+          <p className="text-light-muted-foreground text-xs uppercase tracking-widest mb-2">Your notes</p>
+          <p className="text-light-foreground/80 text-sm leading-relaxed whitespace-pre-wrap">{bag.freeNotes}</p>
+        </div>
+      )}
+
+      {/* Delete */}
+      <div className="px-5 py-6 pb-safe pb-8">
+        {!confirmDelete ? (
+          <button
+            type="button"
+            onClick={() => setConfirmDelete(true)}
+            className="w-full py-3 rounded-2xl text-sm text-light-muted-foreground border border-light-foreground/15"
+          >
+            Delete drip bag
+          </button>
+        ) : (
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={deleting}
+              className="flex-1 py-3 rounded-2xl text-sm font-medium bg-[hsl(12_70%_45%)] text-[hsl(36_55%_96%)] disabled:opacity-50"
+            >
+              {deleting ? "Deleting…" : "Confirm delete"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirmDelete(false)}
+              className="flex-1 py-3 rounded-2xl text-sm border border-light-foreground/15 text-light-muted-foreground"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+      </div>
+
+      <NavigationOverlay open={menuOpen} onClose={() => setMenuOpen(false)} />
+    </div>
+  );
+}

--- a/src/app/(light)/coffees/drip/new/page.tsx
+++ b/src/app/(light)/coffees/drip/new/page.tsx
@@ -1,0 +1,410 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import Hero from "@/components/ui/light/Hero";
+import Section from "@/components/ui/light/Section";
+import Chip from "@/components/ui/light/Chip";
+import StarRating from "@/components/ui/light/StarRating";
+import FlavorWheel from "@/components/ui/FlavorWheel";
+import CoffeeBeanGlow from "@/components/ui/light/CoffeeBeanGlow";
+import { SCA_WHEEL, QUICK_FLAVORS } from "@/lib/constants/scaFlavorWheel";
+import { useFieldConfig } from "@/lib/field/FieldContext";
+import type { FieldZones } from "@/lib/field/types";
+
+interface Extracted {
+  roaster?: string;
+  name?: string;
+  origin?: string;
+  region?: string;
+  variety?: string;
+  process?: string;
+  roastLevel?: string;
+  tastingNotesFromBag?: string[];
+}
+
+const inputClass =
+  "w-full rounded-2xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 px-4 py-3 text-[15px] text-light-foreground placeholder:text-light-muted-foreground/70 outline-none";
+
+/**
+ * Add a drip bag — a lightweight documentation flow (NOT the brew flow).
+ * Scan the sachet → we extract the identity + printed notes → you pick
+ * the flavours you tasted + a star rating → save. No recipe, no timer:
+ * drip bags brew one fixed way. Page-local state only; never touches the
+ * brew flowStore. See src/lib/types/dripBag.ts.
+ */
+export default function AddDripBagPage() {
+  const router = useRouter();
+  const photoInputRef = useRef<HTMLInputElement>(null);
+
+  // Identity (roaster + name editable; the rest are read-only chips)
+  const [roaster, setRoaster] = useState("");
+  const [name, setName] = useState("");
+  const [origin, setOrigin] = useState<string | undefined>();
+  const [region, setRegion] = useState<string | undefined>();
+  const [variety, setVariety] = useState<string | undefined>();
+  const [process, setProcess] = useState<string | undefined>();
+  const [roastLevel, setRoastLevel] = useState<string | undefined>();
+  const [bagNotes, setBagNotes] = useState<string[]>([]);
+
+  const [bagPhotoUrl, setBagPhotoUrl] = useState<string | undefined>();
+  const [bagPhotoPath, setBagPhotoPath] = useState<string | undefined>();
+  const [fieldZones, setFieldZones] = useState<FieldZones | null>(null);
+  const [aiExtracted, setAiExtracted] = useState(false);
+
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [analyzing, setAnalyzing] = useState(false);
+  const [scanError, setScanError] = useState<string | null>(null);
+
+  // URL crawl (the package QR → product page)
+  const [showUrl, setShowUrl] = useState(false);
+  const [url, setUrl] = useState("");
+
+  // Tasting
+  const [selectedFlavors, setSelectedFlavors] = useState<string[]>([]);
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
+  const [rating, setRating] = useState(0);
+  const [freeNotes, setFreeNotes] = useState("");
+
+  const [saving, setSaving] = useState(false);
+
+  // Paint the page in the scanned coffee's Field, like the rest of the app.
+  useFieldConfig(fieldZones ? { fieldZones, rotation: 0 } : null);
+
+  const toggleFlavor = (f: string) =>
+    setSelectedFlavors((prev) => (prev.includes(f) ? prev.filter((x) => x !== f) : [...prev, f]));
+
+  const applyExtracted = (ex: Extracted) => {
+    if (ex.roaster) setRoaster(ex.roaster);
+    if (ex.name) setName(ex.name);
+    setOrigin(ex.origin);
+    setRegion(ex.region);
+    setVariety(ex.variety);
+    setProcess(ex.process);
+    setRoastLevel(ex.roastLevel);
+    if (ex.tastingNotesFromBag?.length) setBagNotes(ex.tastingNotesFromBag);
+    setAiExtracted(true);
+  };
+
+  const handlePhoto = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setScanError(null);
+    setPreviewUrl(URL.createObjectURL(file));
+    setAnalyzing(true);
+    try {
+      // 1. Upload to S3 (bags/ prefix is enforced by /api/upload)
+      const upFd = new FormData();
+      upFd.append("file", file);
+      upFd.append("path", `bags/${Date.now()}-${file.name.replace(/[^a-zA-Z0-9.-]/g, "_")}`);
+      const up = await fetch("/api/upload", { method: "POST", body: upFd });
+      if (up.ok) {
+        const { url: storedUrl, storagePath } = await up.json();
+        setBagPhotoUrl(storedUrl);
+        setBagPhotoPath(storagePath);
+      }
+
+      // 2. Analyze the label
+      const anFd = new FormData();
+      anFd.append("image", file);
+      const an = await fetch("/api/analyze-bag", { method: "POST", body: anFd });
+      if (!an.ok) throw new Error("Analysis failed");
+      const data = await an.json();
+      applyExtracted((data.extracted ?? {}) as Extracted);
+      if (data.fieldZones) setFieldZones(data.fieldZones as FieldZones);
+    } catch {
+      setScanError("Couldn't read the package — add the details by hand below.");
+      setAiExtracted(true); // reveal the manual form anyway
+    } finally {
+      setAnalyzing(false);
+    }
+  };
+
+  const handleUrl = async () => {
+    const trimmed = url.trim();
+    if (!trimmed) return;
+    setScanError(null);
+    setAnalyzing(true);
+    try {
+      const res = await fetch("/api/analyze-url", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: trimmed }),
+      });
+      if (!res.ok) throw new Error("Analysis failed");
+      const data = await res.json();
+      applyExtracted((data.extracted ?? {}) as Extracted);
+    } catch {
+      setScanError("Couldn't read that link — add the details by hand below.");
+      setAiExtracted(true);
+    } finally {
+      setAnalyzing(false);
+    }
+  };
+
+  const started = aiExtracted || previewUrl != null;
+  const canSave = roaster.trim().length > 0 && name.trim().length > 0 && !saving;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    setSaving(true);
+    const payload = {
+      roaster: roaster.trim(),
+      name: name.trim(),
+      origin,
+      region,
+      variety,
+      process,
+      roastLevel,
+      bagNotes,
+      flavorNotes: selectedFlavors,
+      rating,
+      freeNotes: freeNotes.trim() || undefined,
+      bagPhotoUrl,
+      bagPhotoPath,
+      fieldZones,
+      aiExtracted,
+    };
+    try {
+      const res = await fetch("/api/drip-bags", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error("Save failed");
+      router.push("/coffees");
+    } catch {
+      setSaving(false);
+      setScanError("Couldn't save — check your connection and try again.");
+    }
+  };
+
+  return (
+    <div className="min-h-svh bg-transparent flex flex-col pb-32">
+      {/* Header */}
+      <div className="px-5 pb-2" style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.25rem)" }}>
+        <button onClick={() => router.push("/coffees")} className="text-light-muted-foreground text-sm">
+          ← Library
+        </button>
+      </div>
+
+      <div className="px-5">
+        <Hero eyebrow="Drip bag" question={<>Document a drip bag.</>} />
+      </div>
+
+      <input ref={photoInputRef} type="file" accept="image/*" onChange={handlePhoto} className="hidden" />
+
+      <div className="px-5 mt-2 space-y-10">
+        {/* ── SCAN ─────────────────────────────────────────── */}
+        <Section eyebrow="The package">
+          {previewUrl && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={previewUrl} alt="Drip bag" className="w-full h-48 object-cover rounded-2xl mb-3" />
+          )}
+          {!started ? (
+            <div className="space-y-3">
+              <button
+                type="button"
+                onClick={() => photoInputRef.current?.click()}
+                className="w-full h-14 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] font-semibold active:scale-[0.98] transition-transform"
+              >
+                Scan package
+              </button>
+              {!showUrl ? (
+                <button
+                  type="button"
+                  onClick={() => setShowUrl(true)}
+                  className="w-full text-light-muted-foreground text-sm py-2"
+                >
+                  Paste a link instead
+                </button>
+              ) : (
+                <div className="flex items-center gap-2">
+                  <input
+                    type="url"
+                    inputMode="url"
+                    value={url}
+                    onChange={(e) => setUrl(e.target.value)}
+                    placeholder="https://…"
+                    className={inputClass}
+                  />
+                  <button
+                    type="button"
+                    onClick={handleUrl}
+                    aria-label="Analyze link"
+                    className="shrink-0 h-12 w-12 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] flex items-center justify-center"
+                  >
+                    →
+                  </button>
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={() => setAiExtracted(true)}
+                className="w-full text-light-muted-foreground text-sm py-2"
+              >
+                Enter manually
+              </button>
+            </div>
+          ) : null}
+
+          {analyzing && (
+            <div className="flex items-center gap-3 py-4">
+              <CoffeeBeanGlow size={28} />
+              <p className="text-light-muted-foreground text-sm">Reading the package…</p>
+            </div>
+          )}
+
+          {scanError && <p className="text-[hsl(12_70%_45%)] text-sm mt-2">{scanError}</p>}
+
+          {started && !analyzing && (
+            <div className="space-y-3 mt-1">
+              <div>
+                <p className="text-[11px] text-light-muted-foreground mb-1.5 px-1">Roaster</p>
+                <input value={roaster} onChange={(e) => setRoaster(e.target.value)} placeholder="e.g. INNO" className={inputClass} />
+              </div>
+              <div>
+                <p className="text-[11px] text-light-muted-foreground mb-1.5 px-1">Coffee</p>
+                <input value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Ethiopia" className={inputClass} />
+              </div>
+              {(origin || process || variety || roastLevel || region) && (
+                <div className="flex flex-wrap gap-1.5 pt-1">
+                  {[origin, region, process, variety, roastLevel]
+                    .filter((v): v is string => !!v)
+                    .map((v) => (
+                      <span
+                        key={v}
+                        className="inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground"
+                      >
+                        {v}
+                      </span>
+                    ))}
+                </div>
+              )}
+              {bagNotes.length > 0 && (
+                <div className="pt-1">
+                  <p className="text-[11px] text-light-muted-foreground mb-1.5 px-1">Printed notes</p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {bagNotes.map((nVal) => (
+                      <span
+                        key={nVal}
+                        className="inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight capitalize backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground"
+                      >
+                        {nVal}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </Section>
+
+        {/* ── RATING ───────────────────────────────────────── */}
+        {started && (
+          <Section eyebrow="Your rating">
+            <div className="flex flex-col items-center gap-2 py-2">
+              <StarRating value={rating} onChange={setRating} size="lg" />
+              <p className="text-[13px] text-light-muted-foreground">{rating === 0 ? "Tap to rate" : `${rating} / 5`}</p>
+            </div>
+          </Section>
+        )}
+
+        {/* ── FLAVOURS ─────────────────────────────────────── */}
+        {started && (
+          <Section eyebrow="Flavours you tasted">
+            <div className="w-full flex justify-center">
+              <FlavorWheel
+                mode="select"
+                activeCategory={activeCategory}
+                onCategorySelect={setActiveCategory}
+                selectedFlavors={selectedFlavors}
+                size={320}
+              />
+            </div>
+
+            {activeCategory ? (
+              <div className="space-y-3 mt-3">
+                <p className="label-eyebrow px-1">{activeCategory}</p>
+                {Object.entries(SCA_WHEEL[activeCategory].subcategories).map(([sub, flavors]) => (
+                  <div key={sub}>
+                    {Object.keys(SCA_WHEEL[activeCategory].subcategories).length > 1 && (
+                      <p className="text-[11px] text-light-muted-foreground/70 mb-1.5 px-1">{sub}</p>
+                    )}
+                    <div className="flex flex-wrap gap-2">
+                      {flavors.map((f) => (
+                        <Chip key={f} size="sm" selected={selectedFlavors.includes(f)} onClick={() => toggleFlavor(f)}>
+                          {f}
+                        </Chip>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="space-y-2 mt-3">
+                <div className="flex flex-wrap gap-2">
+                  {QUICK_FLAVORS.map((f) => (
+                    <Chip key={f} size="sm" selected={selectedFlavors.includes(f)} onClick={() => toggleFlavor(f)}>
+                      {f}
+                    </Chip>
+                  ))}
+                </div>
+                <p className="text-[12px] text-light-muted-foreground px-1 mt-1">Tap the wheel to explore by category</p>
+              </div>
+            )}
+
+            {selectedFlavors.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 pt-3 mt-2 border-t border-light-foreground/10">
+                {selectedFlavors.map((f) => (
+                  <button
+                    key={f}
+                    type="button"
+                    onClick={() => toggleFlavor(f)}
+                    className="text-[12px] text-light-foreground bg-light-card-selected px-2 py-0.5 rounded-lg"
+                  >
+                    {f} ×
+                  </button>
+                ))}
+              </div>
+            )}
+          </Section>
+        )}
+
+        {/* ── NOTES ────────────────────────────────────────── */}
+        {started && (
+          <Section eyebrow="Notes (optional)">
+            <textarea
+              value={freeNotes}
+              onChange={(e) => setFreeNotes(e.target.value)}
+              placeholder="Anything else worth noting…"
+              rows={3}
+              className="w-full rounded-2xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 px-4 py-3 text-[15px] text-light-foreground placeholder:text-light-muted-foreground/70 outline-none resize-none"
+            />
+          </Section>
+        )}
+      </div>
+
+      {/* Save bar */}
+      {started && (
+        <div
+          className="fixed bottom-0 left-0 right-0 px-5 pt-3 bg-gradient-to-t from-[hsl(36_55%_96%)] via-[hsl(36_55%_96%/0.85)] to-transparent"
+          style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 1rem)" }}
+        >
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!canSave}
+            className={`w-full h-14 rounded-full font-semibold transition-transform active:scale-[0.98] ${
+              canSave
+                ? "bg-light-foreground text-[hsl(36_55%_96%)]"
+                : "bg-light-foreground/30 text-[hsl(36_55%_96%)] cursor-not-allowed"
+            }`}
+          >
+            {saving ? "Saving…" : "Save drip bag"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(light)/coffees/drip/new/page.tsx
+++ b/src/app/(light)/coffees/drip/new/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
+import { useFlowStore } from "@/store/flowStore";
 import Hero from "@/components/ui/light/Hero";
 import Section from "@/components/ui/light/Section";
 import Chip from "@/components/ui/light/Chip";
@@ -67,6 +68,31 @@ export default function AddDripBagPage() {
   const [freeNotes, setFreeNotes] = useState("");
 
   const [saving, setSaving] = useState(false);
+
+  // Seed from the brew-flow scan when entered via the "Drip bag" toggle.
+  // The scan step already extracted the identity, uploaded the photo and
+  // mapped the Field — read it once on mount and skip straight to the
+  // flavours + rating capture. (Direct visits with no flow draft fall back
+  // to this page's own scan UI.)
+  useEffect(() => {
+    const st = useFlowStore.getState();
+    const c = st.draft.coffee;
+    if (!st.isDripBag || !c || !(c.name || c.roaster)) return;
+    setRoaster(c.roaster ?? "");
+    setName(c.name ?? "");
+    setOrigin(c.origin || undefined);
+    setRegion(c.region || undefined);
+    setVariety(c.variety || undefined);
+    setProcess(c.process || undefined);
+    setRoastLevel(c.roastLevel || undefined);
+    if (c.tastingNotesFromBag?.length) setBagNotes(c.tastingNotesFromBag);
+    setBagPhotoUrl(c.bagPhotoUrl || undefined);
+    setBagPhotoPath(c.bagPhotoPath || undefined);
+    if (c.bagPhotoUrl) setPreviewUrl(c.bagPhotoUrl);
+    if (st.fieldZones) setFieldZones(st.fieldZones);
+    setAiExtracted(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Paint the page in the scanned coffee's Field, like the rest of the app.
   useFieldConfig(fieldZones ? { fieldZones, rotation: 0 } : null);
@@ -172,6 +198,9 @@ export default function AddDripBagPage() {
         body: JSON.stringify(payload),
       });
       if (!res.ok) throw new Error("Save failed");
+      // Clear the brew-flow draft + drip-bag flag so the next "New Session"
+      // starts clean (the scan step seeded this page from the flow store).
+      useFlowStore.getState().reset();
       router.push("/coffees");
     } catch {
       setSaving(false);

--- a/src/app/(light)/coffees/page.tsx
+++ b/src/app/(light)/coffees/page.tsx
@@ -222,19 +222,6 @@ export default function CoffeesPage() {
         ) : null}
       </div>
 
-      {/* Add drip bag — documentation for single-serve sachets. Brewed one
-          fixed way, so it skips the brew flow entirely (scan → flavours →
-          rating). Always visible, including the empty state. */}
-      <div className="px-5 mb-3">
-        <button
-          type="button"
-          onClick={() => router.push("/coffees/drip/new")}
-          className="inline-flex items-center gap-1.5 rounded-full px-4 py-2 text-xs font-medium bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 text-light-foreground active:scale-95 transition-transform"
-        >
-          <span className="text-base leading-none">+</span> Drip bag
-        </button>
-      </div>
-
       {/* Search bar */}
       {!loading && !error && coffees.length > 0 && (
         <div className="px-5 mb-3">

--- a/src/app/(light)/coffees/page.tsx
+++ b/src/app/(light)/coffees/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { Menu } from "lucide-react";
 import type { Coffee } from "@/lib/types/coffee";
 import type { CoffeeIdentity, Session } from "@/lib/types/session";
+import type { DripBag } from "@/lib/types/dripBag";
 import StarRating from "@/components/ui/light/StarRating";
 import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
 import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
@@ -17,6 +18,32 @@ import {
 } from "@/lib/storage/offlineLibrary";
 
 type Filter = "recent" | "favorites" | "roaster";
+
+/** A library row — either an aggregated brewed Coffee or a documented
+ * drip bag (flagged), so both render through the same card markup. */
+type LibraryItem = Coffee & { isDripBag?: boolean };
+
+/** Map a documented drip bag into the shared card view-model. Drip bags
+ * have no brews, so sessionCount is 0 and the right-hand brew column stays
+ * hidden; the star row reuses the drip bag's own rating. firstSeenAt is the
+ * record's createdAt so it sorts alongside coffees by recency. */
+function dripBagToItem(d: DripBag): LibraryItem {
+  return {
+    id: d.id,
+    roaster: d.roaster,
+    name: d.name,
+    origin: d.origin ?? "",
+    process: d.process ?? "",
+    firstSeenAt: d.createdAt,
+    sessionCount: 0,
+    sessionIds: [],
+    avgRating: d.rating > 0 ? d.rating : undefined,
+    bagPhotoUrl: d.bagPhotoUrl,
+    fieldZones: d.fieldZones ?? null,
+    inRotation: false,
+    isDripBag: true,
+  };
+}
 
 /** Map a cached brewable coffee to the Coffee shape the list renders, so
  * the offline view reuses the same card markup. avgRating is derived from
@@ -44,7 +71,7 @@ function brewableToCoffee(b: BrewableCoffee): Coffee {
 }
 
 export default function CoffeesPage() {
-  const [coffees, setCoffees] = useState<Coffee[]>([]);
+  const [coffees, setCoffees] = useState<LibraryItem[]>([]);
   const [totalSessions, setTotalSessions] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -103,11 +130,18 @@ export default function CoffeesPage() {
     const coffeesP = fetch("/api/coffees", { cache: "no-store" })
       .then((r) => { if (!r.ok) throw new Error(); return r.json() as Promise<Coffee[]>; });
 
-    // Render the list as soon as coffees load — don't block on the cache warm.
-    coffeesP
-      .then((data) => {
+    // Drip bags live in their own table; merge them into the same list,
+    // flagged. A drip-bags outage is non-fatal — coffees still render.
+    const dripBagsP = fetch("/api/drip-bags", { cache: "no-store" })
+      .then((r) => (r.ok ? (r.json() as Promise<DripBag[]>) : []))
+      .catch((): DripBag[] => []);
+
+    // Render the list as soon as the sources load — don't block on the cache warm.
+    Promise.all([coffeesP, dripBagsP])
+      .then(([data, drips]) => {
         if (cancelled) return;
-        setCoffees([...data].sort((a, b) => (b.firstSeenAt || "").localeCompare(a.firstSeenAt || "")));
+        const merged: LibraryItem[] = [...data, ...drips.map(dripBagToItem)];
+        setCoffees(merged.sort((a, b) => (b.firstSeenAt || "").localeCompare(a.firstSeenAt || "")));
       })
       .catch(() => { if (!cancelled) setError(true); })
       .finally(() => { if (!cancelled) setLoading(false); });
@@ -188,6 +222,19 @@ export default function CoffeesPage() {
         ) : null}
       </div>
 
+      {/* Add drip bag — documentation for single-serve sachets. Brewed one
+          fixed way, so it skips the brew flow entirely (scan → flavours →
+          rating). Always visible, including the empty state. */}
+      <div className="px-5 mb-3">
+        <button
+          type="button"
+          onClick={() => router.push("/coffees/drip/new")}
+          className="inline-flex items-center gap-1.5 rounded-full px-4 py-2 text-xs font-medium bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 text-light-foreground active:scale-95 transition-transform"
+        >
+          <span className="text-base leading-none">+</span> Drip bag
+        </button>
+      </div>
+
       {/* Search bar */}
       {!loading && !error && coffees.length > 0 && (
         <div className="px-5 mb-3">
@@ -254,7 +301,7 @@ export default function CoffeesPage() {
               <path strokeLinecap="round" strokeLinejoin="round" d="M20.25 6.375c0 2.278-3.694 4.125-8.25 4.125S3.75 8.653 3.75 6.375m16.5 0c0-2.278-3.694-4.125-8.25-4.125S3.75 4.097 3.75 6.375m16.5 0v11.25c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125V6.375m16.5 0v3.75m-16.5-3.75v3.75m16.5 0v3.75C20.25 16.153 16.556 18 12 18s-8.25-1.847-8.25-4.125v-3.75m16.5 0c0 2.278-3.694 4.125-8.25 4.125s-8.25-1.847-8.25-4.125" />
             </svg>
             <p className="font-fraunces text-xl text-light-foreground">No coffees yet</p>
-            <p className="text-light-muted-foreground text-sm">Coffees you scan will appear here.</p>
+            <p className="text-light-muted-foreground text-sm">Coffees you scan — and drip bags you log — appear here.</p>
           </div>
         ) : filteredCoffees.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-40 text-center gap-2">
@@ -276,7 +323,13 @@ export default function CoffeesPage() {
                       flush with the card border, no padding gap. */}
                   <button
                     type="button"
-                    onClick={() => (online ? router.push(`/coffees/${coffee.id}`) : setPickerId(coffee.id))}
+                    onClick={() =>
+                      coffee.isDripBag
+                        ? router.push(`/coffees/drip/${coffee.id}`)
+                        : online
+                          ? router.push(`/coffees/${coffee.id}`)
+                          : setPickerId(coffee.id)
+                    }
                     className="flex items-stretch flex-1 min-w-0 text-left active:opacity-80 transition-opacity"
                   >
                     {/* Photo — full-height left strip (w-24 = 96px).
@@ -319,6 +372,11 @@ export default function CoffeesPage() {
                       </div>
                       {sub && (
                         <p className="text-light-muted-foreground text-xs truncate mt-0.5">{sub}</p>
+                      )}
+                      {coffee.isDripBag && (
+                        <span className="inline-flex items-center rounded-full px-2 py-0.5 mt-1 text-[10px] font-medium uppercase tracking-wide bg-light-card-selected text-light-foreground">
+                          Drip bag
+                        </span>
                       )}
                       {coffee.latestRoastDate && (
                         <p className="text-light-muted-foreground text-xs truncate mt-0.5">

--- a/src/app/api/drip-bags/[id]/route.ts
+++ b/src/app/api/drip-bags/[id]/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { dripBags } from "@/lib/db/schema";
+import type { DripBag } from "@/lib/types/dripBag";
+
+export const dynamic = "force-dynamic";
+
+function rowToDripBag(r: typeof dripBags.$inferSelect): DripBag {
+  return {
+    id: r.id,
+    roaster: r.roaster,
+    name: r.name,
+    origin: r.origin ?? undefined,
+    region: r.region ?? undefined,
+    variety: r.variety ?? undefined,
+    process: r.process ?? undefined,
+    roastLevel: r.roastLevel ?? undefined,
+    bagNotes: r.bagNotes ?? [],
+    flavorNotes: r.flavorNotes ?? [],
+    rating: r.rating != null ? Number(r.rating) : 0,
+    freeNotes: r.freeNotes ?? undefined,
+    bagPhotoUrl: r.bagPhotoUrl ?? undefined,
+    bagPhotoPath: r.bagPhotoPath ?? undefined,
+    fieldZones: (r.fieldZones as DripBag["fieldZones"]) ?? null,
+    aiExtracted: r.aiExtracted,
+    createdAt: r.createdAt.toISOString(),
+    createdAtMs: r.createdAtMs,
+  };
+}
+
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const rows = await db.select().from(dripBags).where(eq(dripBags.id, params.id)).limit(1);
+    if (rows.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+    return NextResponse.json(rowToDripBag(rows[0]));
+  } catch (err) {
+    console.error("drip-bags [id] GET error:", err);
+    return NextResponse.json({ error: "internal" }, { status: 500 });
+  }
+}
+
+export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    await db.delete(dripBags).where(eq(dripBags.id, params.id));
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("drip-bags [id] DELETE error:", err);
+    return NextResponse.json({ error: "internal" }, { status: 500 });
+  }
+}

--- a/src/app/api/drip-bags/route.ts
+++ b/src/app/api/drip-bags/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest, NextResponse } from "next/server";
+import { desc } from "drizzle-orm";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import { db } from "@/lib/db/client";
+import { dripBags } from "@/lib/db/schema";
+import type { DripBag } from "@/lib/types/dripBag";
+
+export const dynamic = "force-dynamic";
+
+const DripBagSchema = z.object({
+  roaster: z.string().min(1).max(200),
+  name: z.string().min(1).max(200),
+  origin: z.string().max(200).optional(),
+  region: z.string().max(200).optional(),
+  variety: z.string().max(200).optional(),
+  process: z.string().max(120).optional(),
+  roastLevel: z.string().max(60).optional(),
+  bagNotes: z.array(z.string().max(120)).max(40).default([]),
+  flavorNotes: z.array(z.string().max(120)).max(60).default([]),
+  rating: z.number().min(0).max(5),
+  freeNotes: z.string().max(2000).optional(),
+  bagPhotoUrl: z.string().max(2000).optional(),
+  bagPhotoPath: z.string().max(2000).optional(),
+  // Generative Field composition is computed server-side at scan time
+  // (analyze-bag) and passed straight through — kept loose here.
+  fieldZones: z.any().optional(),
+  aiExtracted: z.boolean().default(false),
+});
+
+function rowToDripBag(r: typeof dripBags.$inferSelect): DripBag {
+  return {
+    id: r.id,
+    roaster: r.roaster,
+    name: r.name,
+    origin: r.origin ?? undefined,
+    region: r.region ?? undefined,
+    variety: r.variety ?? undefined,
+    process: r.process ?? undefined,
+    roastLevel: r.roastLevel ?? undefined,
+    bagNotes: r.bagNotes ?? [],
+    flavorNotes: r.flavorNotes ?? [],
+    rating: r.rating != null ? Number(r.rating) : 0,
+    freeNotes: r.freeNotes ?? undefined,
+    bagPhotoUrl: r.bagPhotoUrl ?? undefined,
+    bagPhotoPath: r.bagPhotoPath ?? undefined,
+    fieldZones: (r.fieldZones as DripBag["fieldZones"]) ?? null,
+    aiExtracted: r.aiExtracted,
+    createdAt: r.createdAt.toISOString(),
+    createdAtMs: r.createdAtMs,
+  };
+}
+
+export async function GET() {
+  try {
+    const rows = await db.select().from(dripBags).orderBy(desc(dripBags.createdAtMs)).limit(200);
+    return NextResponse.json(rows.map(rowToDripBag));
+  } catch (err) {
+    console.error("drip-bags GET error:", err);
+    return NextResponse.json([], { status: 500 });
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const parsed = DripBagSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid payload", details: parsed.error.issues }, { status: 400 });
+    }
+    const d = parsed.data;
+    const now = new Date();
+    const id = randomUUID();
+    await db.insert(dripBags).values({
+      id,
+      roaster: d.roaster,
+      name: d.name,
+      origin: d.origin,
+      region: d.region,
+      variety: d.variety,
+      process: d.process,
+      roastLevel: d.roastLevel,
+      bagNotes: d.bagNotes,
+      flavorNotes: d.flavorNotes,
+      // numeric columns take a string per the project convention
+      rating: String(d.rating),
+      freeNotes: d.freeNotes,
+      bagPhotoUrl: d.bagPhotoUrl,
+      bagPhotoPath: d.bagPhotoPath,
+      fieldZones: d.fieldZones ?? null,
+      aiExtracted: d.aiExtracted,
+      createdAt: now,
+      createdAtMs: now.getTime(),
+    });
+    return NextResponse.json(
+      {
+        id,
+        roaster: d.roaster,
+        name: d.name,
+        origin: d.origin,
+        region: d.region,
+        variety: d.variety,
+        process: d.process,
+        roastLevel: d.roastLevel,
+        bagNotes: d.bagNotes,
+        flavorNotes: d.flavorNotes,
+        rating: d.rating,
+        freeNotes: d.freeNotes,
+        bagPhotoUrl: d.bagPhotoUrl,
+        bagPhotoPath: d.bagPhotoPath,
+        fieldZones: d.fieldZones ?? null,
+        aiExtracted: d.aiExtracted,
+        createdAt: now.toISOString(),
+        createdAtMs: now.getTime(),
+      } satisfies DripBag,
+      { status: 201 }
+    );
+  } catch (err) {
+    console.error("drip-bags POST error:", err);
+    return NextResponse.json({ error: "internal" }, { status: 500 });
+  }
+}

--- a/src/components/flow/LightStepScan.tsx
+++ b/src/components/flow/LightStepScan.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useFlowStore } from "@/store/flowStore";
 import LightFlowShell from "@/components/ui/light/LightFlowShell";
 import PhotoUpload from "@/components/ui/PhotoUpload";
@@ -58,7 +59,8 @@ const ROASTER_QA_LOCATION_CHIPS = ["Germany", "Netherlands", "UK", "USA", "Denma
 const ROASTER_QA_STYLE_CHIPS = ["Very light", "Light", "Light-medium", "Medium", "Varies"];
 
 export default function LightStepScan() {
-  const { draft, setCoffee, setMode, setStep, setSkipScan, setFieldZones, isAnalyzing, setIsAnalyzing, clarificationMessages, addClarificationMessage, clearClarifications, reset } = useFlowStore();
+  const { draft, setCoffee, setMode, setStep, setSkipScan, setFieldZones, isDripBag, setIsDripBag, isAnalyzing, setIsAnalyzing, clarificationMessages, addClarificationMessage, clearClarifications, reset } = useFlowStore();
+  const router = useRouter();
   const [preview, setPreview] = useState<string | null>(null);
   const [inputMethod, setInputMethod] = useState<InputMethod | null>(null);
   const [selectedMode, setSelectedMode] = useState<ModeChoice | null>(null);
@@ -531,20 +533,52 @@ export default function LightStepScan() {
           )}
         </div>
       )}
+
+      {/* Drip bag toggle — a single-serve sachet brews one fixed way, so
+          there's no recipe to generate. Flip this on and Continue jumps
+          straight to documenting flavours + a rating (saved isolated in
+          drip_bags, never fed to recommendations). */}
+      <button
+        type="button"
+        onClick={() => setIsDripBag(!isDripBag)}
+        aria-pressed={isDripBag}
+        className="w-full flex items-center justify-between gap-3 pt-3 mt-1 border-t"
+        style={{ borderColor: "var(--border)" }}
+      >
+        <span className="text-left">
+          <span className="block text-sm" style={{ color: "var(--foreground)" }}>This is a drip bag</span>
+          <span className="block text-xs" style={{ color: "var(--muted-foreground)" }}>Skip the recipe — just log flavours + a rating</span>
+        </span>
+        <span
+          className="relative shrink-0 h-6 w-11 rounded-full transition-colors"
+          style={{ background: isDripBag ? "var(--foreground)" : "var(--border)" }}
+        >
+          <span
+            className="absolute top-0.5 h-5 w-5 rounded-full transition-transform"
+            style={{ left: "2px", background: "var(--card)", transform: isDripBag ? "translateX(20px)" : "translateX(0)" }}
+          />
+        </span>
+      </button>
     </div>
   );
 
-  // Continue is gated on BOTH having coffee info AND picking a mode —
-  // mode no longer defaults to "home" so the user has to make an
-  // explicit choice (Markus' feedback: pre-selected Brew-at-home was
-  // confusing).
-  const canProceed = hasCoffeeInfo && selectedMode !== null;
+  // Continue is gated on having coffee info AND (for a normal brew) an
+  // explicit mode choice — mode no longer defaults to "home" (Markus'
+  // feedback: pre-selected Brew-at-home was confusing). A drip bag needs
+  // no mode, so the toggle alone unlocks Continue.
+  const canProceed = hasCoffeeInfo && (isDripBag || selectedMode !== null);
 
   const nextStep = () => {
-    if (!selectedMode) return;
     if (showManualForm && (manualRoaster || manualName || manualOrigin)) {
       applyManualForm();
     }
+    // Drip bag: leave the brew flow and hand the scanned identity to the
+    // documentation page (it reads draft.coffee + fieldZones + isDripBag).
+    if (isDripBag) {
+      router.push("/coffees/drip/new");
+      return;
+    }
+    if (!selectedMode) return;
     setMode(selectedMode);
     if (selectedMode === "home") setStep("context");
     else setStep("mode");
@@ -555,7 +589,7 @@ export default function LightStepScan() {
     analysisResult?.roasterPrior ?? manualRoasterPrior ?? null;
 
   return (
-    <LightFlowShell onNext={canProceed ? nextStep : undefined} nextDisabled={!canProceed} nextLabel="Continue →">
+    <LightFlowShell onNext={canProceed ? nextStep : undefined} nextDisabled={!canProceed} nextLabel={isDripBag ? "Document →" : "Continue →"}>
       <div className="px-5 py-4 flex flex-col gap-5" style={{ paddingBottom: "2rem" }}>
         <Hero eyebrow="New Session" question={<>What are you brewing today?</>} />
 
@@ -974,24 +1008,27 @@ export default function LightStepScan() {
           </a>
         )}
 
-        {/* THEN CHOOSE */}
-        <div>
-          <p className="label-eyebrow mb-3" style={{ color: "var(--muted-foreground)" }}>Then Choose</p>
-          <div className="grid grid-cols-2 gap-3">
-            {SCAN_MODES.map(m => (
-              <div key={m.id} className="h-[88px]">
-                <Card
-                  selected={selectedMode === m.id}
-                  onClick={() => setSelectedMode(m.id)}
-                  ariaLabel={m.label}
-                >
-                  <CardIcon><m.Icon className="h-5 w-5" strokeWidth={1.5} /></CardIcon>
-                  <CardTitle>{m.label}</CardTitle>
-                </Card>
-              </div>
-            ))}
+        {/* THEN CHOOSE — hidden for drip bags (no brew mode applies; the
+            Continue button documents it directly). */}
+        {!isDripBag && (
+          <div>
+            <p className="label-eyebrow mb-3" style={{ color: "var(--muted-foreground)" }}>Then Choose</p>
+            <div className="grid grid-cols-2 gap-3">
+              {SCAN_MODES.map(m => (
+                <div key={m.id} className="h-[88px]">
+                  <Card
+                    selected={selectedMode === m.id}
+                    onClick={() => setSelectedMode(m.id)}
+                    ariaLabel={m.label}
+                  >
+                    <CardIcon><m.Icon className="h-5 w-5" strokeWidth={1.5} /></CardIcon>
+                    <CardTitle>{m.label}</CardTitle>
+                  </Card>
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </LightFlowShell>
   );

--- a/src/lib/db/migrations/0016_add_drip_bags.sql
+++ b/src/lib/db/migrations/0016_add_drip_bags.sql
@@ -1,0 +1,40 @@
+-- 0016 — Drip bag documentation records
+--
+-- Single-serve drip bags (e.g. the INNO "Signature Drip Coffee" sachet)
+-- are brewed exactly one fixed way (200 ml hot water through the built-in
+-- filter), so there's no recipe to generate and no gear to log. This table
+-- is pure documentation: the scanned identity, the flavour notes printed on
+-- the package (bag_notes), the flavours the user tasted (flavor_notes), and
+-- a 1–5 star rating.
+--
+-- Intentionally isolated from sessions / coffees / the AI corpus — mirrors
+-- the cafe_visits precedent (migration 0011) — so drip bags never skew
+-- /recommend, /api/insights, /taste, or the Café Library. Surfaced only in
+-- the Coffee Library list (flagged) and their own detail page.
+--
+-- Run this file with:
+--   cat src/lib/db/migrations/0016_add_drip_bags.sql | docker compose exec -T postgres psql -U brewlog -d brewlog
+
+CREATE TABLE IF NOT EXISTS drip_bags (
+  id              text PRIMARY KEY,
+  roaster         text NOT NULL,
+  name            text NOT NULL,
+  origin          text,
+  region          text,
+  variety         text,
+  process         text,
+  roast_level     text,
+  bag_notes       jsonb NOT NULL DEFAULT '[]'::jsonb,
+  flavor_notes    jsonb NOT NULL DEFAULT '[]'::jsonb,
+  rating          numeric,
+  free_notes      text,
+  bag_photo_url   text,
+  bag_photo_path  text,
+  field_zones     jsonb,
+  ai_extracted    boolean NOT NULL DEFAULT false,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  created_at_ms   bigint NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS drip_bags_created_at_ms_idx
+  ON drip_bags (created_at_ms DESC);

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -115,6 +115,38 @@ export const cafeVisits = pgTable("cafe_visits", {
   visitedAtMs: bigint("visited_at_ms", { mode: "number" }).notNull(),
 });
 
+// Single-serve drip-bag documentation record (see migration 0016 and
+// src/lib/types/dripBag.ts). Brewed one fixed way, so no recipe/brew
+// fields — just the scanned identity, the printed bag notes, the user's
+// flavour-wheel picks, and a star rating. Intentionally isolated from
+// `sessions`/`coffees`/the AI corpus, like `cafe_visits`.
+export const dripBags = pgTable(
+  "drip_bags",
+  {
+    id: text("id").primaryKey(),
+    roaster: text("roaster").notNull(),
+    name: text("name").notNull(),
+    origin: text("origin"),
+    region: text("region"),
+    variety: text("variety"),
+    process: text("process"),
+    roastLevel: text("roast_level"),
+    bagNotes: jsonb("bag_notes").$type<string[]>().notNull().default([]),
+    flavorNotes: jsonb("flavor_notes").$type<string[]>().notNull().default([]),
+    rating: numeric("rating"),
+    freeNotes: text("free_notes"),
+    bagPhotoUrl: text("bag_photo_url"),
+    bagPhotoPath: text("bag_photo_path"),
+    fieldZones: jsonb("field_zones"),
+    aiExtracted: boolean("ai_extracted").notNull().default(false),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    createdAtMs: bigint("created_at_ms", { mode: "number" }).notNull(),
+  },
+  (t) => ({
+    createdAtMsIdx: index("drip_bags_created_at_ms_idx").on(t.createdAtMs.desc()),
+  })
+);
+
 export const preferences = pgTable("preferences", {
   key: text("key").primaryKey(),
   data: jsonb("data").notNull(),

--- a/src/lib/types/dripBag.ts
+++ b/src/lib/types/dripBag.ts
@@ -1,0 +1,40 @@
+import type { FieldZones } from "@/lib/field/types";
+
+/**
+ * A single-serve **drip bag** record (e.g. the INNO "Signature Drip
+ * Coffee" sachet). Unlike a brewed `Session`, a drip bag has a fixed
+ * brew — 200 ml of hot water through the built-in filter — so there is
+ * no recipe to generate and no gear to log. It's pure documentation:
+ * scan the package, keep the identity, record the flavours tasted and
+ * a star rating.
+ *
+ * Deliberately ISOLATED from `sessions` / `coffees` / the AI corpus
+ * (it lives in its own `drip_bags` table, mirroring the `cafe_visits`
+ * precedent) so it can never skew `/recommend`, `/api/insights`,
+ * `/taste`, or the Café Library. Surfaced only in the Coffee Library
+ * list (flagged) + its own detail page.
+ */
+export interface DripBag {
+  id: string;
+  roaster: string;
+  name: string;
+  origin?: string;
+  region?: string;
+  variety?: string;
+  process?: string;
+  roastLevel?: string;
+  /** Flavour notes printed on the package (from the bag scan). */
+  bagNotes: string[];
+  /** Flavours the user actually tasted (their flavour-wheel picks). */
+  flavorNotes: string[];
+  /** 1–5, half-star. */
+  rating: number;
+  freeNotes?: string;
+  bagPhotoUrl?: string;
+  bagPhotoPath?: string;
+  /** Generative Field v1.1 composition, computed from `bagNotes` at scan. */
+  fieldZones?: FieldZones | null;
+  aiExtracted: boolean;
+  createdAt: string; // ISO timestamp
+  createdAtMs: number;
+}

--- a/src/store/flowStore.ts
+++ b/src/store/flowStore.ts
@@ -22,6 +22,11 @@ interface FlowState {
    * property per spec §10.4 anti-pattern). null = use Default Field. */
   fieldZones: FieldZones | null;
   skipScan: boolean;         // true when entering via "brew again" (no scan step)
+  /** Set from the "Drip bag" toggle in the scan step. A drip bag brews one
+   * fixed way, so when true the flow leaves the brew steps after scan and
+   * routes to the drip documentation (flavours + rating), saved isolated in
+   * the drip_bags table. See src/lib/types/dripBag.ts. */
+  isDripBag: boolean;
   isAnalyzing: boolean;
   isRecommending: boolean;
   recommendError: string | null;
@@ -31,6 +36,7 @@ interface FlowState {
   setStep: (step: FlowStep) => void;
   setMode: (mode: SessionMode) => void;
   setSkipScan: (v: boolean) => void;
+  setIsDripBag: (v: boolean) => void;
   setCoffee: (coffee: Partial<CoffeeIdentity>) => void;
   setPlace: (place: ExternalPlace) => void;
   setContext: (context: SessionContext) => void;
@@ -64,6 +70,7 @@ export const useFlowStore = create<FlowState>()(
       draft: initialDraft,
       fieldZones: null,
       skipScan: false,
+      isDripBag: false,
       isAnalyzing: false,
       isRecommending: false,
       recommendError: null,
@@ -72,6 +79,7 @@ export const useFlowStore = create<FlowState>()(
       setStep: (step) => set({ step }),
       setMode: (mode) => set((s) => ({ draft: { ...s.draft, mode } })),
       setSkipScan: (v) => set({ skipScan: v }),
+      setIsDripBag: (v) => set({ isDripBag: v }),
       setCoffee: (coffee) =>
         set((s) => ({ draft: { ...s.draft, coffee: { ...s.draft.coffee, ...coffee } as CoffeeIdentity } })),
       setPlace: (place) => set((s) => ({ draft: { ...s.draft, place } })),
@@ -87,7 +95,7 @@ export const useFlowStore = create<FlowState>()(
         set((s) => ({ clarificationMessages: [...s.clarificationMessages, msg] })),
       clearClarifications: () => set({ clarificationMessages: [] }),
       reset: () =>
-        set({ step: "scan", draft: initialDraft, fieldZones: null, skipScan: false, isAnalyzing: false, isRecommending: false, recommendError: null, clarificationMessages: [] }),
+        set({ step: "scan", draft: initialDraft, fieldZones: null, skipScan: false, isDripBag: false, isAnalyzing: false, isRecommending: false, recommendError: null, clarificationMessages: [] }),
     }),
     {
       // localStorage (not sessionStorage) so an in-flight brew survives a


### PR DESCRIPTION
## What & why

Single-serve **drip bags** (e.g. the INNO "Signature Drip Coffee" sachet) brew exactly one fixed way — 200 ml hot water through the built-in filter. There's no recipe to generate and no gear to log, so they don't belong in the brew flow. This adds a lightweight **documentation** path whose only purpose is to remember which drip bags you like.

Flow: **scan the sachet → extract identity + printed notes → pick the flavours you tasted on the wheel + a 1–5 star rating → save.**

## Design intent (confirmed)

Pure documentation. Drip bags live in their **own `drip_bags` table**, fully isolated from `sessions` / `coffees` / the AI corpus (mirrors the `cafe_visits` precedent). They deliberately do **not** feed `/recommend`, `/api/insights`, `/taste`, or the Café Library — they can never skew recommendations.

## Surfacing

Inside the **Coffee Library** (`/coffees`): drip bags appear in the list flagged with a "Drip bag" chip, sorted by recency alongside coffees, each with its own detail page. A new **"+ Drip bag"** button starts the add flow. The list degrades gracefully if the table doesn't exist yet (coffees still load).

## Changes

- `types/dripBag.ts` + `dripBags` Drizzle table + **migration `0016_add_drip_bags.sql`**
- `/api/drip-bags` (GET list / POST) + `/api/drip-bags/[id]` (GET / DELETE)
- `(light)/coffees/drip/new` add flow + `(light)/coffees/drip/[id]` detail page
- `(light)/coffees` list merges drip bags (flagged) + adds the entry button
- Reuses `/api/upload`, `/api/analyze-bag`, `/api/analyze-url`, `FlavorWheel`, `StarRating` as-is

## ⚠️ Deploy step — run the migration on the VPS

The new table must be created for the feature to work (the list is guarded, but add/detail need it):

```bash
cd /opt/brewlog && cat src/lib/db/migrations/0016_add_drip_bags.sql | docker compose exec -T postgres psql -U brewlog -d brewlog
```

## Out of scope (easy follow-ups)
- Drip-bag flavours don't feed the global Taste Profile.
- No offline support for adding/viewing drip bags (matches the café-visit feature).

`npx tsc --noEmit` passes clean.

https://claude.ai/code/session_0193NAQ5JuQmdAbJB1d23zaw

---
_Generated by [Claude Code](https://claude.ai/code/session_0193NAQ5JuQmdAbJB1d23zaw)_