### PR TITLE
feat: deterministic recipe-fidelity backstop (catch mangled recipes mechanically)

### DIFF
--- a/src/lib/claude/recipeFidelity.ts
+++ b/src/lib/claude/recipeFidelity.ts
@@ -1,0 +1,234 @@
+/**
+ * Recipe-fidelity backstop — deterministic guard that runs AFTER the model
+ * returns its candidates, before they reach the user.
+ *
+ * The problem it solves (PR #265 + this follow-up): when /recommend adapts a
+ * published reference recipe to the user's batch, the model is supposed to
+ * scale ONLY the gram amounts and keep the recipe's signature (grind, pour
+ * cadence, temperature, total time). It doesn't always obey — the documented
+ * failure was Kasuya's Super Coarse 10-Pour (20g:300g, super-coarse, ~3:30)
+ * coming back as 23g:350g at a normal 412° grind with a 4:45 total: the grind
+ * that DEFINES the recipe was dropped and the brew time nearly doubled for a
+ * 50ml batch bump. The prompt (#265) asks the model not to do this; THIS guard
+ * catches it mechanically when the model ignores the prompt.
+ *
+ * Behaviour: for a candidate whose `basedOn` resolves to a VERIFIED corpus
+ * recipe, compute what the published recipe looks like scaled to the
+ * candidate's batch, and if the candidate's total time, grind, or temperature
+ * has drifted beyond a generous tolerance, REPLACE the candidate's mechanical
+ * signature (time / grind / temp / pour steps) with the faithful scaled
+ * reference. The candidate keeps the user's dose+water and all of its prose
+ * (whyChosen, hypothesis, …) — only the numbers that must match the published
+ * recipe are snapped back.
+ *
+ * Scope guards (kept deliberately narrow so legitimate adaptations pass
+ * untouched):
+ *   - only VERIFIED references (unverified ones have reconstructed pour
+ *     sequences we don't want to snap to);
+ *   - only a "simple scale" (0.5×–2.5× the reference water) — a wildly
+ *     different batch isn't really the same recipe scaled;
+ *   - skipped entirely for iced/bypass recipes, where waterGrams and the
+ *     reference's water basis (hot vs hot+ice) differ and naive scaling
+ *     would mis-map the milestones.
+ */
+
+import type { BrewRecipe, BrewPourStep, BrewStepAction } from "../types/session";
+import type { Recipe } from "../knowledge/recipes";
+import { ALL_RECIPES } from "../knowledge/recipes";
+
+export interface FidelityResult {
+  recipe: BrewRecipe;
+  /** True when the guard rewrote the recipe's mechanics. */
+  changed: boolean;
+  /** Human-readable drift reasons (for logging), empty when unchanged. */
+  reasons: string[];
+  /** The reference recipe name that was snapped to, when changed. */
+  reference?: string;
+}
+
+/** Normalise a name for fuzzy matching — lowercase, punctuation → spaces. */
+function norm(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+/**
+ * Resolve a candidate's `basedOn` string to a corpus recipe. Matches by full
+ * name or shortName, exact-first then containment, and requires a reasonably
+ * specific overlap so a vague "V60" doesn't bind to an arbitrary recipe.
+ * Prefers a verified recipe when two match equally well.
+ */
+export function resolveReference(basedOn: string | undefined): Recipe | null {
+  if (!basedOn) return null;
+  const q = norm(basedOn);
+  if (!q || q === "own recipe") return null;
+
+  let best: Recipe | null = null;
+  let bestScore = 0;
+  for (const r of ALL_RECIPES) {
+    for (const name of [norm(r.name), norm(r.shortName)]) {
+      if (!name) continue;
+      let score = 0;
+      if (name === q) score = 1000;
+      else if (name.includes(q) || q.includes(name)) score = Math.min(name.length, q.length);
+      // Tie-break toward verified recipes.
+      if (score > 0 && r.verified) score += 0.5;
+      if (score > bestScore) {
+        bestScore = score;
+        best = r;
+      }
+    }
+  }
+  // Require a meaningful overlap (≥6 chars or an exact hit) to avoid binding
+  // a short query to an unrelated recipe.
+  return bestScore >= 6 ? best : null;
+}
+
+function refGrindRange(r: Recipe): [number, number] | null {
+  const nz = r.grind?.nicheZeroDegrees;
+  if (nz == null) return null;
+  return Array.isArray(nz) ? [nz[0], nz[1]] : [nz, nz];
+}
+
+function refTemp(r: Recipe): number | null {
+  const t = r.temperature;
+  if (typeof t.celsius === "number") return t.celsius;
+  if (Array.isArray(t.rangeC)) return t.rangeC[1];
+  return null;
+}
+
+/** Pull the leading Niche-degree number out of a free-text grind string. */
+function parseGrindDegrees(grindSize: string | undefined): number | null {
+  if (!grindSize) return null;
+  const m = /(\d{2,3}(?:\.\d+)?)/.exec(grindSize);
+  return m ? Number(m[1]) : null;
+}
+
+/** A recipe that brews onto ice / uses bypass dilution — different water basis. */
+function hasIceOrBypass(ref: Recipe): boolean {
+  const ratio = (ref.water?.ratio || "").toLowerCase();
+  if (ratio.includes("ice") || ratio.includes("bypass")) return true;
+  return ref.pourSequence?.some((s) => s.action === "bypass") ?? false;
+}
+
+/** Scale the reference's structured pour sequence to the candidate's batch.
+ * Milestones scale by the water ratio; durations (the cadence) are preserved
+ * verbatim; per-step temperatures are dropped (single-temperature rule). */
+function scalePourSteps(ref: Recipe, k: number): BrewPourStep[] {
+  return ref.pourSequence.map((s) => {
+    const step: BrewPourStep = {
+      label: s.label,
+      action: s.action as BrewStepAction,
+    };
+    if (typeof s.waterGramsAtEnd === "number") step.waterGramsAtEnd = Math.round(s.waterGramsAtEnd * k);
+    if (typeof s.durationSec === "number") step.durationSec = s.durationSec;
+    if (s.notes) step.notes = s.notes;
+    return step;
+  });
+}
+
+/** Cumulative-grams milestone string (" – "-joined) for the legacy renderer. */
+function cumulativeGramsString(steps: BrewPourStep[]): string {
+  return steps
+    .filter((s) => typeof s.waterGramsAtEnd === "number")
+    .map((s) => s.waterGramsAtEnd)
+    .join(" – ");
+}
+
+/** The published grind, scaling-adjusted to the candidate's dose (a bigger
+ * bed legitimately runs a touch coarser — ~+20°/doubling per grind-settings). */
+function refGrindString(ref: Recipe, doseRatio: number): string {
+  const range = refGrindRange(ref);
+  if (!range) return ref.grind?.referenceSetting ?? ref.grind?.description ?? "";
+  const adj = Math.round(20 * (doseRatio - 1));
+  const mid = Math.round((range[0] + range[1]) / 2) + adj;
+  return `${mid}°`;
+}
+
+/**
+ * Core check: has the candidate drifted from the (scaled) published recipe on
+ * total time, grind, or temperature beyond a generous tolerance?
+ */
+function driftReasons(recipe: BrewRecipe, ref: Recipe, k: number, doseRatio: number): string[] {
+  const reasons: string[] = [];
+
+  // Total time — published time barely moves for a small batch change. Allow a
+  // floor of ±45s or ±20%, plus extra slack proportional to how much bigger
+  // the batch is (a genuine 2× batch adds some drawdown).
+  const refTime = ref.totalTimeSec;
+  if (refTime > 0 && typeof recipe.targetTimeSec === "number") {
+    const tol = Math.max(45, 0.2 * refTime) + (k > 1 ? (k - 1) * refTime * 0.3 : 0);
+    if (Math.abs(recipe.targetTimeSec - refTime) > tol) {
+      reasons.push(
+        `total time ${recipe.targetTimeSec}s vs published ${refTime}s (±${Math.round(tol)}s allowed)`,
+      );
+    }
+  }
+
+  // Grind — window is the published range, shifted by the dose-scaling
+  // adjustment, padded ±15° for normal brew-to-brew variation.
+  const range = refGrindRange(ref);
+  const cg = parseGrindDegrees(recipe.grindSize);
+  if (range && cg != null) {
+    const adj = 20 * (doseRatio - 1);
+    const lo = range[0] + adj - 15;
+    const hi = range[1] + adj + 15;
+    if (cg < lo || cg > hi) {
+      reasons.push(
+        `grind ${cg}° vs published ${range[0]}–${range[1]}° (window ${Math.round(lo)}–${Math.round(hi)}°)`,
+      );
+    }
+  }
+
+  // Temperature — chemistry knob, shouldn't move much from the published value.
+  const rt = refTemp(ref);
+  if (rt != null && typeof recipe.waterTempC === "number" && Math.abs(recipe.waterTempC - rt) > 6) {
+    reasons.push(`temp ${recipe.waterTempC}° vs published ${rt}°`);
+  }
+
+  return reasons;
+}
+
+/**
+ * If the candidate claims to be based on a verified reference recipe but its
+ * grind / total time / temperature has drifted too far from that recipe scaled
+ * to the candidate's batch, snap its mechanical signature back to the faithful
+ * scaled reference. Otherwise return the recipe untouched.
+ */
+export function reconcileToReference(recipe: BrewRecipe, basedOn: string | undefined): FidelityResult {
+  const ref = resolveReference(basedOn);
+  if (!ref || !ref.verified) return { recipe, changed: false, reasons: [] };
+
+  // Iced / bypass references mix water bases (hot vs hot+ice / concentrate) —
+  // naive milestone scaling would mis-map. Leave those to the prompt rule.
+  if (hasIceOrBypass(ref) || (recipe.iceGrams != null && recipe.iceGrams > 0)) {
+    return { recipe, changed: false, reasons: [] };
+  }
+
+  const refWater = ref.water?.grams ?? 0;
+  const refDose = ref.dose?.grams ?? 0;
+  const water = recipe.waterGrams;
+  const dose = recipe.doseGrams;
+  if (!(refWater > 0) || !(water > 0)) return { recipe, changed: false, reasons: [] };
+
+  const k = water / refWater;
+  // Only reconcile a genuine "same recipe, scaled" case.
+  if (k < 0.5 || k > 2.5) return { recipe, changed: false, reasons: [] };
+  const doseRatio = dose > 0 && refDose > 0 ? dose / refDose : k;
+
+  const reasons = driftReasons(recipe, ref, k, doseRatio);
+  if (reasons.length === 0) return { recipe, changed: false, reasons: [] };
+
+  const steps = scalePourSteps(ref, k);
+  const fixed: BrewRecipe = {
+    ...recipe,
+    waterTempC: refTemp(ref) ?? recipe.waterTempC,
+    grindSize: refGrindString(ref, doseRatio),
+    targetTimeSec: ref.totalTimeSec,
+    pourSteps: steps,
+    pourSequence: cumulativeGramsString(steps) || recipe.pourSequence,
+  };
+  return { recipe: fixed, changed: true, reasons, reference: ref.name };
+}

--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -346,7 +346,14 @@ Portfolio rules (non-negotiable):
 EQUIPMENT RULES — these must be followed exactly
 ═══════════════════════════════════════════════════════════════
 
-POUR COUNT ADAPTATION (standard: 4 pours — adapt when justified):
+RECIPE FIDELITY — when a candidate is basedOn a documented reference recipe (basedOn ≠ "Own recipe"):
+Preserve that recipe's DEFINING mechanics exactly. Only the gram amounts (dose, water, per-pour grams) scale to the user's batch — everything else stays as published. KEEP:
+- Its grind character. A recipe published as super-coarse (e.g. Kasuya Super Coarse 10-Pour — Comandante 40–45 clicks ≈ Niche 435–455°) STAYS super-coarse; never substitute a normal V60 grind (~410°). The coarse grind IS the recipe. Likewise keep a fine recipe fine.
+- Its pour COUNT and cadence. A 10-pulse recipe stays 10 pulses on its published spacing (Kasuya Super Coarse = bloom for 30s, then ~30g every 15s, finishing ~3:30). Do NOT collapse it to 4 pours and do NOT stretch the spacing (15s → ~28s) — that doubles the brew and abandons the method.
+- Its temperature and its TOTAL brew time.
+Scaling water for a small batch change (e.g. 300 → 350ml, +17% grams) moves the gram milestones proportionally but does NOT lengthen total time or coarsen the grind: Kasuya Super Coarse is ~3:30 at both 300ml and 350ml. Adding 50ml must never add 1:15. The POUR COUNT ADAPTATION defaults below apply ONLY to "Own recipe" candidates — never to override a documented recipe's published structure.
+
+POUR COUNT ADAPTATION (standard for "Own recipe" candidates: 4 pours — adapt when justified):
 - Sweet mood + Natural/Honey: use 5 pours
 - Quick time: use 3 pours
 - Very fresh (<8 days): prefer 5 pours (CO₂ management)

--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -29,6 +29,7 @@ import {
   formatVarietyPriorsForPrompt,
 } from "../knowledge/varieties";
 import { TECHNIQUES } from "../knowledge/techniques";
+import { reconcileToReference } from "./recipeFidelity";
 import { parseClaudeJson, z } from "./parseJson";
 
 const CandidateSchema = z.object({
@@ -104,6 +105,27 @@ function sanitizeRecipe(recipe: Record<string, unknown>): BrewRecipe {
     delete out.pourSteps;
   }
   return out as unknown as BrewRecipe;
+}
+
+/**
+ * Deterministic backstop: if a candidate claims to adapt a verified reference
+ * recipe but its grind / total time / temperature has drifted too far from
+ * that recipe scaled to the user's batch, snap the mechanics back to the
+ * faithful scaled reference (PR #265 follow-up — the Kasuya Super Coarse case).
+ * Logs every correction so drift stays observable.
+ */
+function guardRecipeFidelity(
+  recipe: BrewRecipe,
+  basedOn: string | undefined,
+  title: string,
+): BrewRecipe {
+  const { recipe: fixed, changed, reasons, reference } = reconcileToReference(recipe, basedOn);
+  if (changed) {
+    console.warn(
+      `[recommend] recipe-fidelity: snapped "${title}" back to "${reference}" — ${reasons.join("; ")}`,
+    );
+  }
+  return fixed;
 }
 
 const client = new Anthropic({
@@ -952,7 +974,7 @@ Return valid JSON only.`;
 
   const candidates: RecommendationCandidate[] = raw.candidates.map((c) => ({
     method: c.method,
-    recipe: sanitizeRecipe(c.recipe),
+    recipe: guardRecipeFidelity(sanitizeRecipe(c.recipe), c.basedOn, c.title),
     role: c.role as CandidateRole,
     title: c.title,
     ...(c.basedOn ? { basedOn: c.basedOn } : {}),

--- a/tests/dataflow/recipe-fidelity.test.mjs
+++ b/tests/dataflow/recipe-fidelity.test.mjs
@@ -1,0 +1,163 @@
+// Recipe-fidelity backstop tests. Bundles the REAL recipeFidelity.ts (which
+// pulls the REAL recipe corpus) with esbuild and asserts the guard against it,
+// so the tests track the actual data — not a re-declared copy.
+//
+//   node --test tests/dataflow/recipe-fidelity.test.mjs
+//
+// The guard's job: when /recommend returns a candidate that claims to adapt a
+// verified published recipe but has mangled its grind / cadence / total time,
+// snap the mechanics back to the faithful scaled reference. This is the exact
+// Kasuya Super Coarse 10-Pour failure (20g:300g super-coarse ~3:30 → served as
+// 23g:350g at a normal 412° with a 4:45 total) that scared the user.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const entry = `export { reconcileToReference, resolveReference } from ${JSON.stringify(
+  path.join(ROOT, "src/lib/claude/recipeFidelity.ts"),
+)};`;
+const dir = await mkdtemp(join(tmpdir(), "fidelity-"));
+const out = join(dir, "b.mjs");
+await build({
+  stdin: { contents: entry, resolveDir: ROOT, loader: "ts" },
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  outfile: out,
+  logLevel: "silent",
+});
+const { reconcileToReference, resolveReference } = await import(pathToFileURL(out).href);
+
+// The exact mangled recipe from the screenshot: Kasuya Super Coarse 10-Pour
+// scaled to 350ml, but with a normal grind and a stretched ~4:45 total.
+function mangledKasuya() {
+  return {
+    doseGrams: 23,
+    waterGrams: 350,
+    waterTempC: 96,
+    grindSize: "412°",
+    targetTimeSec: 285, // 4:45 — should be ~3:30
+    pourSequence: "35 – 70 – 105 – 140 – 175 – 210 – 245 – 280 – 315 – 350",
+    pourSteps: Array.from({ length: 10 }, (_, i) => ({
+      label: i === 0 ? "Bloom" : `Pour ${i + 1}`,
+      action: i === 0 ? "bloom" : "pour",
+      waterGramsAtEnd: 35 * (i + 1),
+      durationSec: 28,
+    })),
+  };
+}
+
+test("resolveReference matches a verified recipe by name (and shortName)", () => {
+  const r1 = resolveReference("Kasuya Super Coarse 10-Pour");
+  assert.ok(r1, "should resolve the full name");
+  assert.match(r1.id, /kasuya-super-coarse/);
+
+  const r2 = resolveReference("Kasuya Super Coarse");
+  assert.ok(r2, "should resolve the short form");
+  assert.match(r2.id, /kasuya-super-coarse/);
+});
+
+test("resolveReference returns null for 'Own recipe' and gibberish", () => {
+  assert.equal(resolveReference("Own recipe"), null);
+  assert.equal(resolveReference(undefined), null);
+  assert.equal(resolveReference("xyzzy not a recipe"), null);
+});
+
+test("a mangled Kasuya Super Coarse is snapped back to the published recipe", () => {
+  const { recipe, changed, reasons, reference } = reconcileToReference(
+    mangledKasuya(),
+    "Kasuya Super Coarse 10-Pour",
+  );
+  assert.equal(changed, true, "should detect drift and correct");
+  assert.match(reference, /Super Coarse/);
+
+  // Total time snapped back to the published ~3:30 (210s), NOT 4:45.
+  assert.equal(recipe.targetTimeSec, 210);
+
+  // Grind snapped back into the super-coarse range (published 435–455°), NOT 412°.
+  const deg = Number(/(\d{2,3})/.exec(recipe.grindSize)[1]);
+  assert.ok(deg >= 430 && deg <= 460, `grind should be super-coarse, got ${recipe.grindSize}`);
+
+  // The user's batch is preserved.
+  assert.equal(recipe.doseGrams, 23);
+  assert.equal(recipe.waterGrams, 350);
+
+  // Pours are the published cadence scaled to 350ml: final milestone lands on 350.
+  const last = recipe.pourSteps.filter((s) => typeof s.waterGramsAtEnd === "number").pop();
+  assert.equal(last.waterGramsAtEnd, 350);
+  // Published pour cadence is fast (5s pulses), NOT the 28s the model invented.
+  // (The drawdown DRAIN step is legitimately ~55s — exclude it; we check pours.)
+  const longestPour = Math.max(
+    ...recipe.pourSteps.filter((s) => s.action === "pour" || s.action === "bloom").map((s) => s.durationSec ?? 0),
+  );
+  assert.ok(longestPour <= 10, `pour pulses should be the published ~5s, got ${longestPour}s`);
+
+  assert.ok(reasons.some((r) => /total time/.test(r)), "reasons should mention the time drift");
+});
+
+test("a faithful scaled Kasuya is left untouched", () => {
+  // 20g:300g published → faithful 350ml scale: super-coarse grind, ~3:30.
+  const faithful = {
+    doseGrams: 23,
+    waterGrams: 350,
+    waterTempC: 96,
+    grindSize: "445°",
+    targetTimeSec: 210,
+    pourSteps: Array.from({ length: 10 }, (_, i) => ({
+      label: i === 0 ? "Bloom" : `Pour ${i + 1}`,
+      action: i === 0 ? "bloom" : "pour",
+      waterGramsAtEnd: 35 * (i + 1),
+      durationSec: 5,
+    })),
+  };
+  const { changed } = reconcileToReference(faithful, "Kasuya Super Coarse 10-Pour");
+  assert.equal(changed, false, "a faithful recipe must not be touched");
+});
+
+test("'Own recipe' candidates are never reconciled", () => {
+  const { changed } = reconcileToReference(mangledKasuya(), "Own recipe");
+  assert.equal(changed, false);
+});
+
+test("a small, legitimate adaptation passes (no over-triggering)", () => {
+  // Same recipe, brewed slightly slower (3:45 vs 3:30) and one notch finer —
+  // within tolerance, should NOT be snapped.
+  const tweaked = {
+    doseGrams: 20,
+    waterGrams: 300,
+    waterTempC: 96,
+    grindSize: "440°",
+    targetTimeSec: 225, // +15s
+    pourSteps: [
+      { label: "Bloom", action: "bloom", waterGramsAtEnd: 30, durationSec: 5 },
+      { label: "Pour", action: "pour", waterGramsAtEnd: 300, durationSec: 5 },
+    ],
+  };
+  const { changed } = reconcileToReference(tweaked, "Kasuya Super Coarse 10-Pour");
+  assert.equal(changed, false, "a small in-tolerance tweak must pass");
+});
+
+test("unverified references are not snapped (we don't trust reconstructed steps)", () => {
+  // Perger High-Extraction V60 is verified:false in the corpus. Even a wild
+  // drift should be left alone — the prompt rule covers it, not this guard.
+  const wild = {
+    doseGrams: 12,
+    waterGrams: 200,
+    waterTempC: 80, // published is 97°C — wildly off
+    grindSize: "300°",
+    targetTimeSec: 600,
+    pourSteps: [
+      { label: "Bloom", action: "bloom", waterGramsAtEnd: 30, durationSec: 5 },
+      { label: "Pour", action: "pour", waterGramsAtEnd: 200, durationSec: 5 },
+    ],
+  };
+  const { changed } = reconcileToReference(wild, "Perger High-Extraction V60");
+  assert.equal(changed, false, "unverified reference → no snap");
+});


### PR DESCRIPTION
Follow-up to #265. That PR told the AI (via prompt) to preserve a published recipe's signature when scaling. **This one catches it mechanically when the AI ignores the prompt** — belt-and-suspenders so a future prompt regression can't sneak another mangled Kasuya through.

## How it works

After `/recommend` parses its candidates, each candidate whose `basedOn` resolves to a **verified** corpus recipe is checked against that recipe scaled to the user's batch. If its **total time, grind, or temperature** has drifted beyond a generous tolerance, the candidate's mechanical signature (time / grind / temperature / pour steps) is **snapped back to the faithful scaled reference**. The user's dose + water and all the prose (`whyChosen`, `hypothesis`, …) are kept — only the numbers that must match the published recipe are corrected. Every correction is logged.

**The Kasuya case, end to end:** a candidate served as `23g:350g, 412°, 4:45` claiming `basedOn: "Kasuya Super Coarse 10-Pour"` → the guard rebuilds it as the real super-coarse grind (~445°), `~3:30`, 15-second pulse cadence, with the pour milestones scaled to land exactly on 350g.

## Deliberately narrow scope (so it never over-triggers)

- **Verified references only** — unverified recipes have reconstructed pour sequences we don't want to snap to.
- **Simple scale only** (0.5×–2.5× the reference water) — a wildly different batch isn't "the same recipe scaled."
- **Skips iced/bypass** — those mix water bases (hot vs hot+ice / concentrate) where naive milestone scaling would mis-map.
- **Generous tolerances** — a small legit tweak (±15s, a notch finer) passes untouched.

## Tests

`tests/dataflow/recipe-fidelity.test.mjs` — bundles the **real** corpus via esbuild (no re-declared copies) and asserts 7 cases: name resolution, the mangled-Kasuya snap-back, a faithful recipe left untouched, "Own recipe" ignored, a small adaptation passing, and unverified references left alone. All pass; full suite 47/47; corpus validator clean; `tsc` clean.

https://claude.ai/code/session_01GJPbS61ARuuC5Fcp6n2GMJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJPbS61ARuuC5Fcp6n2GMJ)_