### PR TITLE
feat: read-only admin lookup endpoint + read-only SQL workflow

### DIFF
--- a/.github/workflows/db-read.yml
+++ b/.github/workflows/db-read.yml
@@ -1,0 +1,48 @@
+name: DB Read (read-only SQL)
+
+# Read-only SQL runner — pipes a SELECT into the production Postgres inside a
+# READ ONLY transaction and prints the result to the Actions log. Used to
+# inspect live data (which only lives in the production DB, never in the repo)
+# without mutating anything.
+#
+# SAFETY: the SQL runs inside `BEGIN; SET TRANSACTION READ ONLY; … ; COMMIT;`
+# so Postgres rejects ANY write (INSERT/UPDATE/DELETE/DDL) with an error — this
+# workflow physically cannot change data. Only repo collaborators can trigger
+# workflow_dispatch, so access is gated by GitHub write access plus the existing
+# deploy SSH key (no new secret, nothing new exposed publicly).
+#
+# Trigger from the Actions tab → "DB Read (read-only SQL)" → Run workflow,
+# or via the GitHub API. Paste a single SELECT into the `sql` input.
+
+on:
+  workflow_dispatch:
+    inputs:
+      sql:
+        description: 'A read-only SQL query, e.g. SELECT data FROM preferences WHERE key = ''default'';'
+        required: true
+        type: string
+
+jobs:
+  read:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run read-only query on VPS
+        env:
+          QUERY_SQL: ${{ inputs.sql }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+              ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} \
+              "QUERY_SQL=$(printf '%q' "$QUERY_SQL") bash -s" <<'REMOTE'
+            set -euo pipefail
+            cd ${{ secrets.DEPLOY_PATH }}
+
+            # Wrap the query in a READ ONLY transaction so any write statement
+            # aborts with an error — this job cannot mutate the database.
+            printf 'BEGIN; SET TRANSACTION READ ONLY;\n%s\nCOMMIT;\n' "$QUERY_SQL" \
+              | docker compose exec -T postgres \
+                  psql -U brewlog -d brewlog -v ON_ERROR_STOP=1
+          REMOTE

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ Removed routes: legacy Dark `page.tsx` (replaced by `(light)/page.tsx`), `match/
 | `cafe-visits` | GET / POST — visit-only café logs with binary thumbs rating (independent of brew sessions) |
 | `cafe-visits/[id]` | DELETE — remove a logged visit |
 | `admin/seed` | Populate knowledge base (run once on new installs) |
+| `admin/lookup` | ★ Read-only live-data lookups (session-cookie gated). `GET ?q=preferences\|counts\|rotation\|coffees\|coffee` — whitelisted, parameterised, no arbitrary SQL. Lets the owner inspect production rows in-browser without SSH. |
 
 ### Components
 
@@ -632,6 +633,17 @@ Cause for sub-rules 5–8: a follow-up audit of all 19 named-expert recipe entri
 | **Grinder** | Niche Zero — uses **degree (°) settings**, continuous (no clicks) |
 | Travel grinder | Comandante C40 MK2 — uses **clicks**, not degrees |
 | **Water** | BWT Bestmax Premium V (bypass 0): ~370 ppm hard local tap → **~220 ppm** filtered (GH 5–6 / KH 4 °dH), daily driver for naturals/honeys · **clarity blend** 1:2 filtered+distilled = **~73 ppm** (KH ~1.3 °dH) for washed florals & championship methods (Peng/Kasuya/Wölfl) |
+
+### Hard rule: single-user PROJECT, not a product — no onboarding
+
+This app has exactly **one user (the owner, roitsch@gmail.com) and always will.** It is a personal project, not a product. Consequences that OVERRIDE any "make it configurable / generic" instinct:
+
+- **There is no onboarding flow to rely on.** The `(light)/onboarding` page is deprecated; do not route new behaviour through it or assume the user will (re-)run it. The user cannot re-select equipment through a wizard — there is no settings screen.
+- **The profile is CODE-CANONICAL.** The owner's equipment, grinder, water, and taste are the source of truth in code: `CANONICAL_PROFILE` (`src/lib/claude/userProfile.ts`) for prompt text and `CANONICAL_EQUIPMENT` (`src/lib/knowledge/recipes/helpers.ts`) for recipe-brewer filtering. When the kit changes, edit those constants — never wait on a DB/onboarding round-trip. `/recommend` unions the stored `preferences.equipment` with `CANONICAL_EQUIPMENT` so a stale DB row can never hide an owned brewer (this was the cause of Origami/Chemex being filtered out of recommendations — PR #250).
+- **Don't add per-user generality** (multi-tenant isolation, per-user onboarding gates, "first-run" UX). It's wasted complexity for a one-person project.
+
+**Reading live data:** the production DB (Postgres on the VPS) is NOT reachable from a Claude Code session — only the repo is. Two read paths exist: the auth-gated `GET /api/admin/lookup?q=…` endpoint (session-cookie only, whitelisted read-only lookups — for the owner in-browser) and the `DB Read (read-only SQL)` GitHub Action (`.github/workflows/db-read.yml`, runs a SELECT inside a READ ONLY transaction on the VPS and prints to the log — for Claude's diagnostic reads). Use these instead of guessing at row contents.
+
 
 **Taste:** silky, balanced, floral/fruity (elegant); light roast SO; avoids anaerobic/infused/dark.
 **Grind quick ref:** @./docs/grind-settings.md

--- a/src/app/api/admin/lookup/route.ts
+++ b/src/app/api/admin/lookup/route.ts
@@ -1,0 +1,143 @@
+import { NextRequest, NextResponse } from "next/server";
+import { and, desc, eq, sql } from "drizzle-orm";
+import { requireAuth } from "@/lib/auth/requireAuth";
+import { db } from "@/lib/db/client";
+import {
+  coffees,
+  sessions,
+  places,
+  preferences,
+  insights,
+} from "@/lib/db/schema";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Read-only admin lookup endpoint — single-user project (see CLAUDE.md).
+ *
+ * Gated by the normal session cookie (requireAuth) — same auth as the rest
+ * of the app, no static bypass secret. Meant to be opened in the owner's
+ * logged-in browser to inspect specific live rows without SSHing into the VPS.
+ *
+ * SAFETY: this is NOT an arbitrary-SQL endpoint. Only the named lookups in
+ * LOOKUPS run, each a fixed, parameterised read. Adding a lookup is a one-line
+ * change here. (For Claude's own diagnostic reads there is a separate SSH
+ * read-only-SQL GitHub Action — .github/workflows/db-read.yml — so this public
+ * endpoint never needs a machine-callable secret.)
+ *
+ * Usage:  GET /api/admin/lookup?q=preferences
+ *         GET /api/admin/lookup?q=coffee&roaster=Friedhats&name=Quiquira
+ */
+const ALLOWED = [
+  "preferences",
+  "counts",
+  "rotation",
+  "coffees",
+  "coffee",
+] as const;
+type LookupName = (typeof ALLOWED)[number];
+
+async function runLookup(
+  q: LookupName,
+  params: URLSearchParams,
+): Promise<unknown> {
+  switch (q) {
+    case "preferences": {
+      const rows = await db
+        .select()
+        .from(preferences)
+        .where(eq(preferences.key, "default"))
+        .limit(1);
+      return rows[0]?.data ?? null;
+    }
+
+    case "counts": {
+      const [c, s, p, i] = await Promise.all([
+        db.select({ n: sql<number>`count(*)::int` }).from(coffees),
+        db.select({ n: sql<number>`count(*)::int` }).from(sessions),
+        db.select({ n: sql<number>`count(*)::int` }).from(places),
+        db
+          .select({ status: insights.status, n: sql<number>`count(*)::int` })
+          .from(insights)
+          .groupBy(insights.status),
+      ]);
+      return {
+        coffees: c[0]?.n ?? 0,
+        sessions: s[0]?.n ?? 0,
+        places: p[0]?.n ?? 0,
+        insightsByStatus: i,
+      };
+    }
+
+    case "rotation": {
+      return db
+        .select({
+          id: coffees.id,
+          roaster: coffees.roaster,
+          name: coffees.name,
+          inRotation: coffees.inRotation,
+          sessionCount: coffees.sessionCount,
+          latestRoastDate: coffees.latestRoastDate,
+        })
+        .from(coffees)
+        .where(eq(coffees.inRotation, true))
+        .orderBy(desc(coffees.firstSeenAt));
+    }
+
+    case "coffees": {
+      return db
+        .select({
+          id: coffees.id,
+          roaster: coffees.roaster,
+          name: coffees.name,
+          inRotation: coffees.inRotation,
+          sessionCount: coffees.sessionCount,
+        })
+        .from(coffees)
+        .orderBy(desc(coffees.firstSeenAt))
+        .limit(100);
+    }
+
+    case "coffee": {
+      const id = params.get("id");
+      const roaster = params.get("roaster");
+      const name = params.get("name");
+      if (id) {
+        const rows = await db.select().from(coffees).where(eq(coffees.id, id)).limit(1);
+        return rows[0] ?? null;
+      }
+      if (roaster && name) {
+        const rows = await db
+          .select()
+          .from(coffees)
+          .where(and(eq(coffees.roaster, roaster), eq(coffees.name, name)))
+          .limit(1);
+        return rows[0] ?? null;
+      }
+      throw new Error("coffee lookup needs ?id= OR ?roaster=&name=");
+    }
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const authError = await requireAuth(req);
+  if (authError) return authError;
+
+  const params = req.nextUrl.searchParams;
+  const q = params.get("q");
+
+  if (!q || !ALLOWED.includes(q as LookupName)) {
+    return NextResponse.json(
+      { error: "Unknown lookup", allowed: ALLOWED },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await runLookup(q as LookupName, params);
+    return NextResponse.json({ q, result });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Lookup failed";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}


### PR DESCRIPTION
## What

Two read-only ways to inspect live production data (which lives only in the VPS Postgres, never in the repo), plus recording the single-user project rules.

**`GET /api/admin/lookup?q=…`** — session-cookie gated (`requireAuth`), **no static bypass secret**. Whitelisted, parameterised, read-only lookups only — not arbitrary SQL:
- `q=preferences` → your saved preferences row
- `q=counts` → coffee / session / place counts + insights-by-status
- `q=rotation` → the ★ in-rotation coffees
- `q=coffees` → compact coffee list
- `q=coffee&id=…` or `&roaster=…&name=…` → one coffee row

Adding a lookup is a one-line change. For the owner to open in a logged-in browser.

**`.github/workflows/db-read.yml`** — runs a SELECT inside a `SET TRANSACTION READ ONLY` block on the VPS over the existing deploy SSH key and prints the result to the Actions log, for Claude's diagnostic reads. Postgres rejects any write, so the job physically cannot mutate data; only repo collaborators can trigger it.

**CLAUDE.md** — records the hard rule: single-user **project**, no onboarding, profile is **code-canonical** (`CANONICAL_PROFILE` + `CANONICAL_EQUIPMENT`), and documents both read paths.

## Auth model

Per the chosen design: cookie-only on the public HTTP endpoint (no machine-callable secret on the internet), and a separate SSH-based read-only SQL action for automated reads. `/api/admin` is already in middleware's public list, so the route's own `requireAuth` is the gate.

`npx tsc --noEmit` clean.

https://claude.ai/code/session_01WKnfcDG1mzawHNZjtPJZ3w

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKnfcDG1mzawHNZjtPJZ3w)_