### PR TITLE
fix: /recommend time buckets match the app's Quick/Normal (drop stale Unhurried)

### DIFF
--- a/src/components/flow/LightStepContext.tsx
+++ b/src/components/flow/LightStepContext.tsx
@@ -18,9 +18,10 @@ import type { CoachInsight } from "@/components/coach/CoachCard";
  * Composition follows lovable-v7/src/pages/Index.tsx verbatim for the
  * non-data-model elements (icons, footnote copy, section order, card
  * layout). Strict-Lovable deviations from the live Dark Brew Context:
- *   - TIME: 2 cards (Quick, Normal) — Unhurried dropped from UI.
- *     The /api/recommend prompt still supports "unhurried" if a
- *     session ever ships it, but this UI no longer offers the choice.
+ *   - TIME: 2 cards (Quick, Normal) — Unhurried dropped from the UI
+ *     AND from the /api/recommend time buckets. The prompt now folds
+ *     any stray "unhurried" into the slow end of "normal" (~330s cap);
+ *     this UI only ever sends "quick" or "normal".
  *   - WATER: 2 cards (Tap only, Championship) — Diluted dropped.
  *   - APPROACH: 2 cards only (Claude picks / I'll choose). The Dark
  *     expanding method list is removed.

--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -308,10 +308,10 @@ HARD CAPACITY LIMITS — never exceed, even in experiment mode:
 - Grind size output: ONE specific value. No ranges. Ever.
 - Kettle: Fellow Corvo EKG — must return to base between pours
 
-Time constraints:
+Time constraints — the app offers only TWO choices, "quick" and "normal". There is no "unhurried" option:
 - "quick" (~2 min): AeroPress, Wölfl Orea Fast. targetTimeSec ≤ 150.
-- "normal" (~5 min): V60, Kalita, Orea, Clever, Moccamaster (it batch-brews 750g in ~3:30), Kasuya 4:6. targetTimeSec 210–300.
-- "unhurried" (7 min+): extended Clever, Gagné Long AeroPress (~10 min). targetTimeSec ≥ 360.
+- "normal" (~5 min): everything else — V60, Kalita, Orea, Clever, Moccamaster (it batch-brews 750g in ~3:30), Kasuya 4:6. targetTimeSec 180–330; aim for the ~4–5 min middle unless the method runs faster.
+(Legacy guard: if a session ever sends "unhurried", treat it as the slow end of "normal" — do not exceed ~330s. Very long brews like a 10-minute Gagné AeroPress are out of scope for the recommend flow.)
 
 LAYER 5 — HISTORY & LEARNING
 A terrain narrative will appear describing what keeps happening in your log.

--- a/src/lib/knowledge/recipes/reference.ts
+++ b/src/lib/knowledge/recipes/reference.ts
@@ -295,7 +295,7 @@ export const REFERENCE_RECIPES: Recipe[] = [
     },
     category: "reference",
     brewer: "moccamaster",
-    brewerNotes: "Technivorm Moccamaster KBGV / KBG Select",
+    brewerNotes: "Standard Technivorm Moccamaster (KBGV / KBG Select) — NOT a special edition. Hoffmann's 3.5-min / 97–98 °C measurement is from this regular machine in his 6-brewer comparison.",
     dose: { grams: 50 },
     water: { grams: 750, ratio: "1:15" },
     temperature: { celsius: 96, rangeC: [92, 98] },


### PR DESCRIPTION
Two fixes from your feedback.

## 1. Time buckets now match the app (your main point)
I checked the app — `LightStepContext` only offers **two** time cards: **Quick (~2 min)** and **Normal (~5 min)**. "Unhurried" was dropped from the UI. But the `/recommend` prompt still carried a third **"unhurried (7 min+, targetTimeSec ≥ 360)"** bucket, so the model could target brew times you can never actually request.

- Dropped the "unhurried" bucket. Now just **quick (≤150s)** and **normal (180–330s, aim ~4–5 min)**.
- Added a legacy guard: if a session ever sends "unhurried", it folds into the slow end of "normal" (~330s cap). Very long brews (e.g. a 10-min Gagné) are simply out of scope for the recommend flow.
- Updated the `LightStepContext` comment to match.

## 2. Moccamaster — confirmed it's the regular machine
You were right to double-check. I re-read the transcript: the **"3 1/2 minute brew time"** line is stated *inside the Technivorm section* of his 6-brewer comparison ("This did a very good job... It's a 3 1/2 minute brew time") — so it's definitely the Moccamaster, not one of the other five (Oxo 5½, Ratio 4½, Behmor ~4). And it's the **standard Technivorm (KBGV/KBG Select)**, not the Jubilee 68 — I made that explicit in the entry's brewer notes so it can't be misread. (The Jubilee video was only cited for the general Technivorm temp range + the optional stir hack, both of which Hoffmann describes for Technivorms broadly.)

`tsc` + 47 tests + validator clean.

https://claude.ai/code/session_01GJPbS61ARuuC5Fcp6n2GMJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJPbS61ARuuC5Fcp6n2GMJ)_