### PR TITLE
fix(deploy): serialise deploys to stop the git-ref-lock race

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,16 @@ on:
   push:
     branches: [main]
 
+# Serialise deploys. Without this, two pushes (or a double-delivered push event)
+# can start two deploy jobs that race on the VPS git checkout — one job's
+# `git fetch` updates refs/remotes/origin/main while the other still expects the
+# old value, giving "cannot lock ref 'refs/remotes/origin/main'" and a failed
+# deploy (June 2026). Queue instead of cancel so an in-flight deploy always
+# finishes cleanly; the next run resets to whatever origin/main is by then.
+concurrency:
+  group: deploy-hetzner
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -32,8 +42,12 @@ jobs:
           ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} bash <<'REMOTE'
             set -e
             cd ${{ secrets.DEPLOY_PATH }}
+            # Clear any stale ref lock left by a crashed/raced prior fetch, then
+            # reset to FETCH_HEAD (doesn't require updating the remote-tracking
+            # ref, so it can't fail on "cannot lock ref refs/remotes/origin/main").
+            rm -f .git/refs/remotes/origin/main.lock 2>/dev/null || true
             git fetch origin main
-            git reset --hard origin/main
+            git reset --hard FETCH_HEAD
 
             # One-shot migration: apply 0017 if it hasn't run yet.
             # The SQL is fully idempotent (column add uses IF NOT EXISTS;


### PR DESCRIPTION
## What happened
The deploy you saw fail was **not a code problem** — and the site is actually **deployed and current**. Two deploy runs fired for the *same* commit (`47f1bf1`, the Stanica split) one second apart, and they raced on the VPS git checkout:

```
error: cannot lock ref 'refs/remotes/origin/main': is at 47f1bf1 but expected 1449c31
```

One run won the race and **deployed successfully** (19:43); the other lost the lock and went red. So your recipe changes are live — the failure was a duplicate run, not a missed deployment.

## The fix
The deploy workflow had **no `concurrency` guard**, so parallel runs could collide. Two changes:

1. **`concurrency: { group: deploy-hetzner, cancel-in-progress: false }`** — deploys now queue instead of running in parallel. No more race.
2. **Lock-free git reset on the VPS** — clear any stale ref lock and `reset --hard FETCH_HEAD` instead of `origin/main`, so the reset can't fail on the remote-tracking ref even if something else touches it.

Merging this triggers one clean (now-serialised) deploy.

https://claude.ai/code/session_01GJPbS61ARuuC5Fcp6n2GMJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJPbS61ARuuC5Fcp6n2GMJ)_