### PR TITLE
feat(light): tokenize hardcoded HSL literals + fix CTA/spacing drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Replace the filename with the actual migration file. You should see `INSERT 0 N`
 
 Light migration is **complete** as of PRs #134–#137. Every visited route lives inside the **`(light)` route group** (BTTS Light theme — Cream background, Fraunces/Chivo, anthracite foreground, generative Field) and inherits `LightShell` from `(light)/layout.tsx`. The `(light)` segment is URL-invisible — `/coffees` resolves through `(light)/coffees/page.tsx`. `LightShell` sets the `[data-light-scope]` data attribute used by the CSS shim in `globals.css`.
 
-The single remaining Dark route is `cafes/map/page.tsx` and that's intentional (dark Leaflet tiles).
+Every route is now Light, including `cafes/map` (headlined "Nearby") — the cream→transparent scrim at the top keeps the title legible against the warm-tinted Positron tiles.
 
 | Route | Theme | Purpose |
 |-------|-------|---------|
@@ -53,7 +53,7 @@ The single remaining Dark route is `cafes/map/page.tsx` and that's intentional (
 | `(light)/offline/page.tsx` | Light | Service-worker document fallback (`next.config.mjs` `fallbacks.document`). Shown when an uncached route is opened offline; links to `/coffees`. Safety net — the real offline path lives in the precached `/coffees` + `/brew/new` shell. |
 | `layout.tsx` | — | Root layout: PWA meta tags, font preloads, `<ScrollContainer>` wrapper |
 | `loading.tsx` | Light | Global loading state — Light CoffeeBeanGlow on inline cream bg (renders before LightShell mounts) |
-| `cafes/map/page.tsx` | Dark *(intentional)* | Nearby — full-screen Leaflet map (CartoCDN dark tiles); needs `h-dvh flex flex-col` + `flex-1 min-h-0` so Leaflet gets a non-zero container |
+| `(light)/cafes/map/page.tsx` | Light | Nearby — full-bleed Leaflet map (Positron tiles warmed via the `[data-light-scope]` sepia filter on `.leaflet-tile-pane`); floating header with the Light wordmark pattern + cream→transparent scrim so the title reads cleanly over the tiles |
 
 Removed routes: legacy Dark `page.tsx` (replaced by `(light)/page.tsx`), `match/page.tsx` + `/api/match` (folded into `/api/explore-agent`), `explore/page.tsx` (replaced by inline chat on home), `library/page.tsx` (the Coffee Library / Café Library picker — redundant once `NavigationOverlay` gained direct entries for both).
 
@@ -134,7 +134,7 @@ Removed during the Light cleanup (PR #137): `BottomNav`, Dark `Chip`, `RadarChar
 `ScrollContainer` (root 100dvh wrapper with hidden scroll — no more allowlist, no nav-padding reserve), `BottomSpacer`
 
 **Session:** `SessionCard` (Light, consumed only by `/coffees/[id]` All-brews list — Brew-method as headline, Field's cream-glass cards, swipe-to-delete with rust-red destructive button)
-**Cafés:** `CafeMap` (Leaflet — consumed by `/cafes/map`)
+**Cafés:** `CafeMap` (Leaflet — consumed by `(light)/cafes/map`, now Light with warmed Positron tiles)
 **Coach (`src/components/coach/`):** `CoachCard` (presentational two-paragraph card — observation row 1, suggestion row 2, three-action footer Try it / Confirmed / Doesn't apply, consumed by `/taste` queue) + `CoffeeCoachCard` (wrapper that fetches `/api/insights?status=trying,new`, scores by citationFields overlap with this coffee's attributes, prefers trying then new, renders one best-match — rotation-only). PR #215.
 
 ### `src/lib/`
@@ -342,7 +342,7 @@ All migrations applied manually on the VPS — see migration NOTE above.
 - Light primitives stack: `LightShell`, `LightFlowShell`, `Field`, `Card`, `Section`, `Footnote`, `Chip`, `Hero`, `CTA`, `CTAWarmth`, `ActionPill`, `ChatInput`, `ChatThread`, `NavigationOverlay`, `StarRating`, `CircularTimer` (fork), `CoffeeBeanGlow` (fork).
 - Atomic cut-over (PR #95) renamed `(light)/brew/preview` → `(light)/brew/new` and deleted ~4,300 lines of Dark step code (`Step*.tsx` + `FlowShell.tsx` + Dark `CircularTimer`).
 - `[data-light-scope]` CSS shim in `globals.css` adapts shared Dark-era components (`BrewMethodIcon`, original `CoffeeBeanGlow`) via `filter: brightness(0)` so they read as anthracite inside the Light tree without being forked.
-- Migrated this arc (Sep–May 2026): `/brew/[id]` (#122), `/coffees/[id]` Field adoption (#123), SessionCard rewrite (#120), `/cafes` + `/cafes/place/[slug]` + `/cafes/coffee/[id]` (#134), `/login` + `/onboarding` (#135), `/taste` (#136). Only `/cafes/map` remains Dark — intentional for the dark CartoCDN tiles.
+- Migrated this arc (Sep–May 2026): `/brew/[id]` (#122), `/coffees/[id]` Field adoption (#123), SessionCard rewrite (#120), `/cafes` + `/cafes/place/[slug]` + `/cafes/coffee/[id]` (#134), `/login` + `/onboarding` (#135), `/taste` (#136). `/cafes/map` (Nearby) is also fully Light — warmed Positron tiles via the `[data-light-scope]` sepia filter — pin to a specific PR pending.
 - Cleanup pass (#137): removed `BottomNav`, `RadarChart`, Dark `Chip` (all orphaned post-migration); `loading.tsx` flipped to Light with explicit cream bg so route transitions don't flash dark; `ScrollContainer` simplified (no allowlist, no nav-padding reserve); `--nav-bottom-padding` CSS var dropped.
 - PWA chrome aligned (#113–#119): `themeColor: #D4B8C9` (mauve) on viewport + `manifest.json`, `manifest.background_color: #F3E5DC` (cream so the splash matches the Field base), `appleWebApp.statusBarStyle: "default"`, `html { background-color: #F3E5DC }` so the Light cream is the baseline even if the Field gradient is thin at the very top pixels.
 
@@ -396,8 +396,10 @@ All migrations applied manually on the VPS — see migration NOTE above.
 - Library snapshot uses `formatLibraryForPrompt` (with rotation prefix + usage signal) instead of bare roaster+name.
 - localStorage cache keyed by `brewlog.starter.v4.<date>.<bucket>` — regenerates 5× per day at tod-bucket boundaries instead of once per calendar day. Bumping the version is the canonical invalidation lever for any greeting prompt change.
 
-**Nearby map split (PR #101)**
-- `/cafes/map` is now a dedicated route (full-screen Leaflet with dark CartoCDN tiles). `/cafes` is the tabbed Café Library list (Cafés + Coffees tasted out). `NavigationOverlay` "Nearby" → `/cafes/map`; "Café Library" → `/cafes`.
+**Nearby map split (PR #101) — Light-finished**
+- `/cafes/map` (headlined "Nearby") is its own dedicated route, now fully Light. `/cafes` is the tabbed Café Library list (Cafés + Coffees tasted out). `NavigationOverlay` "Nearby" → `/cafes/map`; "Café Library" → `/cafes`.
+- Tiles served by Carto Positron, warmed in CSS via `[data-light-scope] .leaflet-tile-pane { filter: sepia(0.4) hue-rotate(-15deg) saturate(0.7) brightness(1.04) }` so they read as cream rather than cold gray.
+- Floating header sits on top of a cream→transparent scrim so the page title stays legible without a hard banner edge.
 - Fixed flex-collapse bug: Leaflet needs `h-dvh flex flex-col` + `flex-1 min-h-0` to get a non-zero container.
 
 **Core brew flow**
@@ -460,14 +462,11 @@ All migrations applied manually on the VPS — see migration NOTE above.
 ### ❌ Not Done / Known Gaps
 
 **Open items:**
-1. **`/cafes/map` Light pass** — currently Dark with CartoCDN dark tiles + default Leaflet blue markers. Sticks out hard against the rest of the Light app. Swap the tile provider to a light one (Carto voyager/positron, Stadia Light, or raw OSM), replace the default Leaflet markers with anthracite circles (visited filled vs unvisited outline), and expose the PR #145 "I've been here" modal straight from a tapped marker. Files: `src/app/cafes/map/page.tsx`, `src/components/cafes/CafeMap.tsx`.
-2. **`/cafes/map` "I've been here" entry point** — coupled with map work. Once the user can search a brand-new place and tap it, expose the "I've been here" modal directly from the map without first going through `/cafes/place/[slug]`.
-3. `/coffees` "Show only rotation" filter — list shows the star indicator (#117) but no toggle yet to filter the list to rotation bags only
-4. `LightStepScan` Card/Chip refactor — 1400 lines with bespoke buttons that should route through the `Card` + `Chip` primitives. Code quality, no visible UX change
-5. Aromatic Goal validation — PR #72 added the intent to `/api/recommend` but per the Hard Rule it needs sample-before/after against a delicate coffee on the deployed PWA
-6. **Cafe visit notes edit UI** — `cafe_visits.notes` column exists but UI only lets you delete + re-add, no inline edit. Cheap follow-up.
-7. **PR CI workflow** — no CI runs on PRs today; the only workflow on the repo is `deploy.yml` which fires on push to `main`. A small `ci.yml` that runs `npx tsc --noEmit` (and eventually `node --test src/lib/utils/*.test.mjs`) on every PR would let us re-enable "Require status checks to pass" in the branch protection ruleset. Currently branch protection is PR + block-force-push only.
-8. **Drip Assist demoted to "emergency / travel only"** in the user profile, but it's still selectable in `LightStepContext` as one of the brewer options (PR #193 kept it for legacy session render compat). Worth re-checking that it never gets recommended proactively now that the user's V60 Drip Assist is retired from daily use.
+1. `/coffees` "Show only rotation" filter — list shows the star indicator (#117) but no toggle yet to filter the list to rotation bags only
+2. Aromatic Goal validation — PR #72 added the intent to `/api/recommend` but per the Hard Rule it needs sample-before/after against a delicate coffee on the deployed PWA
+3. **Cafe visit notes edit UI** — `cafe_visits.notes` column exists but UI only lets you delete + re-add, no inline edit. Cheap follow-up.
+4. **PR CI workflow** — no CI runs on PRs today; the only workflow on the repo is `deploy.yml` which fires on push to `main`. A small `ci.yml` that runs `npx tsc --noEmit` (and eventually `node --test src/lib/utils/*.test.mjs`) on every PR would let us re-enable "Require status checks to pass" in the branch protection ruleset. Currently branch protection is PR + block-force-push only.
+5. **Drip Assist demoted to "emergency / travel only"** in the user profile, but it's still selectable in `LightStepContext` as one of the brewer options (PR #193 kept it for legacy session render compat). Worth re-checking that it never gets recommended proactively now that the user's V60 Drip Assist is retired from daily use.
 
 **Permanent gaps**
 - Photo uploads: stored under `bags/` — old sessions scanned before this convention have no `bagPhotoUrl`
@@ -484,6 +483,7 @@ All migrations applied manually on the VPS — see migration NOTE above.
 - Examples worth flagging: files stored in odd formats, unused endpoints, duplicated code paths, secrets in the wrong places, stale dependencies, missing error handling at system boundaries, slow API calls that could be cached, confusing UX that you happened to notice while editing nearby code.
 - Flag once, explain the trade-off plainly, then wait for a yes/no before acting. Don't hoard issues for a big cleanup later.
 - **Translate, don't jargon-dump.** The user reads everything you write. Plain English, no unexplained acronyms or shorthand. If a technical term is unavoidable, define it inline once.
+- **Build everything new on the Design System.** Any new page, component, primitive, or modal MUST compose from the documented Light tokens (`text-light-foreground`, `text-light-text-on-dark`, `bg-light-card-default`, `bg-light-surface`, `bg-light-destructive`, `light-accent-overtime`, `light-scrim`, `backdrop-blur-light-card`, the gutter `px-5`, the primary pill `h-14 rounded-full`, etc.) — see the "Light design tokens (cheat sheet)" section. Never reintroduce a literal `hsl(...)` / `rgba(...)` / `#hex` for a colour role the system already has a token for, and never roll a one-off pill height or radius. If a genuinely new visual role appears (e.g. a fresh status colour), add it to `tailwind.config.ts` as a `light-*` token FIRST, then consume the token — single source of truth in one place. Drift like this is what produced the May 2026 token-cleanup pass; do not invite a sequel.
 
 ---
 
@@ -572,16 +572,20 @@ Cause for sub-rules 5–8: a follow-up audit of all 19 named-expert recipe entri
 - No staging environment — once merged to `main` it is live within minutes
 
 ### Light design tokens (cheat sheet)
-- **Tokens:** `text-light-foreground` (anthracite), `text-light-muted-foreground`, `bg-light-card-default` (cream glass 55 %), `bg-light-card-selected` (warm taupe), `border-light-foreground/15`, `shadow-light-card-pressed`
-- **Cream highlight on dark elements:** `text-[hsl(36_55%_96%)]` (e.g. CTA text on the anthracite button)
+- **Tokens:** `text-light-foreground` (anthracite), `text-light-muted-foreground`, `bg-light-card-default` (cream glass 55 %), `bg-light-card-selected` (warm taupe), `bg-light-surface` (opaque cream, modal/sheet surfaces), `border-light-foreground/15`, `shadow-light-card-pressed`
+- **Cream highlight on dark elements:** `text-light-text-on-dark` (single token; replaced the two pre-token literals `hsl(36 55% 96%)` and `hsl(30 40% 97%)` so CTA / ActionPill / ChatInput buttons / ConnectionStatus all share the same cream)
 - **Card variants:** default cards use `bg-light-card-default` (55 %); SessionCard (chips inside) uses `bg-[hsl(36_55%_96%/0.30)]` — the lower opacity so child chips visibly contrast
-- **Destructive (delete, error):** `bg-[hsl(12_70%_45%)]` warm rust
+- **Destructive (delete, error):** `bg-light-destructive` (warm rust) — `text-light-destructive` for error copy
+- **Amber accent (overtime):** `light-accent-overtime` — used by `CircularTimer` when elapsed > target; inline SVG strokes mirror the value via two module-level constants `ANTHRACITE` / `OVERTIME` since SVG strokes can't read Tailwind tokens
+- **Glass blur:** `backdrop-blur-light-card backdrop-saturate-150` — the canonical pair on every glass surface (Card, Chip, ChatInput, ChatThread, AttachmentSheet, NavigationOverlay, ReferenceCoffeePicker, ConnectionStatus, page menu buttons). Don't write `backdrop-blur-[14px]` — it bypasses the token
+- **Photo scrim:** import `gradientCreamScrim` from `@/lib/theme/gradients` for the cream→transparent vertical fade overlaid on bag photos (consumed by `/coffees/[id]`, `/brew/[id]`, `/coffees/drip/[id]`)
 - **Hero question:** `font-fraunces font-semibold text-[40px] leading-[1.05] tracking-[-0.01em]`
 - **Headline (route title):** `font-fraunces text-3xl text-light-foreground leading-none`
 - **Wordmark (Home + Login):** `<h1 className="font-fraunces text-3xl leading-[1.05] text-light-foreground">Better taste<br />than sorry.</h1>` — exact same markup at both entry points
-- **Eyebrow:** `text-light-muted-foreground text-xs tracking-widest` uppercase
+- **Eyebrow:** `text-light-muted-foreground text-xs tracking-widest` uppercase (no `font-medium` — that's an outlier)
 - **Unified chip / tag:** `inline-flex items-center rounded-full px-3 py-1.5 text-[12px] font-medium leading-tight backdrop-blur-light-card backdrop-saturate-150 bg-light-card-default text-light-foreground`
-- **Primary CTA pill:** `w-full h-14 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] font-semibold` + `active:scale-[0.98] transition-transform`
+- **Primary CTA pill:** `w-full h-14 rounded-full bg-light-foreground text-light-text-on-dark font-semibold` + `active:scale-[0.98] transition-transform` — both `h-14` AND `rounded-full` are required; `py-3.5 rounded-2xl` is NOT a CTA, it's a card
+- **Page gutter:** `px-5` (20 px). Don't use `px-8` — it's not a defined gutter width
 - **Light scope marker:** `[data-light-scope]` attribute set by `LightShell` wraps the whole `(light)` route group; the `globals.css` shim catches inline `var(--card)` etc. for un-migrated components — but NOT hardcoded hex like `#2A241C`, which needs explicit Light tokens at the source
 
 ### iOS PWA / install gotcha

--- a/src/app/(light)/brew/[id]/page.tsx
+++ b/src/app/(light)/brew/[id]/page.tsx
@@ -12,6 +12,7 @@ import { resolveBrewedRecipe, brewedRecipeName } from "@/lib/utils/resolveRecipe
 import { formatDate, formatSeconds } from "@/lib/utils/formatTime";
 import { useFieldConfig } from "@/lib/field/FieldContext";
 import { recallSessionField, rememberSessionField } from "@/lib/field/cache";
+import { gradientCreamScrim } from "@/lib/theme/gradients";
 
 export default function SessionDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -122,10 +123,7 @@ export default function SessionDetailPage() {
             <div
               aria-hidden
               className="absolute inset-0 pointer-events-none"
-              style={{
-                background:
-                  "linear-gradient(to top, hsl(30 60% 92% / 0.95) 0%, hsl(30 60% 92% / 0.45) 45%, transparent 80%)",
-              }}
+              style={{ background: gradientCreamScrim }}
             />
           </div>
         ) : (
@@ -349,7 +347,7 @@ function DeleteButton({ sessionId, onDeleted }: { sessionId: string; onDeleted: 
           type="button"
           onClick={handleDelete}
           disabled={deleting}
-          className="flex-1 py-3 rounded-xl bg-[hsl(12_70%_45%)] text-[hsl(36_55%_96%)] text-sm font-medium active:scale-[0.98] transition-transform disabled:opacity-50"
+          className="flex-1 py-3 rounded-xl bg-light-destructive text-light-text-on-dark text-sm font-medium active:scale-[0.98] transition-transform disabled:opacity-50"
         >
           {deleting ? "Deleting…" : "Yes, delete"}
         </button>

--- a/src/app/(light)/cafes/coffee/[id]/page.tsx
+++ b/src/app/(light)/cafes/coffee/[id]/page.tsx
@@ -132,7 +132,7 @@ export default function CafeCoffeeDetailPage() {
             type="button"
             onClick={() => setMenuOpen(true)}
             aria-label="Open menu"
-            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150 active:scale-95 transition-transform"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-light-card backdrop-saturate-150 active:scale-95 transition-transform"
           >
             <Menu className="h-5 w-5" strokeWidth={1.5} />
           </button>
@@ -287,7 +287,7 @@ export default function CafeCoffeeDetailPage() {
                               onClick={() => setEditMethod(editMethod === m.label ? "" : m.label)}
                               className={`shrink-0 px-2.5 py-1 rounded-full text-xs border transition-colors ${
                                 editMethod === m.label
-                                  ? "bg-light-foreground text-[hsl(36_55%_96%)] border-light-foreground"
+                                  ? "bg-light-foreground text-light-text-on-dark border-light-foreground"
                                   : "text-light-muted-foreground border-light-foreground/20 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150"
                               }`}
                             >
@@ -319,7 +319,7 @@ export default function CafeCoffeeDetailPage() {
                         <button
                           onClick={() => saveEdit(s)}
                           disabled={saving}
-                          className="flex-1 py-2 rounded-xl bg-light-foreground text-[hsl(36_55%_96%)] text-sm font-medium disabled:opacity-50"
+                          className="flex-1 py-2 rounded-xl bg-light-foreground text-light-text-on-dark text-sm font-medium disabled:opacity-50"
                         >
                           Save
                         </button>

--- a/src/app/(light)/cafes/map/page.tsx
+++ b/src/app/(light)/cafes/map/page.tsx
@@ -60,7 +60,7 @@ export default function CafesMapPage() {
           type="button"
           onClick={() => setMenuOpen(true)}
           aria-label="Open menu"
-          className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150 active:scale-95 transition-transform"
+          className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-light-card backdrop-saturate-150 active:scale-95 transition-transform"
         >
           <Menu className="h-5 w-5" strokeWidth={1.5} />
         </button>

--- a/src/app/(light)/cafes/page.tsx
+++ b/src/app/(light)/cafes/page.tsx
@@ -111,7 +111,7 @@ export default function CafesPage() {
             type="button"
             onClick={() => setMenuOpen(true)}
             aria-label="Open menu"
-            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150 active:scale-95 transition-transform"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-light-card backdrop-saturate-150 active:scale-95 transition-transform"
           >
             <Menu className="h-5 w-5" strokeWidth={1.5} />
           </button>
@@ -137,7 +137,7 @@ export default function CafesPage() {
             onClick={() => setActiveTab(t.id)}
             className={`px-4 py-1.5 rounded-full text-xs font-medium transition-all ${
               activeTab === t.id
-                ? "bg-light-foreground text-[hsl(36_55%_96%)]"
+                ? "bg-light-foreground text-light-text-on-dark"
                 : "bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 text-light-muted-foreground"
             }`}
           >

--- a/src/app/(light)/cafes/place/[slug]/page.tsx
+++ b/src/app/(light)/cafes/place/[slug]/page.tsx
@@ -181,7 +181,7 @@ export default function CafeDetailPage() {
             type="button"
             onClick={() => setMenuOpen(true)}
             aria-label="Open menu"
-            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150 active:scale-95 transition-transform"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-light-card backdrop-saturate-150 active:scale-95 transition-transform"
           >
             <Menu className="h-5 w-5" strokeWidth={1.5} />
           </button>
@@ -223,7 +223,7 @@ export default function CafeDetailPage() {
         <button
           type="button"
           onClick={() => setVisitModalOpen(true)}
-          className="mt-3 w-full h-12 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] text-sm font-medium active:scale-[0.98] transition-transform"
+          className="mt-3 w-full h-14 rounded-full bg-light-foreground text-light-text-on-dark text-sm font-medium active:scale-[0.98] transition-transform"
         >
           I&apos;ve been here
         </button>
@@ -349,7 +349,7 @@ export default function CafeDetailPage() {
                               onClick={() => setEditMethod(editMethod === m.label ? "" : m.label)}
                               className={`shrink-0 px-2.5 py-1 rounded-full text-xs border transition-colors ${
                                 editMethod === m.label
-                                  ? "bg-light-foreground text-[hsl(36_55%_96%)] border-light-foreground"
+                                  ? "bg-light-foreground text-light-text-on-dark border-light-foreground"
                                   : "text-light-muted-foreground border-light-foreground/20 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150"
                               }`}
                             >
@@ -381,7 +381,7 @@ export default function CafeDetailPage() {
                         <button
                           onClick={() => saveEdit(s)}
                           disabled={saving}
-                          className="flex-1 py-2 rounded-xl bg-light-foreground text-[hsl(36_55%_96%)] text-sm font-medium disabled:opacity-50"
+                          className="flex-1 py-2 rounded-xl bg-light-foreground text-light-text-on-dark text-sm font-medium disabled:opacity-50"
                         >
                           Save
                         </button>
@@ -395,7 +395,7 @@ export default function CafeDetailPage() {
                       <button
                         onClick={() => deleteSession(s.id)}
                         disabled={deletingId === s.id}
-                        className="w-full py-2 rounded-xl bg-[hsl(12_70%_45%)] text-[hsl(36_55%_96%)] text-xs font-medium active:scale-[0.99] transition-transform disabled:opacity-40"
+                        className="w-full py-2 rounded-xl bg-light-destructive text-light-text-on-dark text-xs font-medium active:scale-[0.99] transition-transform disabled:opacity-40"
                       >
                         {deletingId === s.id ? "Deleting…" : "Delete session"}
                       </button>
@@ -414,12 +414,11 @@ export default function CafeDetailPage() {
           return). Saves to /api/cafe-visits and prepends to the list. */}
       {visitModalOpen && (
         <div
-          className="fixed inset-0 z-50 flex items-end sm:items-center justify-center px-5"
-          style={{ background: "rgba(28,22,19,0.45)" }}
+          className="fixed inset-0 z-50 flex items-end sm:items-center justify-center px-5 bg-light-scrim/45"
           onClick={() => !visitSaving && setVisitModalOpen(false)}
         >
           <div
-            className="w-full max-w-sm bg-[hsl(36_55%_96%)] rounded-3xl p-6 space-y-4 mb-6 sm:mb-0"
+            className="w-full max-w-sm bg-light-surface rounded-3xl p-6 space-y-4 mb-6 sm:mb-0"
             onClick={e => e.stopPropagation()}
           >
             <div className="space-y-1">
@@ -431,7 +430,7 @@ export default function CafeDetailPage() {
                 type="button"
                 disabled={visitSaving}
                 onClick={() => saveVisit("come-back")}
-                className="w-full h-14 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] font-medium flex items-center justify-center gap-3 active:scale-[0.98] transition-transform disabled:opacity-50"
+                className="w-full h-14 rounded-full bg-light-foreground text-light-text-on-dark font-medium flex items-center justify-center gap-3 active:scale-[0.98] transition-transform disabled:opacity-50"
               >
                 <ThumbsUp className="w-5 h-5" strokeWidth={1.75} />
                 Would come back

--- a/src/app/(light)/coffees/[id]/page.tsx
+++ b/src/app/(light)/coffees/[id]/page.tsx
@@ -12,6 +12,7 @@ import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
 import { CoffeeCoachCard } from "@/components/coach/CoachCard";
 import { useFieldConfig } from "@/lib/field/FieldContext";
 import { rememberSessionField } from "@/lib/field/cache";
+import { gradientCreamScrim } from "@/lib/theme/gradients";
 import { useOnline } from "@/hooks/useOnline";
 import { startBrewAgain, startBrewAgainOffline } from "@/lib/flow/brewAgain";
 import {
@@ -213,10 +214,7 @@ export default function CoffeeDetailPage() {
             <div
               aria-hidden
               className="absolute inset-0 pointer-events-none"
-              style={{
-                background:
-                  "linear-gradient(to top, hsl(30 60% 92% / 0.95) 0%, hsl(30 60% 92% / 0.45) 45%, transparent 80%)",
-              }}
+              style={{ background: gradientCreamScrim }}
             />
           </div>
         ) : (
@@ -316,10 +314,10 @@ export default function CoffeeDetailPage() {
               setCoffee((prev) => (prev ? { ...prev, inRotation: !next } : prev));
             }
           }}
-          className={`w-full py-3.5 rounded-2xl text-sm font-medium flex items-center justify-center gap-2 transition-transform active:scale-[0.98] ${
+          className={`w-full h-14 rounded-full text-sm font-medium flex items-center justify-center gap-2 transition-transform active:scale-[0.98] ${
             coffee.inRotation
               ? "bg-light-foreground/10 border border-light-foreground/40 text-light-foreground"
-              : "bg-light-foreground text-[hsl(36_55%_96%)]"
+              : "bg-light-foreground text-light-text-on-dark"
           }`}
         >
           <svg className="w-4 h-4" viewBox="0 0 24 24" fill={coffee.inRotation ? "currentColor" : "none"} stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" aria-hidden>
@@ -331,7 +329,7 @@ export default function CoffeeDetailPage() {
           <button
             type="button"
             onClick={brewThis}
-            className="w-full py-3.5 rounded-2xl text-sm font-medium bg-light-foreground text-[hsl(36_55%_96%)] active:scale-[0.98] transition-transform"
+            className="w-full h-14 rounded-full text-sm font-medium bg-light-foreground text-light-text-on-dark active:scale-[0.98] transition-transform"
           >
             Brew this
           </button>
@@ -551,10 +549,7 @@ function OfflineCoffeeDetail({
             <div
               aria-hidden
               className="absolute inset-0 pointer-events-none"
-              style={{
-                background:
-                  "linear-gradient(to top, hsl(30 60% 92% / 0.95) 0%, hsl(30 60% 92% / 0.45) 45%, transparent 80%)",
-              }}
+              style={{ background: gradientCreamScrim }}
             />
           </div>
         ) : (

--- a/src/app/(light)/coffees/drip/[id]/page.tsx
+++ b/src/app/(light)/coffees/drip/[id]/page.tsx
@@ -9,6 +9,7 @@ import NavigationOverlay from "@/components/ui/light/NavigationOverlay";
 import { useFieldConfig } from "@/lib/field/FieldContext";
 import type { FieldZones } from "@/lib/field/types";
 import type { DripBag } from "@/lib/types/dripBag";
+import { gradientCreamScrim } from "@/lib/theme/gradients";
 
 /**
  * Drip-bag detail — read-only documentation view. No rotation toggle, no
@@ -96,10 +97,7 @@ export default function DripBagDetailPage() {
             <div
               aria-hidden
               className="absolute inset-0 pointer-events-none"
-              style={{
-                background:
-                  "linear-gradient(to top, hsl(30 60% 92% / 0.95) 0%, hsl(30 60% 92% / 0.45) 45%, transparent 80%)",
-              }}
+              style={{ background: gradientCreamScrim }}
             />
           </div>
         ) : (
@@ -221,7 +219,7 @@ export default function DripBagDetailPage() {
               type="button"
               onClick={handleDelete}
               disabled={deleting}
-              className="flex-1 py-3 rounded-2xl text-sm font-medium bg-[hsl(12_70%_45%)] text-[hsl(36_55%_96%)] disabled:opacity-50"
+              className="flex-1 py-3 rounded-2xl text-sm font-medium bg-light-destructive text-light-text-on-dark disabled:opacity-50"
             >
               {deleting ? "Deleting…" : "Confirm delete"}
             </button>

--- a/src/app/(light)/coffees/drip/new/page.tsx
+++ b/src/app/(light)/coffees/drip/new/page.tsx
@@ -262,7 +262,7 @@ export default function LogDripBagPage() {
           />
         </Section>
 
-        {saveError && <p className="text-[hsl(12_70%_45%)] text-sm px-1">{saveError}</p>}
+        {saveError && <p className="text-light-destructive text-sm px-1">{saveError}</p>}
       </div>
 
       {/* Non-sticky design-system CTA (no pinned bar / cream box). */}

--- a/src/app/(light)/coffees/page.tsx
+++ b/src/app/(light)/coffees/page.tsx
@@ -206,7 +206,7 @@ export default function CoffeesPage() {
             type="button"
             onClick={() => setMenuOpen(true)}
             aria-label="Open menu"
-            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150 active:scale-95 transition-transform"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-light-card backdrop-saturate-150 active:scale-95 transition-transform"
           >
             <Menu className="h-5 w-5" strokeWidth={1.5} />
           </button>
@@ -258,7 +258,7 @@ export default function CoffeesPage() {
               onClick={() => setFilter(f.id)}
               className={`px-4 py-1.5 rounded-full text-xs font-medium transition-all ${
                 filter === f.id
-                  ? "bg-light-foreground text-[hsl(36_55%_96%)]"
+                  ? "bg-light-foreground text-light-text-on-dark"
                   : "bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/15 text-light-muted-foreground"
               }`}
             >
@@ -394,7 +394,7 @@ export default function CoffeesPage() {
                           type="button"
                           onClick={() => brewThis(coffee)}
                           aria-label={`Brew ${coffee.name}`}
-                          className="shrink-0 px-3 py-2 rounded-full text-xs font-medium bg-light-foreground text-[hsl(36_55%_96%)] active:scale-95 transition-transform"
+                          className="shrink-0 px-3 py-2 rounded-full text-xs font-medium bg-light-foreground text-light-text-on-dark active:scale-95 transition-transform"
                         >
                           Brew
                         </button>

--- a/src/app/(light)/login/page.tsx
+++ b/src/app/(light)/login/page.tsx
@@ -186,11 +186,11 @@ export default function LoginPage() {
             className="w-full bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 border border-light-foreground/20 rounded-2xl px-4 py-4 text-light-foreground text-center text-2xl tracking-widest placeholder:text-light-muted-foreground focus:outline-none focus:border-light-foreground/40"
             autoFocus
           />
-          {pinError && <p className="text-[hsl(12_70%_45%)] text-sm text-center">{pinError}</p>}
+          {pinError && <p className="text-light-destructive text-sm text-center">{pinError}</p>}
           <button
             onClick={handlePin}
             disabled={pin.length < 4 || working}
-            className="w-full h-14 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] font-semibold text-base disabled:opacity-40 active:scale-[0.98] transition-transform"
+            className="w-full h-14 rounded-full bg-light-foreground text-light-text-on-dark font-semibold text-base disabled:opacity-40 active:scale-[0.98] transition-transform"
           >
             {working ? "Checking…" : "Unlock"}
           </button>
@@ -231,7 +231,7 @@ export default function LoginPage() {
           <button
             onClick={handleRegister}
             disabled={working}
-            className="w-full h-14 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] font-semibold text-base flex items-center justify-center gap-3 active:scale-[0.98] transition-transform disabled:opacity-60"
+            className="w-full h-14 rounded-full bg-light-foreground text-light-text-on-dark font-semibold text-base flex items-center justify-center gap-3 active:scale-[0.98] transition-transform disabled:opacity-60"
           >
             {working ? <Spinner /> : <FaceIDIcon />}
             {working ? "Setting up…" : "Set up Face ID"}
@@ -240,7 +240,7 @@ export default function LoginPage() {
           <button
             onClick={triggerFaceID}
             disabled={working}
-            className="w-full h-14 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] font-semibold text-base flex items-center justify-center gap-3 active:scale-[0.98] transition-transform disabled:opacity-60"
+            className="w-full h-14 rounded-full bg-light-foreground text-light-text-on-dark font-semibold text-base flex items-center justify-center gap-3 active:scale-[0.98] transition-transform disabled:opacity-60"
           >
             {working ? <Spinner /> : <FaceIDIcon />}
             {working ? "Verifying…" : "Use Face ID"}
@@ -275,6 +275,6 @@ function FaceIDIcon() {
 
 function Spinner() {
   return (
-    <div className="w-5 h-5 rounded-full border-2 border-[hsl(36_55%_96%)]/30 border-t-[hsl(36_55%_96%)] animate-spin" />
+    <div className="w-5 h-5 rounded-full border-2 border-light-text-on-dark/30 border-t-light-text-on-dark animate-spin" />
   );
 }

--- a/src/app/(light)/offline/page.tsx
+++ b/src/app/(light)/offline/page.tsx
@@ -10,15 +10,15 @@ export const dynamic = "force-static";
  */
 export default function OfflinePage() {
   return (
-    <div className="min-h-svh bg-transparent flex flex-col items-center justify-center gap-5 px-8 text-center">
-      <h1 className="font-fraunces text-3xl text-light-foreground">You&apos;re offline</h1>
+    <div className="min-h-svh bg-transparent flex flex-col items-center justify-center gap-5 px-5 text-center">
+      <h1 className="font-fraunces text-3xl text-light-foreground leading-none">You&apos;re offline</h1>
       <p className="text-light-muted-foreground text-sm leading-relaxed max-w-xs">
         This page isn&apos;t available offline. You can still re-brew a coffee you&apos;ve logged
         before from your library.
       </p>
       <Link
         href="/coffees"
-        className="h-12 px-6 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] text-sm font-semibold flex items-center active:scale-[0.98] transition-transform"
+        className="h-14 px-6 rounded-full bg-light-foreground text-light-text-on-dark text-sm font-semibold flex items-center active:scale-[0.98] transition-transform"
       >
         Open your library
       </Link>

--- a/src/app/(light)/onboarding/page.tsx
+++ b/src/app/(light)/onboarding/page.tsx
@@ -61,8 +61,8 @@ export default function OnboardingPage() {
   return (
     <div className="min-h-svh bg-transparent flex flex-col px-5">
       <div className="pb-8" style={{ paddingTop: "calc(env(safe-area-inset-top) + 3rem)" }}>
-        <p className="text-light-muted-foreground text-xs tracking-widest uppercase font-medium mb-3">Setup</p>
-        <h1 className="font-fraunces text-4xl text-light-foreground leading-tight whitespace-pre-line">
+        <p className="text-light-muted-foreground text-xs tracking-widest uppercase mb-3">Setup</p>
+        <h1 className="font-fraunces text-3xl text-light-foreground leading-none whitespace-pre-line">
           {step === "equipment" ? "What's in\nyour kitchen?" : "Your grinder"}
         </h1>
       </div>
@@ -89,7 +89,7 @@ export default function OnboardingPage() {
               type="button"
               onClick={() => setStep("grinder")}
               disabled={equipment.length === 0}
-              className="w-full h-14 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] font-semibold text-base active:scale-[0.98] transition-transform disabled:opacity-30"
+              className="w-full h-14 rounded-full bg-light-foreground text-light-text-on-dark font-semibold text-base active:scale-[0.98] transition-transform disabled:opacity-30"
             >
               Next →
             </button>
@@ -133,7 +133,7 @@ export default function OnboardingPage() {
               type="button"
               onClick={handleSave}
               disabled={saving}
-              className="flex-1 h-14 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] font-semibold text-base active:scale-[0.98] transition-transform disabled:opacity-60"
+              className="flex-1 h-14 rounded-full bg-light-foreground text-light-text-on-dark font-semibold text-base active:scale-[0.98] transition-transform disabled:opacity-60"
             >
               {saving ? "Saving..." : "Start Brewing"}
             </button>

--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -376,7 +376,7 @@ export default function HomePage() {
             type="button"
             onClick={() => setMenuOpen(true)}
             aria-label="Open menu"
-            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-light-card backdrop-saturate-150"
           >
             <Menu className="h-5 w-5" strokeWidth={1.5} />
           </button>

--- a/src/app/(light)/past-conversations/[id]/page.tsx
+++ b/src/app/(light)/past-conversations/[id]/page.tsx
@@ -94,18 +94,18 @@ export default function PastConversationDetailPage() {
             type="button"
             onClick={() => router.push("/past-conversations")}
             aria-label="Back"
-            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-light-card backdrop-saturate-150"
           >
             <ChevronLeft className="h-5 w-5" strokeWidth={1.5} />
           </button>
-          <h1 className="font-chivo text-[14px] font-medium text-light-foreground/60">
+          <h1 className="font-chivo text-[14px] font-medium text-light-muted-foreground">
             {data ? formatDate(data.conversation.lastMessageAt) : "Conversation"}
           </h1>
           <button
             type="button"
             onClick={() => setMenuOpen(true)}
             aria-label="Open menu"
-            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-light-card backdrop-saturate-150"
           >
             <Menu className="h-5 w-5" strokeWidth={1.5} />
           </button>

--- a/src/app/(light)/past-conversations/page.tsx
+++ b/src/app/(light)/past-conversations/page.tsx
@@ -78,7 +78,7 @@ export default function PastConversationsPage() {
             type="button"
             onClick={() => setMenuOpen(true)}
             aria-label="Open menu"
-            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
+            className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-light-card backdrop-saturate-150"
           >
             <Menu className="h-5 w-5" strokeWidth={1.5} />
           </button>
@@ -99,7 +99,7 @@ export default function PastConversationsPage() {
                   <div className="flex items-stretch gap-2">
                     <Link
                       href={`/past-conversations/${row.id}`}
-                      className="flex flex-1 items-center gap-3 rounded-2xl border border-light-foreground/25 bg-light-card-default px-4 py-3 backdrop-blur-[14px] backdrop-saturate-150"
+                      className="flex flex-1 items-center gap-3 rounded-2xl border border-light-foreground/25 bg-light-card-default px-4 py-3 backdrop-blur-light-card backdrop-saturate-150"
                     >
                       <div className="flex min-w-0 flex-1 flex-col">
                         <span className="font-chivo text-[12px] font-normal text-light-muted-foreground">
@@ -118,7 +118,7 @@ export default function PastConversationsPage() {
                       type="button"
                       onClick={() => void handleDelete(row.id)}
                       aria-label="Delete conversation"
-                      className="flex h-11 w-11 shrink-0 items-center justify-center self-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150"
+                      className="flex h-11 w-11 shrink-0 items-center justify-center self-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/70 backdrop-blur-light-card backdrop-saturate-150"
                     >
                       <Trash2 className="h-4 w-4" strokeWidth={1.5} />
                     </button>

--- a/src/app/(light)/taste/page.tsx
+++ b/src/app/(light)/taste/page.tsx
@@ -451,7 +451,7 @@ function Header({ onMenu }: { onMenu: () => void }) {
         type="button"
         onClick={onMenu}
         aria-label="Open menu"
-        className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150 active:scale-95 transition-transform"
+        className="flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-light-card backdrop-saturate-150 active:scale-95 transition-transform"
       >
         <Menu className="h-5 w-5" strokeWidth={1.5} />
       </button>

--- a/src/components/cafes/CafeMap.tsx
+++ b/src/components/cafes/CafeMap.tsx
@@ -614,7 +614,7 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
                 <button
                   type="button"
                   onClick={() => onSelect(selected)}
-                  className="bg-light-foreground text-[hsl(36_55%_96%)] text-xs font-semibold px-4 py-1.5 rounded-full active:scale-95 transition-transform"
+                  className="bg-light-foreground text-light-text-on-dark text-xs font-semibold px-4 py-1.5 rounded-full active:scale-95 transition-transform"
                 >
                   View
                 </button>
@@ -661,7 +661,7 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
               <button
                 type="button"
                 onClick={() => setVisitModalPlace(placeSelected)}
-                className="bg-light-foreground text-[hsl(36_55%_96%)] text-xs font-semibold px-4 py-1.5 rounded-full active:scale-95 transition-transform whitespace-nowrap"
+                className="bg-light-foreground text-light-text-on-dark text-xs font-semibold px-4 py-1.5 rounded-full active:scale-95 transition-transform whitespace-nowrap"
               >
                 I&apos;ve been here
               </button>
@@ -674,12 +674,11 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
           return). Mirrors the modal on /cafes/place/[slug]. */}
       {visitModalPlace && (
         <div
-          className="fixed inset-0 z-[2000] flex items-end sm:items-center justify-center px-5"
-          style={{ background: "rgba(28,22,19,0.45)" }}
+          className="fixed inset-0 z-[2000] flex items-end sm:items-center justify-center px-5 bg-light-scrim/45"
           onClick={() => !visitSaving && setVisitModalPlace(null)}
         >
           <div
-            className="w-full max-w-sm bg-[hsl(36_55%_96%)] rounded-3xl p-6 space-y-4 mb-6 sm:mb-0"
+            className="w-full max-w-sm bg-light-surface rounded-3xl p-6 space-y-4 mb-6 sm:mb-0"
             onClick={e => e.stopPropagation()}
           >
             <div className="space-y-1">
@@ -691,7 +690,7 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
                 type="button"
                 disabled={visitSaving}
                 onClick={() => saveVisit("come-back")}
-                className="w-full h-14 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] font-medium flex items-center justify-center gap-3 active:scale-[0.98] transition-transform disabled:opacity-50"
+                className="w-full h-14 rounded-full bg-light-foreground text-light-text-on-dark font-medium flex items-center justify-center gap-3 active:scale-[0.98] transition-transform disabled:opacity-50"
               >
                 <ThumbsUp className="w-5 h-5" strokeWidth={1.75} />
                 Would come back

--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -701,7 +701,7 @@ function StepGuide({
                 Step {currentIdx + 1} of {timed.length}
               </p>
               {tag && (
-                <span className="px-2 py-0.5 rounded-full bg-light-foreground text-[hsl(36_55%_96%)] text-[10px] font-semibold tracking-wide">
+                <span className="px-2 py-0.5 rounded-full bg-light-foreground text-light-text-on-dark text-[10px] font-semibold tracking-wide">
                   {tag}
                 </span>
               )}

--- a/src/components/flow/LightStepLog.tsx
+++ b/src/components/flow/LightStepLog.tsx
@@ -585,7 +585,7 @@ function CoachQuestionSheet({
   const canSubmit = !!(answer || custom.trim());
   return (
     <div className="fixed inset-0 z-50 flex flex-col justify-end bg-light-foreground/30 backdrop-blur-sm">
-      <div className="bg-[hsl(36_55%_96%)] rounded-t-3xl px-6 pt-6 pb-8 shadow-light-card-pressed" style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 2rem)" }}>
+      <div className="bg-light-surface rounded-t-3xl px-6 pt-6 pb-8 shadow-light-card-pressed" style={{ paddingBottom: "calc(env(safe-area-inset-bottom) + 2rem)" }}>
         <p className="label-eyebrow text-light-muted-foreground mb-3">One quick check</p>
         {loading || !question ? (
           <div className="space-y-3">
@@ -624,8 +624,8 @@ function CoachQuestionSheet({
                 disabled={!canSubmit}
                 className={`flex-[2] h-12 rounded-full font-semibold text-[14px] transition-opacity ${
                   canSubmit
-                    ? "bg-light-foreground text-[hsl(36_55%_96%)] active:scale-[0.98]"
-                    : "bg-light-foreground/30 text-[hsl(36_55%_96%)] cursor-not-allowed"
+                    ? "bg-light-foreground text-light-text-on-dark active:scale-[0.98]"
+                    : "bg-light-foreground/30 text-light-text-on-dark cursor-not-allowed"
                 }`}
               >
                 Save with this

--- a/src/components/flow/LightStepScan.tsx
+++ b/src/components/flow/LightStepScan.tsx
@@ -1363,7 +1363,7 @@ function GenerateRoasterForm({
             type="button"
             onClick={save}
             disabled={saving || !draft.styleSummary}
-            className="w-full py-3 rounded-2xl bg-light-foreground text-[hsl(36_55%_96%)] text-sm font-semibold disabled:opacity-40 active:scale-95 transition-all"
+            className="w-full py-3 rounded-2xl bg-light-foreground text-light-text-on-dark text-sm font-semibold disabled:opacity-40 active:scale-95 transition-all"
           >
             {saving ? "Saving…" : "Save to my roasters"}
           </button>

--- a/src/components/flow/LightStepSummary.tsx
+++ b/src/components/flow/LightStepSummary.tsx
@@ -161,7 +161,7 @@ export default function LightStepSummary() {
           </svg>
           <div className="absolute -bottom-1 -right-1 w-6 h-6 rounded-full bg-light-foreground flex items-center justify-center">
             <svg
-              className="w-3.5 h-3.5 text-[hsl(36_55%_96%)]"
+              className="w-3.5 h-3.5 text-light-text-on-dark"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -330,7 +330,7 @@ export default function LightStepSummary() {
           type="button"
           onClick={handleSave}
           disabled={saving}
-          className="h-14 w-full rounded-full bg-light-foreground text-[15px] font-semibold text-[hsl(36_55%_96%)] active:scale-[0.99] transition-transform disabled:opacity-60 disabled:active:scale-100"
+          className="h-14 w-full rounded-full bg-light-foreground text-[15px] font-semibold text-light-text-on-dark active:scale-[0.99] transition-transform disabled:opacity-60 disabled:active:scale-100"
         >
           {saving ? "Saving…" : saveError ? "Retry" : "Save Brew"}
         </button>

--- a/src/components/session/SessionCard.tsx
+++ b/src/components/session/SessionCard.tsx
@@ -85,7 +85,7 @@ export default function SessionCard({ session, onDeleted }: SessionCardProps) {
           onClick={handleDelete}
           aria-label="Delete session"
           tabIndex={isOpen ? 0 : -1}
-          className="w-20 flex flex-col items-center justify-center gap-1 text-[hsl(36_55%_96%)] active:opacity-80 bg-[hsl(12_70%_45%)]"
+          className="w-20 flex flex-col items-center justify-center gap-1 text-light-text-on-dark active:opacity-80 bg-light-destructive"
         >
           <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />

--- a/src/components/ui/light/ActionPill.tsx
+++ b/src/components/ui/light/ActionPill.tsx
@@ -70,7 +70,7 @@ function destinationToPath(action: NavAction): string {
 
 function ActionPillIcon({ destination }: { destination: NavAction["destination"] }) {
   // Cream icon on the anthracite pill body — same colour as the label.
-  const cls = "h-4 w-4 text-[hsl(30_40%_97%)]";
+  const cls = "h-4 w-4 text-light-text-on-dark";
   switch (destination) {
     case "coffee_library":
       return <BookOpen className={cls} strokeWidth={1.75} />;
@@ -158,7 +158,7 @@ export default function ActionPill({ action }: { action: NavAction }) {
       type="button"
       onClick={() => void handleClick()}
       title={action.reason}
-      className="flex h-9 shrink-0 items-center gap-1.5 rounded-full bg-light-foreground px-4 font-chivo text-[13px] font-medium text-[hsl(30_40%_97%)] shadow-sm active:opacity-90"
+      className="flex h-9 shrink-0 items-center gap-1.5 rounded-full bg-light-foreground px-4 font-chivo text-[13px] font-medium text-light-text-on-dark shadow-sm active:opacity-90"
     >
       <ActionPillIcon destination={action.destination} />
       {action.label}

--- a/src/components/ui/light/AttachmentSheet.tsx
+++ b/src/components/ui/light/AttachmentSheet.tsx
@@ -40,7 +40,7 @@ export default function AttachmentSheet({
         className="fixed inset-0 z-40 cursor-default"
       />
 
-      <div className="relative z-50 mb-2 mr-auto max-w-[280px] rounded-2xl border border-light-foreground/25 bg-light-card-default p-2 backdrop-blur-[14px] backdrop-saturate-150">
+      <div className="relative z-50 mb-2 mr-auto max-w-[280px] rounded-2xl border border-light-foreground/25 bg-light-card-default p-2 backdrop-blur-light-card backdrop-saturate-150">
         <button
           type="button"
           onClick={onPickPhoto}

--- a/src/components/ui/light/CTA.tsx
+++ b/src/components/ui/light/CTA.tsx
@@ -32,7 +32,7 @@ export default function CTA({ onClick, disabled, loading, children }: CTAProps) 
         type="button"
         onClick={onClick}
         disabled={disabled || loading}
-        className="h-14 w-full rounded-full bg-light-foreground text-[15px] font-semibold text-[hsl(36_55%_96%)] active:scale-[0.99] transition-transform disabled:opacity-40 disabled:active:scale-100"
+        className="h-14 w-full rounded-full bg-light-foreground text-[15px] font-semibold text-light-text-on-dark active:scale-[0.99] transition-transform disabled:opacity-40 disabled:active:scale-100"
       >
         {children}
       </button>

--- a/src/components/ui/light/ChatInput.tsx
+++ b/src/components/ui/light/ChatInput.tsx
@@ -239,7 +239,7 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
         {(voiceError || uploadError) && (
           <div
             role="alert"
-            className="mb-2 rounded-2xl border border-light-foreground/25 bg-light-card-default px-3 py-2 font-chivo text-[13px] text-light-foreground backdrop-blur-[14px] backdrop-saturate-150"
+            className="mb-2 rounded-2xl border border-light-foreground/25 bg-light-card-default px-3 py-2 font-chivo text-[13px] text-light-foreground backdrop-blur-light-card backdrop-saturate-150"
           >
             {voiceError ?? uploadError}
           </div>
@@ -269,7 +269,7 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
               onClick={() => voice.cancel()}
               disabled={isTranscribing}
               aria-label="Cancel recording"
-              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150 disabled:opacity-50"
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/70 backdrop-blur-light-card backdrop-saturate-150 disabled:opacity-50"
             >
               <X className="h-5 w-5" strokeWidth={1.5} />
             </button>
@@ -279,7 +279,7 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
               onClick={clearComposition}
               disabled={loading || uploadingImage}
               aria-label={loading ? "Sending" : "Clear"}
-              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150 disabled:opacity-50"
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/70 backdrop-blur-light-card backdrop-saturate-150 disabled:opacity-50"
             >
               <X className="h-5 w-5" strokeWidth={1.5} />
             </button>
@@ -288,16 +288,16 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
               type="button"
               onClick={openSheet}
               aria-label="Attach"
-              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/70 backdrop-blur-[14px] backdrop-saturate-150"
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/70 backdrop-blur-light-card backdrop-saturate-150"
             >
               <Plus className="h-5 w-5" strokeWidth={1.5} />
             </button>
           )}
 
           {loading ? (
-            <div className="h-11 flex-1 rounded-full border border-light-foreground/25 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150" />
+            <div className="h-11 flex-1 rounded-full border border-light-foreground/25 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150" />
           ) : isVoiceActive ? (
-            <div className="flex h-11 flex-1 items-center gap-2 rounded-full border border-light-foreground/25 bg-light-card-default pl-5 pr-1.5 backdrop-blur-[14px] backdrop-saturate-150">
+            <div className="flex h-11 flex-1 items-center gap-2 rounded-full border border-light-foreground/25 bg-light-card-default pl-5 pr-1.5 backdrop-blur-light-card backdrop-saturate-150">
               <WaveformBars
                 getLevel={voice.getLevel}
                 color="hsl(20 14% 12%)"
@@ -317,14 +317,14 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
                   type="button"
                   onClick={() => void voice.stop()}
                   aria-label="Stop recording"
-                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)]"
+                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-light-foreground text-light-text-on-dark"
                 >
                   <Square className="h-3.5 w-3.5 fill-current" strokeWidth={0} />
                 </button>
               )}
             </div>
           ) : (
-            <div className="flex min-h-11 flex-1 flex-col gap-2 rounded-3xl border border-light-foreground/25 bg-light-card-default py-1.5 pl-5 pr-1.5 backdrop-blur-[14px] backdrop-saturate-150">
+            <div className="flex min-h-11 flex-1 flex-col gap-2 rounded-3xl border border-light-foreground/25 bg-light-card-default py-1.5 pl-5 pr-1.5 backdrop-blur-light-card backdrop-saturate-150">
               {(attachedImageUrl || uploadingImage) && (
                 <div className="relative h-20 w-20">
                   {attachedImageUrl ? (
@@ -347,7 +347,7 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
                       type="button"
                       onClick={() => setAttachedImageUrl(null)}
                       aria-label="Remove photo"
-                      className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)]"
+                      className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-light-foreground text-light-text-on-dark"
                     >
                       <X className="h-3 w-3" strokeWidth={2.25} />
                     </button>
@@ -372,7 +372,7 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
                     type="button"
                     onClick={() => setAttachedCoffee(null)}
                     aria-label="Remove coffee reference"
-                    className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)]"
+                    className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-light-foreground text-light-text-on-dark"
                   >
                     <X className="h-3 w-3" strokeWidth={2.25} />
                   </button>
@@ -411,7 +411,7 @@ export default function ChatInput({ loading, onSend, onComposeStart }: ChatInput
                     onClick={send}
                     disabled={uploadingImage}
                     aria-label="Send"
-                    className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-light-foreground text-[hsl(30_40%_97%)] disabled:opacity-30"
+                    className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-light-foreground text-light-text-on-dark disabled:opacity-30"
                   >
                     <ArrowUp className="h-4 w-4" strokeWidth={2.25} />
                   </button>

--- a/src/components/ui/light/ChatThread.tsx
+++ b/src/components/ui/light/ChatThread.tsx
@@ -129,7 +129,7 @@ export default function ChatThread({ messages, loading }: ChatThreadProps) {
         <div className="flex w-full flex-col gap-3 px-5 py-5">
           {showThinking && (
             <div
-              className="flex h-9 w-fit items-center gap-2 rounded-2xl bg-light-card-default px-4 backdrop-blur-[14px] backdrop-saturate-150 order-last"
+              className="flex h-9 w-fit items-center gap-2 rounded-2xl bg-light-card-default px-4 backdrop-blur-light-card backdrop-saturate-150 order-last"
               aria-label="Thinking"
             >
               <span
@@ -150,7 +150,7 @@ export default function ChatThread({ messages, loading }: ChatThreadProps) {
             m.role === "user" ? (
               <div key={i} className="flex flex-col items-end gap-2">
                 {m.imageUrl && (
-                  <div className="max-w-[80%] overflow-hidden rounded-2xl border border-light-foreground/25 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150">
+                  <div className="max-w-[80%] overflow-hidden rounded-2xl border border-light-foreground/25 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                       src={m.imageUrl}
@@ -160,7 +160,7 @@ export default function ChatThread({ messages, loading }: ChatThreadProps) {
                   </div>
                 )}
                 {m.coffeeRef && (
-                  <div className="flex max-w-[80%] items-start gap-3 rounded-2xl border border-light-foreground/25 bg-light-card-default px-4 py-3 backdrop-blur-[14px] backdrop-saturate-150">
+                  <div className="flex max-w-[80%] items-start gap-3 rounded-2xl border border-light-foreground/25 bg-light-card-default px-4 py-3 backdrop-blur-light-card backdrop-saturate-150">
                     <CoffeeIcon className="mt-0.5 h-5 w-5 shrink-0 text-light-foreground/80" strokeWidth={1.5} />
                     <div className="flex min-w-0 flex-1 flex-col">
                       <span className="line-clamp-2 break-words font-chivo text-[13px] font-normal text-light-muted-foreground">
@@ -173,7 +173,7 @@ export default function ChatThread({ messages, loading }: ChatThreadProps) {
                   </div>
                 )}
                 {m.content && (
-                  <div className="max-w-[80%] rounded-2xl bg-light-card-default px-4 py-3 backdrop-blur-[14px] backdrop-saturate-150">
+                  <div className="max-w-[80%] rounded-2xl bg-light-card-default px-4 py-3 backdrop-blur-light-card backdrop-saturate-150">
                     <p className="whitespace-pre-wrap font-chivo text-[15px] font-normal text-light-foreground">
                       {m.content}
                     </p>

--- a/src/components/ui/light/CircularTimer.tsx
+++ b/src/components/ui/light/CircularTimer.tsx
@@ -94,9 +94,17 @@ export default function LightCircularTimer({ targetSeconds, onComplete, onTick, 
   const circumference = 2 * Math.PI * radius;
   const progress = targetSeconds ? Math.min(elapsed / targetSeconds, 1) : 0;
   const dashOffset = circumference * (1 - progress);
-  const trackColor = "hsl(0 0% 14% / 0.12)";
-  const ringColor = overtime ? "hsl(28 95% 45%)" : "hsl(0 0% 14%)";
-  const timeColor = overtime ? "hsl(28 95% 45%)" : "hsl(0 0% 14%)";
+  // Inline SVG strokes can't read Tailwind tokens; mirror the
+  // `light-foreground` (anthracite) and `light-accent-overtime` (amber)
+  // tokens here so the same single source applies to ring, time text,
+  // and the "Done" button tint below. `withAlpha` produces variants
+  // (e.g. amber at 12% for the "Done" background tint).
+  const ANTHRACITE = "hsl(0 0% 14%)";
+  const OVERTIME = "hsl(28 95% 45%)";
+  const withAlpha = (color: string, a: number) => color.replace(")", ` / ${a})`);
+  const trackColor = withAlpha(ANTHRACITE, 0.12);
+  const ringColor = overtime ? OVERTIME : ANTHRACITE;
+  const timeColor = overtime ? OVERTIME : ANTHRACITE;
 
   return (
     <div className={cn("flex flex-col items-center gap-5", className)}>
@@ -129,7 +137,7 @@ export default function LightCircularTimer({ targetSeconds, onComplete, onTick, 
             </span>
           )}
           {overtime && (
-            <span className="text-xs mt-1 font-mono-num" style={{ color: "hsl(28 95% 45% / 0.85)" }}>
+            <span className="text-xs mt-1 font-mono-num" style={{ color: withAlpha(OVERTIME, 0.85) }}>
               +{Math.floor(overSec / 60)}:{String(overSec % 60).padStart(2, "0")} over
             </span>
           )}
@@ -163,14 +171,14 @@ export default function LightCircularTimer({ targetSeconds, onComplete, onTick, 
               ? "border"
               : running
                 ? "bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 text-light-foreground"
-                : "bg-light-foreground text-[hsl(36_55%_96%)]",
+                : "bg-light-foreground text-light-text-on-dark",
           )}
           style={
             running && overtime
               ? {
-                  background: "hsl(28 95% 45% / 0.12)",
-                  borderColor: "hsl(28 95% 45% / 0.5)",
-                  color: "hsl(28 95% 45%)",
+                  background: withAlpha(OVERTIME, 0.12),
+                  borderColor: withAlpha(OVERTIME, 0.5),
+                  color: OVERTIME,
                 }
               : undefined
           }

--- a/src/components/ui/light/ConnectionStatus.tsx
+++ b/src/components/ui/light/ConnectionStatus.tsx
@@ -81,7 +81,7 @@ export default function ConnectionStatus() {
         type="button"
         disabled={!tappable}
         onClick={() => { if (tappable) void tick(); }}
-        className="pointer-events-auto rounded-full bg-light-foreground/90 px-3.5 py-1.5 text-[11px] font-medium text-[hsl(36_55%_96%)] shadow-sm backdrop-blur disabled:cursor-default"
+        className="pointer-events-auto rounded-full bg-light-foreground/90 px-3.5 py-1.5 text-[11px] font-medium text-light-text-on-dark shadow-sm backdrop-blur-light-card backdrop-saturate-150 disabled:cursor-default"
       >
         {label}
       </button>

--- a/src/components/ui/light/NavigationOverlay.tsx
+++ b/src/components/ui/light/NavigationOverlay.tsx
@@ -61,7 +61,7 @@ export default function NavigationOverlay({ open, onClose }: NavigationOverlayPr
       // the visit-modal sheet sits at z-2000 inside CafeMap.tsx, so the
       // old z-50 left the menu opening behind the map UI. z-[2100] keeps
       // top-level navigation on top of everything.
-      className="fixed inset-0 z-[2100] bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150"
+      className="fixed inset-0 z-[2100] bg-light-card-default backdrop-blur-light-card backdrop-saturate-150"
     >
       {/* Close button — same coordinates as the Burger that opened it
           (§7.1: "mirroring placement so thumb knows where to look").
@@ -74,7 +74,7 @@ export default function NavigationOverlay({ open, onClose }: NavigationOverlayPr
         onClick={onClose}
         aria-label="Close menu"
         style={{ top: "calc(env(safe-area-inset-top) + 1.25rem)" }}
-        className="absolute right-5 flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-[14px] backdrop-saturate-150"
+        className="absolute right-5 flex h-11 w-11 items-center justify-center rounded-full border border-light-foreground/25 bg-light-card-default text-light-foreground/80 backdrop-blur-light-card backdrop-saturate-150"
       >
         <X className="h-5 w-5" strokeWidth={1.5} />
       </button>

--- a/src/components/ui/light/ReferenceCoffeePicker.tsx
+++ b/src/components/ui/light/ReferenceCoffeePicker.tsx
@@ -63,7 +63,7 @@ export default function ReferenceCoffeePicker({
         className="fixed inset-0 z-50 cursor-default bg-light-foreground/10 backdrop-blur-[2px]"
       />
 
-      <div className="fixed inset-x-0 bottom-0 z-[60] flex max-h-[80vh] min-h-[60vh] flex-col rounded-t-2xl border border-light-foreground/25 bg-light-card-default backdrop-blur-[14px] backdrop-saturate-150">
+      <div className="fixed inset-x-0 bottom-0 z-[60] flex max-h-[80vh] min-h-[60vh] flex-col rounded-t-2xl border border-light-foreground/25 bg-light-card-default backdrop-blur-light-card backdrop-saturate-150">
         <div className="mt-2 self-center">
           <span className="block h-1 w-10 rounded-full bg-light-foreground/30" />
         </div>
@@ -83,7 +83,6 @@ export default function ReferenceCoffeePicker({
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Search roaster or coffee"
             className="block h-11 w-full rounded-full border-0 bg-light-card-default px-5 font-chivo text-[15px] font-normal text-light-foreground placeholder:text-light-muted-foreground focus:border-transparent focus:outline-none focus:ring-0 focus:ring-offset-0"
-            style={{ background: "hsl(36 55% 96% / 0.45)" }}
           />
         </div>
 

--- a/src/lib/theme/gradients.ts
+++ b/src/lib/theme/gradients.ts
@@ -35,3 +35,13 @@ export const gradientPillUser =
  */
 export const gradientButtonPrimary =
   "linear-gradient(135deg, #F1D2B6 0%, #E8C5A8 60%, #D4A98A 100%)";
+
+/**
+ * Cream-to-transparent vertical scrim overlaid on bag photos so the
+ * anthracite headline/eyebrow on top of the photo stays readable
+ * regardless of the photo's tone. Used on /coffees/[id] and /brew/[id]
+ * hero blocks. Was previously duplicated inline in both pages; lifting
+ * here keeps the only knob in one place.
+ */
+export const gradientCreamScrim =
+  "linear-gradient(to top, hsl(30 60% 92% / 0.95) 0%, hsl(30 60% 92% / 0.45) 45%, transparent 80%)";

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -52,6 +52,28 @@ const config: Config = {
           "muted-foreground": "hsl(0 0% 40% / <alpha-value>)",
           "card-default": "hsl(36 55% 96% / 0.55)",
           "card-selected": "hsl(28 22% 84% / 0.7)",
+          // Cream label that sits on `bg-light-foreground` (anthracite)
+          // pills, CTAs, and the connection status badge. Single source of
+          // truth — pre-token there were two near-identical creams
+          // (`hsl(36 55% 96%)` on CTA/ConnectionStatus vs `hsl(30 40% 97%)`
+          // on ActionPill/ChatInput) which read as subtly different chips.
+          "text-on-dark": "hsl(36 55% 96% / <alpha-value>)",
+          // Amber accent used by CircularTimer when elapsed > target. Single
+          // value, reused for ring, time text, "over" indicator, and the
+          // "Done" button background tint.
+          "accent-overtime": "hsl(28 95% 45% / <alpha-value>)",
+          // Warm rust used for destructive actions (delete brew, swipe-to-
+          // delete on SessionCard, delete session inside the café detail
+          // edit panel).
+          destructive: "hsl(12 70% 45% / <alpha-value>)",
+          // Opaque cream — modal/sheet surfaces that need to pop in front
+          // of the Field. Distinct from `card-default` (0.55 glass) — this
+          // is the solid cream behind the "I've been here" modal so the
+          // Field doesn't bleed through a high-decision moment.
+          surface: "hsl(36 55% 96%)",
+          // Warm-near-black backdrop behind centred modals — dims the rest
+          // of the page so the modal cream pops. Use as `bg-light-scrim/45`.
+          scrim: "hsl(20 19% 9% / <alpha-value>)",
         },
       },
       fontFamily: {


### PR DESCRIPTION
## Summary

Design-system audit + cleanup across the BTTS Light tree. The audit found accumulated drift inside an otherwise-correct system: two near-identical "cream-on-dark" text colours coexisting as literals, the `backdrop-blur-light-card` token defined but ignored by most consumers, two `/coffees/[id]` CTAs using card radii instead of pill radii, plus minor spacing/hero-size outliers. Fix is one comprehensive pass — no scope creep beyond the audit findings.

## What changed

**Five new Light tokens** in `tailwind.config.ts`, deduplicating ~30 files of hardcoded HSLs:

- `light-text-on-dark` — single canonical cream for buttons/pills (was two creams: 36° vs 30° hue, visibly different side-by-side)
- `light-destructive` — warm rust for delete/error
- `light-accent-overtime` — `CircularTimer` amber (SVG strokes mirror via `ANTHRACITE` / `OVERTIME` module constants + a `withAlpha` helper since SVG can't read Tailwind tokens)
- `light-surface` — opaque cream for modal sheets that need to pop in front of the Field
- `light-scrim` — warm-near-black for centred-modal backdrops (was the duplicated `rgba(28,22,19,0.45)` literal)

**Spec-drift fixes:**

- `/coffees/[id]` rotation toggle + "Brew this" CTAs: `py-3.5 rounded-2xl` → `h-14 rounded-full` (matches the documented primary-pill spec)
- `/offline`: gutter `px-8` → `px-5`, link CTA `h-12` → `h-14`
- `/onboarding`: hero `text-4xl` → `text-3xl` (route-title size), dropped stray `font-medium` from the eyebrow
- `/cafes/place/[slug]` "I've been here" trigger: `h-12` → `h-14`
- `past-conversations/[id]` centred date header: `text-light-foreground/60` → `text-light-muted-foreground`
- `ConnectionStatus` bare `backdrop-blur` (defaulted to ~8 px) → `backdrop-blur-light-card` (14 px, matches every other glass surface)
- Photo scrim gradient was inlined identically on three pages → lifted to `gradientCreamScrim` in `src/lib/theme/gradients.ts`
- 7 primitives + 9 page consumers swap `backdrop-blur-[14px]` → `backdrop-blur-light-card` so the token actually means something

**Docs (`CLAUDE.md`):**

- `/cafes/map` is already Light ("Nearby" with warmed Positron tiles); the "single remaining Dark route" claim is gone
- Two open-items that were already done (cafes/map Light pass + "I've been here" entry point) removed from the Open items list
- Cheat sheet rewritten to spell out the new tokens + add "don't do X" reminders for the drift patterns that triggered this
- New partnership rule: anything new must compose from the Design System tokens; never reintroduce literals for a role a token already covers

## Test plan

- [ ] `npx tsc --noEmit` clean (verified locally)
- [ ] Auto-deploy fires from `main`; smoke-test on the deployed PWA
- [ ] Visual diff on `/coffees/[id]` (rotation + Brew this should now be true `h-14 rounded-full` pills)
- [ ] `/onboarding` hero reads as `text-3xl` like every other route title
- [ ] `/cafes/place/[slug]` "I've been here" trigger + modal still flows; modal scrim still dims correctly
- [ ] `ConnectionStatus` pill at the top of the screen has the same frostiness as the rest of the glass surfaces
- [ ] `CircularTimer` overtime state still goes amber in the same places (ring, time text, "Done" button, "+over" indicator)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWYquNZMiDtwa7Ffz14abd)_