### PR TITLE
fix: always name the brewer "V60", never "bare V60" / "without the Drip Assist"

### DIFF
--- a/docs/grind-settings.md
+++ b/docs/grind-settings.md
@@ -21,7 +21,7 @@ Two relationships fall out of those points:
 | Method | Process | Niche° | Comandante | Confidence |
 |--------|---------|--------|------------|------------|
 | V60 | any | 375–385° | 22–25 | **measured** (380°/23 = single cup) |
-| V60 + Drip Assist | any | 380–390° | 24–27 | estimate (emergency/travel only — disc adds resistance → ~+5° coarser than bare V60) |
+| V60 + Drip Assist | any | 380–390° | 24–27 | estimate (emergency/travel only — disc adds resistance → ~+5° coarser than the standard V60) |
 | Orea V4 | any | 380–390° | 23–26 | estimate |
 | Origami Dripper | Washed | 380–386° | 23–25 | estimate |
 | Origami Dripper | Honey | 382–387° | 24–25 | estimate |

--- a/src/app/api/greeting/route.ts
+++ b/src/app/api/greeting/route.ts
@@ -77,16 +77,17 @@ Pair a specific bag from the user's rotation with a brewing method, and give a o
 - "Burundi in the Clever Dripper — that'd be a smart next move for its body."
 - "Warm afternoon — why not take the La Coipa over ice with a Japanese iced V60?"
 - "Hoffmann swears by the V60 for Ethiopians; worth trying yours that way today."
-- "The washed Kenya is built for clarity — bare V60, gentle pours, let it sing."
+- "The washed Kenya is built for clarity — V60, gentle pours, let it sing."
 
 RULES
 - One sentence, 10 to 22 words. A trailing question mark is fine; never an exclamation mark.
 - Name ONE specific bag from the rotation AND ONE brewing method the user actually owns (see Equipment). The pairing must be defensible by the science below.
 - Give a short reason — origin/process fit, time of day, or an expert/championship reference. Keep it to one clause.
 - No emojis, no markdown, no second sentence, no preamble like "Here's your greeting:". Return the sentence only.
+- BREWER NAMING: always call the V60 simply "V60". NEVER write "bare V60", "V60 without the Drip Assist", "plain V60", or any other qualifier — the Drip Assist is an invisible travel backup that is never mentioned to the user. The only time "Drip Assist" may appear is never; just say "V60".
 
 BREWING SCIENCE — pair intelligently (this is what makes it smart, not random):
-- Washed light African (Ethiopia, Kenya, Burundi, Rwanda): clarity-forward. Bare V60, Origami cone, or Chemex. Hoffmann's V60 is the canonical move for Ethiopians. High temp, gentle agitation.
+- Washed light African (Ethiopia, Kenya, Burundi, Rwanda): clarity-forward. V60, Origami cone, or Chemex. Hoffmann's V60 is the canonical move for Ethiopians. High temp, gentle agitation.
 - Naturals & honeys: sweetness/body-forward. Clever Dripper (immersion sweetness), Origami wave, or Kalita. Lower-ish temp, fewer pours.
 - Dense high-grown or competition lots: Kasuya 4:6 to tune acidity vs sweetness across the pour, or a high-extraction V60.
 - Experimental/anaerobic: short bed-contact + turbulence keeps it clean — Orea Fast (Wölfl 2024 WAC method).

--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -259,7 +259,7 @@ A curated style prior will appear in the message if available.
 - If user brew history contradicts the prior → trust the history
 - If no history for this roaster → apply the prior with stated confidence
 - If prior says "clarity-focused" → consider clarity methods in the portfolio
-- If prior says "agitation-sensitive" → use Orea Apex or bare V60 with minimal pour agitation
+- If prior says "agitation-sensitive" → use Orea Apex or V60 with minimal pour agitation
 - Always be explicit about whether and how the prior influenced portfolio choices
 
 LAYER 4 — CONSTRAINTS (NON-NEGOTIABLE physical limits)
@@ -327,7 +327,7 @@ What to avoid:
 
 Role definitions (each candidate is an independent scientific hypothesis — neither is "primary"):
 - hypothesis-A / hypothesis-B: two equal hypotheses about how to extract the best version of THIS coffee. Order in the array is arbitrary; both stand on their own merits.
-- clarity-probe: specifically tests maximum origin clarity (Orea Apex, bare V60, Origami cone, Chemex, minimal agitation)
+- clarity-probe: specifically tests maximum origin clarity (Orea Apex, V60, Origami cone, Chemex, minimal agitation)
 - sweetness-probe: specifically tests sweetness development (Orea Classic, Clever, Origami wave, gentle agitation, richer ratio)
 - body-probe: tests body enhancement (Origami Air M, Clever, immersion methods, longer contact)
 - contrast: genuinely different extraction physics from the other candidate (percolation vs immersion, or very different agitation)
@@ -372,12 +372,12 @@ IMMERSION:
 - Moccamaster: no user agitation. Do not include stir/swirl.
 
 CHEMEX — dedicated rules:
-1. Thick bonded paper filter removes oils + fines → very clean, bright, tea-like cup. Cleaner than bare V60.
+1. Thick bonded paper filter removes oils + fines → very clean, bright, tea-like cup. Cleaner than a V60.
    Best for: washed light/light-medium, Ethiopian florals, Kenyan brightness, clarity-forward goals.
    Trade-off: strips body from naturals/anaerobic — note this when recommending for body-forward intent.
 2. Agitation: gentle swirl at bloom ONLY. NEVER stir — thick filter collapses against ribs → channeling.
 3. Temperature: Washed light 93–96°C | Natural/Honey light 91–94°C | Medium-light 91–94°C
-   (Slightly lower than bare V60 — thick filter slows flow, adding contact time)
+   (Slightly lower than V60 — thick filter slows flow, adding contact time)
 4. Ratio: 1:15–1:16 standard | 1:16–1:17 for lean/clarity focus
 5. Niche° for Chemex: Light washed 396–408° | Natural/Honey 398–410° (slightly coarser than Kalita — thick filter adds resistance)
 6. Small (350ml): 23g:350ml | Bloom 46g → 150g → 250g → 350g | ~4:30 (targetTimeSec: 270)
@@ -414,7 +414,7 @@ OREA V4 — dedicated rules:
 
 NICHE° GRIND REFERENCE:
 (On the Niche Zero dial, HIGHER degree = COARSER grind. The numbers below are starting points; calibrate to drawdown.)
-V60: 396–406° | V60 + Drip Assist: 401–411° (emergency/travel only — disc adds resistance, ~+5° coarser than bare V60)
+V60: 396–406° | V60 + Drip Assist: 401–411° (emergency/travel only — disc adds resistance, ~+5° coarser than the V60 range)
 Orea: 401–411° | Origami Air M: 401–408°
 Origami (cone): 398–408° | Origami (wave): 398–406°
 Kalita: 396–406° | Chemex: 396–410° | Clever Dripper: 416–436° | AeroPress: 377–387° | Moccamaster: 431–441°
@@ -743,8 +743,8 @@ export async function generateRecommendation(
   const dripAssistLocked =
     context.preferredMethod && /drip\s*-?\s*assist/i.test(context.preferredMethod);
   const dripAssistNote = dripAssistLocked
-    ? `\nDRIP ASSIST GRIND OFFSET: The locked V60 + Drip Assist recipe MUST grind ~5° coarser than the V60 baseline in the NICHE° GRIND REFERENCE (use the "V60 + Drip Assist" range, not the bare V60 range). The disc smooths pour distribution but reduces free flow area; coarsen to compensate so total brew time matches a bare V60. Mention in reasoning that this is the disc-on emergency dial-in, not the user's preferred bare-V60 setup.`
-    : `\nDRIP ASSIST IS BANNED: Do NOT suggest "V60 + Drip Assist" as a candidate's primaryMethod. The Hario Drip Assist disc is the user's emergency/travel backup (used only when no gooseneck kettle is available). It is NEVER a proactive recommendation. If the user wanted it, they would have locked it as preferredMethod — they did not. Pick a bare V60 or any other brewer the user owns instead.`;
+    ? `\nDRIP ASSIST GRIND OFFSET: The locked V60 + Drip Assist recipe MUST grind ~5° coarser than the V60 baseline in the NICHE° GRIND REFERENCE (use the "V60 + Drip Assist" range, not the standard V60 range). The disc smooths pour distribution but reduces free flow area; coarsen to compensate so total brew time matches a standard V60. Mention in reasoning that this is the disc-on emergency dial-in, not the user's preferred V60 setup. When you name the brewer, only ever write "V60 + Drip Assist" or "V60" — never "bare V60" or "V60 without the Drip Assist".`
+    : `\nDRIP ASSIST IS BANNED: Do NOT suggest "V60 + Drip Assist" as a candidate's primaryMethod. The Hario Drip Assist disc is the user's emergency/travel backup (used only when no gooseneck kettle is available). It is NEVER a proactive recommendation. If the user wanted it, they would have locked it as preferredMethod — they did not. Pick a plain "V60" (named exactly "V60", never "bare V60" or "V60 without the Drip Assist") or any other brewer the user owns instead.`;
 
   const goal = context.intent || "balanced";
   const goalNote = `\nGOAL: "${goal}" — the user's stated taste direction for this brew. The only user-stated bias allowed; everything else is science. See GOAL VOCABULARY in LAYER 1 for what this means and how it interacts with process defaults.`;

--- a/src/lib/constants/grindSettings.ts
+++ b/src/lib/constants/grindSettings.ts
@@ -43,7 +43,7 @@ export const NICHE_GRIND_SETTINGS: GrindSetting[] = [
     notes: "Anchor: 15 g single cup = 380° / 23 clicks. Larger batches coarsen (see dose-scaling rule).",
   },
   // V60 + Drip Assist (emergency / travel only — the disc adds flow
-  // resistance, so grind a little coarser than bare V60 to keep
+  // resistance, so grind a little coarser than the standard V60 to keep
   // drawdown in the same window. Magnitude is approximate; refine
   // after a real travel brew. Direction confirmed by the user; ~+5°
   // / +2 Comandante clicks is a small starting offset.
@@ -52,7 +52,7 @@ export const NICHE_GRIND_SETTINGS: GrindSetting[] = [
     niche: { min: 380, max: 390 },
     comandante: { min: 24, max: 27 },
     confidence: "estimate",
-    notes: "Emergency / travel only. Disc adds resistance → grind ~5° coarser than bare V60 (one Comandante click). The disc smooths pour distribution at the cost of free flow; coarsen to compensate so timing matches bare V60. Refine after first travel brew.",
+    notes: "Emergency / travel only. Disc adds resistance → grind ~5° coarser than the standard V60 (one Comandante click). The disc smooths pour distribution at the cost of free flow; coarsen to compensate so timing matches the standard V60. Refine after first travel brew.",
   },
   { method: "Orea V4", niche: { min: 380, max: 390 }, comandante: { min: 23, max: 26 }, confidence: "estimate" },
   { method: "Origami Dripper", process: "Washed", niche: { min: 380, max: 386 }, comandante: { min: 23, max: 25 }, confidence: "estimate" },

--- a/src/lib/roasters/priors.ts
+++ b/src/lib/roasters/priors.ts
@@ -85,7 +85,7 @@ export const ROASTER_PRIORS: RoasterPrior[] = [
       "Loses complexity if over-agitated",
     ],
     notes:
-      "Low agitation tolerance is the key signal here. Orea Apex or bare V60 with minimal pour agitation is ideal — anything that adds turbulence can muddy the clarity profile. Championship water (55–75 ppm) is worth considering for competition lots.",
+      "Low agitation tolerance is the key signal here. Orea Apex or V60 with minimal pour agitation is ideal — anything that adds turbulence can muddy the clarity profile. Championship water (55–75 ppm) is worth considering for competition lots.",
     confidence: "curated",
     disclaimer: DISCLAIMER,
   },
@@ -175,7 +175,7 @@ export const ROASTER_PRIORS: RoasterPrior[] = [
       "Too thin at 1:17+ ratios",
     ],
     notes:
-      "Clarity is the product. Orea Apex or bare V60. Minimal agitation. Diluted or championship water to protect delicate floral notes from mineral interference. Kasuya 4:6 can work well if the user wants to tune acid/sweetness balance across phases.",
+      "Clarity is the product. Orea Apex or V60. Minimal agitation. Diluted or championship water to protect delicate floral notes from mineral interference. Kasuya 4:6 can work well if the user wants to tune acid/sweetness balance across phases.",
     confidence: "curated",
     disclaimer: DISCLAIMER,
   },
@@ -564,7 +564,7 @@ export const ROASTER_PRIORS: RoasterPrior[] = [
       "Aggressive stir at bloom can cause agitation bitterness on very light lots",
     ],
     notes:
-      "Orea Apex or bare V60 are the natural picks — minimal agitation preserves transparency. High temp mandatory. Championship water opens up complexity. Kasuya 4:6 is excellent for exploring acid/sweet balance.",
+      "Orea Apex or V60 are the natural picks — minimal agitation preserves transparency. High temp mandatory. Championship water opens up complexity. Kasuya 4:6 is excellent for exploring acid/sweet balance.",
     confidence: "curated",
     disclaimer: DISCLAIMER,
   },
@@ -835,7 +835,7 @@ export const ROASTER_PRIORS: RoasterPrior[] = [
       "Fines migration can muddy clarity on aggressive agitation",
     ],
     notes:
-      "Championship-grade coffees. Orea Apex or bare V60. Championship water can reveal additional complexity. Kasuya 4:6 is excellent for phase-by-phase exploration of these coffees.",
+      "Championship-grade coffees. Orea Apex or V60. Championship water can reveal additional complexity. Kasuya 4:6 is excellent for phase-by-phase exploration of these coffees.",
     confidence: "curated",
     disclaimer: DISCLAIMER,
   },

--- a/src/lib/utils/pourSequence.ts
+++ b/src/lib/utils/pourSequence.ts
@@ -18,7 +18,7 @@
  *
  * NOTE — the 33% multiplier was originally sized for the Drip Assist
  * disc bottleneck. The disc has since been retired from daily use; a
- * bare V60 drawdown sits closer to 15–20% of total time, so the
+ * standard V60 drawdown sits closer to 15–20% of total time, so the
  * reserve is currently larger than the physics demand and total
  * recipe times come out conservatively padded. Re-calibrating the
  * multiplier is a behavioral change touching every brew and needs an


### PR DESCRIPTION
The daily greeting Haiku surfaced "your V60 **without the Drip Assist**". Root cause: prompts used "bare V60" as shorthand to distinguish from the locked "V60 + Drip Assist" method, and the model paraphrased it into the unwanted "V60 without the Drip Assist". The Drip Assist disc is a silent travel-only backup and must never be named to the user — the brewer is just "V60".

**Changes (prompt-facing text + mirrors):**
- **greeting** — drop "bare V60" from the science block; add an explicit BREWER NAMING rule forbidding any V60 qualifier
- **recommend** — "bare V60" → "V60" across roaster-prior / probe-role / Chemex / grind-reference text; tighten the Drip-Assist offset + ban notes so the model only ever writes "V60" or "V60 + Drip Assist"
- **roaster priors** — "bare V60" → "V60" in the four injected notes
- **grindSettings / pourSequence / docs** — same phrasing cleanup (internal/data, for consistency)

The "V60 + Drip Assist" method itself is unchanged — still selectable as the emergency/travel option, never recommended proactively. `tsc --noEmit` passes.

https://claude.ai/code/session_01FbrfeWzS3YLgPSo1unGrZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbrfeWzS3YLgPSo1unGrZx)_