### PR TITLE
fix: chat + greeting use the actual ★ in-rotation bags, not the 6 newest

### DIFF
--- a/src/app/api/explore-agent/route.ts
+++ b/src/app/api/explore-agent/route.ts
@@ -4,7 +4,7 @@ import { requireAuth } from "@/lib/auth/requireAuth";
 import { buildRecentRecipes } from "@/lib/claude/historyUtils";
 import { resolveBrewedRecipe, brewedRecipeName } from "@/lib/utils/resolveRecipe";
 import { loadUserProfile, formatProfileForPrompt } from "@/lib/claude/userProfile";
-import { loadCoffeeLibraryCompact } from "@/lib/claude/coffeeLibrary";
+import { loadRotationCoffees } from "@/lib/claude/coffeeLibrary";
 import type { CompactCoffee } from "@/lib/claude/coffeeLibrary";
 import { getRoasterPrior, formatRoasterPriorForPrompt } from "@/lib/roasters/priors";
 import {
@@ -71,9 +71,9 @@ You're a chat agent inside BTTS. When the user asks "what can you do?" or "can I
 - **suggest_navigation**: propose navigating to a BTTS feature. Call this *during your response* whenever the conversation makes one of the in-app features genuinely useful. Be selective — only when it adds clear value, not as a reflex. You can call it multiple times in one turn (e.g. map + coffee detail).
 - **start_brew**: drop the user STRAIGHT into the step-by-step brew timer with the exact recipe you just gave — no context questions, no re-recommendation. For when you've just laid out a complete recipe for a specific library bag (often a one-off for the last few grams that isn't worth saving).
 
-**Personalized context injected each turn (you don't need a tool — it's already below):** current local time + weekday, the user's recent recipes (dose/water/grind/temp/timing), the bags **currently in rotation** (last 6 — this is *not* the full library, just what's open and active right now), their equipment & grind settings, roaster style priors for roasters they're brewing, and recent research insights.
+**Personalized context injected each turn (you don't need a tool — it's already below):** current local time + weekday, the user's recent recipes (dose/water/grind/temp/timing), the bags **currently in rotation** (the bags the user has explicitly marked ★ in rotation — this is *not* the full library, just what's open and active on the counter right now), their equipment & grind settings, roaster style priors for roasters they're brewing, and recent research insights.
 
-When the user asks "what should I brew?" / "what should I drink today?" / similar open-ended brew commands, restrict your candidates to the bags in the Coffee Library block below — that's the active rotation. Don't pull older bags out of memory; if none of the rotation fits, say so plainly.
+When the user asks "what should I brew?" / "what should I drink today?" / similar open-ended brew commands, restrict your candidates to the bags in the Coffee Library block below — that's the active rotation. Don't pull older bags out of memory; if none of the rotation fits, say so plainly. If the Coffee Library block is empty, nothing is marked in rotation — say so and suggest opening/marking a bag rather than naming one from memory.
 
 Mention capabilities only when relevant — don't pitch them unprompted.
 
@@ -540,7 +540,8 @@ function formatLibraryForAgent(library: CompactCoffee[]): string {
         c.avgRating != null
           ? `${c.avgRating.toFixed(1)}★ · ${c.sessionCount} sessions`
           : `${c.sessionCount} sessions`;
-      return `- [id:${c.id}] ${c.roaster} — ${c.name} | ${c.origin} ${c.process} | ${usage}`;
+      const rotationMark = c.inRotation ? "★ IN ROTATION | " : "";
+      return `- [id:${c.id}] ${rotationMark}${c.roaster} — ${c.name} | ${c.origin} ${c.process} | ${usage}`;
     })
     .join("\n");
 }
@@ -584,12 +585,12 @@ export async function POST(req: NextRequest) {
 
     const [userPrefs, library] = await Promise.all([
       loadUserProfile().catch(() => null),
-      // Only the bags in active rotation. Recommendations bias toward
-      // what the user is actually brewing right now, not their full
-      // historical library. The agent can still answer questions about
-      // older bags by name; this just keeps "what should I brew?"
-      // grounded in recent stock.
-      loadCoffeeLibraryCompact(6).catch(() => []),
+      // The bags the user has explicitly marked ★ in rotation — the real
+      // "what's on the counter right now" set, NOT a recency proxy. Using the
+      // actual flag means an older-but-still-open bag (e.g. a coffee roasted
+      // weeks ago with many brews) is never dropped just because newer bags
+      // were added after it.
+      loadRotationCoffees().catch(() => []),
     ]);
 
     const profileBlock = formatProfileForPrompt(userPrefs);

--- a/src/app/api/greeting/route.ts
+++ b/src/app/api/greeting/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import Anthropic from "@anthropic-ai/sdk";
 import { requireAuth } from "@/lib/auth/requireAuth";
-import { loadCoffeeLibraryCompact, formatLibraryForPrompt } from "@/lib/claude/coffeeLibrary";
+import { loadRotationCoffees, formatLibraryForPrompt } from "@/lib/claude/coffeeLibrary";
 import { loadUserProfile } from "@/lib/claude/userProfile";
 import { db } from "@/lib/db/client";
 import { sessions, insights as insightsTable } from "@/lib/db/schema";
@@ -137,10 +137,12 @@ export async function POST(req: NextRequest) {
     await req.json().catch(() => ({} as RequestBody));
 
     const [library, recentRows, profile, weather, activeInsights] = await Promise.all([
-      // Only the last few bags in active rotation — the line biases
-      // toward what the user is brewing right now, not their full
-      // historical library.
-      loadCoffeeLibraryCompact(4).catch(() => []),
+      // The bags the user has explicitly marked ★ in rotation — what they're
+      // actually brewing right now, by the rotation flag rather than a
+      // recency proxy. An older-but-still-open bag is no longer dropped just
+      // because newer bags were added after it. The prompt already handles the
+      // zero-rotation case (acknowledge the gap, don't invent a bag).
+      loadRotationCoffees().catch(() => []),
       db
         .select()
         .from(sessions)

--- a/src/lib/claude/coffeeLibrary.ts
+++ b/src/lib/claude/coffeeLibrary.ts
@@ -1,4 +1,4 @@
-import { desc } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import { coffees } from "@/lib/db/schema";
 
@@ -21,6 +21,28 @@ export interface CompactCoffee {
   inRotation?: boolean;
 }
 
+type CoffeeRow = typeof coffees.$inferSelect;
+
+function rowToCompact(r: CoffeeRow): CompactCoffee {
+  return {
+    id: r.id,
+    roaster: r.roaster,
+    name: r.name,
+    origin: r.origin,
+    process: r.process,
+    latestRoastDate: r.latestRoastDate ?? undefined,
+    firstSeenAt: r.firstSeenAt,
+    sessionCount: r.sessionCount,
+    avgRating: r.avgRating != null ? Number(r.avgRating) : undefined,
+    commonNotes:
+      Array.isArray(r.commonNotes) && r.commonNotes.length > 0
+        ? r.commonNotes
+        : undefined,
+    writtenSummary: r.writtenSummary ?? undefined,
+    inRotation: r.inRotation ?? false,
+  };
+}
+
 export async function loadCoffeeLibraryCompact(limit = 30): Promise<CompactCoffee[]> {
   try {
     const rows = await db
@@ -28,25 +50,31 @@ export async function loadCoffeeLibraryCompact(limit = 30): Promise<CompactCoffe
       .from(coffees)
       .orderBy(desc(coffees.firstSeenAt))
       .limit(limit);
-    return rows.map((r) => ({
-      id: r.id,
-      roaster: r.roaster,
-      name: r.name,
-      origin: r.origin,
-      process: r.process,
-      latestRoastDate: r.latestRoastDate ?? undefined,
-      firstSeenAt: r.firstSeenAt,
-      sessionCount: r.sessionCount,
-      avgRating: r.avgRating != null ? Number(r.avgRating) : undefined,
-      commonNotes:
-        Array.isArray(r.commonNotes) && r.commonNotes.length > 0
-          ? r.commonNotes
-          : undefined,
-      writtenSummary: r.writtenSummary ?? undefined,
-      inRotation: r.inRotation ?? false,
-    }));
+    return rows.map(rowToCompact);
   } catch (err) {
     console.error("loadCoffeeLibraryCompact error:", err);
+    return [];
+  }
+}
+
+/**
+ * The bags the user has explicitly marked ★ in rotation (in_rotation = true).
+ * This is the real "what's on the counter right now" set — NOT a recency proxy.
+ * The greeting + home chat must use this so an older-but-still-open bag (e.g. a
+ * coffee roasted weeks ago with many brews) is never dropped just because newer
+ * bags were added after it. Returns [] if nothing is marked.
+ */
+export async function loadRotationCoffees(limit = 12): Promise<CompactCoffee[]> {
+  try {
+    const rows = await db
+      .select()
+      .from(coffees)
+      .where(eq(coffees.inRotation, true))
+      .orderBy(desc(coffees.firstSeenAt))
+      .limit(limit);
+    return rows.map(rowToCompact);
+  } catch (err) {
+    console.error("loadRotationCoffees error:", err);
     return [];
   }
 }


### PR DESCRIPTION
## Why

This morning the home chat said **"Ineffable La Coipa — not in your library"** when asked what to brew from the two bags in rotation — even though La Coipa is in the library with 7 brews and marked ★ in rotation.

## Root cause

Both `/api/explore-agent` (home chat) and `/api/greeting` claimed to use *"the bags in active rotation"* but actually loaded the **N most recently *added*** coffees:

```ts
loadCoffeeLibraryCompact(6)  // ORDER BY first_seen_at DESC LIMIT 6
```

The `in_rotation` flag was never consulted, and the chat's formatter never even rendered the ★ marker. La Coipa was roasted weeks ago, so once ≥6 newer bags were added it fell outside the top-N-by-date window — the chat literally never received the row and concluded it wasn't in the library. The system prompt compounded this by telling the model that this newest-N list *was* the active rotation.

## Fix

- Add `loadRotationCoffees()` — `WHERE in_rotation = true` — and use it in both routes. Rotation is now defined by the ★ flag the toggle exists for, never by recency, so an older-but-still-open bag is never dropped.
- Render the `★ IN ROTATION` marker in the agent's library formatter.
- Update the agent prompt to describe rotation by the flag (not "last 6") and to handle an empty rotation explicitly (say so, don't name a bag from memory). The greeting already had zero-rotation handling.

`npx tsc --noEmit` clean.

https://claude.ai/code/session_01WKnfcDG1mzawHNZjtPJZ3w

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKnfcDG1mzawHNZjtPJZ3w)_