### PR TITLE
feat: living-Field rebuild — finger bloom, scroll parallax, liquid haiku

### DIFF
--- a/src/components/ui/light/Field.tsx
+++ b/src/components/ui/light/Field.tsx
@@ -6,25 +6,21 @@ import { composeFieldGradient } from "@/lib/field/composeGradient";
 import { useFieldMotion } from "@/hooks/useFieldMotion";
 import FieldBlobs from "./FieldBlobs";
 import FieldGrain from "./FieldGrain";
+import FieldBloom from "./FieldBloom";
 
 /**
  * Generative Field v1.1 + living motion (fluidity pass).
  *
- * Three stacked layers inside the fixed sandwich:
- *   1. base   — the original composed per-coffee gradient (static, blurred);
- *               unchanged in spirit, so it's the steady floor the blobs ride.
- *   2. blobs  — the same coffee zones lifted out as four slowly-drifting radial
- *               blobs; flow comes from them moving over the static base.
- *   3. grain  — static film grain, soft-light, for tooth.
+ *   scroll layer  — the whole colour field translates with scroll (--field-shift-y)
+ *     1. base   — the static per-coffee gradient (blurred floor)
+ *     2. blobs  — coffee zones lifted out as drifting radial blobs (the flow)
+ *     3. grain  — static film grain, soft-light
+ *   bloom         — a warm glow that follows the finger (--ptr-*), in viewport
+ *                   coords so it doesn't scroll-shift
  *
- * `useFieldMotion` writes --field-* CSS vars on the wrapper; the blob layers
- * read them, so pointer / scroll / tap nudge the Field with ZERO React
- * re-render. `isolation: isolate` keeps the grain's blend mode contained to
- * the Field so it never tints the page content above it.
- *
- * Bold-tier hook (deferred): an feDisplacementMap "quicksilver lens" over the
- * blobs/base would slot here — animated feTurbulence → displacement filter on
- * the inner layers. Out of this slice (GPU + taste risk).
+ * `useFieldMotion` writes the --field-* / --ptr-* vars; the layers read them, so
+ * pointer / scroll / tap nudge the Field with ZERO React re-render. `isolation`
+ * keeps the bloom/grain blends contained to the Field.
  */
 export default function Field() {
   const { fieldZones, rotation } = useContext(FieldContext);
@@ -41,20 +37,32 @@ export default function Field() {
       className="pointer-events-none fixed inset-0 -z-10 overflow-hidden"
       style={{ isolation: "isolate" }}
     >
-      {/* 1 — static per-coffee base */}
+      {/* Scroll-parallax layer — the field is oversized, so it has room to move
+          without revealing an edge. */}
       <div
-        className="absolute inset-[-10%]"
+        className="absolute inset-0"
         style={{
-          background: gradient,
-          filter: "blur(60px)",
-          transform: "scale(1.18)",
-          transformOrigin: "center",
+          transform: "translate3d(0, var(--field-shift-y, 0px), 0)",
+          willChange: "transform",
         }}
-      />
-      {/* 2 — drifting colour blobs (the living layer) */}
-      <FieldBlobs fieldZones={fieldZones} />
-      {/* 3 — film grain */}
-      <FieldGrain />
+      >
+        {/* 1 — static per-coffee base */}
+        <div
+          className="absolute inset-[-12%]"
+          style={{
+            background: gradient,
+            filter: "blur(60px)",
+            transform: "scale(1.2)",
+            transformOrigin: "center",
+          }}
+        />
+        {/* 2 — drifting colour blobs (the living layer) */}
+        <FieldBlobs fieldZones={fieldZones} />
+        {/* 3 — film grain */}
+        <FieldGrain />
+      </div>
+      {/* 4 — warm bloom that follows the finger */}
+      <FieldBloom />
     </div>
   );
 }

--- a/src/components/ui/light/FieldBlobs.tsx
+++ b/src/components/ui/light/FieldBlobs.tsx
@@ -4,87 +4,68 @@ import { useMemo } from "react";
 import { fieldBlobColors } from "@/lib/field/composeGradient";
 import type { FieldZones } from "@/lib/field/types";
 
-// Per-blob autonomous drift: keyframe name + duration + negative start-delay
-// (begin mid-phase so the four never sit at 0% together on first paint).
-// Co-prime-ish durations → the composite never visibly re-syncs. Keyframes
-// live in globals.css and translate in vmax (the drift layer is 0-size, so a
-// % translate would resolve against 0).
+// Per-blob autonomous drift (name + duration + negative start-delay so the four
+// never sit at 0% together). Co-prime-ish durations → the composite never
+// visibly re-syncs. Shorthand `animation` (the form the haiku entrance uses and
+// that renders reliably). Keyframes in globals.css, in vmax (the drift layer is
+// 0-size, so a % translate would resolve against 0).
 const DRIFT = [
-  { name: "blob-drift-1", dur: "16s", delay: "-6s" },
-  { name: "blob-drift-2", dur: "21s", delay: "-13s" },
-  { name: "blob-drift-3", dur: "18s", delay: "-3s" },
-  { name: "blob-drift-4", dur: "24s", delay: "-17s" },
+  "blob-drift-1 16s ease-in-out -6s infinite",
+  "blob-drift-2 21s ease-in-out -13s infinite",
+  "blob-drift-3 18s ease-in-out -3s infinite",
+  "blob-drift-4 24s ease-in-out -17s infinite",
 ];
 
-// Two of the four pick up scroll-momentum parallax (§D) for a sense of depth.
-const PARALLAX = [false, true, true, false];
-
 /**
- * The drifting colour blobs of the living Field. Each blob is three nested
- * layers so the ONLY continuously-animating element (the drift layer) carries
- * a transform-only keyframe with NO filter — it stays on the GPU compositor —
- * while the blurred colour disc underneath is painted once and merely moved:
- *
- *   anchor + interaction   absolute at cx/cy %, transform from --field-* vars
- *                          (recomputes only on scroll/touch/tap)
- *   drift                  slow transform keyframe (continuous; data-field-blob)
- *   visual                 the blurred radial-gradient disc, centred, STATIC
- *
- * Bold-tier hook (deferred): an feDisplacementMap "quicksilver lens" would
- * wrap the visual layer here. Out of this slice (GPU + taste risk).
+ * The drifting colour blobs of the living Field. Three nested layers so the
+ * only continuously-animating element (the drift layer) carries a transform-
+ * only keyframe with NO filter — it stays on the GPU compositor — while the
+ * blurred colour disc underneath is painted once and merely moved. The outer
+ * layer leans/scales from the --field-* interaction vars.
  */
 export default function FieldBlobs({ fieldZones }: { fieldZones: FieldZones }) {
   const blobs = useMemo(() => fieldBlobColors(fieldZones), [fieldZones]);
 
   return (
     <>
-      {blobs.map((b, i) => {
-        const drift = DRIFT[i % DRIFT.length];
-        const y = PARALLAX[i]
-          ? "calc(var(--field-drift-y, 0px) + var(--field-scroll, 0px))"
-          : "var(--field-drift-y, 0px)";
-        return (
+      {blobs.map((b, i) => (
+        <div
+          key={i}
+          aria-hidden
+          className="absolute"
+          style={{
+            left: `${b.cx}%`,
+            top: `${b.cy}%`,
+            transform:
+              "translate(var(--field-drift-x, 0px), var(--field-drift-y, 0px)) rotate(var(--field-tilt, 0deg)) scale(calc(1 + var(--field-pulse, 0) * 0.05))",
+          }}
+        >
           <div
-            key={i}
-            aria-hidden
-            className="absolute"
+            data-field-blob
             style={{
-              left: `${b.cx}%`,
-              top: `${b.cy}%`,
-              transform: `translate(var(--field-drift-x, 0px), ${y}) rotate(var(--field-tilt, 0deg)) scale(calc(1 + var(--field-pulse, 0) * 0.05))`,
+              position: "absolute",
+              left: 0,
+              top: 0,
+              willChange: "transform",
+              animation: DRIFT[i % DRIFT.length],
             }}
           >
             <div
-              data-field-blob
               style={{
                 position: "absolute",
                 left: 0,
                 top: 0,
-                willChange: "transform",
-                animationName: drift.name,
-                animationDuration: drift.dur,
-                animationDelay: drift.delay,
-                animationTimingFunction: "ease-in-out",
-                animationIterationCount: "infinite",
+                width: "62vmax",
+                height: "62vmax",
+                transform: "translate(-50%, -50%)",
+                borderRadius: "50%",
+                background: `radial-gradient(circle, ${b.color} 0%, transparent 70%)`,
+                filter: "blur(40px)",
               }}
-            >
-              <div
-                style={{
-                  position: "absolute",
-                  left: 0,
-                  top: 0,
-                  width: "62vmax",
-                  height: "62vmax",
-                  transform: "translate(-50%, -50%)",
-                  borderRadius: "50%",
-                  background: `radial-gradient(circle, ${b.color} 0%, transparent 70%)`,
-                  filter: "blur(36px)",
-                }}
-              />
-            </div>
+            />
           </div>
-        );
-      })}
+        </div>
+      ))}
     </>
   );
 }

--- a/src/components/ui/light/FieldBloom.tsx
+++ b/src/components/ui/light/FieldBloom.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+// A warm bloom that follows the finger across the Field (fluidity pass). Driven
+// entirely by --ptr-x / --ptr-y / --ptr-on (set by useFieldMotion) so it tracks
+// touch/drag with zero React re-render. It lives behind all content (the Field
+// is -z-10), so it glows *behind* the page — including behind the welcome
+// haiku, which gets its own blur as you drag over it.
+export default function FieldBloom() {
+  return (
+    <div
+      aria-hidden
+      style={{
+        position: "absolute",
+        left: 0,
+        top: 0,
+        width: "46vmax",
+        height: "46vmax",
+        transform:
+          "translate3d(var(--ptr-x, -100vw), var(--ptr-y, -100vh), 0) translate(-50%, -50%)",
+        opacity: "var(--ptr-on, 0)",
+        borderRadius: "50%",
+        background:
+          "radial-gradient(circle, hsl(36 96% 82% / 0.55) 0%, hsl(346 80% 80% / 0.28) 42%, transparent 70%)",
+        filter: "blur(26px)",
+        willChange: "transform, opacity",
+      }}
+    />
+  );
+}

--- a/src/components/ui/light/HaikuStarter.tsx
+++ b/src/components/ui/light/HaikuStarter.tsx
@@ -1,18 +1,38 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { usePresence } from "@/hooks/usePresence";
 
 const EXIT_MS = 280;
-const WORD_STAGGER_MS = 70;
-const SETTLE_MS = 600;
+const STAGGER_MS = 52;
+const POP_MS = 680;
+const DISTURB_MAX_BLUR = 7; // px — finger-over-haiku smudge
+const DISTURB_FALLOFF = 120; // px — distance over which the blur fades to 0
 
 const P_CLASS =
   "font-fraunces text-[40px] font-semibold leading-[1.05] tracking-[-0.01em] text-light-foreground";
 
+// Deterministic scatter: a delay (ms) per word so they pop in a shuffled,
+// non-left-to-right order — spontaneous, not a typewriter. Same text → same
+// scatter (an LCG-shuffled permutation), so it's stable across re-renders.
+function scatterDelays(n: number): number[] {
+  const order = Array.from({ length: n }, (_, i) => i);
+  let seed = 1337;
+  for (let i = n - 1; i > 0; i--) {
+    seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+    const j = seed % (i + 1);
+    const tmp = order[i];
+    order[i] = order[j];
+    order[j] = tmp;
+  }
+  const delay = new Array<number>(n);
+  order.forEach((origIdx, pos) => {
+    delay[origIdx] = pos * STAGGER_MS;
+  });
+  return delay;
+}
+
 function HaikuSkeleton() {
-  // Three stacked bars with a slow sheen so the slot breathes while
-  // /api/greeting resolves, instead of sitting blank.
   const widths = ["72%", "90%", "54%"];
   return (
     <div aria-hidden className="w-full space-y-3.5">
@@ -24,60 +44,126 @@ function HaikuSkeleton() {
 }
 
 /**
- * Home welcome-haiku with a liquid lifecycle (fluidity pass §E): shimmer while
- * it loads → a per-word blur-into-focus entrance → a soft dissolve (not a hard
- * cut) when the user starts composing. usePresence keeps the node mounted
- * through the exit so the dissolve can play. Motion gated by
- * prefers-reduced-motion in globals.css.
- *
- * The words render as inline-block spans for the WHOLE life of the haiku —
- * entrance AND settled — never swapping to a single text node. That swap used
- * to re-wrap the line the instant the entrance finished: it let "stone-fruit"
- * break at the hyphen and yanked the whole poem up a line (the jump Markus
- * caught). One structure → the line is laid out once and never reflows, and a
- * whole word (inline-block) can't break internally.
- *
- * Rendered as an absolute, pointer-events-none overlay so it can dissolve over
- * the ChatThread that mounts underneath when the user starts composing.
+ * Home welcome-haiku (fluidity pass §E). Shimmer while it loads → a LIQUID
+ * per-word entrance (each word springs in from a different direction, with an
+ * overshoot, in a scattered order — not a left-to-right typewriter) → a soft
+ * dissolve when the user starts composing. Once settled, dragging a finger over
+ * the line blurs it (the same soft blur it arrives with). One inline-block
+ * structure throughout so the line never re-wraps. Motion gated by
+ * prefers-reduced-motion (the .haiku-word rule in globals.css).
  */
 export default function HaikuStarter({ text, show }: { text: string; show: boolean }) {
   const { mounted, state } = usePresence(show, EXIT_MS);
   const loading = text.trim() === "";
-  const words = useMemo(() => text.split(/(\s+)/), [text]);
+  const tokens = useMemo(() => text.split(/(\s+)/), [text]);
+  const wordCount = useMemo(() => tokens.filter((t) => t.trim() !== "").length, [tokens]);
+  const delays = useMemo(() => scatterDelays(wordCount), [wordCount]);
+  const settleDoneMs = wordCount * STAGGER_MS + POP_MS;
+  const exiting = state === "exit";
+
+  const pRef = useRef<HTMLParagraphElement | null>(null);
+
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    if (loading || exiting) {
+      setReady(false);
+      return;
+    }
+    const t = setTimeout(() => setReady(true), settleDoneMs);
+    return () => clearTimeout(t);
+  }, [loading, exiting, settleDoneMs]);
+
+  // Finger-over-haiku smudge: blur the line by proximity to the pointer, on its
+  // own rAF (direct filter, no React re-render). Only once the entrance is done
+  // — during it the words own their filter, during the exit the dissolve does.
+  useEffect(() => {
+    const p = pRef.current;
+    if (!p || !ready || exiting) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    let target = 0;
+    let cur = 0;
+    let raf = 0;
+    let running = false;
+    const frame = () => {
+      cur += (target - cur) * 0.2;
+      p.style.filter = cur > 0.05 ? `blur(${cur.toFixed(2)}px)` : "";
+      if (Math.abs(target - cur) < 0.04) {
+        running = false;
+        return;
+      }
+      raf = requestAnimationFrame(frame);
+    };
+    const kick = () => {
+      if (!running) {
+        running = true;
+        raf = requestAnimationFrame(frame);
+      }
+    };
+    const onMove = (e: PointerEvent) => {
+      const r = p.getBoundingClientRect();
+      const dx = Math.max(r.left - e.clientX, 0, e.clientX - r.right);
+      const dy = Math.max(r.top - e.clientY, 0, e.clientY - r.bottom);
+      const d = Math.hypot(dx, dy);
+      target = DISTURB_MAX_BLUR * Math.max(0, 1 - d / DISTURB_FALLOFF);
+      kick();
+    };
+    window.addEventListener("pointermove", onMove, { passive: true });
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      cancelAnimationFrame(raf);
+      p.style.filter = "";
+    };
+  }, [ready, exiting]);
 
   if (!mounted) return null;
 
-  const exiting = state === "exit";
-
+  let wi = -1;
   return (
     <div className="pointer-events-none absolute inset-0 flex items-center px-5">
+      <style jsx global>{`
+        @keyframes haiku-pop-1 {
+          0% { opacity: 0; filter: blur(10px); transform: translate(-7px, 12px) scale(0.84) rotate(-3deg); }
+          60% { opacity: 1; filter: blur(0); transform: translate(0, -2px) scale(1.07) rotate(1deg); }
+          100% { opacity: 1; filter: blur(0); transform: translate(0, 0) scale(1) rotate(0deg); }
+        }
+        @keyframes haiku-pop-2 {
+          0% { opacity: 0; filter: blur(12px); transform: translate(9px, -10px) scale(0.8) rotate(4deg); }
+          58% { opacity: 1; filter: blur(0); transform: translate(-1px, 1px) scale(1.08) rotate(-1deg); }
+          100% { opacity: 1; filter: blur(0); transform: translate(0, 0) scale(1) rotate(0deg); }
+        }
+        @keyframes haiku-pop-3 {
+          0% { opacity: 0; filter: blur(9px); transform: translateY(16px) scale(0.9); }
+          62% { opacity: 1; filter: blur(0); transform: translateY(-3px) scale(1.05); }
+          100% { opacity: 1; filter: blur(0); transform: translateY(0) scale(1); }
+        }
+      `}</style>
       {loading ? (
         <HaikuSkeleton />
       ) : (
-        // The exit dissolve animates the whole <p>; the word spans inside hold
-        // their settled state and ride along — no structure change, no reflow.
         <p
+          ref={pRef}
           className={exiting ? `${P_CLASS} haiku-exit` : P_CLASS}
           style={
             exiting ? { animation: `haiku-dissolve ${EXIT_MS}ms ease-in forwards` } : undefined
           }
         >
-          {words.map((w, i) =>
-            w.trim() === "" ? (
-              <span key={i}>{w}</span>
-            ) : (
+          {tokens.map((w, i) => {
+            if (w.trim() === "") return <span key={i}>{w}</span>;
+            wi += 1;
+            const variant = (wi % 3) + 1;
+            return (
               <span
                 key={i}
                 className="haiku-word inline-block"
                 style={{
-                  animation: `haiku-settle ${SETTLE_MS}ms ease-out both`,
-                  animationDelay: `${i * WORD_STAGGER_MS}ms`,
+                  animation: `haiku-pop-${variant} ${POP_MS}ms ease-out both`,
+                  animationDelay: `${delays[wi] ?? 0}ms`,
                 }}
               >
                 {w}
               </span>
-            ),
-          )}
+            );
+          })}
         </p>
       )}
     </div>

--- a/src/hooks/useFieldMotion.ts
+++ b/src/hooks/useFieldMotion.ts
@@ -3,30 +3,27 @@
 import { useEffect, useRef } from "react";
 
 /**
- * Living-Field motion driver (fluidity pass §D).
- *
- * Returns a ref to attach to the Field root. While mounted — and unless the
- * user has Reduce Motion on — it listens to scroll + pointer and writes a
- * handful of CSS custom properties on that root. The blob layers read those
- * vars in their transforms, so the Field reacts to scroll/touch/tap on the GPU
- * compositor without a single React re-render:
- *
- *   --field-drift-x / --field-drift-y  pointer lean (eased glide)
- *   --field-tilt                       pointer-driven rotation
- *   --field-scroll                     scroll-momentum parallax (decays to 0)
- *   --field-pulse                      0→1 swell on press/touch (eases back)
- *
- * Bounded + gentle by construction (a lean, not a lurch). Scroll is caught in
- * the CAPTURE phase at document level because ScrollContainer's overflow div
- * doesn't bubble its scroll and we don't want to touch it.
+ * Living-Field motion driver. Writes CSS vars on the Field root; the layers
+ * read them, so the Field reacts on the GPU compositor with no React re-render:
+ *   --field-drift-x/y   pointer lean (eased)
+ *   --field-tilt        pointer rotation
+ *   --field-shift-y     scroll parallax — the WHOLE field translates with scroll
+ *   --field-pulse       0→1 tap swell
+ *   --ptr-x / --ptr-y   pointer position (px) for the finger bloom
+ *   --ptr-on            0→1 bloom opacity (finger down/moving → 1, idle → 0)
+ * Reduced-motion → no listeners, vars stay neutral. Scroll is caught in the
+ * capture phase because ScrollContainer's overflow div doesn't bubble scroll.
  */
 
-const MAX_DRIFT = 18; // px — pointer lean
+const MAX_DRIFT = 22; // px — pointer lean
 const MAX_TILT = 2.5; // deg
-const MAX_SCROLL = 30; // px — parallax travel cap
-const GLIDE = 0.06; // pointer/tilt easing per frame (the "fluid" lag)
-const PULSE_GLIDE = 0.12; // tap-swell easing per frame
-const SCROLL_DECAY = 0.9; // scroll-momentum decay per frame
+const SCROLL_PARALLAX = 0.18;
+const MAX_SHIFT = 90; // px — parallax clamp (stays within the oversized field)
+const GLIDE = 0.08;
+const PULSE_GLIDE = 0.12;
+const PTR_GLIDE = 0.28; // bloom follows the finger fairly tightly
+const ON_GLIDE = 0.14;
+const IDLE_MS = 1100;
 const EPS = 0.01;
 
 export function useFieldMotion<T extends HTMLElement = HTMLDivElement>() {
@@ -35,7 +32,6 @@ export function useFieldMotion<T extends HTMLElement = HTMLDivElement>() {
   useEffect(() => {
     const el = ref.current;
     if (!el || typeof window === "undefined") return;
-
     const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
     let detach: (() => void) | null = null;
 
@@ -43,79 +39,117 @@ export function useFieldMotion<T extends HTMLElement = HTMLDivElement>() {
       el.style.setProperty("--field-drift-x", "0px");
       el.style.setProperty("--field-drift-y", "0px");
       el.style.setProperty("--field-tilt", "0deg");
-      el.style.setProperty("--field-scroll", "0px");
+      el.style.setProperty("--field-shift-y", "0px");
       el.style.setProperty("--field-pulse", "0");
+      el.style.setProperty("--ptr-on", "0");
     };
 
     const setup = () => {
       if (mq.matches) {
         neutral();
-        return; // reduced motion → no listeners, blobs rest in place
+        return; // reduced motion → no listeners
       }
 
       let tx = 0;
       let ty = 0;
       let tTilt = 0;
       let pulseTarget = 0;
+      let onTarget = 0;
+      let tShift = 0;
       let cx = 0;
       let cy = 0;
       let cTilt = 0;
       let pulse = 0;
-      let scroll = 0;
-      let lastTop: number | null = null;
+      let on = 0;
+      let shift = 0;
+      let px = window.innerWidth / 2;
+      let py = window.innerHeight / 2;
+      let tpx = px;
+      let tpy = py;
       let raf = 0;
       let running = false;
+      let idle: ReturnType<typeof setTimeout> | null = null;
+
+      const write = () => {
+        el.style.setProperty("--field-drift-x", `${cx.toFixed(2)}px`);
+        el.style.setProperty("--field-drift-y", `${cy.toFixed(2)}px`);
+        el.style.setProperty("--field-tilt", `${cTilt.toFixed(3)}deg`);
+        el.style.setProperty("--field-shift-y", `${shift.toFixed(2)}px`);
+        el.style.setProperty("--field-pulse", pulse.toFixed(3));
+        el.style.setProperty("--ptr-x", `${px.toFixed(1)}px`);
+        el.style.setProperty("--ptr-y", `${py.toFixed(1)}px`);
+        el.style.setProperty("--ptr-on", on.toFixed(3));
+      };
 
       const frame = () => {
         cx += (tx - cx) * GLIDE;
         cy += (ty - cy) * GLIDE;
         cTilt += (tTilt - cTilt) * GLIDE;
         pulse += (pulseTarget - pulse) * PULSE_GLIDE;
-        scroll *= SCROLL_DECAY;
-        if (Math.abs(scroll) < 0.1) scroll = 0;
-
-        el.style.setProperty("--field-drift-x", `${cx.toFixed(2)}px`);
-        el.style.setProperty("--field-drift-y", `${cy.toFixed(2)}px`);
-        el.style.setProperty("--field-tilt", `${cTilt.toFixed(3)}deg`);
-        el.style.setProperty("--field-scroll", `${scroll.toFixed(2)}px`);
-        el.style.setProperty("--field-pulse", pulse.toFixed(3));
-
-        const settled =
+        on += (onTarget - on) * ON_GLIDE;
+        px += (tpx - px) * PTR_GLIDE;
+        py += (tpy - py) * PTR_GLIDE;
+        shift += (tShift - shift) * GLIDE;
+        write();
+        const s =
           Math.abs(tx - cx) < EPS &&
           Math.abs(ty - cy) < EPS &&
           Math.abs(tTilt - cTilt) < EPS &&
           Math.abs(pulseTarget - pulse) < EPS &&
-          scroll === 0;
-        if (settled) {
+          Math.abs(onTarget - on) < EPS &&
+          Math.abs(tpx - px) < 0.5 &&
+          Math.abs(tpy - py) < 0.5 &&
+          Math.abs(tShift - shift) < 0.5;
+        if (s) {
           running = false;
           return;
         }
         raf = requestAnimationFrame(frame);
       };
-
       const kick = () => {
-        if (running) return;
-        running = true;
-        raf = requestAnimationFrame(frame);
+        if (!running) {
+          running = true;
+          raf = requestAnimationFrame(frame);
+        }
+      };
+      const armIdle = () => {
+        if (idle) clearTimeout(idle);
+        idle = setTimeout(() => {
+          onTarget = 0; // fade the bloom out if the finger goes still
+          kick();
+        }, IDLE_MS);
       };
 
-      const onPointerMove = (e: PointerEvent) => {
-        const nx = (e.clientX / window.innerWidth - 0.5) * 2; // -1..1
-        const ny = (e.clientY / window.innerHeight - 0.5) * 2;
+      const aim = (clientX: number, clientY: number) => {
+        const nx = (clientX / window.innerWidth - 0.5) * 2;
+        const ny = (clientY / window.innerHeight - 0.5) * 2;
         tx = nx * MAX_DRIFT;
         ty = ny * MAX_DRIFT;
         tTilt = nx * MAX_TILT;
+        tpx = clientX;
+        tpy = clientY;
+      };
+      const onPointerMove = (e: PointerEvent) => {
+        aim(e.clientX, e.clientY);
+        onTarget = 1;
+        armIdle();
         kick();
       };
       const onPointerDown = (e: PointerEvent) => {
-        pulseTarget = 1; // swell toward the press
-        onPointerMove(e);
+        px = tpx = e.clientX; // snap the bloom to the touch immediately
+        py = tpy = e.clientY;
+        pulseTarget = 1;
+        onTarget = 1;
+        aim(e.clientX, e.clientY);
+        armIdle();
+        kick();
       };
       const relax = () => {
         tx = 0;
         ty = 0;
         tTilt = 0;
-        pulseTarget = 0; // settle back to centre when the finger lifts
+        pulseTarget = 0;
+        onTarget = 0;
         kick();
       };
       const onScroll = (e: Event) => {
@@ -123,12 +157,7 @@ export function useFieldMotion<T extends HTMLElement = HTMLDivElement>() {
         let top = 0;
         if (t instanceof HTMLElement) top = t.scrollTop;
         else if (t instanceof Document) top = t.scrollingElement?.scrollTop ?? 0;
-        if (lastTop !== null) {
-          scroll += top - lastTop;
-          if (scroll > MAX_SCROLL) scroll = MAX_SCROLL;
-          else if (scroll < -MAX_SCROLL) scroll = -MAX_SCROLL;
-        }
-        lastTop = top;
+        tShift = Math.max(-MAX_SHIFT, Math.min(MAX_SHIFT, -top * SCROLL_PARALLAX));
         kick();
       };
 
@@ -136,10 +165,11 @@ export function useFieldMotion<T extends HTMLElement = HTMLDivElement>() {
       window.addEventListener("pointerdown", onPointerDown, { passive: true });
       window.addEventListener("pointerup", relax, { passive: true });
       window.addEventListener("pointercancel", relax, { passive: true });
-      document.addEventListener("scroll", onScroll, true); // capture — catches the inner scroller
+      document.addEventListener("scroll", onScroll, true);
 
       detach = () => {
         cancelAnimationFrame(raf);
+        if (idle) clearTimeout(idle);
         window.removeEventListener("pointermove", onPointerMove);
         window.removeEventListener("pointerdown", onPointerDown);
         window.removeEventListener("pointerup", relax);
@@ -149,8 +179,6 @@ export function useFieldMotion<T extends HTMLElement = HTMLDivElement>() {
     };
 
     setup();
-
-    // Re-evaluate live if the user toggles Reduce Motion in Accessibility.
     const onMqChange = () => {
       detach?.();
       detach = null;
@@ -158,7 +186,6 @@ export function useFieldMotion<T extends HTMLElement = HTMLDivElement>() {
       setup();
     };
     mq.addEventListener("change", onMqChange);
-
     return () => {
       mq.removeEventListener("change", onMqChange);
       detach?.();

--- a/src/lib/field/composeGradient.ts
+++ b/src/lib/field/composeGradient.ts
@@ -222,9 +222,8 @@ export interface FieldBlob {
  * Lifts the same sorted zones the base gradient uses (z0/z1/z2) out as four
  * individually-transformable radial blobs so they can drift over the static
  * base — flow comes from the relative motion, never from repainting the base.
- * Resting positions echo composeFieldGradient's hotspot anchors (layers
- * 6/2/3/4) so the at-rest frame ≈ the painted base. Pure + deterministic,
- * same contract as composeFieldGradient.
+ * The four span a wide light↔deep range so the motion reads on the pale
+ * default palette. Pure + deterministic, same contract as composeFieldGradient.
  */
 export function fieldBlobColors(fieldZones: FieldZones): FieldBlob[] {
   const zones = [...fieldZones.zones].sort((a, b) => b.weight - a.weight);
@@ -235,28 +234,24 @@ export function fieldBlobColors(fieldZones: FieldZones): FieldBlob[] {
   const z1 = zones[1] ?? zones[0];
   const z2 = zones[2] ?? null;
 
-  // Saturate the blobs a touch above the base so the drift reads, hold a
-  // constant alpha, and apply the same global modifiers as every other layer.
-  const richer = (hsl: Hsl): Hsl => ({
-    h: hsl.h,
-    s: clamp(hsl.s + BLOB_SAT_BOOST, 0, 100),
-    l: hsl.l,
-  });
-  const blob = (hsl: Hsl): string => hslToCss(richer(applyMods(hsl, mods)), BLOB_ALPHA);
+  // A blob colour: the zone's hue, saturation pushed to the top of its range
+  // (+ boost), and an EXPLICIT lightness so the four blobs span a wide
+  // light↔deep range. On the pale default palette an even lightness reads as a
+  // static wash — moving LIGHT highlights against DEEP warm shadows is what
+  // makes the flow actually visible.
+  const blob = (zoneId: ZoneId, lightness: number, hueOffset = 0): string => {
+    const sampled = sampleZone(zoneId, 0.5, 1.0, 0.5, hueOffset);
+    const tuned = applyMods(
+      { h: sampled.h, s: clamp(sampled.s + BLOB_SAT_BOOST, 0, 100), l: lightness },
+      mods,
+    );
+    return hslToCss(tuned, BLOB_ALPHA);
+  };
 
-  // Spread the lightness wide (1.0 → 0.0) so the moving blobs carry visible
-  // light/deep regions — on the pale default palette an even lightness reads as
-  // a static wash. satPos 1.0 takes the top of each zone's range for colour.
   return [
-    { color: blob(sampleZone(z0.id, 0.5, 1.0, 1.0)), cx: 88, cy: 12 }, // top-right highlight (≈ layer 6)
-    { color: blob(sampleZone(z0.id, 0.5, 1.0, 0.0)), cx: 15, cy: 88 }, // bottom-left, deepest (≈ layer 2)
-    { color: blob(sampleZone(z1.id, 0.5, 1.0, 0.6)), cx: 92, cy: 46 }, // mid-right (≈ layer 3)
-    {
-      color: blob(
-        z2 ? sampleZone(z2.id, 0.5, 1.0, 0.3) : sampleZone(z0.id, 0.5, 1.0, 0.3, 10),
-      ),
-      cx: 16,
-      cy: 52,
-    }, // mid-left, deep (≈ layer 4)
+    { color: blob(z0.id, 84), cx: 86, cy: 14 }, // top-right highlight (bright)
+    { color: blob(z0.id, 52), cx: 16, cy: 86 }, // bottom-left warm shadow (deep)
+    { color: blob(z1.id, 76), cx: 90, cy: 50 }, // mid-right (mid-bright)
+    { color: blob(z2 ? z2.id : z0.id, 54, z2 ? 0 : 12), cx: 14, cy: 48 }, // mid-left shadow (deep)
   ];
 }


### PR DESCRIPTION
The motion was too subtle to perceive (pale-on-pale blobs, homeopathic interaction) and the haiku entrance was a left-to-right typewriter. This rebuilds the effects so they're actually felt — pushed via the GitHub API because the local command-runner was down (type-check runs here in CI).

## What changed
- **Blobs span bright highlights AND deep warm shadows** (explicit wide lightness range in `fieldBlobColors`) so the drift reads on the pale default palette — the pale-on-pale was why it looked dead.
- **Finger bloom** — a warm glow follows touch/drag anywhere (`FieldBloom` + `--ptr-*` in `useFieldMotion`).
- **Scroll parallax** — the whole field translates with scroll (`--field-shift-y`).
- **Drag over the welcome haiku → it blurs** by proximity (the same soft blur it arrives with), sharpening as you move off.
- **Liquid haiku entrance** — no more typewriter: words spring in from different directions with an overshoot, in a **scattered (LCG-shuffled) order**. Keyframes live in the component (styled-jsx-global) to keep this push small.

All driven by CSS vars on the GPU compositor (no React re-render); all gated by `prefers-reduced-motion`.

⚠️ I couldn't run `tsc` locally (runner outage) — **CI is the gate here.** If the `check` job is green this is safe to merge.

https://claude.ai/code/session_017ntrLsAC9Xi6Ma2HEupAZD

---
_Generated by [Claude Code](https://claude.ai/code/session_017ntrLsAC9Xi6Ma2HEupAZD)_