### PR TITLE
audit: owner-supplied recipes — Hatakeyama, Stanica, Perger, Wallgren + Hoffmann iced + Nemo Pop 2025

### DIFF
--- a/docs/coffee-experts.md
+++ b/docs/coffee-experts.md
@@ -25,7 +25,8 @@ Each entry: dose / water / ratio / temperature / Niche Zero degrees / total time
 | 2019 | **Du Origami Wave** (Jia Ning Du, China) | Origami + wave filter | 20g : 240g | 1:12 | 94°C | 377–387° | 3:15 | false |
 | 2023 | **Medina Conical** (Carlos Medina, Chile) | Conical paper filter | 15.5g : 250g | 1:16.1 | 91°C | 387–393° | 3:30 | false |
 | 2024 | **Wölfl Orea Fast** (Martin Wölfl, Austria) | Orea V4 Fast | 17g : 270g | 1:15.9 | 93°C | 380–390° | 2:20 | true |
-| 2024 (WAC) | **Stanica AeroPress + Bypass** (George Stanica, Romania) | Inverted AeroPress, Aesir filter | 18g : 200g (120g extract + 80g bypass) | 1:11 ext | 96°C | 415–425° | 2:00 | true |
+| 2024 (WAC) | **Stanica AeroPress + Melodrip + Bypass** (George Stanica, Romania) | Inverted AeroPress, Melodrip | 18g : 100g → ~80g concentrate + bypass to ~155g | 1:5.5 ext | 88–93°C | 388–396° | 2:15 | true |
+| 2025 (WAC) | **Nemo Pop — Flow Control Bypass** | Upright AeroPress, Flow Control cap, 2 filters | 18g : 100g brew + 70g bypass (50°C) | 1:5.5 ext | 84°C | 403–411° | 1:10 | true |
 
 **Teaching summaries**
 
@@ -33,7 +34,8 @@ Each entry: dose / water / ratio / temperature / Niche Zero degrees / total time
 - **Du Origami Wave** — How a rich brewing ratio (1:12) combined with custom low-mineral water (4ppm Ca / 15ppm Mg / 80ppm TDS) produces extreme clarity without sacrificing sweetness.
 - **Medina Conical** — How a lean ratio (1:16) at moderate 91°C extracts the fermentation-derived sweetness of a Natural Sidra without amplifying ester sharpness.
 - **Wölfl Orea Fast** — How fast-flowing geometry combined with turbulent pours delivers clarity on a Natural — the paradox of high agitation producing a clean cup because total bed-contact time stays in Zone 1–2.
-- **Stanica AeroPress + Bypass** — How concentrate-and-bypass separates extraction from dilution. Over-pull a tight, intense concentrate at 1:11, then dial the cup back to drinking strength with cool water.
+- **Stanica AeroPress + Melodrip + Bypass** — His WAC 2024 routine: inverted, gentle Melodrip pours (50g + 30s bloom + 50g) of 88–93°C water, NSEW stir, press out air at 1:20, flip, press to ~80g concentrate at 1:35, then rebuild to ~150–165g with warm + room-temp bypass. Concentrate-and-bypass = extraction and drink strength as independent controls. (An upright Flow-Control home version also exists.)
+- **Nemo Pop 2025 (WAC champion)** — Bypass-FIRST: 70g of 50°C water waits in the carafe, then an 18g:100g concentrate is brewed at a cool 84°C (Comandante 31 clicks, fines sifted at 200µm), NSNS-WEWE stir at 0:25, gentle press from 0:50, ~1:10 total. The concentrate lands on the warm bypass for an even, sweet, fast cup.
 
 ### 1b. Reference recipes
 
@@ -50,8 +52,9 @@ Each entry: dose / water / ratio / temperature / Niche Zero degrees / total time
 | **Gagné Long AeroPress** | AeroPress + Prismo | 18g : 260g | 100°C | calibrate | 10:00 | true |
 | **Perger High-Extraction V60** | V60 | 12g : 200g | 97°C | — (calibrate) | 2:20 | false |
 | **Rao V60 Spin Method** | V60 | 20g : 330g | 97°C | calibrate | 4:00–4:30 | true |
-| **Hatakeyama Cafec Flower (roast-tailored)** | Cafec Flower Dripper | 15g : 225g *(unsourced — flagged)* | 88–95°C (by roast) | 396–406° | 3:10 | false |
-| **Wallgren Kalita with Sieved Fines** | Kalita Wave 155 | 22g : 330g | 94°C | 396–406° | 3:35 | false |
+| **Hatakeyama 2024 JBrC (Origami)** | Origami Air S/M + Cafec Abaca | 15g : 240g | **85°C** | 387–397° | 2:20 | true |
+| **Wallgren Kalita with Sieved Fines** | Kalita Wave 155 | 15g : 250g | 96°C | 388–398° | 2:35 | false |
+| **Hoffmann Japanese Iced V60** | V60 onto ice | 32.5g : 500g (300 hot + 200 ice) | off the boil | calibrate | 2:45 | true |
 
 † **Hoffmann roast-temperature staircase (as he states it in the Better 1 Cup video):** light = **freshly boiled (100 °C)**, medium 96 °C, darkest roasts down to 90 °C. The doc cell shows the full staircase range; brew by the bag's roast level. The TS `temperature.celsius` field is the canonical light-roast value; `rangeC` is the staircase span. (Verified against the video transcription, June 2026.)
 ‡ Hoffmann does not publish a Niche Zero degree number — calibrate empirically against the recipe's drawdown target. The old "Niche 396–406°" claim had no Hoffmann source behind it and was removed per the third Hard Rule. See `src/lib/knowledge/recipes/reference.ts` (Hoffmann V60 `notes`) for the rescue moves Hoffmann published in his 2024 follow-up video.
@@ -67,9 +70,10 @@ Each entry: dose / water / ratio / temperature / Niche Zero degrees / total time
 - **Kasuya Super Coarse 10-Pour** — Full extraction of a light roast WITHOUT bitterness: grind super-coarse (Comandante 40–45 clicks; 40 is the dependable default, 45 is extreme and can run thin) to drop out the over-extracting fines, then claw the yield back with near-boiling water (95–96 °C) and ten even 30 g pulses (bloom 30 s, then a 30 g pour every 15 s). At 1:15 this grind would normally give <1% TDS; the ten percolation cycles pull it to ~1.3% and, crucially, build a thick, almost syrupy **body** — Kasuya's point is that the *number* of pours is what creates mouthfeel (7–8 already help). Early pours drain straight through; the bed clogs slightly near the end (~2:00–2:15). Trade-off: sweetness dominates and **acidity is deliberately toned down** — not for an acidity-forward cup. Designed around the Hario Neo but he brews it on a V60; flat-bottom untested. A different Kasuya recipe from the 4:6 method — even pours, not phase-separated — pitched as its 10th-anniversary evolution. Source: his 2026 YouTube video ("Multi-Pour Recipe"), transcribed.
 - **April House V60 (Rolf)** — April's agitation-forward house recipe: six even 50g pours on a ~30s cadence, each poured deliberately aggressively, finished with one stir. The opposite of a minimal-agitation brew. (Replaces a prior "Minimum Variables" entry that was a misattribution — no such single-continuous-pour Rolf recipe exists.)
 - **Gagné Long AeroPress** — A long (~10-minute) **HOT** steep (100°C, 18g:260g) in an upright AeroPress with a no-drip Prismo valve, finished with a very gentle ~1-minute press. Contact time + gentleness reach ~23.5% extraction — full, sweet, clean — without astringency. (Corrected June 2026 against Gagné's own blog: the previous "80°C second sweet spot / low-temp" framing was a misattribution — his published recipe is hot.)
-- **Perger High-Extraction V60** — Vigorous bloom stir + fine grind + spinning swirl during drawdown drives extraction yield above 22%. Bitterness comes from over-extracting the wrong compounds, not high yield itself.
+- **Perger High-Extraction V60** — 12g:200g/97°C/2:20 (~20.8% extraction). Vigorous bloom stir ("stir like a bandit") + fine grind, then OUTWARD-SPIRAL pours (the spiral IS the Rao-spin — no separate spin), and tap to level the bed AFTER the final pour. Bitterness comes from over-extracting the wrong compounds, not high yield itself.
 - **Rao V60 Spin Method** — 20g:330g at 97°C: aggressive bloom spin, then **two** pours (to 200g, to 330g) each followed by a brief gentle spin to refill the ribbed channels; ~4:00–4:30. The defining feature is the spin, NOT equal thirds. (Corrected June 2026 against Rao's own published recipe: he explicitly argues AGAINST breaking a V60 into more than two parts, so the prior "Rule of Thirds / equal thirds / 22g:352g" attribution was wrong.)
-- **Hatakeyama Cafec Flower** — Match filter paper thickness to roast level. Light roast → thin paper (faster flow tolerable); dark roast → thick paper (slows flow where less contact is needed).
+- **Hatakeyama 2024 JBrC** — His Japan Brewers Cup champion recipe: 15g:240g, a COARSE grind (Comandante 25–27) with notably COOL 85°C water, and five even circular pours (30 → 120 → 160 → 200 → 240) finishing ~2:20, then swirl the carafe. Coarse + cool, yield recovered through pour count → sweet, clean, soft acidity. (Replaces the old unsourced "roast-tailored Cafec filter" reconstruction.)
+- **Hoffmann Japanese Iced V60** — Pour-over iced: brew HOT (off the boil) onto ice. 65 g/L, 40% ice / 60% hot (≈300g hot + 200g ice), slightly finer grind, bloom 2–3× for ≥45s, brew 2:30–3:00, finish with a circular stir then the opposite direction, drip onto ice, swirl, pour onto fresh ice. Keeps the origin character cold brew flattens.
 - **Wallgren Kalita** — Sieve out fines pre-brew. Fines over-extract relative to the rest of the grind; removing them tightens the extraction distribution and produces a startlingly clean cup.
 
 > *Removed:* the **Turbo V60 (Hedrick)** entry — "turbo" is an espresso technique (Cameron/Hendon, *Matter* 2020; popularised by Hedrick ~2021), and no primary source documents a Hedrick filter recipe with the parameters it carried. The boiling-water + coarse-grind mechanism survives as a technique (§3a), de-attributed.

--- a/src/lib/knowledge/recipes/championship.ts
+++ b/src/lib/knowledge/recipes/championship.ts
@@ -412,7 +412,7 @@ export const CHAMPIONSHIP_RECIPES: Recipe[] = [
 
   {
     id: "wac-2024-stanica",
-    name: "Stanica 2024 — Inverted AeroPress + Bypass",
+    name: "Stanica 2024 — Inverted AeroPress + Melodrip + Bypass",
     shortName: "Stanica 2024",
     attribution: {
       person: "George Stanica",
@@ -423,68 +423,174 @@ export const CHAMPIONSHIP_RECIPES: Recipe[] = [
     category: "championship",
     brewer: "aeropress",
     brewerNotes:
-      "Inverted AeroPress with Aesir paper filter. Mixed Aquacode water at 85–90 ppm TDS.",
+      "INVERTED AeroPress, plunger at the 4th mark, standard paper filter (rinsed). Pours go through a Melodrip. His WAC 2024 competition routine. Brew water 88–93 °C; dilution = warm kettle water + room-temp water.",
     dose: { grams: 18 },
-    water: { grams: 200, ratio: "1:11.1 (extraction) + bypass" },
-    temperature: { celsius: 96 },
+    water: { grams: 100, ratio: "1:5.5 (extraction) + bypass → ~150–165 g cup" },
+    temperature: { celsius: 90, rangeC: [88, 93] },
     grind: {
-      referenceGrinder: "Comandante C40 Mk4 Red Clix",
-      referenceSetting: "58 clicks",
-      nicheZeroDegrees: [415, 425],
+      referenceGrinder: "Comandante C40",
+      referenceSetting: "medium / medium-coarse (~800 µm, ~26 clicks)",
+      nicheZeroDegrees: [388, 396],
       description:
-        "Red Clix has 50 clicks per turn vs. standard 30, so 58 Red Clix ≈ 35 standard clicks. The published 58 Red Clix is kept verbatim; Niche derived from it via the user's map (35 standard clicks ≈ 420°) — medium-coarse, as expected for an inverted-AeroPress concentrate.",
+        "Medium/medium-coarse, ~800 µm (~26 Comandante clicks). Niche derived from the clicks (~26 ≈ 392°); calibrate empirically.",
     },
     pourSequence: [
       {
-        label: "Invert and load",
+        label: "Invert (plunger 4th mark), 18 g coffee",
         action: "invert",
         durationSec: 0,
-        notes: "Inverted orientation, 18g dose, Aesir filter in cap (off).",
+        notes: "Inverted, plunger set at the 4th mark; add 18 g coffee.",
       },
       {
-        label: "Pour concentrate water at 96°C",
-        action: "pour",
-        waterGramsAtEnd: 120,
-        durationSec: 15,
+        label: "First pour 50 g via Melodrip",
+        action: "melodrip",
+        waterGramsAtEnd: 50,
+        durationSec: 6,
+        notes: "Pour 50 g of 88–93 °C water through a Melodrip (~5–6 s).",
       },
-      { label: "Stir 2–3× evenly", action: "stir", durationSec: 10 },
-      { label: "Steep", action: "wait", durationSec: 60 },
+      { label: "Bloom → 0:30", action: "wait", durationSec: 24 },
       {
-        label: "Cap, flip, and press",
+        label: "Second pour 50 g via Melodrip (→100 g)",
+        action: "melodrip",
+        waterGramsAtEnd: 100,
+        durationSec: 6,
+      },
+      {
+        label: "NSEW stir 10 s",
+        action: "stir",
+        durationSec: 10,
+        notes: "Light paddle stir North-South-East-West. Rinse the cap filter and crack the kettle lid to cool the dilution water.",
+      },
+      { label: "Wait → 1:20", action: "wait", durationSec: 34 },
+      {
+        label: "Press out air (inverted, ~10 s)",
         action: "press",
-        durationSec: 30,
+        durationSec: 10,
+        notes: "At 1:20, cap on, gently press while inverted just to push the air out.",
       },
       {
-        label: "Add bypass water to taste",
+        label: "Swirl, then flip onto the server",
+        action: "flip",
+        durationSec: 3,
+        notes: "Gently swirl inverted, then flip onto your server.",
+      },
+      { label: "Wait → 1:35", action: "wait", durationSec: 2 },
+      {
+        label: "Press slowly 30–40 s → ~80 g concentrate",
+        action: "press",
+        durationSec: 35,
+        notes: "From 1:35, press slowly until you have ~80 g of concentrate.",
+      },
+      {
+        label: "Dilute → ~150–165 g cup",
         action: "bypass",
-        waterGramsAtEnd: 200,
+        waterGramsAtEnd: 160,
         durationSec: 5,
-        notes:
-          "~80g cool bypass water added directly to the cup. Separates extraction strength from final drink concentration.",
+        notes: "Add warm kettle water to bring the ~80 g concentrate to 130–135 g, then add 20–30 g room-temp (25 °C) water.",
       },
     ],
-    totalTimeSec: 120,
-    techniques: ["aeropress-inversion", "concentrate-and-bypass", "low-mineral-water"],
+    totalTimeSec: 135,
+    techniques: ["aeropress-inversion", "concentrate-and-bypass"],
     bestFor: {
       roastLevels: ["light", "medium-light"],
       processes: ["washed", "natural", "honey"],
       goals: ["high-clarity", "balanced", "explore"],
     },
     teaches:
-      "How concentrate-and-bypass separates extraction from dilution. You can over-pull a tight, intense concentrate at 1:6–1:11, then dial the cup back to drinking strength with cool water — the cup's flavour profile and its strength become independent controls.",
+      "His WAC 2024 routine: over-extract a tight ~1:5.5 concentrate inverted with gentle Melodrip pours, press to ~80 g, then rebuild the cup with warm + room-temp bypass water. Concentrate-and-bypass makes extraction strength and drink strength independent controls.",
     science:
-      "At 1:11 extraction, the AeroPress extracts deeply into Zone 2 (sugars, maillard) without the diluted, watery cup that a 1:16 brew would produce. The bypass water then adjusts cup weight — adding water doesn't extract anything (the puck is already pressed), it only changes concentration. 85–90 ppm mineral water is the SCA sweet spot for clarity-with-body. Aesir paper retains more oils than standard AeroPress paper, pushing the cup toward filter-cup clarity rather than the typical AeroPress mouthfeel.",
+      "Pulling a small 1:5.5 concentrate at 88–93 °C extracts deeply into Zone 2 (sugars, body) without the watery cup a 1:16 brew gives; the Melodrip breaks the pour into many fine streams so the small bed saturates with almost no turbulence. Pressing fully means the bypass water only sets concentration, not extraction — warm water to 130–135 g rebuilds body, and a final 20–30 g of room-temp water cools and lengthens it. The NSEW stir agitates the small bed evenly without a vortex.",
     whenToUse:
-      "For an AeroPress brew where you want filter-style clarity at the strength of a concentrated extraction. Excellent for competition-grade light roasts where standard AeroPress recipes feel under-extracted.",
+      "When you want filter-style clarity at the intensity of a concentrate, with full control over final strength. Competition-grade light roasts that feel under-extracted on a standard AeroPress.",
     sources: [
       {
-        type: "official-competition",
-        citation: "2024 World AeroPress Championship",
+        type: "report",
+        citation:
+          "George Stanica — 2024 World AeroPress Championship recipe with dilution (owner-supplied): inverted, plunger 4th mark, 18 g, ~800 µm; 100 g brew water at 88–93 °C via Melodrip (50 g + 30 s bloom + 50 g), NSEW stir 10 s, press out air at 1:20, flip, press to ~80 g concentrate at 1:35, dilute with warm water to 130–135 g + 20–30 g room-temp.",
         year: 2024,
       },
     ],
     verified: true,
     notes:
-      "The Comandante 'Red Clix' setting (58 clicks) only translates correctly on Red Clix burrs — standard Comandante owners should use ~35 clicks as the equivalent.",
+      "George Stanica's WAC 2024 competition routine (owner-supplied, with the full dilution). Inverted + Melodrip; 100 g brew water → ~80 g concentrate → diluted to ~150–165 g with warm + room-temp bypass. He won the 2024 World AeroPress Championship (Lisbon). One constant brewing temperature (88–93 °C); the warm/room-temp dilution water is bypass, not staging. An alternative UPRIGHT Flow-Control home version also circulates (18 g : 225 g, 93 °C, Comandante 25 clicks, NSEW stir, press at 1:30, dilute 15–30 g) — this entry is the competition recipe. Parameters owner-supplied; Niche derived from the Comandante clicks.",
+  },
+
+  {
+    id: "wac-2025-nemo-pop",
+    name: "Nemo Pop 2025 — Flow Control Bypass AeroPress",
+    shortName: "Nemo Pop 2025",
+    attribution: {
+      person: "Nemo Pop",
+      title: "2025 World AeroPress Champion",
+      year: 2025,
+    },
+    category: "championship",
+    brewer: "aeropress",
+    brewerNotes:
+      "UPRIGHT AeroPress, Flow Control Filter Cap, 2× paper filters, set over the carafe. 125 ppm water (Apax prototype). BYPASS-FIRST: 70 g of 50 °C bypass water goes into the carafe BEFORE brewing, and the pressed concentrate lands on it. Comandante Trailmaster (Tigershark burrs); grind slow, blow off chaff, sift fines at 200 µm.",
+    dose: { grams: 18 },
+    water: { grams: 100, ratio: "1:5.5 (brew concentrate) + 70 g bypass → ~170 g cup (1:9.4)" },
+    temperature: { celsius: 84 },
+    grind: {
+      referenceGrinder: "Comandante (Trailmaster x25, Tigershark burrs)",
+      referenceSetting: "31 clicks, sifted at 200 µm",
+      nicheZeroDegrees: [403, 411],
+      description:
+        "Comandante 31 clicks, fines sifted out at 200 µm and chaff blown off. Niche derived from the published clicks (~31 clicks ≈ 407°); calibrate empirically.",
+    },
+    pourSequence: [
+      {
+        label: "Pour 100 g brewing water (84 °C)",
+        action: "pour",
+        waterGramsAtEnd: 100,
+        durationSec: 10,
+        notes: "70 g of 50 °C bypass water is already in the carafe below. Pour 100 g of 84 °C water into the AeroPress, wetting all the grounds.",
+      },
+      { label: "Wait → 0:25", action: "wait", durationSec: 15 },
+      {
+        label: "Stir NSNS-WEWE",
+        action: "stir",
+        durationSec: 5,
+        notes: "At 25 s, stir north-south-north-south, then west-east-west-east.",
+      },
+      { label: "Wait → 0:50", action: "wait", durationSec: 20 },
+      {
+        label: "Gently press (~20 s)",
+        action: "press",
+        durationSec: 20,
+        notes: "From 50 s, press gently for ~20 s — the concentrate presses down onto the 70 g bypass in the carafe.",
+      },
+      {
+        label: "Serve",
+        action: "bypass",
+        waterGramsAtEnd: 170,
+        durationSec: 0,
+        notes: "~100 g concentrate pressed onto the 70 g of 50 °C bypass ≈ 170 g cup. Serve.",
+      },
+    ],
+    totalTimeSec: 70,
+    techniques: ["concentrate-and-bypass", "fines-removal-sieving"],
+    bestFor: {
+      roastLevels: ["light", "medium-light"],
+      processes: ["washed", "natural", "honey"],
+      goals: ["high-clarity", "sweetness-forward", "balanced"],
+    },
+    teaches:
+      "Bypass-FIRST concentrate AeroPress: brew a small, cool (84 °C) concentrate at 1:5.5 and press it straight onto warm (50 °C) bypass water already waiting in the carafe. Sifting the fines + a coarse-ish grind keep it clean; the cool brew water lands a sweet, low-bitterness cup fast (~1:10).",
+    science:
+      "Pressing a 1:5.5 concentrate onto bypass water separates extraction from strength — the puck is fully pressed, so the 70 g bypass only sets drinking concentration, not extraction. Brewing at a cool 84 °C with a coarse-ish sifted grind keeps the fast-extracting bitter compounds down, and removing the fines (sifted at 200 µm) tightens the extraction distribution for clarity. The NSNS-WEWE stir evenly agitates a small bed without a vortex. Putting the warm bypass in the carafe first means the concentrate mixes on contact for an even cup. One constant brewing temperature (84 °C); the 50 °C bypass is dilution, not staging.",
+    whenToUse:
+      "A fast, clean, sweet AeroPress when you want filter-style clarity at controllable strength — dial the cup with the bypass amount. Upright + Flow Control, no inversion.",
+    sources: [
+      {
+        type: "report",
+        citation:
+          "Nemo Pop — 2025 World AeroPress Champion recipe (owner-supplied): upright, 18 g, Comandante 31 clicks sifted at 200 µm, 100 g brew water at 84 °C + 70 g bypass at 50 °C (bypass first in carafe), 125 ppm water, NSNS-WEWE stir at 0:25, gentle press from 0:50 (~20 s), ~1:10 total.",
+        year: 2025,
+      },
+    ],
+    verified: true,
+    notes:
+      "New entry (June 2026), owner-supplied 2025 World AeroPress Championship winning recipe. Bypass-first method (70 g of 50 °C water in the carafe before brewing). Single 84 °C brew temperature; the 50 °C bypass is dilution, not staging. Parameters owner-supplied; Niche degrees derived from the published Comandante clicks. Not independently web-fetched.",
   },
 ];

--- a/src/lib/knowledge/recipes/reference.ts
+++ b/src/lib/knowledge/recipes/reference.ts
@@ -422,6 +422,76 @@ export const REFERENCE_RECIPES: Recipe[] = [
       "Corrected from Hoffmann's 2023 iced video: dose is 75 g/L of TOTAL water (~37.5 g for a 500 g drink, was 20 g), water split is ~2/3 hot + 1/3 ice (~330 g + ~170 g, was 250 g + 200 g), steep ~5 min (was 3:40), brewed as hot as possible (was 95°C), plus a saline finish. The earlier '1:12.5 + 200 g ice' figures were a different reconstruction.",
   },
 
+  {
+    id: "hoffmann-iced-v60-pourover",
+    name: "Hoffmann Japanese Iced V60 (pour-over)",
+    shortName: "Hoffmann Iced V60",
+    attribution: {
+      person: "James Hoffmann",
+      country: "United Kingdom",
+    },
+    category: "reference",
+    brewer: "v60",
+    brewerNotes:
+      "V60 pour-over with the server holding ~200 g ice (40% of the total water). The hot brew drips straight onto the ice to flash-chill. 60% hot brew water / 40% ice by weight; finish onto fresh ice in the glass.",
+    dose: { grams: 32.5 },
+    water: { grams: 500, ratio: "1:15.4 (65 g/L total: ~300 g hot brew + ~200 g ice)" },
+    temperature: { celsius: 99, rangeC: [96, 100] },
+    grind: {
+      referenceSetting:
+        "slightly finer than a standard V60 — the smaller hot-brew-water volume needs help extracting",
+    },
+    pourSequence: [
+      {
+        label: "Bloom (→65 g) @ 0:00",
+        action: "pour",
+        waterGramsAtEnd: 65,
+        durationSec: 10,
+        notes: "2× dose, off the boil, onto the GROUNDS (the ~200 g ice is in the server below). Bloom at least 45 s.",
+      },
+      { label: "Bloom rest (≥45 s)", action: "wait", durationSec: 45 },
+      { label: "Pour 2 (→150 g)", action: "pour", waterGramsAtEnd: 150, durationSec: 15 },
+      { label: "Pour 3 (→225 g)", action: "pour", waterGramsAtEnd: 225, durationSec: 15 },
+      { label: "Final pour (→300 g)", action: "pour", waterGramsAtEnd: 300, durationSec: 15 },
+      {
+        label: "Stir circular, then opposite",
+        action: "stir",
+        durationSec: 5,
+        notes: "At the end: one circular stir one way, then once the opposite direction — then let it draw down.",
+      },
+      {
+        label: "Drawdown onto ice — then swirl the decanter",
+        action: "drain",
+        durationSec: 60,
+        notes: "Drains onto the ~200 g ice and flash-chills. Swirl the decanter to melt any leftover ice, then pour onto fresh ice in the glass.",
+      },
+    ],
+    totalTimeSec: 165,
+    techniques: ["flash-chilling", "pulse-pouring"],
+    bestFor: {
+      roastLevels: ["light", "medium-light"],
+      processes: ["washed", "natural", "honey"],
+      goals: ["high-clarity", "aromatic", "sweetness-forward"],
+      occasions: ["summer-time", "iced"],
+    },
+    teaches:
+      "Japanese-style iced: brew HOT over ice so the cup keeps the origin character (florals, fruit, acidity) that cold brew flattens. 65 g/L with 40% of the water as ice, a slightly finer grind and a long-ish bloom recover the extraction the reduced hot-water volume gives up.",
+    science:
+      "Cold brew loses origin character — it reads chocolatey and low-acid. Brewing HOT extracts the volatile aromatics and acids; the brewed coffee then drips straight onto ice and flash-chills, locking those aromatics in before they volatilise. Because only ~60% of the total water is hot brew water, Hoffmann doses ~5 g/L heavier than usual and grinds a touch finer + blooms longer (≥45 s) to keep extraction up; the closing two-direction stir levels the bed for an even finish. Rule of thumb: use as much brew water (and as little ice) as you can while still chilling it — more brew water means a better extraction.",
+    whenToUse:
+      "A hot day and a light, fruity, juicy coffee (washed Kenyan / Ethiopian shine). When you want the cup to taste like the coffee you paid for, not generic cold-brew chocolate.",
+    sources: [
+      {
+        type: "transcript",
+        citation:
+          "James Hoffmann — pour-over 'Japanese-style' iced filter coffee (owner-supplied transcript). 65 g/L, 40% ice / 60% hot, grind a touch finer, bloom 2–3× for ≥45 s, brew 2:30–3:00 onto ice, finish with a circular stir then the opposite direction, swirl the decanter, pour onto fresh ice.",
+      },
+    ],
+    verified: true,
+    notes:
+      "New entry (June 2026) from Hoffmann's pour-over Japanese-style iced video (owner-supplied transcript) — the PERCOLATION iced, distinct from his immersion (Clever) iced. Temperature: he says only 'off the boil' in this video (no number published), so the 99 °C is his standard off-the-boil, not a fabricated figure. Bloom 65 g = 2× dose (he says 2–3×). ~200 g ice sits in the server; the brew drips onto it to flash-chill. One constant brewing temperature (the ice dilutes/chills; it is not staging).",
+  },
+
   // ── Tetsu Kasuya (standalone 4:6, separate from his 2016 routine) ────────
 
   {
@@ -854,30 +924,38 @@ export const REFERENCE_RECIPES: Recipe[] = [
         notes: "~4× dose.",
       },
       {
-        label: "Vigorous stir 3–5×",
+        label: "Vigorous stir ('stir like a bandit')",
         action: "stir",
         durationSec: 10,
         notes:
-          "Perger's signature — vigorous bloom stir to ensure full saturation and to drive extraction yield up.",
+          "Perger's signature — a vigorous bloom stir for full saturation, driving extraction yield up.",
       },
       { label: "Bloom rest → 0:30", action: "wait", durationSec: 10 },
       {
-        label: "Pour 2 (→100 g) @ 0:30",
+        label: "Pour 2 (→100 g) @ 0:30 — outward spiral",
         action: "pour",
         waterGramsAtEnd: 100,
         durationSec: 10,
+        notes: "Outward spiral pour; finish around the edges to wash grounds back down.",
       },
       { label: "Wait → 1:00", action: "wait", durationSec: 20 },
       {
-        label: "Pour 3 (→200 g) @ 1:00",
+        label: "Pour 3 (→200 g) @ 1:00 — outward spiral",
         action: "pour",
         waterGramsAtEnd: 200,
         durationSec: 15,
+        notes: "Outward spiral — the spiral pour itself creates the Rao-spin vortex, so no separate spin is needed. Finish around the edges.",
       },
-      { label: "Drawdown", action: "drain", durationSec: 65 },
+      {
+        label: "Tap to level the bed",
+        action: "agitate-bed",
+        durationSec: 3,
+        notes: "AFTER the final pour, tap the dripper so the bed sits flat — even bed, even extraction. Water should disappear across the whole bed at once.",
+      },
+      { label: "Drawdown", action: "drain", durationSec: 62 },
     ],
     totalTimeSec: 140,
-    techniques: ["high-agitation-high-extraction"],
+    techniques: ["high-agitation-high-extraction", "spiral-pour", "rao-spin"],
     bestFor: {
       roastLevels: ["light", "medium-light"],
       processes: ["washed"],
@@ -898,7 +976,7 @@ export const REFERENCE_RECIPES: Recipe[] = [
     ],
     verified: false,
     notes:
-      "Corrected from the prior 22 g : 352 g / 95 °C / ~3:35 values, which could not be sourced to Perger and closely match a different recipe (a 22 g : 375 g / 98 °C method attributed in a coffeeadastra comment to Alessandro Galtieri, explicitly NOT Perger) — i.e. a likely misattribution. Perger's documented headline recipe is 12 g : 200 g at 97 °C with a vigorous bloom stir. Kept verified:false: the numbers come from secondary transcriptions of his video / Barista Hustle article, not a verbatim-fetched primary source. The old fabricated Niche degree range was removed per the Hard Rule.",
+      "12 g : 200 g, 97 °C, 2:20, confirmed against a demonstration of the recipe (measured 1.40% TDS / 20.8% extraction): bloom 50 g + a vigorous 'stir like a bandit', then OUTWARD-SPIRAL pours to 100 g @ 0:30 and 200 g @ 1:00 — the spiral pour itself supplies the Rao-spin (there is no separate spin step). TAP the dripper to level the bed AFTER the final pour, not after the bloom. Finish each pour around the edges to wash grounds down; aim for the water disappearing across the whole bed simultaneously. Kept verified:false: the source is a recipe demonstration, not Perger's own verbatim publication. (Prior 22 g : 352 g / 95 °C / 3:35 was a misattribution — removed.)",
   },
 
   // ── Scott Rao ────────────────────────────────────────────────────────────
@@ -1000,8 +1078,8 @@ export const REFERENCE_RECIPES: Recipe[] = [
 
   {
     id: "hatakeyama-cafec-flower",
-    name: "Hatakeyama — Cafec Flower Dripper, Roast-Tailored",
-    shortName: "Hatakeyama Cafec",
+    name: "Hatakeyama 2024 Japan Brewers Cup — Origami",
+    shortName: "Hatakeyama 2024",
     attribution: {
       person: "Daiki Hatakeyama",
       title:
@@ -1009,73 +1087,85 @@ export const REFERENCE_RECIPES: Recipe[] = [
       country: "Japan",
     },
     category: "reference",
-    brewer: "cafec-flower",
+    brewer: "origami-air-m",
     brewerNotes:
-      "Cafec Flower Dripper (six tall ribs, cup-shaped) with roast-tailored Cafec paper (Light Roast / Medium Roast / Dark Roast / Abaca variants). The technique is to match paper to roast level.",
+      "Origami Air M (the owner's dripper) with Cafec Abaca paper. Hatakeyama brewed it on an Origami Air S; his recipe notes it 'should be' the Cafec Flower Dripper. Single 85 °C water — notably cool — and a coarse grind.",
     dose: { grams: 15 },
-    water: { grams: 225, ratio: "1:15" },
-    temperature: {
-      rangeC: [88, 95],
-      celsius: 92,
-    },
+    water: { grams: 240, ratio: "1:16" },
+    temperature: { celsius: 85 },
     grind: {
-      referenceSetting: "medium",
-      nicheZeroDegrees: [375, 385],
+      referenceGrinder: "Comandante C40",
+      referenceSetting: "coarse — Comandante 25–27 clicks",
+      nicheZeroDegrees: [387, 397],
+      description:
+        "Coarse — he states ~900–1000 µm / Comandante 25–27 clicks. Niche derived from the published Comandante clicks via the owner's map (~26 clicks ≈ 392°); calibrate empirically.",
     },
     pourSequence: [
       {
-        label: "Bloom",
+        label: "Bloom (→30 g) @ 0:00",
         action: "pour",
-        waterGramsAtEnd: 40,
-        durationSec: 30,
+        waterGramsAtEnd: 30,
+        durationSec: 10,
+        notes: "Circular pour, saturate the bed evenly; bloom 30 s.",
       },
+      { label: "Bloom rest → 0:30", action: "wait", durationSec: 20 },
       {
-        label: "Pour 1",
+        label: "Pour 2 (→120 g)",
         action: "pour",
-        waterGramsAtEnd: 100,
-        durationSec: 20,
+        waterGramsAtEnd: 120,
+        durationSec: 15,
+        notes: "Circular pour from the centre out, then back to the centre; wait until 1:00.",
       },
+      { label: "Wait → 1:00", action: "wait", durationSec: 15 },
       {
-        label: "Pour 2",
+        label: "Pour 3 (→160 g) @ 1:00",
         action: "pour",
         waterGramsAtEnd: 160,
-        durationSec: 20,
+        durationSec: 10,
+        notes: "Circular pour; wait until 1:20.",
       },
+      { label: "Wait → 1:20", action: "wait", durationSec: 10 },
       {
-        label: "Pour 3",
+        label: "Pour 4 (→200 g) @ 1:20",
         action: "pour",
-        waterGramsAtEnd: 225,
-        durationSec: 20,
+        waterGramsAtEnd: 200,
+        durationSec: 10,
+        notes: "Circular pour; wait until 1:40.",
       },
-      { label: "Drawdown", action: "drain", durationSec: 80 },
+      { label: "Wait → 1:40", action: "wait", durationSec: 10 },
+      {
+        label: "Pour 5 (→240 g) @ 1:40",
+        action: "pour",
+        waterGramsAtEnd: 240,
+        durationSec: 10,
+        notes: "Final circular pour.",
+      },
+      { label: "Drawdown (~2:20) — then swirl the carafe", action: "drain", durationSec: 30 },
     ],
-    totalTimeSec: 190,
-    techniques: ["roast-tailored-filter"],
+    totalTimeSec: 140,
+    techniques: ["pulse-pouring", "spiral-pour"],
     bestFor: {
-      roastLevels: ["light", "medium-light", "medium", "medium-dark"],
+      roastLevels: ["light", "medium-light", "medium"],
       processes: ["washed", "natural", "honey"],
-      goals: ["balanced", "explore"],
+      goals: ["balanced", "sweetness-forward", "high-clarity"],
     },
     teaches:
-      "How filter paper choice and water temperature should change with roast level — a dimension most pour-over recipes ignore. Light roast → high temp (95°C) + thinner paper (Light Roast Cafec). Dark roast → lower temp (88°C) + thicker paper (Dark Roast Cafec).",
+      "A counter-intuitive championship combination: a COARSE grind with notably COOL water (85 °C) and a long-ish set of gentle circular pours. Coarse + cool would normally under-extract, but five even pours over a deep-ish bed and a 1:16 ratio pull a balanced, sweet, clean cup with soft acidity.",
     science:
-      "Lighter roasts have lower solubility and need more aggressive extraction (high temperature, more contact). Darker roasts have higher solubility and over-extract easily (lower temperature, less contact). The Flower Dripper's six tall ribs create air channels along the entire filter height — drawdown is fast regardless of paper. So paper thickness becomes the timing variable: a thicker Dark Roast paper slows flow precisely where the darker coffee needs less contact. Hatakeyama systematises what most brewers do haphazardly.",
+      "A coarse grind (Comandante 25–27 clicks) shrinks the fines fraction that drives harsh over-extraction, and 85 °C keeps the fast-extracting bitter compounds in check. Hatakeyama recovers the yield the coarse/cool setup gives up through pour COUNT — five even circular pours (each from the centre out and back), each a fresh agitation/percolation cycle — landing a high, even extraction that reads as sweetness and clarity rather than astringency. The single constant temperature keeps it everyday-practical (no staging).",
     whenToUse:
-      "When you want a single dripper that handles a range of roast levels well, and you're willing to keep multiple papers on hand. The principles (match paper to roast, match temperature to roast) transfer to any dripper if you have papers of varying thickness.",
+      "A delicate, sweetness-forward cup from a clean coffee where you want softness and clarity over punchy acidity — and you can grind coarse and pour patiently. The single 85 °C / coarse-grind combination is the signature.",
     sources: [
       {
-        type: "interview",
-        citation: "Cafec Ambassador materials — Hatakeyama published interviews",
-      },
-      {
-        type: "video",
+        type: "report",
         citation:
-          "Cafec / Sanyo Sangyo published brewing demonstrations (Japanese, with English subtitles on some)",
+          "Daiki Hatakeyama — 2024 Japan Brewers Cup champion recipe (owner-supplied). 15 g : 240 g at 85 °C, Comandante 25–27 clicks, Origami Air S + Cafec Abaca paper; bloom 30 mL/30 s, then circular pours to 120 g (by 1:00) / 160 g (1:20) / 200 g (1:40) / 240 g, swirl the carafe, total ~2:20.",
+        year: 2024,
       },
     ],
-    verified: false,
+    verified: true,
     notes:
-      "Two honesty flags from web research. (1) The specific numbers here (15 g : 225 g, 88–95 °C, ~3:10) could NOT be sourced to any publication, primary or secondary — treat them as an unverified reconstruction, not Hatakeyama's recipe. (2) The 'roast-tailored filter' framing is a Cafec PRODUCT concept that Hatakeyama promotes as a Cafec brand ambassador (Cafec sells roast-specific papers: Light / Medium-Dark T-90 / Dark T-83) — it is not documented as his WBrC-winning method. His actual WBrC 2021 routine (Milan; he placed 2nd / runner-up, champion was Matt Winton — he was NOT world champion) is reported, secondary-tier only, as: Cafec Flower Dripper + Abaca filter, 20 g : 260 g (~1:13), KRUVE-sieved to remove microfines, staged temperature ~90 °C (pours 1–3) dropping to ~60 °C (late pours), target ~3:00, brewed on a Colombia/Bolivia Geisha blend. The exact per-pour schedule and bloom time are NOT reliably documented. This entry is kept as a roast-tailored teaching demo and stays verified:false until a primary source can be fetched.",
+      "Replaced (June 2026) with Hatakeyama's actual 2024 Japan Brewers Cup champion recipe, supplied by the owner: 15 g : 240 g, single 85 °C (no staircase), coarse Comandante 25–27 clicks, five even circular pours (30 → 120 → 160 → 200 → 240) finishing ~2:20, swirl the carafe. The previous entry was an unsourced 'roast-tailored Cafec filter' reconstruction (15 g : 225 g, 88–95 °C staircase) and has been removed. Brewer set to Origami Air M (the owner's dripper; Hatakeyama used Air S, and his recipe notes the Cafec Flower Dripper as the intended dripper). Owner-supplied — not independently web-fetched; Niche degrees derived from the published Comandante clicks.",
   },
 
   // ── Mikaela Wallgren ─────────────────────────────────────────────────────
@@ -1114,21 +1204,22 @@ export const REFERENCE_RECIPES: Recipe[] = [
           "Sieve off the fines before brewing — less bitterness because the fines can't over-extract.",
       },
       {
-        label: "Bloom",
+        label: "Bloom — spiral pour 30 g in 10 s",
         action: "pour",
-        waterGramsAtEnd: 50,
-        durationSec: 30,
-        notes: "30 s bloom.",
+        waterGramsAtEnd: 30,
+        durationSec: 10,
+        notes: "Shake the brewer to level the bed first, then spiral-pour 30 g in 10 s.",
       },
+      { label: "Bloom rest → 0:30", action: "wait", durationSec: 20 },
       {
-        label: "Continuous circular pour to 250 g",
+        label: "Continuous spiral pour to 250 g (by 1:45)",
         action: "pour",
         waterGramsAtEnd: 250,
         durationSec: 75,
         notes:
-          "One continuous pour in circles, all the way to 1:45 — gentle, even agitation of the whole bed the entire pour. Flow restrictors on the kettle keep the stream steady and controlled.",
+          "From 0:30, one slow continuous spiral pour with pacing to reach 250 g at 1:45 — gentle, even agitation of the whole bed the entire pour. A flow restrictor on the kettle keeps the stream steady.",
       },
-      { label: "Drawdown", action: "drain", durationSec: 50 },
+      { label: "Drawdown — remove brewer at 2:35", action: "drain", durationSec: 50 },
     ],
     totalTimeSec: 155,
     techniques: ["fines-removal-sieving", "flat-bed-pour", "continuous-pour"],


### PR DESCRIPTION
All from owner-supplied championship/recipe sources, implemented in one pass.

## Corrected
- **Hatakeyama** — replaced the unsourced "roast-tailored Cafec filter" reconstruction with his actual **2024 Japan Brewers Cup** recipe: 15g:240g, single **85°C**, coarse Comandante 25–27, five circular pours (30→120→160→200→240), swirl, ~2:20. Brewer = **Origami Air M** (your dripper; he used Air S).
- **Stanica** — rebuilt to his **WAC 2024 competition routine with full dilution**: inverted + Melodrip, 100g brew at 88–93°C (50g + 30s bloom + 50g), NSEW stir, press out air at 1:20, flip, press to ~80g concentrate at 1:35, dilute with warm + room-temp bypass → ~150–165g. (Replaces the old fabricated 120g/80g/1:11.) *Note: you sent two Stanica recipes — I used this inverted competition one; the upright Flow-Control home version is referenced in the entry notes.*
- **Perger** — outward-spiral pours (the spiral **is** the Rao-spin, no separate spin) + **tap to level after the final pour**; measured 1.40% TDS / 20.8% extraction noted.
- **Wallgren** — bloom corrected 50g → **30g** (spiral in 10s) per the Barista Mag recipe.

## New entries (corpus 125 → 127)
- **Hoffmann Japanese Iced V60 (pour-over)** — 32.5g:500g (300 hot + 200 ice), off the boil, finer grind, bloom 2–3×/≥45s, brew 2:30–3:00, stir circular then opposite, onto ice.
- **Nemo Pop — 2025 World AeroPress Champion** — bypass-first (70g of 50°C in the carafe), 18g:100g at 84°C, Comandante 31 sifted at 200µm, NSNS-WEWE stir, gentle press, ~1:10.

`tsc` + 47 tests + validator all clean. Owner-supplied parameters; Niche degrees derived from the published Comandante clicks where given.

https://claude.ai/code/session_01GJPbS61ARuuC5Fcp6n2GMJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJPbS61ARuuC5Fcp6n2GMJ)_