### PR TITLE
fix: rewrite save/scan error copy to follow PACE

### DIFF
--- a/src/components/flow/LightStepScan.tsx
+++ b/src/components/flow/LightStepScan.tsx
@@ -191,7 +191,7 @@ export default function LightStepScan() {
       }
     } catch (err) {
       console.error(err);
-      setScanError("Could not analyze the photo. Please try again or enter details manually.");
+      setScanError("Couldn't read this photo. Try again or enter the details manually.");
     } finally {
       setIsAnalyzing(false);
     }
@@ -311,7 +311,7 @@ export default function LightStepScan() {
       });
       const data = await res.json();
       if (!res.ok) {
-        setUrlError(data.error || "Could not extract details from that page.");
+        setUrlError(data.error || "Couldn't pull details from that page. Try a different URL or enter the details manually.");
         return;
       }
       const { extracted, clarifications, roasterPrior } = data as {

--- a/src/components/flow/LightStepSummary.tsx
+++ b/src/components/flow/LightStepSummary.tsx
@@ -92,7 +92,7 @@ export default function LightStepSummary() {
         finishSaved(true);
       } catch (err) {
         console.error("Offline queue error:", err);
-        setSaveError("Couldn't save offline — please try again");
+        setSaveError("Couldn't queue this brew on your phone. Try again.");
       } finally {
         setSaving(false);
       }
@@ -118,7 +118,7 @@ export default function LightStepSummary() {
         const detailMsg = firstField
           ? `${firstField[0]}: ${firstField[1][0]}`
           : errBody.details?.formErrors?.[0];
-        const baseMsg = errBody.error || `Save failed (${res.status})`;
+        const baseMsg = errBody.error || "Couldn't save this brew. Try again in a moment.";
         setSaveError(detailMsg ? `${baseMsg} — ${detailMsg}` : baseMsg);
       }
     } catch (err) {
@@ -130,7 +130,7 @@ export default function LightStepSummary() {
         finishSaved(true);
       } catch (queueErr) {
         console.error("Offline queue error:", queueErr);
-        setSaveError("Failed to save — please try again");
+        setSaveError("Couldn't save this brew. Try again — your notes are still here.");
       }
     } finally {
       setSaving(false);

--- a/src/components/ui/PhotoUpload.tsx
+++ b/src/components/ui/PhotoUpload.tsx
@@ -78,7 +78,7 @@ export default function PhotoUpload({ onFile, preview, loading, className }: Pho
             <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="3" />
             <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
           </svg>
-          <span className="text-brew-muted text-sm">Analysing bag…</span>
+          <span className="text-brew-muted text-sm">Analyzing bag…</span>
         </div>
       ) : (
         /* Empty state — two tap targets */


### PR DESCRIPTION
## Summary

Audit of BTTS user-facing copy against Apple's PACE framework (Purpose / Anticipation / Context / Empathy) surfaced one pocket of writing that violated it: save-failure messages in `LightStepSummary.tsx` leaked HTTP status codes to the user and apologized with "please try again", and two `LightStepScan.tsx` errors used "Please try again" boilerplate. Three thin fixes here:

- **`LightStepSummary.tsx`** — strip `(${res.status})` from the server-rejected branch; drop "please" from the two queue-failed fallbacks; reframe the network-throw + queue-failed case as "your notes are still here" rather than an open-ended apology.
- **`LightStepScan.tsx`** — drop "Please" from photo and URL extraction errors; tighten to imperative form.
- **`PhotoUpload.tsx`** — `"Analysing bag…"` → `"Analyzing bag…"` to match the American spelling used elsewhere in the codebase (`analyze`, `isAnalyzing`, etc.).

No behaviour change — same branches still fire, same flow store still backs the data. The offline-success state already reads correctly (`"Saved offline — will sync when you're back online"`) and is untouched.

PACE pillars touched: **Context** (no HTTP jargon, verb-the-action), **Empathy** (no apology, no "please"), **Anticipation** (network-throw fallback now reassures the draft is preserved). Not touched (deliberately out of scope): a11y findings on FlavorWheel segments, form input labels, `aria-live` on `ConnectionStatus`, the native `window.confirm()` in past-conversations.

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Manual on the deployed PWA: airplane mode on → finish a brew → tap Save → confirm the success state still fires (queue accepts), no error pill
- [ ] DevTools → block `POST /api/sessions` while online → confirm error copy reads as imperative, no HTTP code visible
- [ ] Scan an unreadable bag photo → confirm L194 copy
- [ ] Paste a junk URL on the URL-extract path → confirm L314 copy
- [ ] Trigger any bag-photo analyze → confirm spinner says "Analyzing bag…"

https://claude.ai/code/session_019guPUAKPQVkVy1mDVm18Ji

---
_Generated by [Claude Code](https://claude.ai/code/session_019guPUAKPQVkVy1mDVm18Ji)_