### PR TITLE
fix: suppress "based on Own recipe" subtitle

### DIFF
--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -15,6 +15,7 @@ import {
   type GuideStep,
 } from "@/lib/utils/pourSequence";
 import type { BrewStepAction } from "@/lib/types/session";
+import { basedOnReference } from "@/lib/utils/resolveRecipe";
 
 /**
  * Light System fork of /components/flow/StepBrew.tsx.
@@ -56,7 +57,7 @@ export default function LightStepBrew() {
   // brewing, not just the brewer). title is the AI's per-brew name; basedOn is
   // the stable reference recipe it adapts (populated by the recommend model).
   const recipeName = selectedCandidate?.title;
-  const basedOn = selectedCandidate?.basedOn;
+  const basedOn = basedOnReference(selectedCandidate?.basedOn, selectedCandidate?.title);
 
   // Belt-and-suspenders: even if the structured steps aren't explicit, a recipe
   // that describes itself as minimal/reduced agitation must never show a swirl

--- a/src/components/flow/LightStepRecommend.tsx
+++ b/src/components/flow/LightStepRecommend.tsx
@@ -12,6 +12,7 @@ import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
 import { getLoadingHints, COFFEE_HINTS } from "@/lib/coffeeHints";
 import { useWakeLock } from "@/hooks/useWakeLock";
 import type { RecommendationCandidate, CandidateRole, CandidateConfidence } from "@/lib/types/session";
+import { basedOnReference } from "@/lib/utils/resolveRecipe";
 
 /**
  * Light System fork of /components/flow/StepRecommend.tsx.
@@ -190,8 +191,10 @@ export default function LightStepRecommend() {
           <h1 className="font-fraunces text-[28px] leading-tight tracking-[-0.01em] text-light-foreground px-1">
             {active.title}
           </h1>
-          {active.basedOn && active.basedOn.toLowerCase() !== active.title.toLowerCase() && (
-            <p className="text-[12px] text-light-muted-foreground mt-1 px-1">based on {active.basedOn}</p>
+          {basedOnReference(active.basedOn, active.title) && (
+            <p className="text-[12px] text-light-muted-foreground mt-1 px-1">
+              based on {basedOnReference(active.basedOn, active.title)}
+            </p>
           )}
           <div className="flex items-center justify-between mt-2 px-1">
             <div className="flex items-center gap-2">

--- a/src/lib/utils/pourSequence.test.mjs
+++ b/src/lib/utils/pourSequence.test.mjs
@@ -502,3 +502,45 @@ test("resolveBrewedRecipe: legacy session without idx falls back to primary", ()
   assert.equal(recipe.grindSize, "388°");
   assert.equal(method, "V60");
 });
+
+// ── basedOnReference / brewedRecipeName: suppress the "Own recipe" sentinel ──
+// Re-declared logic (MUST stay in sync with src/lib/utils/resolveRecipe.ts).
+
+function basedOnReference(basedOn, title) {
+  const ref = basedOn?.trim();
+  if (!ref) return undefined;
+  if (ref.toLowerCase() === "own recipe") return undefined;
+  if (title && ref.toLowerCase() === title.trim().toLowerCase()) return undefined;
+  return ref;
+}
+
+function brewedRecipeName(candidate) {
+  if (!candidate) return undefined;
+  const title = candidate.title?.trim();
+  const ref = basedOnReference(candidate.basedOn, candidate.title);
+  if (title && ref) return `${title} (based on ${ref})`;
+  return title || candidate.basedOn?.trim() || undefined;
+}
+
+test("basedOnReference: 'Own recipe' placeholder is suppressed", () => {
+  assert.equal(basedOnReference("Own recipe", "Orea Classic, sweetness floor"), undefined);
+  assert.equal(basedOnReference("own recipe", "X"), undefined);
+});
+
+test("basedOnReference: a real reference passes through", () => {
+  assert.equal(basedOnReference("Kasuya 4:6", "My morning V60"), "Kasuya 4:6");
+});
+
+test("basedOnReference: a reference that just repeats the title is suppressed", () => {
+  assert.equal(basedOnReference("Kasuya 4:6", "Kasuya 4:6"), undefined);
+});
+
+test("brewedRecipeName: 'Own recipe' gives the bare title, no (based on …)", () => {
+  const name = brewedRecipeName({ title: "Orea Classic, sweetness floor", basedOn: "Own recipe" });
+  assert.equal(name, "Orea Classic, sweetness floor");
+});
+
+test("brewedRecipeName: a real reference is appended", () => {
+  const name = brewedRecipeName({ title: "My morning V60", basedOn: "Kasuya 4:6" });
+  assert.equal(name, "My morning V60 (based on Kasuya 4:6)");
+});

--- a/src/lib/utils/resolveRecipe.ts
+++ b/src/lib/utils/resolveRecipe.ts
@@ -33,14 +33,23 @@ export function resolveBrewedRecipe(session: Session): ResolvedBrew {
   return { recipe, candidate, method };
 }
 
+/** The reference recipe to surface as a "based on …" subtitle, or undefined when
+ * there's nothing worth showing: no reference, the "Own recipe" placeholder, or a
+ * value that just repeats the title. Single source of truth for the sentinel. */
+export function basedOnReference(basedOn?: string, title?: string): string | undefined {
+  const ref = basedOn?.trim();
+  if (!ref) return undefined;
+  if (ref.toLowerCase() === "own recipe") return undefined;
+  if (title && ref.toLowerCase() === title.trim().toLowerCase()) return undefined;
+  return ref;
+}
+
 /** The display name for a brewed recipe: the AI title, with the stable
  * reference appended when present ("Reduced agitation Orea — based on April 1-2-3"). */
 export function brewedRecipeName(candidate?: RecommendationCandidate): string | undefined {
   if (!candidate) return undefined;
   const title = candidate.title?.trim();
-  const basedOn = candidate.basedOn?.trim();
-  if (title && basedOn && basedOn.toLowerCase() !== title.toLowerCase()) {
-    return `${title} (based on ${basedOn})`;
-  }
-  return title || basedOn || undefined;
+  const ref = basedOnReference(candidate.basedOn, candidate.title);
+  if (title && ref) return `${title} (based on ${ref})`;
+  return title || candidate.basedOn?.trim() || undefined;
 }


### PR DESCRIPTION
## What

"Own recipe" is the recommend model's sentinel for a candidate that adapts no documented reference. It carries no information for the user, but the brew timer and recommend screen rendered it verbatim as **"based on Own recipe"** — confusing noise (this is the exact line that prompted the report, seen on an Orea Classic brew).

The "based on …" subtitle now appears **only when `basedOn` points at a real reference** like "Kasuya 4:6".

## How

- New helper `basedOnReference()` in `src/lib/utils/resolveRecipe.ts` — single source of truth for the "Own recipe" sentinel; returns `undefined` for the placeholder, an empty value, or a value that just repeats the title.
- Routed all surfaces through it:
  - **Brew timer** (`LightStepBrew.tsx`) — had no guard, so "Own recipe" leaked through.
  - **Recommend screen** (`LightStepRecommend.tsx`) — previously only suppressed the title-match case.
  - **`brewedRecipeName()`** — used by the brew-detail page title + chat context — no longer appends "(based on Own recipe)".

No type, prompt, or DB changes. The model still emits "Own recipe" exactly as before; this is a display-layer suppression only.

## Verification

- `npx tsc --noEmit` clean.
- Added 5 cases to `src/lib/utils/pourSequence.test.mjs` (sentinel suppressed, real reference preserved) — all 34 tests pass.

https://claude.ai/code/session_01JfKmYgi2g4GRroTZJbiJ9r

---
_Generated by [Claude Code](https://claude.ai/code/session_01JfKmYgi2g4GRroTZJbiJ9r)_