### PR TITLE
audit: verify named-expert recipes against primary sources (batch 1 — Hoffmann V60)

### DIFF
--- a/docs/coffee-experts.md
+++ b/docs/coffee-experts.md
@@ -39,7 +39,7 @@ Each entry: dose / water / ratio / temperature / Niche Zero degrees / total time
 
 | Recipe | Brewer | Dose : Water | Temp | Niche° | Total | Verified |
 |---|---|---|---|---|---|---|
-| **Hoffmann V60 (Better 1 Cup)** | V60 size 02 | 15g : 250g | 80–100°C † | calibrate ‡ | 3:00 | true |
+| **Hoffmann V60 (Better 1 Cup)** | V60 size 02 | 15g : 250g | 90–100°C † | calibrate ‡ | 3:00 | true |
 | **Hoffmann Ultimate Clever** | Clever Dripper | 18g : 300g | 96–100°C | 400–410° | 4:00 | true |
 | **Hoffmann AeroPress** | Inverted AeroPress | 11g : 200g | 85–100°C † | 356–366° | 3:35 | true |
 | **Hoffmann Moccamaster Method** | Technivorm Moccamaster | 50g : 750g | 96°C | 410–420° | 8:00 | true |
@@ -53,7 +53,7 @@ Each entry: dose / water / ratio / temperature / Niche Zero degrees / total time
 | **Hatakeyama Cafec Flower (roast-tailored)** | Cafec Flower Dripper | 15g : 225g *(unsourced — flagged)* | 88–95°C (by roast) | 396–406° | 3:10 | false |
 | **Wallgren Kalita with Sieved Fines** | Kalita Wave 155 | 22g : 330g | 94°C | 396–406° | 3:35 | false |
 
-† **Hoffmann roast-temperature staircase:** light = **freshly boiled (100 °C)**, medium 90–95 °C, dark 80–85 °C. The doc cell shows the full staircase range; brew by the bag's roast level. The TS `temperature.celsius` field is the canonical light-roast value; `rangeC` is the staircase span.
+† **Hoffmann roast-temperature staircase (as he states it in the Better 1 Cup video):** light = **freshly boiled (100 °C)**, medium 96 °C, darkest roasts down to 90 °C. The doc cell shows the full staircase range; brew by the bag's roast level. The TS `temperature.celsius` field is the canonical light-roast value; `rangeC` is the staircase span. (Verified against the video transcription, June 2026.)
 ‡ Hoffmann does not publish a Niche Zero degree number — calibrate empirically against the recipe's drawdown target. The old "Niche 396–406°" claim had no Hoffmann source behind it and was removed per the third Hard Rule. See `src/lib/knowledge/recipes/reference.ts` (Hoffmann V60 `notes`) for the rescue moves Hoffmann published in his 2024 follow-up video.
 § Kasuya publishes the Super Coarse grind only as **Comandante 40–45 clicks**. The Niche 435–455° range is DERIVED from grind-settings.md's ~3.3°/click conversion and extrapolated well past the measured 23–29-click anchors — calibrate empirically against the ~3:30 finish.
 

--- a/docs/coffee-experts.md
+++ b/docs/coffee-experts.md
@@ -44,12 +44,12 @@ Each entry: dose / water / ratio / temperature / Niche Zero degrees / total time
 | **Hoffmann AeroPress** | Inverted AeroPress | 11g : 200g | 85–100°C † | 356–366° | 3:35 | true |
 | **Hoffmann Moccamaster Method** | Technivorm Moccamaster | 50g : 750g | 96°C | 410–420° | 8:00 | true |
 | **Hoffmann Immersion Iced** | Clever onto ice | 37.5g : 500g (~330g hot + ~170g ice) | 96–100°C | 400–410° | 6:05 | true |
-| **Kasuya 4:6 (standard)** | V60 | 20g : 300g | 92°C | 411–421° | 3:30 | true |
+| **Kasuya 4:6 (standard)** | V60 | 20g : 300g | 93°C † (88 med / 83 dark) | 411–421° | 3:30 | true |
 | **Kasuya Super Coarse 10-Pour** | V60 / Neo | 20g : 300g | 95–96°C | 435–455° § | 3:30 | true |
 | **April House V60 (Rolf)** | V60 | 20g : 300g | 92°C | — (calibrate) | 3:20–3:30 | true |
-| **Gagné Long AeroPress** | AeroPress + Prismo | 20g : 200g | 80°C | 365–375° | 6:25 | true |
+| **Gagné Long AeroPress** | AeroPress + Prismo | 18g : 260g | 100°C | calibrate | 10:00 | true |
 | **Perger High-Extraction V60** | V60 | 12g : 200g | 97°C | — (calibrate) | 2:20 | false |
-| **Rao Rule of Thirds** | V60 | 22g : 352g | 96°C | 396–404° | 3:25 | true |
+| **Rao V60 Spin Method** | V60 | 20g : 330g | 97°C | calibrate | 4:00–4:30 | true |
 | **Hatakeyama Cafec Flower (roast-tailored)** | Cafec Flower Dripper | 15g : 225g *(unsourced — flagged)* | 88–95°C (by roast) | 396–406° | 3:10 | false |
 | **Wallgren Kalita with Sieved Fines** | Kalita Wave 155 | 22g : 330g | 94°C | 396–406° | 3:35 | false |
 
@@ -66,9 +66,9 @@ Each entry: dose / water / ratio / temperature / Niche Zero degrees / total time
 - **Hoffmann Immersion Iced** — Flash-chilling preserves aromatics that cold-brew loses to its long extraction time. 75 g coffee per litre of total water; total water split ~2/3 hot brew + ~1/3 ice (e.g. 37.5 g : 330 g hot + ~170 g ice = 1:13.3 final). Hot extraction at 1:8.8 then diluted by ice to the drinking ratio.
 - **Kasuya Super Coarse 10-Pour** — Full extraction of a light roast WITHOUT bitterness: grind super-coarse (Comandante 40–45 clicks; 40 is the dependable default, 45 is extreme and can run thin) to drop out the over-extracting fines, then claw the yield back with near-boiling water (95–96 °C) and ten even 30 g pulses (bloom 30 s, then a 30 g pour every 15 s). At 1:15 this grind would normally give <1% TDS; the ten percolation cycles pull it to ~1.3% and, crucially, build a thick, almost syrupy **body** — Kasuya's point is that the *number* of pours is what creates mouthfeel (7–8 already help). Early pours drain straight through; the bed clogs slightly near the end (~2:00–2:15). Trade-off: sweetness dominates and **acidity is deliberately toned down** — not for an acidity-forward cup. Designed around the Hario Neo but he brews it on a V60; flat-bottom untested. A different Kasuya recipe from the 4:6 method — even pours, not phase-separated — pitched as its 10th-anniversary evolution. Source: his 2026 YouTube video ("Multi-Pour Recipe"), transcribed.
 - **April House V60 (Rolf)** — April's agitation-forward house recipe: six even 50g pours on a ~30s cadence, each poured deliberately aggressively, finished with one stir. The opposite of a minimal-agitation brew. (Replaces a prior "Minimum Variables" entry that was a misattribution — no such single-continuous-pour Rolf recipe exists.)
-- **Gagné Long AeroPress** — The "second sweet spot": fine grind + 80°C + 5-minute steep. Bitter Zone 3 compounds extract orders of magnitude slower at low temp; long steep saturates Zone 2 fully without invading Zone 3.
+- **Gagné Long AeroPress** — A long (~10-minute) **HOT** steep (100°C, 18g:260g) in an upright AeroPress with a no-drip Prismo valve, finished with a very gentle ~1-minute press. Contact time + gentleness reach ~23.5% extraction — full, sweet, clean — without astringency. (Corrected June 2026 against Gagné's own blog: the previous "80°C second sweet spot / low-temp" framing was a misattribution — his published recipe is hot.)
 - **Perger High-Extraction V60** — Vigorous bloom stir + fine grind + spinning swirl during drawdown drives extraction yield above 22%. Bitterness comes from over-extracting the wrong compounds, not high yield itself.
-- **Rao Rule of Thirds** — Equal-volume thirds + Rao spin (vortex swirl). Lower extraction variance run-to-run, easier to troubleshoot.
+- **Rao V60 Spin Method** — 20g:330g at 97°C: aggressive bloom spin, then **two** pours (to 200g, to 330g) each followed by a brief gentle spin to refill the ribbed channels; ~4:00–4:30. The defining feature is the spin, NOT equal thirds. (Corrected June 2026 against Rao's own published recipe: he explicitly argues AGAINST breaking a V60 into more than two parts, so the prior "Rule of Thirds / equal thirds / 22g:352g" attribution was wrong.)
 - **Hatakeyama Cafec Flower** — Match filter paper thickness to roast level. Light roast → thin paper (faster flow tolerable); dark roast → thick paper (slows flow where less contact is needed).
 - **Wallgren Kalita** — Sieve out fines pre-brew. Fines over-extract relative to the rest of the grind; removing them tightens the extraction distribution and produces a startlingly clean cup.
 
@@ -157,7 +157,7 @@ WCR-grounded priors. Genetic / agronomic facts (parentage, identification year) 
 | Technique | Author | Mechanism (1 line) | Exemplified by |
 |---|---|---|---|
 | **boiling-water-coarse-grind** *(Turbo)* | Cameron/Hendon (*Matter* 2020); Hedrick popularised | 100°C raises extraction rate across all zones; coarse grind partially cancels — net is high yield in short time. | *(no verified recipe — espresso-origin; filter "turbo pour-over" is a community application)* |
-| **low-temp-long-steep** *(Gagné second sweet spot)* | Gagné | Bitter Zone-3 compounds extract orders of magnitude slower at 80°C — fine grind + long steep saturates Zone 2 without Zone 3. | gagne-long-aeropress |
+| **low-temp-long-steep** | General (physics documented by Gagné) | Bitter Zone-3 compounds extract orders of magnitude slower at ~80°C — a long cool steep saturates Zone 2 without Zone 3. *(NOT Gagné's AeroPress recipe, which is hot — see correction.)* | cold-bloom / low-temp experimental recipes |
 
 ### 3b. Agitation
 
@@ -175,7 +175,7 @@ WCR-grounded priors. Genetic / agronomic facts (parentage, identification year) 
 | Technique | Author | Mechanism (1 line) | Exemplified by |
 |---|---|---|---|
 | **phase-separated-pouring** *(4:6)* | Kasuya | First 40% (two pours) controls acid/sweet axis; last 60% (3+ pours) controls strength. | wbrc-2016-kasuya, kasuya-4-6-standard |
-| **rule-of-thirds** | Rao | Equal-volume pours after the bloom. Lower run-to-run variance. | rao-rule-of-thirds |
+| **rule-of-thirds** | General (NOT Rao) | Equal-volume pours after the bloom. Lower run-to-run variance. *(Mis-attributed to Rao historically — he opposes >2 pours; corrected.)* | — |
 
 ### 3d. Pre-brew
 
@@ -227,10 +227,10 @@ Common-practice moves with no single originator (`verified: false` — the mecha
 |---|---|---|
 | **James Hoffmann** | Better 1 Cup, Ultimate Clever, AeroPress, Moccamaster, Immersion Iced | swirl-not-stir, water-first (popularised), concentrate-and-bypass (popularised), flash-chilling (popularised) |
 | **Tetsu Kasuya** | WBrC 2016, 4:6 standard | phase-separated-pouring |
-| **Scott Rao** | Rule of Thirds | rao-spin, rule-of-thirds |
+| **Scott Rao** | V60 Spin Method (bloom spin + two pours) | rao-spin |
 | **Matt Perger** | High-Extraction V60 | high-agitation-high-extraction |
 | **Patrik Rolf** | April House V60 | (agitation-forward — none atomic) |
-| **Jonathan Gagné** | Long-Brew AeroPress + Prismo | low-temp-long-steep |
+| **Jonathan Gagné** | Long-Brew AeroPress + Prismo (HOT, 100°C) | immersion-steep |
 | **Daiki Hatakeyama** | Cafec Flower (roast-tailored) | roast-tailored-filter |
 | **Mikaela Wallgren** | Kalita with Sieved Fines | fines-removal-sieving |
 | **Lance Hedrick** | (popularised the espresso "turbo"; no verified filter recipe) | boiling-water-coarse-grind (popularised) |

--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -487,8 +487,8 @@ CHAMPIONSHIP / REFERENCE RECIPES — available for any goal when the coffee and 
 - Origami Air M standard: 28g:420ml | Washed 95°C / Natural 93°C | 401–407° | bloom → light stir 1–2× at 0:10 → 3 even pours → ~2:45 (targetTimeSec: 165)
 - Origami Air M clarity: 28g:420ml | Washed 96°C | 401–405° | bloom → light stir 1× at 0:10 → 3 even pours, minimal agitation → ~2:30 (targetTimeSec: 150)
 - Origami Air M sweet: 30g:450ml | Natural/Honey 93°C | 403–408° | bloom → light stir 1–2× at 0:10 → 3 pours → ~3:00 (targetTimeSec: 180)
-- Wölfl 2024 Orea FAST: 17g:270ml | Water 1:3 (55ppm) | 401–411° | bloom → stir 1–2× at 0:10 → 4 rapid pours → ~2:20 (targetTimeSec: 140)
-- Kasuya 4:6 (V60, no Assist): 20g:300ml | Water 1:3 (55ppm) | 411–421° | bloom → gentle stir at 0:15 → 40% acid/sweet phase → 60% strength phase → ~3:30–4:00
+- Wölfl 2024 Orea FAST: 17g:270ml | soft low-mineral water (he used an Apax concentrate; no public TDS — do NOT state a ppm) | 401–411° | bloom → stir 1–2× at 0:10 → 4 rapid pours → ~2:20 (targetTimeSec: 140)
+- Kasuya 4:6 (V60, no Assist): 20g:300ml | soft water (Kasuya: light 93°C / medium 88 / dark 83) | 411–421° | bloom → gentle stir at 0:15 → 40% acid/sweet phase → 60% strength phase → ~3:30
 - Hoffmann AeroPress: 11g:200g | 85°C | 377–382° | inverted · add water 10s · stir 2–3× 10s · steep 1:30 · stir 10s · press 30s (targetTimeSec: 150)
 - AeroPress Bypass: 14g:90g concentrate | 88°C | 372–377° | inverted · add 90g water 10s · stir 2–3× 10s · press 20s · swirl cup after adding 140g bypass water (targetTimeSec: 90)
 - Clever Extended: 20g:300ml | 92°C | 421–431° | pour water 15s · swirl 5s · steep 4:20 · swirl 5s · swirl 5s · drain 40s (targetTimeSec: 330)

--- a/src/lib/knowledge/recipes/reference.ts
+++ b/src/lib/knowledge/recipes/reference.ts
@@ -430,7 +430,7 @@ export const REFERENCE_RECIPES: Recipe[] = [
     brewer: "v60",
     dose: { grams: 20 },
     water: { grams: 300, ratio: "1:15" },
-    temperature: { celsius: 92 },
+    temperature: { celsius: 93, rangeC: [83, 93] },
     grind: {
       referenceSetting: "medium-coarse",
       nicheZeroDegrees: [390, 400],
@@ -753,55 +753,62 @@ export const REFERENCE_RECIPES: Recipe[] = [
     brewer: "aeropress-prismo",
     brewerNotes:
       "Upright AeroPress with a Fellow Prismo metal valve (acts like espresso portafilter — no drip until pressed).",
-    dose: { grams: 20 },
-    water: { grams: 200, ratio: "1:10" },
-    temperature: { celsius: 80, rangeC: [78, 82] },
+    dose: { grams: 18 },
+    water: { grams: 260, ratio: "1:14.4" },
+    temperature: { celsius: 100, rangeC: [99, 100] },
     grind: {
-      referenceSetting: "fine, espresso-adjacent",
-      nicheZeroDegrees: [344, 354],
+      referenceSetting:
+        "fine — fine enough for high extraction, but not so fine the press is hard (a hard press is what brings astringency)",
     },
     pourSequence: [
       {
-        label: "Add water",
+        label: "Add 18 g, pour 100 °C water to fill (~260 g)",
         action: "pour",
-        waterGramsAtEnd: 200,
+        waterGramsAtEnd: 260,
         durationSec: 15,
+        notes: "Fill the chamber off the boil; start the timer.",
       },
       {
-        label: "Stir thoroughly",
+        label: "Stir back-and-forth",
         action: "stir",
         durationSec: 10,
+        notes: "Bottom-to-top, NOT circular (Gagné is explicit — avoid a vortex). Then rest the plunger slightly in the chamber to pull a partial vacuum.",
       },
+      { label: "Steep to 5:00", action: "wait", durationSec: 275 },
       {
-        label: "Long steep",
-        action: "wait",
-        durationSec: 300,
-        notes: "5-minute steep — Gagné's PSD analyses show this lets fines fully saturate without channeling.",
+        label: "Vigorous swirl",
+        action: "swirl",
+        durationSec: 5,
+        notes: "At the 5-minute mark, swirl to level the bed.",
       },
+      { label: "Steep to 9:00", action: "wait", durationSec: 235 },
       {
-        label: "Slow press",
+        label: "Gentle press",
         action: "press",
         durationSec: 60,
-        notes: "60-second press — slow enough that the puck doesn't tear.",
+        notes: "From ~9:00, press as gently as you can — a bit over a minute to the bottom. Gentleness is what keeps it clean.",
       },
     ],
-    totalTimeSec: 385,
-    techniques: ["immersion-steep", "low-temp-long-steep", "aeropress-inversion"],
+    totalTimeSec: 600,
+    techniques: ["immersion-steep"],
     bestFor: {
-      roastLevels: ["light", "medium-light"],
-      processes: ["washed"],
-      goals: ["high-clarity"],
+      roastLevels: ["light", "medium-light", "medium"],
+      processes: ["washed", "natural", "honey"],
+      goals: ["body-forward", "sweetness-forward"],
     },
     teaches:
-      "How a long, low-temperature steep with a fine grind extracts deeply into Zone 2 without invading Zone 3. The Prismo valve lets the steep run without drip, so extraction time is purely contact time.",
+      "How a long (~10-minute) HOT steep with a no-drip valve (Prismo) and a very gentle press reaches high extraction (~23.5%) on a fine grind without astringency — contact time and gentleness do the work, not a low temperature.",
     science:
-      "Conventional wisdom says 'fine grind + long time = bitter.' Gagné's PSD analyses show that's only true at high temperatures — the bitter, phenolic Zone 3 compounds have steep temperature dependencies. At 80°C they extract orders of magnitude more slowly than at 95°C. So a fine grind (high surface area) at 80°C (low Zone 3 extraction rate) over 5 minutes (full Zone 2 saturation) lands in a uniquely sweet, dense, and clean part of the extraction space — what Gagné calls the 'second sweet spot.'",
+      "Gagné fills with 100 °C water and steeps ~10 minutes; the Prismo valve means that whole time is pure steep, not drip. A back-and-forth (non-circular) stir plus one mid-steep swirl keep the bed even. Because the final press is very gentle and the grind isn't pushed espresso-fine, the long hot steep climbs to ~23.5 % extraction — full, sweet, dense — without dragging in the harsh, astringent compounds a hard press or over-fine grind would. (The earlier codebase entry attributed an 80 °C 'second sweet spot' LOW-temperature steep to Gagné — that was an error; his published AeroPress recipe is HOT. Corrected against his own blog, coffeeadastra.com 2021.)",
     whenToUse:
-      "When you have a precise washed coffee and want a body-forward but extremely clean cup. Requires a Prismo or equivalent — standard AeroPress drips through the paper filter and ruins the timing.",
+      "When you want a full, sweet, very clean AeroPress cup and own a Prismo (a standard AeroPress drips through the paper and ruins the long-steep timing). Patience required — it's a ~10-minute brew.",
     sources: [
       {
         type: "blog",
-        citation: "Jonathan Gagné — coffeeadastra.com (Prismo / long-brew posts)",
+        citation:
+          "Jonathan Gagné — 'Reaching Fuller Flavor Profiles with the AeroPress', coffeeadastra.com (2021-09-07). Verified in-session.",
+        url: "https://coffeeadastra.com/2021/09/07/reaching-fuller-flavor-profiles-with-the-aeropress/",
+        year: 2021,
       },
       {
         type: "book",
@@ -891,8 +898,8 @@ export const REFERENCE_RECIPES: Recipe[] = [
 
   {
     id: "rao-rule-of-thirds",
-    name: "Rao — Rule of Thirds Pour Pattern",
-    shortName: "Rao 1/3 1/3 1/3",
+    name: "Rao — V60 Spin Method",
+    shortName: "Rao V60 (spin)",
     attribution: {
       person: "Scott Rao",
       title: "*The Professional Barista's Handbook* author",
@@ -900,79 +907,86 @@ export const REFERENCE_RECIPES: Recipe[] = [
     },
     category: "reference",
     brewer: "v60",
-    dose: { grams: 22 },
-    water: { grams: 352, ratio: "1:16" },
-    temperature: { celsius: 96 },
+    dose: { grams: 20 },
+    water: { grams: 330, ratio: "1:16.5" },
+    temperature: { celsius: 97 },
     grind: {
-      referenceSetting: "medium-fine",
-      nicheZeroDegrees: [375, 383],
+      referenceSetting:
+        "medium-fine — fine enough to reach 22–24.5% extraction; Rao does not recommend brewing a V60 with much less than 20–22 g",
     },
     pourSequence: [
       {
-        label: "Bloom",
+        label: "Bloom (→ 60 g)",
         action: "pour",
-        waterGramsAtEnd: 66,
-        durationSec: 10,
+        waterGramsAtEnd: 60,
+        durationSec: 8,
       },
       {
-        label: "Rao spin",
+        label: "Aggressive Rao spin",
         action: "swirl",
         durationSec: 5,
         notes:
-          "Rao's signature — a vigorous swirl during the bloom that spins the slurry like a vortex. Saturates evenly without stirring.",
+          "Spin the bloom AGGRESSIVELY — the vortex saturates the bed evenly without stirring fines to the walls.",
       },
-      { label: "Bloom rest", action: "wait", durationSec: 30 },
+      { label: "Bloom rest", action: "wait", durationSec: 47 },
       {
-        label: "Pour 1 (one-third)",
+        label: "Pour to 200 g",
         action: "pour",
-        waterGramsAtEnd: 162,
+        waterGramsAtEnd: 200,
         durationSec: 20,
+        notes: "Low, steady, near-vertical stream; move the kettle around the whole slurry.",
       },
       {
-        label: "Pour 2 (one-third)",
-        action: "pour",
-        waterGramsAtEnd: 257,
-        durationSec: 20,
-      },
-      {
-        label: "Pour 3 (one-third)",
-        action: "pour",
-        waterGramsAtEnd: 352,
-        durationSec: 20,
-      },
-      {
-        label: "Final Rao spin",
+        label: "Gentle spin",
         action: "swirl",
-        durationSec: 5,
-        notes: "Flatten the bed; encourage an even drawdown.",
+        durationSec: 2,
+        notes: "A very gentle spin (<1 s of motion) — just enough to fill in the ribbed channels.",
       },
-      { label: "Drawdown", action: "drain", durationSec: 95 },
+      { label: "Wait until ~70% drained", action: "wait", durationSec: 58 },
+      {
+        label: "Pour to 330 g",
+        action: "pour",
+        waterGramsAtEnd: 330,
+        durationSec: 15,
+      },
+      {
+        label: "Gentle spin",
+        action: "swirl",
+        durationSec: 2,
+        notes: "Another brief gentle spin to settle the bed.",
+      },
+      { label: "Drawdown", action: "drain", durationSec: 98 },
     ],
-    totalTimeSec: 205,
-    techniques: ["rule-of-thirds", "rao-spin", "pulse-pouring"],
+    totalTimeSec: 255,
+    techniques: ["rao-spin", "pulse-pouring"],
     bestFor: {
       roastLevels: ["light", "medium-light", "medium"],
       processes: ["washed", "natural", "honey"],
       goals: ["balanced"],
     },
     teaches:
-      "Equal-volume thirds + swirl-not-stir agitation = predictable, repeatable extraction. The Rao spin is its own technique — a vortex swirl that distributes water evenly without disturbing the bed.",
+      "The Rao Spin: one AGGRESSIVE bloom spin to saturate evenly, then a brief GENTLE spin after each of the two main pours to refill the ribbed channels. Rao deliberately uses FEW pours — he argues against breaking a V60 into many parts because it drops the average extraction temperature.",
     science:
-      "Equal-volume pours produce a more uniform total extraction time per ground-water contact unit than weighted pour distributions. The Rao spin's vortex motion drags water down through the puck centre-first rather than wall-first, counteracting the V60's tendency to channel along the filter walls. Combined effect: lower extraction variance run-to-run, easier diagnosis when things go wrong.",
+      "The bloom spin's vortex drags water down through the puck centre-first rather than wall-first, counteracting the V60's tendency to channel along the filter walls. Keeping to two main pours (not many pulses) holds a higher average extraction temperature, which Rao prefers for reaching 22–24.5% extraction. The post-pour gentle spins re-wet the ribs without dropping fresh fines, so the bed stays even and the run-to-run variance stays low.",
     whenToUse:
-      "Default V60 daily-driver when you want consistency you can troubleshoot from. Pair with a known coffee to isolate technique drift; pair with an unknown coffee for a baseline read.",
+      "Default V60 daily-driver when you want consistency you can troubleshoot from, and you have the time for a ~4:00–4:30 brew. Not for someone who wants a fast, many-pulse routine — that's the opposite of Rao's approach.",
     sources: [
       {
-        type: "book",
+        type: "article",
         citation:
-          "Rao, S. — *The Professional Barista's Handbook* (multiple editions)",
+          "Scott Rao — V60 recipe as published by Hario UK (he is their ambassador): 20 g : 330 g, 97 °C, aggressive bloom spin + two pours (to 200 g, to 330 g) each with a gentle spin, 4:00–4:30. Verified in-session.",
+        url: "https://www.hario.co.uk/blogs/hario-ambassadors/hario-v60-recipe-interview-with-hario-ambassador-scott-rao",
       },
       {
-        type: "video",
-        citation: "Scott Rao — published V60 technique videos",
+        type: "blog",
+        citation:
+          "scottrao.com — Rao's stated position against breaking the pour into more than two parts (lowers average extraction temperature).",
+        url: "https://www.scottrao.com",
       },
     ],
     verified: true,
+    notes:
+      "Corrected June 2026 against Rao's own published recipe (Hario UK ambassador page) + his blog. The prior entry called this 'Rule of Thirds' with three EQUAL pours (22 g : 352 g, 96 °C) — a misattribution: Rao explicitly opposes breaking a V60 into more than two parts and does not publish equal thirds. His actual recipe is 20 g : 330 g / 97 °C, an aggressive bloom spin then two pours (to 200 g, to 330 g) each followed by a gentle spin, finishing 4:00–4:30. Renamed from 'Rule of Thirds' accordingly; the generic 'rule-of-thirds' technique tag was removed from this recipe.",
   },
 
   // ── Daiki Hatakeyama ─────────────────────────────────────────────────────

--- a/src/lib/knowledge/recipes/reference.ts
+++ b/src/lib/knowledge/recipes/reference.ts
@@ -40,7 +40,7 @@ export const REFERENCE_RECIPES: Recipe[] = [
       "Hario V60 size 02, paper filter rinsed. Plastic V60 preferred per Hoffmann for thermal retention. Dripper preheated with very hot tap water — not boiling (Hoffmann calls boiling-water preheat wasteful). Expected liquid out: ~215–220 g from 250 g poured.",
     dose: { grams: 15 },
     water: { grams: 250, ratio: "1:16.7" },
-    temperature: { celsius: 100, rangeC: [80, 100] },
+    temperature: { celsius: 100, rangeC: [90, 100] },
     grind: {
       referenceGrinder: "Various",
       referenceSetting:
@@ -111,7 +111,7 @@ export const REFERENCE_RECIPES: Recipe[] = [
     science:
       "Bloom saturation via bulk-puck motion (swirl) keeps fines distributed evenly instead of dragging them to the filter walls where they form flow restrictions. The 4× 50 g pulse structure gives controlled alternation of agitation (pour) and bed-settling (10 s pause), so each pour drives a moment of extraction without accumulated turbulence. Per Hoffmann's measurement work, a ~5 g/s pour rate with a low spout produces the bed agitation needed for high extraction without channeling.",
     whenToUse:
-      "Default single-cup V60. Roast-temperature staircase per Hoffmann: light at freshly boiled (100 °C), medium 90–95, dark 80–85 (up to 90). Plastic V60-02 preferred for thermal retention; preheat with very hot tap water, not boiling.",
+      "Default single-cup V60. Roast-temperature staircase as Hoffmann states it IN THIS video: light = freshly boiled (100 °C), medium = 96 °C, darkest roasts down to 90 °C. Plastic V60-02 preferred for thermal retention; preheat with very hot tap water, not boiling.",
     sources: [
       {
         type: "video",

--- a/src/lib/knowledge/techniques/data.ts
+++ b/src/lib/knowledge/techniques/data.ts
@@ -49,15 +49,15 @@ export const TECHNIQUES: Technique[] = [
   {
     id: "low-temp-long-steep",
     name: "Low-Temperature Long Steep",
-    shortName: "Gagné second sweet spot",
+    shortName: "Low-temp steep",
     attribution: {
-      person: "Jonathan Gagné",
-      title: "*The Physics of Filter Coffee* (2021); coffeeadastra.com",
+      person: "General technique",
+      title: "extraction temperature-dependence documented by Jonathan Gagné (*The Physics of Filter Coffee*, 2021)",
     },
     category: "temperature",
     manipulates: ["zone-2 saturation", "zone-3 suppression"],
     description:
-      "Brew at low temperature (78–82°C) with a fine grind and a long steep (4–6 minutes). Lands in a unique extraction zone Gagné calls the 'second sweet spot.'",
+      "Brew at a low temperature (~78–85°C) with a long steep, trading heat for time: the slow cool extraction reaches the sweet Zone-2 fractions while under-extracting the harsher Zone-3 compounds. (NOTE: this is NOT Jonathan Gagné's AeroPress recipe — that is brewed HOT at 100°C; the prior 'Gagné second sweet spot' framing here was a misattribution, corrected June 2026. Gagné is credited only for documenting the temperature-dependence physics.)",
     mechanism:
       "The bitter, phenolic Zone 3 compounds have steep temperature dependencies — at 80°C they extract orders of magnitude more slowly than at 95°C. So a fine grind (high surface area) at 80°C (low Zone 3 extraction rate) over 5 minutes (full Zone 2 saturation) lands in a uniquely sweet, dense, and clean part of the extraction space. The long steep is doing the work the heat would normally do, but only for the soluble fractions you want.",
     whenToUse:
@@ -68,7 +68,7 @@ export const TECHNIQUES: Technique[] = [
     ],
     requiredEquipment: ["Fellow Prismo or equivalent valved AeroPress cap"],
     compatibleBrewers: ["aeropress-prismo"],
-    exemplifiedBy: ["gagne-long-aeropress"],
+    exemplifiedBy: [],
     sources: [
       {
         type: "blog",
@@ -322,25 +322,25 @@ export const TECHNIQUES: Technique[] = [
     name: "Rule of Thirds",
     shortName: "1/3 1/3 1/3",
     attribution: {
-      person: "Scott Rao",
+      person: "General pour-over practice (NOT Scott Rao)",
     },
     category: "pour-pattern",
     manipulates: ["pour evenness", "extraction uniformity"],
     description:
-      "Equal-volume pours after the bloom. Each pour adds the same gram count.",
+      "Equal-volume pours after the bloom. Each pour adds the same gram count. (Commonly MIS-attributed to Scott Rao — corrected June 2026: Rao explicitly argues AGAINST breaking a V60 into more than two parts because it lowers the average extraction temperature, and does not publish an equal-thirds recipe. This is a generic pour-over pattern, not Rao's.)",
     mechanism:
       "Equal-volume pours produce a more uniform total extraction time per ground-water contact unit than weighted pour distributions. With a known bloom + 3 equal pours + drawdown, the only timing variable is pour-to-pour spacing — every other variable is fixed. Run-to-run variance drops; troubleshooting becomes possible because there are fewer things that could have gone wrong.",
     whenToUse:
       "V60 daily-driver when you want consistency you can troubleshoot from. Default pour pattern unless a recipe specifies otherwise.",
     compatibleBrewers: ["v60", "origami-cone", "orea-classic"],
-    exemplifiedBy: ["rao-rule-of-thirds"],
+    exemplifiedBy: [],
     sources: [
       {
-        type: "book",
-        citation: "Rao, S. — *The Professional Barista's Handbook*",
+        type: "report",
+        citation: "Generic pour-over practice — no single originator; the prior Rao attribution was removed as a misattribution (June 2026).",
       },
     ],
-    verified: true,
+    verified: false,
   },
 
   // ── Pre-brew / grind ─────────────────────────────────────────────────────


### PR DESCRIPTION
Primary-source verification audit (now that web access is open). This PR is the **first batch**; I'll add commits as the parallel verification of the other named-expert recipes completes.

## Hoffmann V60 "Better 1 Cup" — verified against his own video

Checked every parameter against Hoffmann's "A Better 1 Cup V60 Technique."

**Confirmed faithful** (no change needed): 15g : 250g, medium-fine grind, 50g bloom, four pours to **100 / 150 / 200 / 250** at **1:00 / 1:20 / 1:40 / 2:00**, swirl at bloom + swirl at 2:00, ~3:00 total. This is the recipe that originally triggered the project's anti-fabrication Hard Rule, so confirming it's accurate is the reassuring headline.

**One discrepancy fixed:** our entry carried a `90–95 medium / 80–85 dark` temperature staircase (Hoffmann's *general* guidance) instead of the staircase he states **in this video**: **light 100°C / medium 96°C / darkest down to 90°C**. Updated `rangeC` 80–100 → 90–100, plus the `whenToUse` text and the `docs/coffee-experts.md` mirror.

## In progress (parallel verification running)
Five background agents are verifying the rest against primary sources, each required to quote the originator's own publication and flag aggregator-only/unverified data:
- Hoffmann Ultimate Clever / AeroPress / Moccamaster / Immersion Iced
- Kasuya 4:6 standard + Wölfl WBrC 2024
- Stanica WAC 2024 + Du WBrC 2019 + Medina WBrC 2023 (incl. championship-fact checks)
- Rao / Gagné / Perger (the previously-flagged misattributions)
- Hatakeyama / Wallgren / Rolf (April)

Corrections from those will land as additional commits here before merge. `tsc` clean, 47/47 tests, validator clean.

https://claude.ai/code/session_01GJPbS61ARuuC5Fcp6n2GMJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJPbS61ARuuC5Fcp6n2GMJ)_