### PR TITLE
fix(chat): TTS only when the turn was voice-initiated

### DIFF
--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -240,7 +240,7 @@ export default function HomePage() {
       .catch(() => null);
   };
 
-  const handleSend = async ({ text, imageUrl, coffeeRef }: SendPayload) => {
+  const handleSend = async ({ text, imageUrl, coffeeRef, voiceInitiated }: SendPayload) => {
     const userMsg: Message = {
       role: "user",
       content: text,
@@ -261,8 +261,10 @@ export default function HomePage() {
     let assistantContent = "";
     let assistantActions: NavAction[] | undefined;
     let ttsBuffer = "";
-    // Stop any audio still playing from the previous reply so the assistant
-    // doesn't overlap itself when the user fires the next question.
+    // TTS only for voice-initiated turns — typed messages get a silent
+    // assistant reply. Stop any audio still playing from the previous turn
+    // either way so a new voice turn doesn't overlap the old one.
+    const speakReply = voiceInitiated === true;
     voice.cancel();
 
     try {
@@ -323,15 +325,18 @@ export default function HomePage() {
               const payload = JSON.parse(data) as { text?: string };
               if (payload.text) {
                 assistantContent += payload.text;
-                ttsBuffer += payload.text;
-                // Drain every complete sentence into the TTS queue. The hook
-                // pre-fetches up to MAX_AHEAD ahead and plays them in order,
-                // so the user hears the first sentence while the rest stream.
-                while (true) {
-                  const taken = takeSentence(ttsBuffer);
-                  if (!taken) break;
-                  ttsBuffer = taken.rest;
-                  voice.enqueue(taken.sentence);
+                if (speakReply) {
+                  ttsBuffer += payload.text;
+                  // Drain every complete sentence into the TTS queue. The
+                  // hook pre-fetches up to MAX_AHEAD ahead and plays them in
+                  // order, so the user hears the first sentence while the
+                  // rest still stream.
+                  while (true) {
+                    const taken = takeSentence(ttsBuffer);
+                    if (!taken) break;
+                    ttsBuffer = taken.rest;
+                    voice.enqueue(taken.sentence);
+                  }
                 }
                 setMessages((prev) => {
                   const copy = prev.slice();
@@ -350,7 +355,7 @@ export default function HomePage() {
             assistantContent = "";
             ttsBuffer = "";
             // Drop whatever was about to be spoken — the agent walked it back.
-            voice.cancel();
+            if (speakReply) voice.cancel();
             setMessages((prev) => {
               const copy = prev.slice();
               const lastIdx = copy.length - 1;
@@ -384,8 +389,10 @@ export default function HomePage() {
 
       // Speak any tail that didn't end in punctuation (the model sometimes
       // closes a reply with a clause that has no terminating period).
-      const tail = ttsBuffer.trim();
-      if (tail.length >= 2) voice.enqueue(tail);
+      if (speakReply) {
+        const tail = ttsBuffer.trim();
+        if (tail.length >= 2) voice.enqueue(tail);
+      }
       ttsBuffer = "";
 
       if (assistantContent || assistantActions) {

--- a/src/components/ui/light/ChatInput.tsx
+++ b/src/components/ui/light/ChatInput.tsx
@@ -33,6 +33,8 @@ export interface SendPayload {
   text: string;
   imageUrl?: string;
   coffeeRef?: CompactCoffee;
+  /** True if any part of this message originated from voice capture. */
+  voiceInitiated?: boolean;
 }
 
 interface ChatInputProps {
@@ -85,6 +87,11 @@ export default function ChatInput({
   const editorRef = useRef<HTMLDivElement | null>(null);
   const photoInputRef = useRef<HTMLInputElement | null>(null);
   const composeStartedRef = useRef(false);
+  // True once the current composition has picked up any voice-transcribed
+  // text. Reset on send and on clear. Drives the SendPayload flag the home
+  // page reads to decide whether to read the assistant reply aloud — typed
+  // messages stay silent, voice-initiated ones get spoken.
+  const voiceInitiatedRef = useRef(false);
   const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Compact coffee list for the picker — fetched once on mount.
@@ -153,6 +160,7 @@ export default function ChatInput({
   const voice = useVoiceCapture({
     onTranscript: (transcript) => {
       markComposed();
+      voiceInitiatedRef.current = true;
       setText(transcript);
       if (editorRef.current) {
         editorRef.current.textContent = transcript;
@@ -226,23 +234,29 @@ export default function ChatInput({
     setAttachedImageUrl(null);
     setAttachedCoffee(null);
     setUploadError(null);
+    voiceInitiatedRef.current = false;
     editorRef.current?.focus();
   };
 
   const send = () => {
     if (!sendActive || loading || uploadingImage) return;
-    onUnlockAudio?.();
+    const voiceInitiated = voiceInitiatedRef.current;
+    // Unlock iOS audio only when this message was voice-initiated, so a
+    // pure-text exchange doesn't prime the audio element unnecessarily.
+    if (voiceInitiated) onUnlockAudio?.();
     if (assistantSpeaking) onCancelSpeak?.();
     onSend({
       text: text.trim(),
       ...(attachedImageUrl ? { imageUrl: attachedImageUrl } : {}),
       ...(attachedCoffee ? { coffeeRef: attachedCoffee } : {}),
+      ...(voiceInitiated ? { voiceInitiated: true } : {}),
     });
     if (editorRef.current) editorRef.current.textContent = "";
     setText("");
     setAttachedImageUrl(null);
     setAttachedCoffee(null);
     composeStartedRef.current = false;
+    voiceInitiatedRef.current = false;
     editorRef.current?.blur();
   };
 
@@ -250,6 +264,9 @@ export default function ChatInput({
     if (loading || sendActive) return;
     setVoiceError(null);
     markComposed();
+    // The mic tap is a user gesture — prime iOS audio now so the reply
+    // (which we'll route to TTS because this composition is voice-initiated)
+    // plays without an autoplay block.
     onUnlockAudio?.();
     if (assistantSpeaking) onCancelSpeak?.();
     await voice.start();


### PR DESCRIPTION
## Why
The previous fix made the assistant speak every reply. The user wants speech only when their turn was voice-initiated — typed messages should stay silent.

## What changed
- `ChatInput` tracks `voiceInitiatedRef` per composition: set true the moment a transcript lands, reset on send and on clear.
- New optional `voiceInitiated` field on `SendPayload` rides to the home page.
- `(light)/page.tsx` only chunks deltas into `voice.enqueue()` when the flag is set. Audio is still cancelled at the start of every send (so a queued tail from a previous voice turn can't bleed over the new one) but the new reply stays silent if the user typed it.
- iOS audio unlock now only fires from voice-initiated gestures (mic tap + voice-initiated send) — no unnecessary unlock for pure-text exchanges.

## Test plan
- [ ] Type a question → assistant replies silently in the bubble.
- [ ] Tap mic, speak, send → assistant reads the reply aloud sentence-by-sentence.
- [ ] Voice turn, then while it's reading start a typed reply → playback stops on focus, new reply is silent.
- [ ] Voice turn, then a follow-up voice turn → previous audio cuts, new reply speaks.

https://claude.ai/code/session_01A2WyaP3fz8CUWuWvjiBZv8

---
_Generated by [Claude Code](https://claude.ai/code/session_01A2WyaP3fz8CUWuWvjiBZv8)_