### PR TITLE
docs: log Acaia Lunar + Pearl in the kit profile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -663,6 +663,7 @@ Cause for sub-rules 5–8: a follow-up audit of all 19 named-expert recipe entri
 | **Kettle** | Fellow Stagg EKG — gooseneck, precise temp control, 60-min hold |
 | **Grinder** | Niche Zero — uses **degree (°) settings**, continuous (no clicks) |
 | Travel grinder | Comandante C40 MK2 — uses **clicks**, not degrees |
+| **Scale** | Acaia Lunar (2017) + Acaia Pearl (älter, exaktes Jahr nicht bestätigt) — 0.1 g precision. |
 | **Water** | BWT Bestmax Premium V (bypass 0): ~370 ppm hard local tap → **~220 ppm** filtered (GH 5–6 / KH 4 °dH), daily driver for naturals/honeys · **clarity blend** 1:2 filtered+distilled = **~73 ppm** (KH ~1.3 °dH) for washed florals & championship methods (Kasuya/Wölfl) |
 
 ### Hard rule: single-user PROJECT, not a product — no onboarding


### PR DESCRIPTION
## Summary
- Adds a `Scale` row to the User / Equipment Profile table in `CLAUDE.md`: Acaia Lunar (2017) + Acaia Pearl (older, exact year unconfirmed) — 0.1 g precision.
- Background: Mistral floated a Web Bluetooth integration of the Acaias into the PWA. Not feasible (iOS Safari doesn't support Web Bluetooth, and all iOS browsers run under WebKit). Per owner's call, only the equipment gets logged — no integration write-up in the doc.
- Pure documentation change. No code, no prompts, no DB.

## Test plan
- [ ] `CLAUDE.md:657-668` reads cleanly with the new `Scale` row sitting between `Travel grinder` and `Water`, same pipe formatting as the surrounding rows.
- [ ] Nothing else in `CLAUDE.md` changed.

https://claude.ai/code/session_01VyeqrYKCSHVMEnVB9cYXBQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyeqrYKCSHVMEnVB9cYXBQ)_