### PR TITLE
fix: stop the welcome-haiku re-wrapping after its entrance

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -461,27 +461,6 @@
   to   { opacity: 0; filter: blur(10px); transform: scale(1.02); }
 }
 
-/* Home haiku — restrained warm sheen across the settled line (kill-switch in
-   HaikuStarter). The band is warm anthracite, NOT white/neon, so the type
-   stays legible and on-brand. */
-@keyframes haiku-sheen {
-  from { background-position: 120% 0; }
-  to   { background-position: -20% 0; }
-}
-.haiku-sheen {
-  background-image: linear-gradient(
-    100deg,
-    hsl(0 0% 14%) 0%, hsl(0 0% 14%) 42%,
-    hsl(28 30% 34%) 50%,
-    hsl(0 0% 14%) 58%, hsl(0 0% 14%) 100%
-  );
-  background-size: 220% 100%;
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-  animation: haiku-sheen 9s linear infinite;
-}
-
 /* Respect Reduce Motion: blobs rest in place, the haiku appears statically. */
 @media (prefers-reduced-motion: reduce) {
   [data-field-blob] { animation: none !important; }
@@ -493,11 +472,4 @@
     transform: none !important;
   }
   .haiku-exit { animation: none !important; }
-  .haiku-sheen {
-    animation: none !important;
-    background-image: none;
-    -webkit-background-clip: border-box;
-    background-clip: border-box;
-    color: hsl(0 0% 14%);
-  }
 }

--- a/src/components/ui/light/HaikuStarter.tsx
+++ b/src/components/ui/light/HaikuStarter.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { usePresence } from "@/hooks/usePresence";
 
 const EXIT_MS = 280;
 const WORD_STAGGER_MS = 70;
 const SETTLE_MS = 600;
-// Kill-switch for the warm liquid sheen that sweeps the settled haiku. The
-// most taste-sensitive piece — flip to false to ship entrance + dissolve only.
-const SHEEN = true;
 
 const P_CLASS =
   "font-fraunces text-[40px] font-semibold leading-[1.05] tracking-[-0.01em] text-light-foreground";
@@ -27,11 +24,18 @@ function HaikuSkeleton() {
 }
 
 /**
- * Home welcome-haiku with a full liquid lifecycle (fluidity pass §E):
- * shimmer while it loads → a per-word blur-into-focus entrance → an optional
- * warm sheen once settled → a soft dissolve (not a hard cut) when the user
- * starts typing. usePresence keeps the node mounted through the exit so the
- * dissolve can play. All motion gated by prefers-reduced-motion in globals.css.
+ * Home welcome-haiku with a liquid lifecycle (fluidity pass §E): shimmer while
+ * it loads → a per-word blur-into-focus entrance → a soft dissolve (not a hard
+ * cut) when the user starts composing. usePresence keeps the node mounted
+ * through the exit so the dissolve can play. Motion gated by
+ * prefers-reduced-motion in globals.css.
+ *
+ * The words render as inline-block spans for the WHOLE life of the haiku —
+ * entrance AND settled — never swapping to a single text node. That swap used
+ * to re-wrap the line the instant the entrance finished: it let "stone-fruit"
+ * break at the hyphen and yanked the whole poem up a line (the jump Markus
+ * caught). One structure → the line is laid out once and never reflows, and a
+ * whole word (inline-block) can't break internally.
  *
  * Rendered as an absolute, pointer-events-none overlay so it can dissolve over
  * the ChatThread that mounts underneath when the user starts composing.
@@ -40,38 +44,24 @@ export default function HaikuStarter({ text, show }: { text: string; show: boole
   const { mounted, state } = usePresence(show, EXIT_MS);
   const loading = text.trim() === "";
   const words = useMemo(() => text.split(/(\s+)/), [text]);
-  const settleDoneMs = words.length * WORD_STAGGER_MS + SETTLE_MS;
-
-  // Swap the staggered word-spans for a plain line once the entrance is done
-  // (identical text + position → seamless). The plain line is where the sheen
-  // lives; running it during the per-word entrance would fight the blur-in.
-  const [settled, setSettled] = useState(false);
-  useEffect(() => {
-    if (loading) {
-      setSettled(false);
-      return;
-    }
-    const t = setTimeout(() => setSettled(true), settleDoneMs);
-    return () => clearTimeout(t);
-  }, [loading, settleDoneMs]);
 
   if (!mounted) return null;
+
+  const exiting = state === "exit";
 
   return (
     <div className="pointer-events-none absolute inset-0 flex items-center px-5">
       {loading ? (
         <HaikuSkeleton />
-      ) : state === "exit" ? (
-        <p
-          className={`${P_CLASS} haiku-exit`}
-          style={{ animation: `haiku-dissolve ${EXIT_MS}ms ease-in forwards` }}
-        >
-          {text}
-        </p>
-      ) : settled ? (
-        <p className={SHEEN ? `${P_CLASS} haiku-sheen` : P_CLASS}>{text}</p>
       ) : (
-        <p className={P_CLASS}>
+        // The exit dissolve animates the whole <p>; the word spans inside hold
+        // their settled state and ride along — no structure change, no reflow.
+        <p
+          className={exiting ? `${P_CLASS} haiku-exit` : P_CLASS}
+          style={
+            exiting ? { animation: `haiku-dissolve ${EXIT_MS}ms ease-in forwards` } : undefined
+          }
+        >
           {words.map((w, i) =>
             w.trim() === "" ? (
               <span key={i}>{w}</span>


### PR DESCRIPTION
Follow-up to #291. The welcome-haiku had a visible **jump** the instant its per-word entrance finished.

## Cause
The entrance rendered each word as an `inline-block` span (so "stone-fruit" stayed whole on its own line), then **swapped to a single text node** once settled. The text node re-wraps differently — it **hyphenates "stone-fruit" → "stone-" / "fruit"** and packs tighter — so the whole poem jumped up a line at the swap.

## Fix
Keep the `inline-block` word-span structure for the haiku's **entire** life (entrance, settled, and during the exit dissolve). The line is laid out once and never reflows; a whole word can't break internally → no hyphen split, no jump.

This drops the whole-line sheen (it was the only reason for the text-node swap). The per-word entrance + the dissolve + the living Field still carry the "alive" feel; a jump-free sheen can come back later.

`tsc --noEmit` clean. Pure layout/CSS change — best eyeballed on-device (CI screenshots render the haiku in its loading skeleton without an API key).

https://claude.ai/code/session_017ntrLsAC9Xi6Ma2HEupAZD

---
_Generated by [Claude Code](https://claude.ai/code/session_017ntrLsAC9Xi6Ma2HEupAZD)_