### PR TITLE
fix: stop /recommend mangling a published recipe's grind, cadence and time when scaling

### DIFF
--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -346,7 +346,14 @@ Portfolio rules (non-negotiable):
 EQUIPMENT RULES — these must be followed exactly
 ═══════════════════════════════════════════════════════════════
 
-POUR COUNT ADAPTATION (standard: 4 pours — adapt when justified):
+RECIPE FIDELITY — when a candidate is basedOn a documented reference recipe (basedOn ≠ "Own recipe"):
+Preserve that recipe's DEFINING mechanics exactly. Only the gram amounts (dose, water, per-pour grams) scale to the user's batch — everything else stays as published. KEEP:
+- Its grind character. A recipe published as super-coarse (e.g. Kasuya Super Coarse 10-Pour — Comandante 40–45 clicks ≈ Niche 435–455°) STAYS super-coarse; never substitute a normal V60 grind (~410°). The coarse grind IS the recipe. Likewise keep a fine recipe fine.
+- Its pour COUNT and cadence. A 10-pulse recipe stays 10 pulses on its published spacing (Kasuya Super Coarse = bloom for 30s, then ~30g every 15s, finishing ~3:30). Do NOT collapse it to 4 pours and do NOT stretch the spacing (15s → ~28s) — that doubles the brew and abandons the method.
+- Its temperature and its TOTAL brew time.
+Scaling water for a small batch change (e.g. 300 → 350ml, +17% grams) moves the gram milestones proportionally but does NOT lengthen total time or coarsen the grind: Kasuya Super Coarse is ~3:30 at both 300ml and 350ml. Adding 50ml must never add 1:15. The POUR COUNT ADAPTATION defaults below apply ONLY to "Own recipe" candidates — never to override a documented recipe's published structure.
+
+POUR COUNT ADAPTATION (standard for "Own recipe" candidates: 4 pours — adapt when justified):
 - Sweet mood + Natural/Honey: use 5 pours
 - Quick time: use 3 pours
 - Very fresh (<8 days): prefer 5 pours (CO₂ management)


### PR DESCRIPTION
## The problem you spotted

You compared Kasuya's real **Super Coarse 10-Pour** (img 1) with what the app served (img 2) and flagged the math: **+50ml water but +1:15 brew time.** You were right — that doesn't make sense, and it's not the only thing that went wrong.

Kasuya's published recipe:
- **20g : 300g**, super-coarse grind (Comandante 40–45 clicks ≈ Niche 435–455°)
- bloom 30s, then **30g every 15s** × 10 pours
- **finishes ~3:30**

What the app showed:
- 23g : 350g, **412° (a normal V60 grind, NOT super-coarse)**
- pours spaced **~28s apart**
- **4:45 total**

So three of the recipe's defining numbers were rewritten: the grind (the *whole point* of "Super Coarse"), the pour cadence, and the total time.

## Root cause

I traced the timing math (`buildPourOver` in `pourSequence.ts`) and **ruled it out** — I ran the real formula and it can't produce the screenshot's even ~28s cadence with a 28s drawdown. The timings came from the **model's own authored steps**: when `/recommend` adapted Kasuya's recipe to your 350ml batch, Opus freely rewrote the grind and stretched the cadence/time instead of just scaling the grams. The recipe block it was given *did* include the super-coarse grind and the 15s cadence — it had the right numbers and overrode them anyway.

Scaling 300→350ml is a 17% grams change; it should barely touch the time. The +1:15 was pure invention.

## The fix

A **RECIPE FIDELITY** rule in the `/recommend` prompt: when a candidate is based on a documented recipe, preserve its grind character, pour count + cadence, temperature and total time — scale **only** the gram amounts. Super-coarse stays super-coarse; a 10-pulse 15s-cadence recipe stays that; adding 50ml never adds 1:15. The old "4 pours standard" defaults are now explicitly scoped to "Own recipe" candidates so they can't quietly overwrite a published structure.

Prompt-only, surgical, its own commit (behavioral change per CLAUDE.md). `tsc` clean.

## Optional follow-up (not in this PR)
A deterministic backstop could reject/flag any candidate whose `targetTimeSec` or grind drifts too far from the scaled reference it claims to be `basedOn`. More involved and risks false rejections, so I left it out — say the word if you want it.

https://claude.ai/code/session_01GJPbS61ARuuC5Fcp6n2GMJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJPbS61ARuuC5Fcp6n2GMJ)_