### PR TITLE
Welcome haiku: sticks through the + sheet, returns on cancel

### DIFF
--- a/docs/liquid-design.md
+++ b/docs/liquid-design.md
@@ -140,8 +140,8 @@ dissolve). Swapping to a single text node mid-life re-wraps the line and hyphena
 |---|---|---|
 | `src/components/ui/light/HaikuStarter.tsx` | Shimmer → entrance → dissolve → touch lens; owns the `haiku-pop-*` keyframes (co-located). | `STAGGER_MS`, `POP_MS` (entrance speed), `EXIT_MS` (dissolve), `DISTURB_MAX_BLUR`, `DISTURB_FALLOFF` (lens) |
 | `src/hooks/usePresence.ts` | Generic delayed-unmount `(present, exitMs) → {mounted, state}`. Replaces framer-motion AnimatePresence. | — |
-| `src/app/(light)/page.tsx` | Renders the haiku as an absolute overlay over `ChatThread`; `showStarter = messages.length===0 && !interacted`. | when the haiku shows / dissolves (the `interacted` flip) |
-| `src/components/ui/light/ChatInput.tsx` | `markComposed()` flips `interacted` → dissolves the haiku. Fires on focus / typing / photo / **transcript** (not on the bare mic tap — see voice fix). | which compose actions dismiss the haiku |
+| `src/app/(light)/page.tsx` | Renders the haiku as an absolute overlay over `ChatThread`; `showStarter = messages.length===0 && !composing` (declarative — NOT a one-way latch, so the haiku returns when a draft clears). | when the haiku shows / dissolves (the `composing` flag) |
+| `src/components/ui/light/ChatInput.tsx` | Reports `onComposingChange(isCompositionActive)` — true only with a real draft (text / photo / coffee / uploading). Opening the `+` sheet or a bare mic tap is NOT composing, so the haiku sticks; clearing the draft re-runs its entrance. The `+` sheet is overlaid (`absolute bottom-full` in a `relative` input row) so opening it doesn't grow the footer and shove the centred haiku up. | what counts as "composing" (dismisses the haiku) |
 
 **Shared CSS** — `src/app/globals.css`: `haiku-shimmer`, `haiku-dissolve` (static, used), the
 `prefers-reduced-motion` disable block (`[data-field-blob]`, `.haiku-word`, `.haiku-exit`,
@@ -319,4 +319,25 @@ When adding any new motion, add its selector to that globals.css block in the sa
 - **Traps found:** — (ChatInput edit-ordering footgun handled in-session: invert inner
   `bg-light-foreground text-light-text-on-dark` BEFORE swapping the glass controls to it, or the
   new control class gets re-inverted by the substring match).
+- **PRs this session:** (number assigned on open)
+
+### 2026-06-12 — welcome haiku: sticks through the + sheet, returns on cancel
+- **Done:** the haiku used a one-way `interacted` latch (flipped true on first focus/photo/etc.,
+  never reset) — so once you poked the `+` sheet and backed out, it stayed gone on an otherwise
+  empty screen. Replaced with a **declarative** model: `ChatInput` reports
+  `onComposingChange(isCompositionActive)` (true only with a real draft — text/photo/coffee/
+  uploading; NOT a bare mic tap, NOT an open `+` sheet), and the page computes
+  `showStarter = messages.length===0 && !composing`. The existing `usePresence` + `ready`
+  machinery already re-runs the scatter entrance when `show` flips back true, so the haiku
+  **returns with its setup animation** when a draft clears. Removed the dead
+  `markComposed`/`composeStartedRef`/`onComposeStart` plumbing. Also fixed the **"jump"**: the
+  `+` `AttachmentSheet` was in the footer flow, so opening it grew the footer and shoved the
+  centred haiku up — it's now overlaid (`absolute bottom-full` inside a `relative` input row), so
+  the footer height is constant and the haiku stays put.
+- **Open / next:** owner verifies on device — `+` → sheet (haiku stays put), X out → haiku
+  re-enters; type → dissolve; mic tap → haiku stays until a transcript lands. Note: focusing the
+  empty field no longer dissolves the haiku on its own (only real content does) — flag if you
+  want the old focus-dissolve back.
+- **Traps found:** the latch had a THIRD setter (`handleSend` set `interacted=true` post-send) +
+  a conversation-load setter — both removed; `messages.length>0` already hides the starter.
 - **PRs this session:** (number assigned on open)

--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -112,7 +112,7 @@ export default function HomePage() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [recentSessions, setRecentSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(false);
-  const [interacted, setInteracted] = useState(false);
+  const [composing, setComposing] = useState(false);
   // Empty initial — the daily Starter is the AI-generated greeting from
   // /api/greeting (cached per (date, time-bucket) in localStorage). No
   // hardcoded placeholder: the slot stays empty until the real line
@@ -157,7 +157,6 @@ export default function HomePage() {
             ...(m.actions ? { actions: m.actions } : {}),
           }))
         );
-        if (data.messages.length > 0) setInteracted(true);
       })
       .catch(() => {});
     return () => {
@@ -208,7 +207,11 @@ export default function HomePage() {
       .catch(() => {});
   }, []);
 
-  const showStarter = messages.length === 0 && !interacted;
+  // The welcome haiku shows whenever the screen is idle: no conversation yet
+  // AND nothing being composed. `composing` is reported live by ChatInput, so
+  // opening the + sheet or tapping the mic keeps the haiku (those aren't
+  // composing) and clearing a draft brings it back with its entrance animation.
+  const showStarter = messages.length === 0 && !composing;
 
   const persistMessage = (
     role: "user" | "assistant",
@@ -251,7 +254,6 @@ export default function HomePage() {
     const next = [...messages, userMsg];
     setMessages(next);
     setLoading(true);
-    setInteracted(true);
 
     // Persist the user message in parallel with the agent request.
     void persistMessage("user", text, {
@@ -442,7 +444,7 @@ export default function HomePage() {
         <ChatInput
           loading={loading}
           onSend={handleSend}
-          onComposeStart={() => setInteracted(true)}
+          onComposingChange={setComposing}
           assistantSpeaking={voice.speaking}
           onCancelSpeak={voice.cancel}
           onUnlockAudio={voice.unlock}

--- a/src/components/ui/light/AttachmentSheet.tsx
+++ b/src/components/ui/light/AttachmentSheet.tsx
@@ -40,7 +40,7 @@ export default function AttachmentSheet({
         className="fixed inset-0 z-40 cursor-default"
       />
 
-      <div className="relative z-50 mb-2 mr-auto max-w-[280px] rounded-2xl border border-light-foreground/25 bg-light-card-default p-2 shadow-light-float backdrop-blur-light-card backdrop-saturate-150">
+      <div className="absolute bottom-full left-0 z-50 mb-2 mr-auto max-w-[280px] rounded-2xl border border-light-foreground/25 bg-light-card-default p-2 shadow-light-float backdrop-blur-light-card backdrop-saturate-150">
         <button
           type="button"
           onClick={onPickPhoto}

--- a/src/components/ui/light/ChatInput.tsx
+++ b/src/components/ui/light/ChatInput.tsx
@@ -40,7 +40,13 @@ export interface SendPayload {
 interface ChatInputProps {
   loading: boolean;
   onSend: (payload: SendPayload) => void;
-  onComposeStart?: () => void;
+  /**
+   * Live composition state: true when a draft exists (text / photo / coffee
+   * ref / uploading), false when idle. NOT triggered by a bare mic tap or an
+   * open + sheet. Drives the home welcome-haiku (show when idle, dissolve when
+   * composing, re-enter when cleared).
+   */
+  onComposingChange?: (composing: boolean) => void;
   /** True while the assistant's reply is being read aloud. */
   assistantSpeaking?: boolean;
   /** Stop the current TTS playback (silence the assistant). */
@@ -70,7 +76,7 @@ async function uploadPhoto(file: File): Promise<string> {
 export default function ChatInput({
   loading,
   onSend,
-  onComposeStart,
+  onComposingChange,
   assistantSpeaking = false,
   onCancelSpeak,
   onUnlockAudio,
@@ -86,7 +92,6 @@ export default function ChatInput({
   const [coffeeList, setCoffeeList] = useState<CompactCoffee[]>([]);
   const editorRef = useRef<HTMLDivElement | null>(null);
   const photoInputRef = useRef<HTMLInputElement | null>(null);
-  const composeStartedRef = useRef(false);
   // True once the current composition has picked up any voice-transcribed
   // text. Reset on send and on clear. Drives the SendPayload flag the home
   // page reads to decide whether to read the assistant reply aloud — typed
@@ -150,16 +155,8 @@ export default function ChatInput({
     }, delay);
   };
 
-  const markComposed = () => {
-    if (!composeStartedRef.current) {
-      composeStartedRef.current = true;
-      onComposeStart?.();
-    }
-  };
-
   const voice = useVoiceCapture({
     onTranscript: (transcript) => {
-      markComposed();
       voiceInitiatedRef.current = true;
       setText(transcript);
       if (editorRef.current) {
@@ -192,12 +189,20 @@ export default function ChatInput({
   const isVoiceActive = isRecording || isTranscribing;
   const isCompositionActive = hasText || hasPhoto || hasCoffee || uploadingImage;
 
+  // Report live composition state up so the home page can show the welcome
+  // haiku whenever the screen is idle (no messages, nothing being composed)
+  // and dissolve / re-run its entrance as a draft starts and clears. Opening
+  // the + sheet or a bare mic tap is deliberately NOT composing — the haiku
+  // sticks through those and only leaves once real content lands.
+  useEffect(() => {
+    onComposingChange?.(isCompositionActive);
+  }, [isCompositionActive, onComposingChange]);
+
   const handleInput = (e: React.FormEvent<HTMLDivElement>) => {
     setText(e.currentTarget.textContent ?? "");
   };
 
   const handleFocus = () => {
-    markComposed();
     // The user is composing — silence the assistant so it doesn't talk over
     // their reply. iOS audio also needs a gesture before later playbacks; the
     // focus event itself isn't a gesture, but follow-up taps within this
@@ -212,7 +217,6 @@ export default function ChatInput({
   };
 
   const handleFileSelected = async (file: File) => {
-    markComposed();
     setUploadError(null);
     setUploadingImage(true);
     setAttachedCoffee(null); // §3.3 — one attachment at a time
@@ -255,7 +259,6 @@ export default function ChatInput({
     setText("");
     setAttachedImageUrl(null);
     setAttachedCoffee(null);
-    composeStartedRef.current = false;
     voiceInitiatedRef.current = false;
     editorRef.current?.blur();
   };
@@ -263,10 +266,10 @@ export default function ChatInput({
   const startVoice = async () => {
     if (loading || sendActive) return;
     setVoiceError(null);
-    // Deliberately do NOT markComposed() here: the bare mic tap shouldn't
-    // dismiss the welcome haiku before a word is spoken (and leave it gone if
-    // the user cancels). The haiku dissolves when a transcript actually lands —
-    // onTranscript() calls markComposed() — so recording keeps it on screen.
+    // Recording is deliberately NOT "composing" (isCompositionActive excludes
+    // voice), so the bare mic tap keeps the welcome haiku on screen — it only
+    // dissolves once a transcript lands and fills the editor (text → composing).
+    // Cancelling leaves the haiku untouched.
     // The mic tap is a user gesture — prime iOS audio now so the reply
     // (which we'll route to TTS because this composition is voice-initiated)
     // plays without an autoplay block.
@@ -291,7 +294,6 @@ export default function ChatInput({
   };
 
   const handleCoffeeSelected = (coffee: CompactCoffee) => {
-    markComposed();
     setAttachedImageUrl(null); // §3.3 — one attachment at a time
     setAttachedCoffee(coffee);
     setPickerOpen(false);
@@ -315,15 +317,6 @@ export default function ChatInput({
           </div>
         )}
 
-        {sheetOpen && (
-          <AttachmentSheet
-            onClose={() => setSheetOpen(false)}
-            onPickPhoto={handlePickPhoto}
-            onPickCoffee={handlePickCoffeeRef}
-            coffeeLibraryEmpty={coffeeList.length === 0}
-          />
-        )}
-
         <input
           ref={photoInputRef}
           type="file"
@@ -332,7 +325,17 @@ export default function ChatInput({
           onChange={handleInputChange}
         />
 
-        <div className="flex items-center gap-3">
+        <div className="relative flex items-center gap-3">
+          {/* Overlaid, not in flow — anchored above the input row so opening it
+              doesn't grow the footer and shove the centred welcome haiku up. */}
+          {sheetOpen && (
+            <AttachmentSheet
+              onClose={() => setSheetOpen(false)}
+              onPickPhoto={handlePickPhoto}
+              onPickCoffee={handlePickCoffeeRef}
+              coffeeLibraryEmpty={coffeeList.length === 0}
+            />
+          )}
           {isVoiceActive ? (
             <button
               type="button"


### PR DESCRIPTION
Two welcome-haiku bugs in the `+` / attachment flow.

## The bugs
1. **Haiku didn't come back.** It used a one-way `interacted` latch — flipped true on the first focus/photo/etc. and never reset. So once you opened the `+` sheet (or attached something) and backed out, the haiku stayed gone on an otherwise empty home screen.
2. **Haiku "jumped" when opening `+`.** The `AttachmentSheet` rendered in the footer flow, so opening it grew the footer and shoved the vertically-centred haiku up.

## The fix
- **Declarative visibility instead of a latch.** `ChatInput` now reports `onComposingChange(isCompositionActive)`; the page computes `showStarter = messages.length === 0 && !composing`. Opening the `+` sheet or a bare mic tap is **not** composing (the haiku sticks); the moment a draft clears, `showStarter` flips back true and the existing `usePresence` + `ready` path **re-runs the scatter entrance animation**. Removed the dead `markComposed` / `composeStartedRef` / `onComposeStart` plumbing (plus two other stray latch setters — post-send and conversation-load — both redundant since `messages.length > 0` already hides the starter).
- **Overlay the sheet.** `AttachmentSheet` is now `absolute bottom-full` inside a `relative` input row, so opening it doesn't change the footer height — the haiku stays put.

## Behaviour after
- `+` → sheet opens, haiku stays put · pick/cancel (X) on an empty screen → haiku re-enters with its setup animation · type → dissolve · mic tap → haiku stays until a transcript lands.
- Note: focusing the empty field no longer dissolves the haiku on its own (only real content does) — intentional, matches "stick until I commit". Easy to restore the focus-dissolve if wanted.

## Verification
- `tsc --noEmit` clean; `node --test` green; no stray latch references in `src/`.
- Best confirmed on device (force-quit & reopen the PWA first).

https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR)_