### PR TITLE
fix: make the living-Field motion clearly visible

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -402,24 +402,24 @@
    layer is 0-size (a % translate would resolve against 0). */
 @keyframes blob-drift-1 {
   0%   { transform: translate3d(0, 0, 0) scale(1); }
-  33%  { transform: translate3d(3vmax, -2vmax, 0) scale(1.08); }
-  66%  { transform: translate3d(-2vmax, 3vmax, 0) scale(0.96); }
+  33%  { transform: translate3d(11vmax, -8vmax, 0) scale(1.12); }
+  66%  { transform: translate3d(-8vmax, 10vmax, 0) scale(0.9); }
   100% { transform: translate3d(0, 0, 0) scale(1); }
 }
 @keyframes blob-drift-2 {
   0%   { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
-  50%  { transform: translate3d(-3vmax, -1.5vmax, 0) rotate(8deg) scale(1.06); }
+  50%  { transform: translate3d(-12vmax, -7vmax, 0) rotate(10deg) scale(1.1); }
   100% { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
 }
 @keyframes blob-drift-3 {
   0%   { transform: translate3d(0, 0, 0) scale(1); }
-  40%  { transform: translate3d(1.5vmax, 3vmax, 0) scale(1.05); }
-  75%  { transform: translate3d(-1.5vmax, -2vmax, 0) scale(0.97); }
+  40%  { transform: translate3d(7vmax, 12vmax, 0) scale(1.08); }
+  75%  { transform: translate3d(-9vmax, -7vmax, 0) scale(0.92); }
   100% { transform: translate3d(0, 0, 0) scale(1); }
 }
 @keyframes blob-drift-4 {
   0%   { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
-  50%  { transform: translate3d(2.5vmax, 2vmax, 0) rotate(-6deg) scale(1.1); }
+  50%  { transform: translate3d(10vmax, 9vmax, 0) rotate(-8deg) scale(1.14); }
   100% { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
 }
 

--- a/src/components/ui/light/FieldBlobs.tsx
+++ b/src/components/ui/light/FieldBlobs.tsx
@@ -10,10 +10,10 @@ import type { FieldZones } from "@/lib/field/types";
 // live in globals.css and translate in vmax (the drift layer is 0-size, so a
 // % translate would resolve against 0).
 const DRIFT = [
-  { name: "blob-drift-1", dur: "23s", delay: "-8s" },
-  { name: "blob-drift-2", dur: "31s", delay: "-19s" },
-  { name: "blob-drift-3", dur: "29s", delay: "-3s" },
-  { name: "blob-drift-4", dur: "37s", delay: "-25s" },
+  { name: "blob-drift-1", dur: "16s", delay: "-6s" },
+  { name: "blob-drift-2", dur: "21s", delay: "-13s" },
+  { name: "blob-drift-3", dur: "18s", delay: "-3s" },
+  { name: "blob-drift-4", dur: "24s", delay: "-17s" },
 ];
 
 // Two of the four pick up scroll-momentum parallax (§D) for a sense of depth.
@@ -51,7 +51,7 @@ export default function FieldBlobs({ fieldZones }: { fieldZones: FieldZones }) {
             style={{
               left: `${b.cx}%`,
               top: `${b.cy}%`,
-              transform: `translate(var(--field-drift-x, 0px), ${y}) rotate(var(--field-tilt, 0deg)) scale(calc(1 + var(--field-pulse, 0) * 0.03))`,
+              transform: `translate(var(--field-drift-x, 0px), ${y}) rotate(var(--field-tilt, 0deg)) scale(calc(1 + var(--field-pulse, 0) * 0.05))`,
             }}
           >
             <div

--- a/src/components/ui/light/FieldGrain.tsx
+++ b/src/components/ui/light/FieldGrain.tsx
@@ -21,7 +21,7 @@ export default function FieldGrain() {
         backgroundImage: `url("data:image/svg+xml,${NOISE}")`,
         backgroundSize: "180px 180px",
         mixBlendMode: "soft-light",
-        opacity: 0.05,
+        opacity: 0.09,
       }}
     />
   );

--- a/src/hooks/useFieldMotion.ts
+++ b/src/hooks/useFieldMotion.ts
@@ -21,9 +21,9 @@ import { useEffect, useRef } from "react";
  * doesn't bubble its scroll and we don't want to touch it.
  */
 
-const MAX_DRIFT = 12; // px — pointer lean
-const MAX_TILT = 1.5; // deg
-const MAX_SCROLL = 20; // px — parallax travel cap
+const MAX_DRIFT = 18; // px — pointer lean
+const MAX_TILT = 2.5; // deg
+const MAX_SCROLL = 30; // px — parallax travel cap
 const GLIDE = 0.06; // pointer/tilt easing per frame (the "fluid" lag)
 const PULSE_GLIDE = 0.12; // tap-swell easing per frame
 const SCROLL_DECAY = 0.9; // scroll-momentum decay per frame

--- a/src/lib/field/composeGradient.ts
+++ b/src/lib/field/composeGradient.ts
@@ -19,14 +19,14 @@ import type { FieldModifiers, FieldZones, ZoneWeight } from "./types";
 // 10 lightness and the coloured hotspots capped low. "Warm but richer" eases
 // that back a notch so the (now drifting) colour reads, while the cream still
 // dominates at rest. These six numbers are the whole richness surface — safe
-// to nudge on-device. Guardrails: keep BASE_DIM ≥ 4 and BLOB_ALPHA ≤ 0.6 so
+// to nudge on-device. Guardrails: keep BASE_DIM ≥ 4 and BLOB_ALPHA ≤ 0.7 so
 // the cream never tips into a saturated wash.
 const BASE_DESAT = 8; // linear-base desaturation (was the hard-coded 15)
 const BASE_DIM = 6; // linear-base dimming (was the hard-coded 10)
 const RADIAL_ALPHA_BOOST = 0.12; // added to each hotspot's alpha …
 const RADIAL_ALPHA_CAP = 0.9; // … then clamped so no hotspot blows to a hard disc
-const BLOB_ALPHA = 0.55; // alpha of the drifting FieldBlobs (the living layer)
-const BLOB_SAT_BOOST = 6; // blobs a touch more saturated than the base so motion reads
+const BLOB_ALPHA = 0.62; // alpha of the drifting FieldBlobs (the living layer)
+const BLOB_SAT_BOOST = 12; // blobs clearly more saturated than the base so the drift reads
 
 interface Hsl {
   h: number; // 0–360 (allowed to go past during interpolation, wrap at render)
@@ -244,16 +244,19 @@ export function fieldBlobColors(fieldZones: FieldZones): FieldBlob[] {
   });
   const blob = (hsl: Hsl): string => hslToCss(richer(applyMods(hsl, mods)), BLOB_ALPHA);
 
+  // Spread the lightness wide (1.0 → 0.0) so the moving blobs carry visible
+  // light/deep regions — on the pale default palette an even lightness reads as
+  // a static wash. satPos 1.0 takes the top of each zone's range for colour.
   return [
-    { color: blob(sampleZone(z0.id, 0.5, 1.0, 1.0)), cx: 88, cy: 12 }, // top-right (≈ layer 6)
-    { color: blob(sampleZone(z0.id, 0.5, 1.0, 0.5)), cx: 15, cy: 88 }, // bottom-left (≈ layer 2)
-    { color: blob(sampleZone(z1.id, 0.5, 0.5, 1.0)), cx: 92, cy: 46 }, // mid-right (≈ layer 3)
+    { color: blob(sampleZone(z0.id, 0.5, 1.0, 1.0)), cx: 88, cy: 12 }, // top-right highlight (≈ layer 6)
+    { color: blob(sampleZone(z0.id, 0.5, 1.0, 0.0)), cx: 15, cy: 88 }, // bottom-left, deepest (≈ layer 2)
+    { color: blob(sampleZone(z1.id, 0.5, 1.0, 0.6)), cx: 92, cy: 46 }, // mid-right (≈ layer 3)
     {
       color: blob(
-        z2 ? sampleZone(z2.id, 0.5, 0.5, 1.0) : sampleZone(z0.id, 0.5, 0.5, 1.0, 10),
+        z2 ? sampleZone(z2.id, 0.5, 1.0, 0.3) : sampleZone(z0.id, 0.5, 1.0, 0.3, 10),
       ),
       cx: 16,
       cy: 52,
-    }, // mid-left (≈ layer 4)
+    }, // mid-left, deep (≈ layer 4)
   ];
 }

--- a/tests/dataflow/field-gradient.test.mjs
+++ b/tests/dataflow/field-gradient.test.mjs
@@ -68,7 +68,7 @@ test("fieldBlobColors: four blobs, valid hsl, alpha under the cream-preserving c
     assert.equal(typeof b.cy, "number");
     const m = b.color.match(/\/\s*([0-9.]+)\s*\)/); // explicit alpha
     assert.ok(m, `blob colour should carry an alpha: ${b.color}`);
-    assert.ok(Number(m[1]) <= 0.6, `alpha ${m?.[1]} should stay ≤ 0.6`);
+    assert.ok(Number(m[1]) <= 0.7, `alpha ${m?.[1]} should stay ≤ 0.7`);
   }
 });
 


### PR DESCRIPTION
Follow-up to #291. The Field drift was tuned far too subtle — ~3vmax (~25px) over 23–37s, with the blobs deliberately echoing the static base — so on the pale default home palette it read as a static wash. Markus saw the haiku entrance but none of the background motion.

## Changes (turn it up to "clearly alive")
- **Drift magnitude** ~3vmax → **~8–12vmax**; cycles 23–37s → **16–24s**. Clearly perceptible, still ambient.
- **Blobs more distinct:** alpha 0.55 → 0.62, saturation boost 6 → 12, and a **wide lightness spread (1.0 / 0.0 / 0.6 / 0.3)** so the moving blobs carry visible light/deep regions instead of an even pastel wash.
- **Grain** opacity 0.05 → 0.09.
- **Stronger touch response:** pointer drift 12→18px, tilt 1.5→2.5°, scroll parallax 20→30px, tap swell 3%→5%.

Note: scroll parallax only shows on scrollable screens (the home screen is a fixed layout); the pointer-lean responds to a finger **drag**, and a tap gives the swell.

Test alpha cap follows the guardrail (≤0.6 → ≤0.7). `tsc --noEmit` clean; field-gradient test green. Best judged on-device — if it's now *too* much, every number here is a one-line dial.

https://claude.ai/code/session_017ntrLsAC9Xi6Ma2HEupAZD

---
_Generated by [Claude Code](https://claude.ai/code/session_017ntrLsAC9Xi6Ma2HEupAZD)_