### PR TITLE
fix: validate clarify endpoint output (root cause of string cuppingScore)

### DIFF
--- a/src/app/api/analyze-bag/clarify/route.ts
+++ b/src/app/api/analyze-bag/clarify/route.ts
@@ -1,9 +1,35 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import Anthropic from "@anthropic-ai/sdk";
 
 export const dynamic = "force-dynamic";
 
 const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+// Coerce a numeric value that Haiku may re-emit as a quoted string (e.g.
+// "89" instead of 89) back to a number; drop empty/garbage to undefined so
+// it doesn't reach the save schema as a bad type. This is the root-cause
+// guard for the "coffee: expected number, received string" save failure —
+// the clarify round-trip previously returned Haiku's JSON verbatim with no
+// type validation at all.
+const numeric = z.preprocess((v) => {
+  if (v == null || v === "") return undefined;
+  if (typeof v === "string") {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return v;
+}, z.number().optional());
+
+// Only the numeric coffee fields need coercing; everything else passes
+// through untouched. Unknown keys are preserved (.passthrough()) so this
+// never silently drops a field Haiku added.
+const ClarifiedCoffeeSchema = z
+  .object({
+    cuppingScore: numeric,
+    altitudeMeters: numeric,
+  })
+  .passthrough();
 
 export async function POST(req: NextRequest) {
   try {
@@ -29,11 +55,17 @@ Update the coffee data with this new information and return the updated JSON obj
     const text = response.content[0].type === "text" ? response.content[0].text : "{}";
     const match = text.match(/\{[\s\S]*\}/);
     const parsed = match ? JSON.parse(match[0]) : currentCoffeeData;
-    const updated = parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? Object.fromEntries(
-          Object.entries(parsed).filter(([, v]) => v !== null && v !== undefined)
-        )
-      : parsed;
+
+    let updated = parsed;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      // Coerce the numeric fields (Haiku sometimes quotes them) before
+      // stripping nulls, so the returned object carries correct types.
+      const coerced = ClarifiedCoffeeSchema.safeParse(parsed);
+      const base = coerced.success ? coerced.data : parsed;
+      updated = Object.fromEntries(
+        Object.entries(base).filter(([, v]) => v !== null && v !== undefined)
+      );
+    }
 
     return NextResponse.json({ updated });
   } catch (err) {

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -22,7 +22,19 @@ const SessionPostSchema = z.object({
     fermentationStyle: z.string().max(200).optional(),
     roastLevel: z.string().max(100).optional().default(""),
     roastDate: z.string().optional(),
-    cuppingScore: z.number().min(0).max(100).optional(),
+    // Tolerate a numeric string here: sessions migrated from Firestore (and
+    // any coffee identity re-submitted via "Brew Again") can carry
+    // cuppingScore as a string like "89". Coerce numeric strings to numbers;
+    // empty/garbage becomes undefined rather than a bogus 0. Without this the
+    // POST rejects with "coffee: expected number, received string".
+    cuppingScore: z.preprocess((v) => {
+      if (v == null || v === "") return undefined;
+      if (typeof v === "string") {
+        const n = Number(v);
+        return Number.isFinite(n) ? n : undefined;
+      }
+      return v;
+    }, z.number().min(0).max(100).optional()),
     bagPhotoUrl: z.string().url().optional().or(z.literal("")),
     bagPhotoPath: z.string().max(500).optional(),
     aiExtracted: z.boolean().default(false),


### PR DESCRIPTION
## What

Follow-up to #253. That PR added a safety net at the session-save boundary; this one fixes the **root cause** in the café/home scan flow.

## Root cause

When a bag scan triggers a clarification question, the answer goes to `analyze-bag/clarify`, which asks Haiku to re-emit the **entire** coffee object and then returned its JSON **verbatim with no type validation** (`JSON.parse` + null-strip only). Haiku sometimes re-serialises numeric fields as quoted strings (`cuppingScore: "89"` instead of `89`). That corrupted value flowed into the draft and then failed the session POST schema with *"coffee: Invalid input: expected number, received string"* — the error seen on the café-session Summary screen.

## Fix

Validate/coerce the clarify endpoint's output at the source: the numeric coffee fields (`cuppingScore`, `altitudeMeters`) are coerced back to numbers; everything else passes through untouched (`.passthrough()`), so no field Haiku adds is dropped. Combined with #253's save-boundary coercion this is belt-and-suspenders.

`npx tsc --noEmit` passes.

https://claude.ai/code/session_01WfrfTrf1FzriM6TGRAq8XQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfrfTrf1FzriM6TGRAq8XQ)_