### PR TITLE
fix: stop filtering Origami + Chemex recipes out of recommendations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -627,7 +627,7 @@ Cause for sub-rules 5–8: a follow-up audit of all 19 named-expert recipe entri
 | Device | Details |
 |--------|---------|
 | **PRIMARY** | V60 size 2 (Hario Drip Assist **retired from daily use** — emergency-only when no gooseneck kettle is around, e.g. travelling. Selectable in the flow as "V60 + Drip Assist" but never recommended proactively; PR #193) |
-| Other | Orea V4 Wide, Origami Dripper, Clever Dripper, Kalita Wave, AeroPress, Moccamaster, Chemex |
+| Other | Orea V4 Wide, Origami Air M (resin / AS-resin "Air" line — lighter, lower thermal mass than ceramic; takes both V60 conical and Kalita Wave flat-bottom filters), Clever Dripper, Kalita Wave, AeroPress, Moccamaster, Chemex |
 | **Kettle** | Fellow Stagg EKG — gooseneck, precise temp control, 60-min hold |
 | **Grinder** | Niche Zero — uses **degree (°) settings**, continuous (no clicks) |
 | Travel grinder | Comandante C40 MK2 — uses **clicks**, not degrees |

--- a/src/app/(light)/onboarding/page.tsx
+++ b/src/app/(light)/onboarding/page.tsx
@@ -15,9 +15,11 @@ async function savePreferences(prefs: UserPreferences): Promise<void> {
 const EQUIPMENT_OPTIONS = [
   { id: "V60", label: "V60" },
   { id: "OreaV4", label: "Orea V4" },
+  { id: "Origami", label: "Origami" },
   { id: "Kalita", label: "Kalita Wave" },
   { id: "CleverDripper", label: "Clever Dripper" },
   { id: "AeroPress", label: "AeroPress" },
+  { id: "Chemex", label: "Chemex" },
   { id: "Moccamaster", label: "Moccamaster" },
   { id: "FrenchPress", label: "French Press" },
   { id: "Espresso", label: "Espresso" },

--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -18,6 +18,7 @@ import {
   selectRecipes,
   formatRecipesForPrompt,
   brewersAvailableFromEquipment,
+  CANONICAL_EQUIPMENT,
   brewersFromMethod,
   normaliseRoastLevel,
   normaliseProcess,
@@ -826,7 +827,15 @@ export async function generateRecommendation(
             ? 750
             : undefined;
 
-  const brewersAvailable = brewersAvailableFromEquipment(preferences.equipment);
+  // Union the stored onboarding equipment with the owner's canonical kit.
+  // The onboarding picker never offered Origami or Chemex, so keying off the
+  // saved row alone silently filtered out every Origami/Chemex recipe before
+  // scoring. Single-user app — the canonical kit is the real, authoritative
+  // equipment list (see CLAUDE.md). Method-lock filtering still narrows from here.
+  const brewersAvailable = brewersAvailableFromEquipment([
+    ...(preferences.equipment ?? []),
+    ...CANONICAL_EQUIPMENT,
+  ]);
   // If the user locked a method in the flow, hard-filter recipe selection to
   // that method so the prompt only carries recipes for the brewer they chose.
   const lockedBrewers = brewersFromMethod(context.preferredMethod);

--- a/src/lib/claude/userProfile.ts
+++ b/src/lib/claude/userProfile.ts
@@ -21,7 +21,7 @@ const CANONICAL_PROFILE = `**Equipment:**
 - Primary grinder: Niche Zero (Niche DEGREES, never clicks!)
 - Travel grinder: Comandante C40 MK2 (clicks, not degrees)
 - Primary brewer: V60 size 2 (daily driver)
-- Other brewers: Orea V4 Wide, Origami Dripper, Clever Dripper, Kalita Wave, AeroPress, Moccamaster, Chemex
+- Other brewers: Orea V4 Wide, Origami Air M (resin, AS-resin "Air" line — lighter, lower thermal mass than ceramic), Clever Dripper, Kalita Wave, AeroPress, Moccamaster, Chemex
 - Kettle: Fellow Stagg EKG (gooseneck, precise temp control, 60-min hold)
 - Water: BWT Bestmax Premium V filter (bypass 0) turns ~370 ppm Düsseldorf tap into ~220 ppm TDS (GH 5–6 °dH, KH 4 °dH) — the daily driver, fine straight for naturals & honeys. For washed/floral coffees a 1:2 blend (BWT-filtered + distilled) gives ~73 ppm TDS (KH ~1.3 °dH) for maximum clarity — ideal for championship methods (Peng, Kasuya, Wölfl)
 

--- a/src/lib/knowledge/recipes/helpers.ts
+++ b/src/lib/knowledge/recipes/helpers.ts
@@ -82,7 +82,12 @@ const EQUIPMENT_PATTERNS: Array<{
   },
   {
     match: (k) => k.includes("origamiairm") || k.includes("airm"),
-    brewers: ["origami-air-m"],
+    // The Origami Air M physically takes BOTH a V60 conical filter and a
+    // Kalita Wave flat-bottom filter, so every cone- and wave-shaped Origami
+    // recipe is brewable on it. (There is no recipe with brewer
+    // "origami-air-m" — mapping it there would dead-end and hide all Origami
+    // recipes, which was the cause of Origami being under-represented.)
+    brewers: ["origami-cone", "origami-wave"],
   },
   {
     match: (k) => k.includes("origami"),
@@ -122,6 +127,26 @@ const EQUIPMENT_PATTERNS: Array<{
     match: (k) => k.includes("cafec") || k.includes("flower"),
     brewers: ["cafec-flower"],
   },
+];
+
+/**
+ * The owner's full, real brewing kit (single-user app — see CLAUDE.md
+ * "User / Equipment Profile"). The onboarding equipment picker is a thin
+ * subset (it never offered Origami or Chemex), so a recommendation that keyed
+ * ONLY off the stored onboarding row silently filtered out every Origami and
+ * Chemex recipe. We union this canonical kit into brewersAvailable so the
+ * recipe selector always sees the brewers the owner actually has. Strings are
+ * chosen to resolve through EQUIPMENT_PATTERNS (e.g. "Origami" → cone + wave).
+ */
+export const CANONICAL_EQUIPMENT: string[] = [
+  "V60",
+  "OreaV4",
+  "Origami",
+  "Kalita",
+  "CleverDripper",
+  "AeroPress",
+  "Moccamaster",
+  "Chemex",
 ];
 
 export function brewersAvailableFromEquipment(

--- a/src/lib/knowledge/recipes/index.ts
+++ b/src/lib/knowledge/recipes/index.ts
@@ -31,6 +31,7 @@ export { MARKUS_ADDITIONS } from "./markusAdditions";
 
 export {
   ALL_RECIPES,
+  CANONICAL_EQUIPMENT,
   brewersAvailableFromEquipment,
   brewersFromMethod,
   normaliseRoastLevel,


### PR DESCRIPTION
## Why Origami (and Chemex) were under-represented

Recipe selection hard-filters recipes to the brewers the user owns (`helpers.ts:227`), keyed off the stored onboarding equipment row (`recommend/route.ts:82`). But the onboarding equipment picker **never offered Origami or Chemex**:

```
onboarding/page.tsx — EQUIPMENT_OPTIONS = [V60, Orea V4, Kalita, Clever, AeroPress, Moccamaster, French Press, Espresso]
```

So they could never be saved into preferences, and **all 15 Origami recipes (12 cone + 3 wave) plus every Chemex recipe were filtered out before scoring.** The model only surfaced Origami occasionally by free-handing it from the profile prose — with no structured recipe behind it. That's the "under-represented" behavior.

Also found: the equipment matcher mapped "Origami Air M" → brewer id `origami-air-m`, which has **zero recipes** — a dead-end that would hide Origami entirely.

## Fix (code-only, effective on deploy, no DB change)

- **recommend**: union the stored equipment with the owner's `CANONICAL_EQUIPMENT` kit, so the selector always sees the brewers actually owned. Single-user app — the canonical kit is authoritative. Method-lock filtering still narrows from there.
- **helpers**: add `CANONICAL_EQUIPMENT`; repoint the "Origami Air M" match to `origami-cone` + `origami-wave` (it physically takes both filter shapes) instead of the recipe-less `origami-air-m` id.
- **onboarding**: add Origami + Chemex to the equipment picker.
- **profile**: name the Origami as the Air M (resin) in the canonical profile + CLAUDE.md.

**Trade-off:** because the canonical kit is always unioned in, equipment "deselection" in onboarding no longer hides a brewer for this single user (they own all of them) — that's the intended state per CLAUDE.md, and it's what makes the fix take effect without a prod-DB edit.

`npx tsc --noEmit` clean.

https://claude.ai/code/session_01WKnfcDG1mzawHNZjtPJZ3w

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKnfcDG1mzawHNZjtPJZ3w)_