### PR TITLE
fix(drip bag): align Log page with the design system

### DIFF
--- a/src/app/(light)/coffees/drip/new/page.tsx
+++ b/src/app/(light)/coffees/drip/new/page.tsx
@@ -1,42 +1,41 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { ChevronLeft } from "lucide-react";
 import { useFlowStore } from "@/store/flowStore";
 import Hero from "@/components/ui/light/Hero";
 import Section from "@/components/ui/light/Section";
 import Chip from "@/components/ui/light/Chip";
 import StarRating from "@/components/ui/light/StarRating";
+import CTA from "@/components/ui/light/CTA";
 import FlavorWheel from "@/components/ui/FlavorWheel";
-import CoffeeBeanGlow from "@/components/ui/light/CoffeeBeanGlow";
 import { SCA_WHEEL, QUICK_FLAVORS } from "@/lib/constants/scaFlavorWheel";
 import { useFieldConfig } from "@/lib/field/FieldContext";
 import type { FieldZones } from "@/lib/field/types";
 
-interface Extracted {
-  roaster?: string;
-  name?: string;
-  origin?: string;
-  region?: string;
-  variety?: string;
-  process?: string;
-  roastLevel?: string;
-  tastingNotesFromBag?: string[];
-}
+// Same wording as the post-brew taste log so a drip-bag rating reads
+// identically to a brewed coffee's. Half-star values fall back to "".
+const RATING_LABELS = ["", "Disappointing", "Okay", "Good", "Great", "Outstanding"];
 
 const inputClass =
   "w-full rounded-2xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 px-4 py-3 text-[15px] text-light-foreground placeholder:text-light-muted-foreground/70 outline-none";
 
+const chipStatic =
+  "inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground";
+
 /**
- * Add a drip bag — a lightweight documentation flow (NOT the brew flow).
- * Scan the sachet → we extract the identity + printed notes → you pick
- * the flavours you tasted + a star rating → save. No recipe, no timer:
- * drip bags brew one fixed way. Page-local state only; never touches the
- * brew flowStore. See src/lib/types/dripBag.ts.
+ * Log a drip bag — a lightweight documentation page (NOT the brew flow).
+ * Always entered from the New Session scan via the "This is a drip bag"
+ * toggle: the scan already extracted the identity, uploaded the photo and
+ * mapped the Field, so this page just records the flavours tasted + a star
+ * rating and saves (isolated, in drip_bags). Direct visits with no flow
+ * draft bounce back to /brew/new.
  */
-export default function AddDripBagPage() {
+export default function LogDripBagPage() {
   const router = useRouter();
-  const photoInputRef = useRef<HTMLInputElement>(null);
+
+  const [ready, setReady] = useState(false);
 
   // Identity (roaster + name editable; the rest are read-only chips)
   const [roaster, setRoaster] = useState("");
@@ -51,15 +50,6 @@ export default function AddDripBagPage() {
   const [bagPhotoUrl, setBagPhotoUrl] = useState<string | undefined>();
   const [bagPhotoPath, setBagPhotoPath] = useState<string | undefined>();
   const [fieldZones, setFieldZones] = useState<FieldZones | null>(null);
-  const [aiExtracted, setAiExtracted] = useState(false);
-
-  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-  const [analyzing, setAnalyzing] = useState(false);
-  const [scanError, setScanError] = useState<string | null>(null);
-
-  // URL crawl (the package QR → product page)
-  const [showUrl, setShowUrl] = useState(false);
-  const [url, setUrl] = useState("");
 
   // Tasting
   const [selectedFlavors, setSelectedFlavors] = useState<string[]>([]);
@@ -68,16 +58,17 @@ export default function AddDripBagPage() {
   const [freeNotes, setFreeNotes] = useState("");
 
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
-  // Seed from the brew-flow scan when entered via the "Drip bag" toggle.
-  // The scan step already extracted the identity, uploaded the photo and
-  // mapped the Field — read it once on mount and skip straight to the
-  // flavours + rating capture. (Direct visits with no flow draft fall back
-  // to this page's own scan UI.)
+  // Seed from the brew-flow scan once on mount. No seed = arrived here
+  // without scanning → send the user to the scan where the toggle lives.
   useEffect(() => {
     const st = useFlowStore.getState();
     const c = st.draft.coffee;
-    if (!st.isDripBag || !c || !(c.name || c.roaster)) return;
+    if (!st.isDripBag || !c || !(c.name || c.roaster)) {
+      router.replace("/brew/new");
+      return;
+    }
     setRoaster(c.roaster ?? "");
     setName(c.name ?? "");
     setOrigin(c.origin || undefined);
@@ -88,9 +79,8 @@ export default function AddDripBagPage() {
     if (c.tastingNotesFromBag?.length) setBagNotes(c.tastingNotesFromBag);
     setBagPhotoUrl(c.bagPhotoUrl || undefined);
     setBagPhotoPath(c.bagPhotoPath || undefined);
-    if (c.bagPhotoUrl) setPreviewUrl(c.bagPhotoUrl);
     if (st.fieldZones) setFieldZones(st.fieldZones);
-    setAiExtracted(true);
+    setReady(true);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -100,102 +90,34 @@ export default function AddDripBagPage() {
   const toggleFlavor = (f: string) =>
     setSelectedFlavors((prev) => (prev.includes(f) ? prev.filter((x) => x !== f) : [...prev, f]));
 
-  const applyExtracted = (ex: Extracted) => {
-    if (ex.roaster) setRoaster(ex.roaster);
-    if (ex.name) setName(ex.name);
-    setOrigin(ex.origin);
-    setRegion(ex.region);
-    setVariety(ex.variety);
-    setProcess(ex.process);
-    setRoastLevel(ex.roastLevel);
-    if (ex.tastingNotesFromBag?.length) setBagNotes(ex.tastingNotesFromBag);
-    setAiExtracted(true);
-  };
-
-  const handlePhoto = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setScanError(null);
-    setPreviewUrl(URL.createObjectURL(file));
-    setAnalyzing(true);
-    try {
-      // 1. Upload to S3 (bags/ prefix is enforced by /api/upload)
-      const upFd = new FormData();
-      upFd.append("file", file);
-      upFd.append("path", `bags/${Date.now()}-${file.name.replace(/[^a-zA-Z0-9.-]/g, "_")}`);
-      const up = await fetch("/api/upload", { method: "POST", body: upFd });
-      if (up.ok) {
-        const { url: storedUrl, storagePath } = await up.json();
-        setBagPhotoUrl(storedUrl);
-        setBagPhotoPath(storagePath);
-      }
-
-      // 2. Analyze the label
-      const anFd = new FormData();
-      anFd.append("image", file);
-      const an = await fetch("/api/analyze-bag", { method: "POST", body: anFd });
-      if (!an.ok) throw new Error("Analysis failed");
-      const data = await an.json();
-      applyExtracted((data.extracted ?? {}) as Extracted);
-      if (data.fieldZones) setFieldZones(data.fieldZones as FieldZones);
-    } catch {
-      setScanError("Couldn't read the package — add the details by hand below.");
-      setAiExtracted(true); // reveal the manual form anyway
-    } finally {
-      setAnalyzing(false);
-    }
-  };
-
-  const handleUrl = async () => {
-    const trimmed = url.trim();
-    if (!trimmed) return;
-    setScanError(null);
-    setAnalyzing(true);
-    try {
-      const res = await fetch("/api/analyze-url", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ url: trimmed }),
-      });
-      if (!res.ok) throw new Error("Analysis failed");
-      const data = await res.json();
-      applyExtracted((data.extracted ?? {}) as Extracted);
-    } catch {
-      setScanError("Couldn't read that link — add the details by hand below.");
-      setAiExtracted(true);
-    } finally {
-      setAnalyzing(false);
-    }
-  };
-
-  const started = aiExtracted || previewUrl != null;
+  const meta = [origin, region, process, variety, roastLevel].filter((v): v is string => !!v);
   const canSave = roaster.trim().length > 0 && name.trim().length > 0 && !saving;
 
   const handleSave = async () => {
     if (!canSave) return;
     setSaving(true);
-    const payload = {
-      roaster: roaster.trim(),
-      name: name.trim(),
-      origin,
-      region,
-      variety,
-      process,
-      roastLevel,
-      bagNotes,
-      flavorNotes: selectedFlavors,
-      rating,
-      freeNotes: freeNotes.trim() || undefined,
-      bagPhotoUrl,
-      bagPhotoPath,
-      fieldZones,
-      aiExtracted,
-    };
+    setSaveError(null);
     try {
       const res = await fetch("/api/drip-bags", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
+        body: JSON.stringify({
+          roaster: roaster.trim(),
+          name: name.trim(),
+          origin,
+          region,
+          variety,
+          process,
+          roastLevel,
+          bagNotes,
+          flavorNotes: selectedFlavors,
+          rating,
+          freeNotes: freeNotes.trim() || undefined,
+          bagPhotoUrl,
+          bagPhotoPath,
+          fieldZones,
+          aiExtracted: true,
+        }),
       });
       if (!res.ok) throw new Error("Save failed");
       // Clear the brew-flow draft + drip-bag flag so the next "New Session"
@@ -204,236 +126,149 @@ export default function AddDripBagPage() {
       router.push("/coffees");
     } catch {
       setSaving(false);
-      setScanError("Couldn't save — check your connection and try again.");
+      setSaveError("Couldn't save — check your connection and try again.");
     }
   };
 
+  if (!ready) return null;
+
   return (
-    <div className="min-h-svh bg-transparent flex flex-col pb-32">
-      {/* Header */}
-      <div className="px-5 pb-2" style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.25rem)" }}>
-        <button onClick={() => router.push("/coffees")} className="text-light-muted-foreground text-sm">
-          ← Library
+    <div className="relative mx-auto max-w-[430px] px-5 pb-4">
+      {/* Header — standard borderless back button (design system §7.3). */}
+      <div className="flex items-center" style={{ paddingTop: "calc(env(safe-area-inset-top) + 1.5rem)", paddingBottom: "1rem" }}>
+        <button
+          type="button"
+          onClick={() => router.back()}
+          aria-label="Back"
+          className="h-9 w-9 -ml-2 rounded-full flex items-center justify-center text-light-foreground/70 active:scale-95 transition-transform"
+        >
+          <ChevronLeft className="h-5 w-5" strokeWidth={1.75} />
         </button>
       </div>
 
-      <div className="px-5">
-        <Hero eyebrow="Drip bag" question={<>Document a drip bag.</>} />
-      </div>
+      <Hero eyebrow="Drip bag" question={<>Log a drip bag.</>} />
 
-      <input ref={photoInputRef} type="file" accept="image/*" onChange={handlePhoto} className="hidden" />
-
-      <div className="px-5 mt-2 space-y-10">
-        {/* ── SCAN ─────────────────────────────────────────── */}
-        <Section eyebrow="The package">
-          {previewUrl && (
+      <div className="mt-6 space-y-10">
+        {/* ── IDENTITY ─────────────────────────────────────── */}
+        <div className="space-y-3">
+          {bagPhotoUrl && (
             // eslint-disable-next-line @next/next/no-img-element
-            <img src={previewUrl} alt="Drip bag" className="w-full h-48 object-cover rounded-2xl mb-3" />
+            <img src={bagPhotoUrl} alt={name} className="w-full h-48 object-cover rounded-2xl mb-2" />
           )}
-          {!started ? (
-            <div className="space-y-3">
-              <button
-                type="button"
-                onClick={() => photoInputRef.current?.click()}
-                className="w-full h-14 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] font-semibold active:scale-[0.98] transition-transform"
-              >
-                Scan package
-              </button>
-              {!showUrl ? (
-                <button
-                  type="button"
-                  onClick={() => setShowUrl(true)}
-                  className="w-full text-light-muted-foreground text-sm py-2"
-                >
-                  Paste a link instead
-                </button>
-              ) : (
-                <div className="flex items-center gap-2">
-                  <input
-                    type="url"
-                    inputMode="url"
-                    value={url}
-                    onChange={(e) => setUrl(e.target.value)}
-                    placeholder="https://…"
-                    className={inputClass}
-                  />
-                  <button
-                    type="button"
-                    onClick={handleUrl}
-                    aria-label="Analyze link"
-                    className="shrink-0 h-12 w-12 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] flex items-center justify-center"
-                  >
-                    →
-                  </button>
-                </div>
-              )}
-              <button
-                type="button"
-                onClick={() => setAiExtracted(true)}
-                className="w-full text-light-muted-foreground text-sm py-2"
-              >
-                Enter manually
-              </button>
-            </div>
-          ) : null}
-
-          {analyzing && (
-            <div className="flex items-center gap-3 py-4">
-              <CoffeeBeanGlow size={28} />
-              <p className="text-light-muted-foreground text-sm">Reading the package…</p>
+          <div>
+            <p className="label-eyebrow mb-1.5 px-1">Roaster</p>
+            <input value={roaster} onChange={(e) => setRoaster(e.target.value)} placeholder="e.g. INNO" className={inputClass} />
+          </div>
+          <div>
+            <p className="label-eyebrow mb-1.5 px-1">Coffee</p>
+            <input value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Ethiopia" className={inputClass} />
+          </div>
+          {meta.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 pt-1">
+              {meta.map((v) => (
+                <span key={v} className={chipStatic}>{v}</span>
+              ))}
             </div>
           )}
-
-          {scanError && <p className="text-[hsl(12_70%_45%)] text-sm mt-2">{scanError}</p>}
-
-          {started && !analyzing && (
-            <div className="space-y-3 mt-1">
-              <div>
-                <p className="text-[11px] text-light-muted-foreground mb-1.5 px-1">Roaster</p>
-                <input value={roaster} onChange={(e) => setRoaster(e.target.value)} placeholder="e.g. INNO" className={inputClass} />
+          {bagNotes.length > 0 && (
+            <div className="pt-1">
+              <p className="label-eyebrow mb-1.5 px-1">Printed notes</p>
+              <div className="flex flex-wrap gap-1.5">
+                {bagNotes.map((n) => (
+                  <span key={n} className={`${chipStatic} capitalize`}>{n}</span>
+                ))}
               </div>
-              <div>
-                <p className="text-[11px] text-light-muted-foreground mb-1.5 px-1">Coffee</p>
-                <input value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Ethiopia" className={inputClass} />
-              </div>
-              {(origin || process || variety || roastLevel || region) && (
-                <div className="flex flex-wrap gap-1.5 pt-1">
-                  {[origin, region, process, variety, roastLevel]
-                    .filter((v): v is string => !!v)
-                    .map((v) => (
-                      <span
-                        key={v}
-                        className="inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground"
-                      >
-                        {v}
-                      </span>
-                    ))}
-                </div>
-              )}
-              {bagNotes.length > 0 && (
-                <div className="pt-1">
-                  <p className="text-[11px] text-light-muted-foreground mb-1.5 px-1">Printed notes</p>
-                  <div className="flex flex-wrap gap-1.5">
-                    {bagNotes.map((nVal) => (
-                      <span
-                        key={nVal}
-                        className="inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight capitalize backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground"
-                      >
-                        {nVal}
-                      </span>
+            </div>
+          )}
+        </div>
+
+        {/* ── RATING — identical to the post-brew taste log ── */}
+        <Section eyebrow="Your rating">
+          <div className="flex flex-col items-center gap-3 py-2">
+            <StarRating value={rating} onChange={setRating} size="lg" />
+            <p className="text-[13px] text-light-muted-foreground">
+              {rating === 0 ? "Tap to rate" : RATING_LABELS[rating] ?? ""}
+            </p>
+          </div>
+        </Section>
+
+        {/* ── FLAVOURS ─────────────────────────────────────── */}
+        <Section eyebrow="Flavours you tasted">
+          <div className="w-full flex justify-center">
+            <FlavorWheel
+              mode="select"
+              activeCategory={activeCategory}
+              onCategorySelect={setActiveCategory}
+              selectedFlavors={selectedFlavors}
+              size={320}
+            />
+          </div>
+
+          {activeCategory ? (
+            <div className="space-y-3 mt-3">
+              <p className="label-eyebrow px-1">{activeCategory}</p>
+              {Object.entries(SCA_WHEEL[activeCategory].subcategories).map(([sub, flavors]) => (
+                <div key={sub}>
+                  {Object.keys(SCA_WHEEL[activeCategory].subcategories).length > 1 && (
+                    <p className="text-[11px] text-light-muted-foreground/70 mb-1.5 px-1">{sub}</p>
+                  )}
+                  <div className="flex flex-wrap gap-2">
+                    {flavors.map((f) => (
+                      <Chip key={f} size="sm" selected={selectedFlavors.includes(f)} onClick={() => toggleFlavor(f)}>
+                        {f}
+                      </Chip>
                     ))}
                   </div>
                 </div>
-              )}
+              ))}
+            </div>
+          ) : (
+            <div className="space-y-2 mt-3">
+              <div className="flex flex-wrap gap-2">
+                {QUICK_FLAVORS.map((f) => (
+                  <Chip key={f} size="sm" selected={selectedFlavors.includes(f)} onClick={() => toggleFlavor(f)}>
+                    {f}
+                  </Chip>
+                ))}
+              </div>
+              <p className="text-[12px] text-light-muted-foreground px-1 mt-1">Tap the wheel to explore by category</p>
+            </div>
+          )}
+
+          {selectedFlavors.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 pt-3 mt-2 border-t border-light-foreground/10">
+              {selectedFlavors.map((f) => (
+                <button
+                  key={f}
+                  type="button"
+                  onClick={() => toggleFlavor(f)}
+                  className="text-[12px] text-light-foreground bg-light-card-selected px-2 py-0.5 rounded-lg"
+                >
+                  {f} ×
+                </button>
+              ))}
             </div>
           )}
         </Section>
 
-        {/* ── RATING ───────────────────────────────────────── */}
-        {started && (
-          <Section eyebrow="Your rating">
-            <div className="flex flex-col items-center gap-2 py-2">
-              <StarRating value={rating} onChange={setRating} size="lg" />
-              <p className="text-[13px] text-light-muted-foreground">{rating === 0 ? "Tap to rate" : `${rating} / 5`}</p>
-            </div>
-          </Section>
-        )}
-
-        {/* ── FLAVOURS ─────────────────────────────────────── */}
-        {started && (
-          <Section eyebrow="Flavours you tasted">
-            <div className="w-full flex justify-center">
-              <FlavorWheel
-                mode="select"
-                activeCategory={activeCategory}
-                onCategorySelect={setActiveCategory}
-                selectedFlavors={selectedFlavors}
-                size={320}
-              />
-            </div>
-
-            {activeCategory ? (
-              <div className="space-y-3 mt-3">
-                <p className="label-eyebrow px-1">{activeCategory}</p>
-                {Object.entries(SCA_WHEEL[activeCategory].subcategories).map(([sub, flavors]) => (
-                  <div key={sub}>
-                    {Object.keys(SCA_WHEEL[activeCategory].subcategories).length > 1 && (
-                      <p className="text-[11px] text-light-muted-foreground/70 mb-1.5 px-1">{sub}</p>
-                    )}
-                    <div className="flex flex-wrap gap-2">
-                      {flavors.map((f) => (
-                        <Chip key={f} size="sm" selected={selectedFlavors.includes(f)} onClick={() => toggleFlavor(f)}>
-                          {f}
-                        </Chip>
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <div className="space-y-2 mt-3">
-                <div className="flex flex-wrap gap-2">
-                  {QUICK_FLAVORS.map((f) => (
-                    <Chip key={f} size="sm" selected={selectedFlavors.includes(f)} onClick={() => toggleFlavor(f)}>
-                      {f}
-                    </Chip>
-                  ))}
-                </div>
-                <p className="text-[12px] text-light-muted-foreground px-1 mt-1">Tap the wheel to explore by category</p>
-              </div>
-            )}
-
-            {selectedFlavors.length > 0 && (
-              <div className="flex flex-wrap gap-1.5 pt-3 mt-2 border-t border-light-foreground/10">
-                {selectedFlavors.map((f) => (
-                  <button
-                    key={f}
-                    type="button"
-                    onClick={() => toggleFlavor(f)}
-                    className="text-[12px] text-light-foreground bg-light-card-selected px-2 py-0.5 rounded-lg"
-                  >
-                    {f} ×
-                  </button>
-                ))}
-              </div>
-            )}
-          </Section>
-        )}
-
         {/* ── NOTES ────────────────────────────────────────── */}
-        {started && (
-          <Section eyebrow="Notes (optional)">
-            <textarea
-              value={freeNotes}
-              onChange={(e) => setFreeNotes(e.target.value)}
-              placeholder="Anything else worth noting…"
-              rows={3}
-              className="w-full rounded-2xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 px-4 py-3 text-[15px] text-light-foreground placeholder:text-light-muted-foreground/70 outline-none resize-none"
-            />
-          </Section>
-        )}
+        <Section eyebrow="Notes (optional)">
+          <textarea
+            value={freeNotes}
+            onChange={(e) => setFreeNotes(e.target.value)}
+            placeholder="Anything else worth noting…"
+            rows={3}
+            className="w-full rounded-2xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 px-4 py-3 text-[15px] text-light-foreground placeholder:text-light-muted-foreground/70 outline-none resize-none"
+          />
+        </Section>
+
+        {saveError && <p className="text-[hsl(12_70%_45%)] text-sm px-1">{saveError}</p>}
       </div>
 
-      {/* Save bar */}
-      {started && (
-        <div
-          className="fixed bottom-0 left-0 right-0 px-5 pt-3 bg-gradient-to-t from-[hsl(36_55%_96%)] via-[hsl(36_55%_96%/0.85)] to-transparent"
-          style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 1rem)" }}
-        >
-          <button
-            type="button"
-            onClick={handleSave}
-            disabled={!canSave}
-            className={`w-full h-14 rounded-full font-semibold transition-transform active:scale-[0.98] ${
-              canSave
-                ? "bg-light-foreground text-[hsl(36_55%_96%)]"
-                : "bg-light-foreground/30 text-[hsl(36_55%_96%)] cursor-not-allowed"
-            }`}
-          >
-            {saving ? "Saving…" : "Save drip bag"}
-          </button>
-        </div>
-      )}
+      {/* Non-sticky design-system CTA (no pinned bar / cream box). */}
+      <CTA onClick={handleSave} disabled={!canSave} loading={saving}>
+        Save drip bag
+      </CTA>
     </div>
   );
 }


### PR DESCRIPTION
Design-system cleanup of the "Log a drip bag" page (follow-up to #229), addressing direct feedback:

- **CTA**: replace the bespoke pinned save bar (with its ugly cream-gradient box behind the button) with the non-sticky `CTA` primitive at the end of content.
- **Back**: standard borderless `ChevronLeft` button (§7.3) instead of a stray "← Library" text link.
- **Headline**: "Document a drip bag" → "Log a drip bag".
- **Rating**: reuse the post-brew `LightStarRating` verbatim — half-star tapping + the same word-label caption; drop the "4 / 5" text.
- **Cleanup**: remove the dead self-scan UI. The scan toggle is the only entry, so the page is always seeded from the flow store (direct visits with no draft redirect to `/brew/new`).

No schema/API/migration changes. `npx tsc --noEmit` passes clean.

https://claude.ai/code/session_0193NAQ5JuQmdAbJB1d23zaw

---
_Generated by [Claude Code](https://claude.ai/code/session_0193NAQ5JuQmdAbJB1d23zaw)_