### PR TITLE
fix: pin immersion drawdown overhead so it doesn't scale with water volume

### DIFF
--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -479,6 +479,13 @@ Worked examples — verify your arithmetic before outputting:
     "fill tank 30s · brew 7:30"  ← 30+450 = 480 ✓
 Formula: steep = targetTimeSec − (pour + stirs + press/drain overhead). Compute steep last.
 
+DRAIN / DRAWDOWN OVERHEAD IS ROUGHLY CONSTANT — it does NOT scale up with water volume.
+The water-first Clever drains fast by design (water poured before the coffee = the paper never
+clogs, so drawdown is ~half a coffee-first brew). Keep its drain overhead at 0:55–1:15 (use ~1:00;
+a deep 500ml bed may sit at the top of the range, but NEVER stretch toward 1:20+). AeroPress press
+≈ 30s; Moccamaster fill ≈ 30s. When targetTimeSec grows for a larger brew, extend the STEEP, not
+the drain — a 500ml Clever and a 250ml Clever have nearly the same drawdown.
+
 HYPOTHESIS/WHY CONSISTENCY: In hypothesis, whyChosen, and predictedCupProfile text, always
 reference the TOTAL brew time (targetTimeSec as mm:ss), never just the steep phase.
 Write "a 5-minute immersion" not "a 4-minute steep" for targetTimeSec=300.


### PR DESCRIPTION
## Why

A water-first Hoffmann Clever brew at 30g:500g showed a **1:25 drawdown** (start 4:05, done 5:30) on the brew timer. Hoffmann's published recipe drains in **~1 min**, and the codebase's reference recipe encodes exactly that (`reference.ts:180` → `durationSec: 65`). The brew finished naturally at ~5:05 (≈1:00 drawdown), confirming 1:25 was too long.

## Cause

- The brew screen reads immersion step durations straight from the candidate recipe (`buildGuideSteps`), and Opus **regenerates those timings on every brew**. The `/recommend` prompt told it to "compute steep last" but left the **drain overhead unconstrained**, so it padded the drawdown to 1:25 with no source.
- 500ml on a Clever is past its 400ml design cap; it's reachable only via the existing user-override path (method locked + exact volume typed). Improvising timings outside the recipe's validated range is exactly where the drift showed.

## Fix

One rule added to the IMMERSION timing block in `recommend.ts`: drain/drawdown overhead is roughly constant and **does not scale with water volume**. Clever water-first stays **0:55–1:15** (~1:00), AeroPress press ≈30s, Moccamaster fill ≈30s. When total time grows for a larger brew, extend the **steep**, not the drain.

Behavioral change, isolated to its own commit per the AI-behavior convention. `npx tsc --noEmit` clean.

https://claude.ai/code/session_01WKnfcDG1mzawHNZjtPJZ3w

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKnfcDG1mzawHNZjtPJZ3w)_