### PR TITLE
feat: lock-screen notifications at brew-step boundaries (iOS shell Phase 1)

### DIFF
--- a/docs/ios-shell-roadmap.md
+++ b/docs/ios-shell-roadmap.md
@@ -27,10 +27,10 @@ This file is the source of truth for the iOS shell project across sessions. The 
 
 *Updated at the end of every advancing session. A fresh session reads this immediately after Context + Multi-session model.*
 
-- **Current phase:** pre-Phase-1. Roadmap doc + CLAUDE.md reference shipped (PR TBD). No code touched in `src/`, `native/`, or `.github/workflows/ios-*` yet.
-- **Blocked on owner?** No.
-- **Apple Developer enrollment status:** not started — the €99 enrollment from the Owner Checklist is the gate for Phases 3–4. Phase 1 (web-side notification bridge) and Phase 2 (`native/` scaffold) ship without it.
-- **Next entry-point:** create `src/lib/native/brewNotifications.ts` per the Phase 1 spec below.
+- **Current phase:** Phase 1 SHIPPED — web-side notification bridge (`src/lib/native/brewNotifications.ts` + `src/hooks/useBrewStepNotifications.ts` + LightStepBrew wiring + boundary tests). Runtime no-op until the shell exists.
+- **Blocked on owner?** No (Apple approval pending runs in parallel).
+- **Apple Developer enrollment status:** submitted 2026-06-10 with the private Apple ID, purchase processing — Apple says up to 48 h. Gates Phases 3–4 only. The 4 GitHub secrets + App ID + ASC app entry (checklist items 2–5) still pending behind it.
+- **Next entry-point:** Phase 2 — create the `native/` scaffold (`package.json`, `capacitor.config.ts`, `www/index.html`, `exportOptions.plist`, assets, README) + add `"native"` to root `tsconfig.json` `exclude`.
 
 ## Architecture (decided, research-verified)
 
@@ -196,4 +196,12 @@ G1 (Acaia — biggest daily payoff, smallest cost, independent track) → G2 (wi
 - **Open / blocked:** Apple Developer enrollment not started (blocks Phases 3–4 only — Phase 1 + 2 are pure code).
 - **Traps found:** —
 - **Next entry-point:** create `src/lib/native/brewNotifications.ts` per the Phase 1 spec (pure-web module, zero `@capacitor/*` deps, ambient types).
-- **PRs / commits this session:** #286, Apple-ID follow-up PR
+- **PRs / commits this session:** #286, #287, #288
+
+### 2026-06-10 — Phase 1 (web-side notification bridge)
+
+- **Done:** `src/lib/native/brewNotifications.ts` (pure-web bridge module — ambient `window.Capacitor` types, zero `@capacitor/*` deps; `buildBrewBoundaries` skips bloom/setup/t=0 steps, appends a "brew finishing" boundary at target when ≥5 s after the last step; `ensurePermission` caches denial; `scheduleBrew` is cancel-then-schedule on a fixed id range 9300–9339 with a 2 s minimum lead; `cancelBrew` sweeps the full range so a mid-brew reload can't orphan notifications). `src/hooks/useBrewStepNotifications.ts` (schedule at first tick on the timer's own wall-clock anchor; reschedule on >1.5 s anchor drift = Stop→Resume; cancel on Reset/Done/unmount and via the visible-but-paused watchdog — backgrounding does NOT cancel, `visibilityState` distinguishes). `LightStepBrew.tsx` wired additively (boundaries + hook + cancel before `handleDone` on Done Brewing). Tests: `tests/dataflow/brew-notifications.test.mjs` bundles the real TS (esbuild, recipe-fidelity pattern) and locks the notification schedule to the on-screen step schedule. Owner side: Apple Developer enrollment submitted (private Apple ID, browser path), purchase processing per Apple up to 48 h.
+- **Open / blocked:** checklist items 2–5 (API key, secrets, App ID, ASC app) wait on Apple's approval; Phases 3–4 gated behind them. Phase 2 is pure code, ready now.
+- **Traps found:** —
+- **Next entry-point:** Phase 2 — `native/` scaffold + `tsconfig.json` exclude (foldable into the Phase 3 session if preferred).
+- **PRs / commits this session:** Phase 1 PR (number assigned on open)

--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -16,6 +16,8 @@ import {
 } from "@/lib/utils/pourSequence";
 import type { BrewStepAction } from "@/lib/types/session";
 import { basedOnReference } from "@/lib/utils/resolveRecipe";
+import { useBrewStepNotifications } from "@/hooks/useBrewStepNotifications";
+import { buildBrewBoundaries } from "@/lib/native/brewNotifications";
 
 /**
  * Light System fork of /components/flow/StepBrew.tsx.
@@ -131,8 +133,25 @@ export default function LightStepBrew() {
   // legacy path for older recommendations.
   const proseSequence = !guideSteps && !steps && recipe?.pourSequence ? recipe.pourSequence : null;
 
+  // iOS shell: schedule a lock-screen notification at every step boundary so
+  // cues survive a locked phone. Silent no-op in browsers — the Web Audio cue
+  // + vibration below remain the foreground path (no double cue: the shell
+  // suppresses foreground banners via presentationOptions: []).
+  const boundaries = buildBrewBoundaries(steps, guideSteps, recipe?.targetTimeSec);
+  const { cancelAll: cancelStepNotifications } = useBrewStepNotifications(
+    boundaries,
+    elapsed,
+    started,
+  );
+
   return (
-    <LightFlowShell onNext={() => handleDone()} nextLabel="Done Brewing">
+    <LightFlowShell
+      onNext={() => {
+        cancelStepNotifications();
+        handleDone();
+      }}
+      nextLabel="Done Brewing"
+    >
       <div className="flex flex-col gap-5">
         {recipe && (
           <div className="rounded-3xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 p-4">

--- a/src/hooks/useBrewStepNotifications.ts
+++ b/src/hooks/useBrewStepNotifications.ts
@@ -1,0 +1,100 @@
+"use client";
+import { useEffect, useRef, useCallback } from "react";
+import {
+  type BrewBoundary,
+  ensurePermission,
+  scheduleBrew,
+  cancelBrew,
+  isNativeShell,
+} from "@/lib/native/brewNotifications";
+
+/**
+ * Glue between the brew timer and the native notification bridge (iOS shell
+ * Phase 1 — see docs/ios-shell-roadmap.md). Pure no-op in browsers.
+ *
+ * Lifecycle, all driven by the timer's existing signals — no new events:
+ *  - SCHEDULE at the first tick (`started && elapsed ≥ 1`, the same moment the
+ *    wake lock engages). Anchor = Date.now() − elapsed·1000, i.e. the same
+ *    wall-clock brew start the timer itself runs on.
+ *  - RESCHEDULE when the anchor drifts > 1.5 s (Stop → Resume shifts the
+ *    timer's start timestamp by the pause length).
+ *  - CANCEL on Reset (CircularTimer emits onTick(0)), on Done (the component
+ *    calls `cancelAll()`), on unmount (navigating away mid-brew), and when the
+ *    watchdog sees *visible-but-paused* — ticks stall on both Stop and
+ *    backgrounding, but only Stop leaves `visibilityState === "visible"`.
+ *    Backgrounding must NOT cancel: surviving it is the whole point.
+ */
+export function useBrewStepNotifications(
+  boundaries: BrewBoundary[],
+  elapsed: number,
+  started: boolean,
+): { cancelAll: () => void } {
+  const scheduledRef = useRef(false);
+  const anchorRef = useRef(0);
+  const prevElapsedRef = useRef(-1);
+  const lastTickAtRef = useRef(0);
+  const boundariesRef = useRef(boundaries);
+  useEffect(() => {
+    boundariesRef.current = boundaries;
+  }, [boundaries]);
+
+  const cancelAll = useCallback(() => {
+    if (scheduledRef.current) {
+      scheduledRef.current = false;
+      void cancelBrew();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isNativeShell()) return;
+
+    // Track genuine ticks only (renders can fire without an elapsed change).
+    if (elapsed !== prevElapsedRef.current) {
+      prevElapsedRef.current = elapsed;
+      lastTickAtRef.current = Date.now();
+    }
+
+    if (started && elapsed >= 1) {
+      const anchor = Date.now() - elapsed * 1000;
+      if (!scheduledRef.current) {
+        scheduledRef.current = true;
+        anchorRef.current = anchor;
+        void ensurePermission().then(async (ok) => {
+          if (!ok) {
+            scheduledRef.current = false;
+            return;
+          }
+          await scheduleBrew(boundariesRef.current, anchorRef.current);
+          // Reset/Done may have raced the permission round-trip.
+          if (!scheduledRef.current) void cancelBrew();
+        });
+      } else if (Math.abs(anchor - anchorRef.current) > 1500) {
+        anchorRef.current = anchor;
+        void scheduleBrew(boundariesRef.current, anchor);
+      }
+    }
+
+    if (scheduledRef.current && elapsed === 0) {
+      cancelAll(); // Reset pressed
+    }
+  }, [elapsed, started, boundaries, cancelAll]);
+
+  // Visible-but-paused watchdog (1 s cadence; ticks land ~1/s while running).
+  useEffect(() => {
+    if (!isNativeShell()) return;
+    const id = setInterval(() => {
+      if (
+        scheduledRef.current &&
+        document.visibilityState === "visible" &&
+        Date.now() - lastTickAtRef.current > 2500
+      ) {
+        cancelAll(); // Stop pressed — ticks stalled while the page stayed visible
+      }
+    }, 1000);
+    return () => clearInterval(id);
+  }, [cancelAll]);
+
+  useEffect(() => () => cancelAll(), [cancelAll]);
+
+  return { cancelAll };
+}

--- a/src/lib/native/brewNotifications.ts
+++ b/src/lib/native/brewNotifications.ts
@@ -1,0 +1,218 @@
+/**
+ * Brew-step lock-screen notifications — the web side of the iOS shell bridge.
+ *
+ * Pure-web module with ZERO npm dependencies on `@capacitor/*`. When BTTS runs
+ * inside the Capacitor shell (TestFlight build, see docs/ios-shell-roadmap.md),
+ * the native bridge injects `window.Capacitor` with a `LocalNotifications`
+ * plugin proxy; this module schedules an iOS local notification at every
+ * pour/step boundary so the cues survive a locked phone — closing the
+ * documented "Step alerts during background are missed" gap. In any normal
+ * browser (Safari PWA, desktop, CI Chromium) every export is a silent no-op
+ * and the existing Web Audio cue + vibration remain the only cues.
+ *
+ * Design (Phase 1 of the roadmap):
+ *  - The full step schedule is known at brew start (`PourStep[]`/`GuideStep[]`
+ *    carry `startTimeSec`), so everything is scheduled ONCE, anchored to the
+ *    timer's wall-clock start. No background JS needed — iOS fires on time.
+ *  - The shell's LocalNotifications config uses `presentationOptions: []`, so
+ *    a foregrounded app swallows the banners (Web Audio covers foreground);
+ *    locked/backgrounded shows the banner. No double cue.
+ *  - A bridge failure must never break the brew timer: every native call is
+ *    try/caught and failure degrades to exactly today's behavior.
+ *  - Prose-only legacy sequences produce no notifications (documented
+ *    limitation — they carry no machine-readable boundaries).
+ */
+
+import type { PourStep, GuideStep } from "@/lib/utils/pourSequence";
+
+// ── Ambient bridge types (no @capacitor/* imports — strict-TS clean) ────────
+
+interface LocalNotificationLike {
+  id: number;
+  title: string;
+  body: string;
+  schedule: { at: Date };
+}
+
+interface LocalNotificationsLike {
+  checkPermissions(): Promise<{ display: string }>;
+  requestPermissions(): Promise<{ display: string }>;
+  schedule(options: { notifications: LocalNotificationLike[] }): Promise<unknown>;
+  cancel(options: { notifications: Array<{ id: number }> }): Promise<unknown>;
+}
+
+interface CapacitorLike {
+  isNativePlatform?: () => boolean;
+  Plugins?: { LocalNotifications?: LocalNotificationsLike };
+}
+
+declare global {
+  interface Window {
+    Capacitor?: CapacitorLike;
+  }
+}
+
+// ── Boundary model ───────────────────────────────────────────────────────────
+
+/** One notification-worthy moment in a brew, relative to brew start. */
+export interface BrewBoundary {
+  /** Seconds since brew start. */
+  atSec: number;
+  title: string;
+  body: string;
+}
+
+/** Fixed notification id range — cancel always sweeps the whole range so a
+ * mid-brew reload can't leave orphans from the previous page load. iOS caps
+ * pending local notifications at 64; no brew has anywhere near 40 steps. */
+const ID_BASE = 9300;
+const ID_RANGE = 40;
+
+/** Skip boundaries closer than this to "now" when scheduling — the user is
+ * looking at the screen and the foreground cue already covers them. */
+const MIN_LEAD_MS = 2000;
+
+function formatClock(sec: number): string {
+  return `${Math.floor(sec / 60)}:${String(sec % 60).padStart(2, "0")}`;
+}
+
+/**
+ * Derive the notification schedule from a brew's parsed steps. Pure — safe to
+ * call on every render. Skips the bloom (t=0, the user just pressed Start and
+ * is watching) and setup steps, and appends a final "brew finishing" boundary
+ * at `targetTimeSec` when it lands meaningfully after the last step.
+ */
+export function buildBrewBoundaries(
+  steps: PourStep[] | null,
+  guideSteps: GuideStep[] | null,
+  targetTimeSec?: number,
+): BrewBoundary[] {
+  const out: BrewBoundary[] = [];
+
+  if (steps && steps.length > 0) {
+    // Percolation (V60/Orea/Kalita/Chemex) — cumulative-grams pours.
+    for (const s of steps) {
+      if (s.startTimeSec <= 0) continue;
+      const parts = [`→ ${s.cumulativeGrams}g total`];
+      if (s.temperatureC != null) parts.push(`${s.temperatureC}°C`);
+      out.push({
+        atSec: s.startTimeSec,
+        title: `${s.label} — +${s.pourGrams}g`,
+        body: parts.join(" · "),
+      });
+    }
+    if (targetTimeSec != null && targetTimeSec - (out[out.length - 1]?.atSec ?? 0) >= 5) {
+      out.push({
+        atSec: targetTimeSec,
+        title: "Drawdown — brew finishing",
+        body: `Target ${formatClock(targetTimeSec)} reached.`,
+      });
+    }
+    return out;
+  }
+
+  if (guideSteps && guideSteps.length > 0) {
+    // Immersion / AeroPress / iced — action steps (steep end, flip, press…).
+    for (const s of guideSteps) {
+      if (s.isSetup || s.startTimeSec <= 0) continue;
+      const parts: string[] = [];
+      if (s.cumulativeGrams != null) parts.push(`→ ${s.cumulativeGrams}g`);
+      if (s.temperatureC != null) parts.push(`${s.temperatureC}°C`);
+      if (s.notes) parts.push(s.notes);
+      out.push({
+        atSec: s.startTimeSec,
+        title: s.label,
+        body: parts.join(" · "),
+      });
+    }
+    if (targetTimeSec != null && targetTimeSec - (out[out.length - 1]?.atSec ?? 0) >= 5) {
+      out.push({
+        atSec: targetTimeSec,
+        title: "Brew finishing",
+        body: `Target ${formatClock(targetTimeSec)} reached.`,
+      });
+    }
+    return out;
+  }
+
+  return out; // prose-only legacy sequence — no machine-readable boundaries
+}
+
+// ── Native bridge access ─────────────────────────────────────────────────────
+
+function getPlugin(): LocalNotificationsLike | null {
+  try {
+    if (typeof window === "undefined") return null;
+    const cap = window.Capacitor;
+    if (!cap?.isNativePlatform?.()) return null;
+    return cap.Plugins?.LocalNotifications ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** True only inside the Capacitor shell with the plugin present. */
+export function isNativeShell(): boolean {
+  return getPlugin() !== null;
+}
+
+/** iOS never re-prompts after a denial — cache it so a denied user doesn't pay
+ * a failed permission round-trip on every brew. */
+let permissionDenied = false;
+
+/**
+ * Resolve notification permission, prompting at most once (in-foreground,
+ * right after Start Brew — the moment the user's intent is clearest).
+ */
+export async function ensurePermission(): Promise<boolean> {
+  const plugin = getPlugin();
+  if (!plugin || permissionDenied) return false;
+  try {
+    const status = await plugin.checkPermissions();
+    if (status.display === "granted") return true;
+    if (status.display === "denied") {
+      permissionDenied = true;
+      return false;
+    }
+    const req = await plugin.requestPermissions();
+    if (req.display === "granted") return true;
+    permissionDenied = true;
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Cancel-then-schedule the full brew. `anchorMs` is the wall-clock timestamp
+ * of brew start (Date.now() − elapsed·1000 — same anchor the timer runs on).
+ * Boundaries already past or within MIN_LEAD_MS are skipped.
+ */
+export async function scheduleBrew(boundaries: BrewBoundary[], anchorMs: number): Promise<void> {
+  const plugin = getPlugin();
+  if (!plugin) return;
+  try {
+    await cancelBrew();
+    const now = Date.now();
+    const notifications = boundaries.slice(0, ID_RANGE).flatMap((b, i) => {
+      const at = new Date(anchorMs + b.atSec * 1000);
+      if (at.getTime() - now < MIN_LEAD_MS) return [];
+      return [{ id: ID_BASE + i, title: b.title, body: b.body, schedule: { at } }];
+    });
+    if (notifications.length > 0) await plugin.schedule({ notifications });
+  } catch {
+    /* bridge failure — brew continues with foreground cues only */
+  }
+}
+
+/** Cancel every brew notification (full fixed id range). */
+export async function cancelBrew(): Promise<void> {
+  const plugin = getPlugin();
+  if (!plugin) return;
+  try {
+    const ids = Array.from({ length: ID_RANGE }, (_, i) => ({ id: ID_BASE + i }));
+    await plugin.cancel({ notifications: ids });
+  } catch {
+    /* bridge failure — nothing actionable */
+  }
+}

--- a/tests/dataflow/brew-notifications.test.mjs
+++ b/tests/dataflow/brew-notifications.test.mjs
@@ -1,0 +1,136 @@
+// Brew-notification boundary tests (iOS shell Phase 1). Bundles the REAL
+// brewNotifications.ts + pourSequence.ts with esbuild so the asserted schedule
+// is the one the app actually computes — not a re-declared copy.
+//
+//   node --test tests/dataflow/brew-notifications.test.mjs
+//
+// What's locked down: the lock-screen notification schedule must mirror the
+// on-screen step schedule exactly — same startTimeSec per pour, bloom and
+// setup steps skipped (the user just pressed Start and is watching), a final
+// "brew finishing" boundary at targetTimeSec, and prose-only legacy recipes
+// producing NO notifications. A drifting boundary would buzz the phone at the
+// wrong moment of a live brew — worse than no notification at all.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const entry = `
+export { buildBrewBoundaries } from ${JSON.stringify(
+  path.join(ROOT, "src/lib/native/brewNotifications.ts"),
+)};
+export { parsePourSteps, buildGuideSteps } from ${JSON.stringify(
+  path.join(ROOT, "src/lib/utils/pourSequence.ts"),
+)};
+`;
+const dir = await mkdtemp(join(tmpdir(), "brewnotif-"));
+const out = join(dir, "b.mjs");
+await build({
+  stdin: { contents: entry, resolveDir: ROOT, loader: "ts" },
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  outfile: out,
+  logLevel: "silent",
+});
+const { buildBrewBoundaries, parsePourSteps, buildGuideSteps } = await import(
+  pathToFileURL(out).href
+);
+
+// ── Percolation (V60 grams string → PourStep[]) ─────────────────────────────
+
+test("percolation: one boundary per non-bloom pour, times mirror the step schedule", () => {
+  // 4 milestones at 210s target, no roastDate → bloom 45s, reserve 69s.
+  const steps = parsePourSteps("50 – 120 – 180 – 250", 210);
+  assert.ok(steps && steps.length === 4);
+
+  const boundaries = buildBrewBoundaries(steps, null, 210);
+  // Bloom (t=0) skipped → 3 pour boundaries + 1 drawdown boundary.
+  assert.equal(boundaries.length, 4);
+
+  // Times must be EXACTLY the steps' startTimeSec — same schedule the screen shows.
+  assert.deepEqual(
+    boundaries.slice(0, 3).map((b) => b.atSec),
+    steps.slice(1).map((s) => s.startTimeSec),
+  );
+
+  // Title carries the pour delta, body the running total.
+  assert.equal(boundaries[0].title, "Pour 2 — +70g");
+  assert.equal(boundaries[0].body, "→ 120g total");
+  assert.equal(boundaries[2].title, "Final pour — +70g");
+
+  // Final boundary lands at target.
+  assert.equal(boundaries[3].atSec, 210);
+  assert.equal(boundaries[3].title, "Drawdown — brew finishing");
+  assert.match(boundaries[3].body, /3:30/);
+});
+
+test("percolation: per-pour temperature annotation lands in the body", () => {
+  const steps = parsePourSteps("70 (@70°C) – 220 – 370", 240);
+  assert.ok(steps);
+  const boundaries = buildBrewBoundaries(steps, null, 240);
+  // Bloom carries the 70°C but is skipped; later pours have no temp → plain body.
+  assert.equal(boundaries[0].body, "→ 220g total");
+});
+
+// ── Immersion / AeroPress (structured steps → GuideStep[]) ──────────────────
+
+test("immersion: setup and t=0 steps skipped, hand-actions get boundaries", () => {
+  const recipe = {
+    targetTimeSec: 180,
+    pourSteps: [
+      { label: "Invert the AeroPress", action: "invert" },
+      { label: "Pour to 200g", action: "pour", durationSec: 30, waterGramsAtEnd: 200 },
+      { label: "Steep", action: "wait", durationSec: 90 },
+      { label: "Flip onto cup", action: "flip", durationSec: 5 },
+      { label: "Press slowly", action: "press", durationSec: 25 },
+    ],
+  };
+  const guide = buildGuideSteps(recipe);
+  assert.ok(guide);
+
+  const boundaries = buildBrewBoundaries(null, guide, 180);
+  // Invert (setup) + first pour (t=0) skipped → Steep@30, Flip@120, Press@125,
+  // + finishing boundary at 180 (≥5s after the last step boundary).
+  assert.deepEqual(
+    boundaries.map((b) => [b.atSec, b.title]),
+    [
+      [30, "Steep"],
+      [120, "Flip onto cup"],
+      [125, "Press slowly"],
+      [180, "Brew finishing"],
+    ],
+  );
+  assert.equal(boundaries[0].body, ""); // no grams/temp/notes on the steep step
+});
+
+test("immersion: no finishing boundary when the last step already lands at target", () => {
+  const recipe = {
+    targetTimeSec: 150,
+    pourSteps: [
+      { label: "Pour to 250g", action: "pour", durationSec: 30, waterGramsAtEnd: 250 },
+      { label: "Steep", action: "wait", durationSec: 117 },
+      { label: "Press", action: "press", durationSec: 3 },
+    ],
+  };
+  const guide = buildGuideSteps(recipe);
+  const boundaries = buildBrewBoundaries(null, guide, 150);
+  // Press starts at 147 — within 5s of target, so no extra finishing boundary.
+  assert.deepEqual(
+    boundaries.map((b) => b.atSec),
+    [30, 147],
+  );
+});
+
+// ── Legacy prose + empty inputs ──────────────────────────────────────────────
+
+test("prose-only legacy recipe produces no notifications", () => {
+  assert.deepEqual(buildBrewBoundaries(null, null, 240), []);
+  assert.deepEqual(buildBrewBoundaries([], [], 240), []);
+});


### PR DESCRIPTION
## Summary

**iOS shell Phase 1** (docs/ios-shell-roadmap.md) — the web side of the notification bridge. In any browser this is a **silent runtime no-op**: the Web Audio cue + vibration remain the only step cues, and the brew flow renders unchanged. Inside the future Capacitor TestFlight shell, every pour/step boundary gets an iOS local notification scheduled once at brew start, so step cues survive a locked phone — closing the documented "Step alerts during background are missed" permanent gap.

### What's in it

- **`src/lib/native/brewNotifications.ts`** — pure-web module, zero `@capacitor/*` npm deps (ambient `window.Capacitor` types, strict-TS clean). `buildBrewBoundaries(steps, guideSteps, targetTimeSec)` mirrors the on-screen step schedule exactly: bloom/setup/t=0 steps skipped (user just pressed Start and is watching), per-pour titles like "Pour 2 — +70g" with "→ 120g total · 92°C" bodies, guide actions (steep/flip/press) included, and a final "brew finishing" boundary at target when it lands ≥5 s after the last step. Prose-only legacy recipes produce no notifications (documented limitation). `ensurePermission()` caches denial; `scheduleBrew()` cancel-then-schedules a fixed id range (9300–9339, far under the iOS 64-pending cap) with a 2 s minimum lead; `cancelBrew()` sweeps the whole range so a mid-brew reload can't orphan notifications. Every native call is try/caught — a bridge failure degrades to exactly today's behavior.
- **`src/hooks/useBrewStepNotifications.ts`** — all-refs glue. Schedules at the first tick (`started && elapsed ≥ 1`, the same moment the wake lock engages), anchored to the timer's own wall-clock anchor (`Date.now() − elapsed·1000`). Reschedules when the anchor drifts >1.5 s (Stop→Resume). Cancels on Reset (`onTick(0)`), on Done, on unmount, and via a 1 s **visible-but-paused watchdog** — ticks stall on both Stop and backgrounding, but only Stop leaves `visibilityState === "visible"`. Backgrounding does NOT cancel; surviving it is the whole point.
- **`LightStepBrew.tsx`** — additive wiring only (~15 lines): boundary derivation, hook call, cancel before `handleDone` on Done Brewing. No existing effects, step transitions, or timer logic touched.
- **`tests/dataflow/brew-notifications.test.mjs`** — bundles the real TS via esbuild (recipe-fidelity test pattern) and locks the notification schedule to the on-screen step schedule: percolation times must equal `PourStep.startTimeSec`, setup/t=0 skipping, finishing-boundary threshold, prose → empty.
- **Roadmap doc** — session-log entry + status updated in the same commit (Phase 1 shipped; Apple enrollment submitted, purchase processing; next entry-point Phase 2 `native/` scaffold).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] New suite: 5/5 green (`tests/dataflow/brew-notifications.test.mjs`)
- [x] Full suite green: 34 (src) + 24 (tests)
- [ ] CI `check` + `screenshots` green — screenshots artifact should show the brew flow rendering identically (bridge is a no-op in Chromium)
- [ ] After merge: a real brew on the live PWA behaves identically (no shell yet — pure no-op verification)

https://claude.ai/code/session_015jynUUMkjZYNUhw634Gsph

---
_Generated by [Claude Code](https://claude.ai/code/session_015jynUUMkjZYNUhw634Gsph)_