### PR TITLE
fix: tolerate string cuppingScore on session save

### DIFF
--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -22,7 +22,19 @@ const SessionPostSchema = z.object({
     fermentationStyle: z.string().max(200).optional(),
     roastLevel: z.string().max(100).optional().default(""),
     roastDate: z.string().optional(),
-    cuppingScore: z.number().min(0).max(100).optional(),
+    // Tolerate a numeric string here: sessions migrated from Firestore (and
+    // any coffee identity re-submitted via "Brew Again") can carry
+    // cuppingScore as a string like "89". Coerce numeric strings to numbers;
+    // empty/garbage becomes undefined rather than a bogus 0. Without this the
+    // POST rejects with "coffee: expected number, received string".
+    cuppingScore: z.preprocess((v) => {
+      if (v == null || v === "") return undefined;
+      if (typeof v === "string") {
+        const n = Number(v);
+        return Number.isFinite(n) ? n : undefined;
+      }
+      return v;
+    }, z.number().min(0).max(100).optional()),
     bagPhotoUrl: z.string().url().optional().or(z.literal("")),
     bagPhotoPath: z.string().max(500).optional(),
     aiExtracted: z.boolean().default(false),


### PR DESCRIPTION
## What

Saving a brew failed with **"Invalid session data — coffee: Invalid input: expected number, received string"** (seen on the Summary screen with a "Retry" button).

## Root cause

The `coffee` object's only numeric field is `cuppingScore`. Sessions migrated from Firestore (`scripts/migrate-firestore-to-postgres.mjs` writes `d.coffee` verbatim into the JSONB column) can carry `cuppingScore` as a **string** like `"89"`. When you hit **Brew Again** on such a coffee, the identity is copied from that old session and re-submitted — and the POST schema in `src/app/api/sessions/route.ts` required a `number`, so the save was rejected.

This was hitting Nogales Geisha (Colombia · Huila, Natural) in the screenshot.

## Fix

Coerce `cuppingScore` at the schema boundary: numeric strings become numbers, empty/garbage becomes `undefined` (not a bogus `0`). This is the single save chokepoint, so it covers online save, offline-queue replay, Brew Again, and fresh scans.

`npx tsc --noEmit` passes.

https://claude.ai/code/session_01WfrfTrf1FzriM6TGRAq8XQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfrfTrf1FzriM6TGRAq8XQ)_