### PR TITLE
Calmer recipe insight (per-word reverse exit) + pages open at the top

### DIFF
--- a/docs/liquid-design.md
+++ b/docs/liquid-design.md
@@ -140,8 +140,8 @@ dissolve). Swapping to a single text node mid-life re-wraps the line and hyphena
 | File | Role | Dials it owns |
 |---|---|---|
 | `src/components/ui/light/HaikuStarter.tsx` | Shimmer → entrance → dissolve → touch lens; owns the `haiku-pop-*` keyframes (co-located). Home welcome-haiku ONLY (it has the touch-lens). | `STAGGER_MS`, `POP_MS` (entrance speed), `EXIT_MS` (dissolve), `DISTURB_MAX_BLUR`, `DISTURB_FALLOFF` (lens) |
-| `src/components/ui/light/LiquidHeadline.tsx` | The haiku's per-word scatter entrance, extracted + reusable (NO touch-lens). Owns `lh-pop-*` + `lh-dissolve-up/down` keyframes (co-located) + reduced-motion gate. Used by `Hero` (entrance only, `as="h1"`) and the recipe-crafting insight (entrance + `dissolveDir="down"` = the OPPOSITE of the haiku's up-float). Keyed on `text` so it replays the entrance whenever the headline changes. | `LH_POP_MS` / `LH_STAGGER_MS` (entrance speed), `LH_EXIT_MS` (dissolve), the `lh-dissolve-down` translate/scale (the "opposite" feel) |
-| `src/components/flow/LightStepRecommend.tsx` | Recipe-crafting loading screen: a `LiquidHeadline` insight deck (shuffled `COFFEE_HINTS`) shown big (Fraunces 40), one at a time — scatter-in, hold to read, dissolve down, next sets up. Replaced the bean glow + "Did you know?". | `dwellMs` (= `liquidEntranceMs(words) + 2600` read buffer), the deck size (`shuffleSubset(…, 12)`), `max-w-[15ch]` (wrap width) |
+| `src/components/ui/light/LiquidHeadline.tsx` | The haiku's per-word scatter entrance, extracted + reusable (NO touch-lens). Owns `lh-pop-*` + `lh-out-*-up/down` keyframes (co-located) + reduced-motion gate. **Exit is the entrance in REVERSE** — each word retreats one after another (last word in, first out), scattered + staggered, NOT a whole-line fade; `dissolveDir` only sets where they drift ("down" sinks/shrinks = the opposite of the haiku's up-float). Per-word duration via the `--lh-dur` CSS var so timings are prop-driven. Used by `Hero` (entrance only, `as="h1"`) and the recipe-crafting insight. Keyed on `text` so it replays the entrance whenever the headline changes. | props `popMs` / `staggerMs` / `exitMs` (per-instance speed); `LH_POP_MS` / `LH_STAGGER_MS` (Hero defaults); `liquidEntranceMs` / `liquidExitMs` helpers; the `lh-out-*` translate/scale (the "opposite" feel) |
+| `src/components/flow/LightStepRecommend.tsx` | Recipe-crafting loading screen: a `LiquidHeadline` insight deck (shuffled `COFFEE_HINTS`) shown big (Fraunces 40), one at a time — scatter-in, hold to read, leave word-by-word in reverse (sinking down), next sets up. Slow + calm on purpose. Replaced the bean glow + "Did you know?". | `INSIGHT_POP_MS` 1000 / `INSIGHT_STAGGER_MS` 110 / `INSIGHT_EXIT_MS` 850 / `INSIGHT_READ_MS` 4800 (the settled read time); the deck size (`shuffleSubset(…, 12)`); `max-w-[15ch]` (wrap width) |
 | `src/components/ui/light/Hero.tsx` | Page hero — animates the question via `LiquidHeadline` when it's a plain string (callers pass `question="What's the vibe?"`); rich JSX stays static. | whether a hero animates (string vs JSX) |
 | `src/hooks/usePresence.ts` | Generic delayed-unmount `(present, exitMs) → {mounted, state}`. Replaces framer-motion AnimatePresence. Backs both `HaikuStarter` and `LiquidHeadline`. | — |
 | `src/app/(light)/page.tsx` | Renders the haiku as an absolute overlay over `ChatThread`; `showStarter = messages.length===0 && !composing` (declarative — NOT a one-way latch, so the haiku returns when a draft clears). | when the haiku shows / dissolves (the `composing` flag) |
@@ -366,4 +366,25 @@ When adding any new motion, add its selector to that globals.css block in the sa
 - **Traps found:** Hero questions were JSX fragments, not strings — a string-only animator needs
   the callers converted (and `coachQuestion` at LightStepLog:538 is a `CoachQuestionSheet` prop,
   NOT a Hero — left alone).
+- **PRs this session:** (number assigned on open)
+
+### 2026-06-12 — recipe insight: slower, per-word reverse exit, longer hold (+ scroll-to-top fix)
+- **Done (motion):** the rotating recipe insight read as stressful — too fast, and the dissolve was
+  a one-shot whole-line fade. Reworked `LiquidHeadline`'s exit to be the **entrance in reverse**:
+  each word retreats one after another (last word in, first out), scattered + staggered, drifting in
+  the `dissolveDir` direction (recipe = "down", sink + shrink). Made all timings prop-driven via a
+  `--lh-dur` CSS var (so the Hero stays snappy at the defaults while the recipe is slow). Recipe now
+  runs at `INSIGHT_POP_MS` 1000 / `INSIGHT_STAGGER_MS` 110 / `INSIGHT_EXIT_MS` 850 and holds
+  `INSIGHT_READ_MS` 4800ms fully settled before leaving (was ~2600 + a 360ms whole-line fade). Added
+  `liquidExitMs()` so the rotation waits exactly until every word has gone.
+- **Done (scroll — separate concern, same session):** "How was it?" (and every step) opened at the
+  previous step's scroll offset. Root cause: the app scrolls inside `ScrollContainer` (a 100dvh
+  overflow div in the root layout), but `LightFlowShell` reset `window.scrollTo(0)` — a no-op on the
+  real scroller. Fix: `ScrollContainer` now resets itself to top on every route change (`usePathname`)
+  and exports `SCROLL_CONTAINER_ID`; `LightFlowShell` resets that element by id on step change (window
+  call kept as a fallback). All pages/steps now open at the top.
+- **Open / next:** owner eyeballs the new pace on device — `INSIGHT_*` are all one-number dials if it
+  wants to go slower/faster or hold longer still.
+- **Traps found:** `window.scrollTo` is a no-op when the real scroller is a custom overflow container
+  that persists in the root layout — reset the element, and also on `usePathname` for route changes.
 - **PRs this session:** (number assigned on open)

--- a/src/components/flow/LightStepRecommend.tsx
+++ b/src/components/flow/LightStepRecommend.tsx
@@ -8,7 +8,7 @@ import Chip from "@/components/ui/light/Chip";
 import CTA from "@/components/ui/light/CTA";
 import { formatSeconds } from "@/lib/utils/formatTime";
 import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
-import LiquidHeadline, { liquidEntranceMs, LH_EXIT_MS } from "@/components/ui/light/LiquidHeadline";
+import LiquidHeadline, { liquidEntranceMs, liquidExitMs } from "@/components/ui/light/LiquidHeadline";
 import { COFFEE_HINTS } from "@/lib/coffeeHints";
 import { useWakeLock } from "@/hooks/useWakeLock";
 import type { RecommendationCandidate, CandidateRole, CandidateConfidence } from "@/lib/types/session";
@@ -37,6 +37,14 @@ function shuffleSubset(arr: string[], count: number): string[] {
   const shuffled = [...arr].sort(() => Math.random() - 0.5);
   return shuffled.slice(0, count);
 }
+
+// Recipe-crafting insight animation — deliberately slow + calm (the earlier
+// fast rotation read as stressful). Raise any of these to slow further / hold
+// longer; INSIGHT_READ_MS is the pure settled reading time before it leaves.
+const INSIGHT_POP_MS = 1000; // per-word entrance spring
+const INSIGHT_STAGGER_MS = 110; // gap between words (entrance + exit)
+const INSIGHT_EXIT_MS = 850; // per-word exit duration
+const INSIGHT_READ_MS = 4800; // how long it sits fully settled before leaving
 
 const ROLE_LABELS: Record<CandidateRole, string> = {
   anchor: "Anchor",
@@ -77,8 +85,10 @@ export default function LightStepRecommend() {
 
   const currentInsight = insights[insightIdx] ?? "";
   const insightWordCount = currentInsight.trim() === "" ? 0 : currentInsight.trim().split(/\s+/).length;
-  // Visible window = entrance time + a read buffer, so it stands long enough to read.
-  const dwellMs = liquidEntranceMs(insightWordCount) + 2600;
+  // Visible window = entrance time + a generous read buffer, so it stands long
+  // enough to read calmly before it starts to leave.
+  const dwellMs = liquidEntranceMs(insightWordCount, INSIGHT_POP_MS, INSIGHT_STAGGER_MS) + INSIGHT_READ_MS;
+  const insightExitMs = liquidExitMs(insightWordCount, INSIGHT_EXIT_MS, INSIGHT_STAGGER_MS);
 
   useEffect(() => {
     if (!isRecommending || insights.length === 0) return;
@@ -86,13 +96,13 @@ export default function LightStepRecommend() {
       const t = setTimeout(() => setInsightVisible(false), dwellMs);
       return () => clearTimeout(t);
     }
-    // Dissolving — once it's gone (LH_EXIT_MS), advance and set up the next.
+    // Leaving — once every word has gone, advance and set up the next.
     const t = setTimeout(() => {
       setInsightIdx((i) => (i + 1) % insights.length);
       setInsightVisible(true);
-    }, LH_EXIT_MS);
+    }, insightExitMs);
     return () => clearTimeout(t);
-  }, [insightVisible, isRecommending, insights.length, dwellMs]);
+  }, [insightVisible, isRecommending, insights.length, dwellMs, insightExitMs]);
 
   useEffect(() => {
     setSelectedIdx(0);
@@ -128,6 +138,9 @@ export default function LightStepRecommend() {
           text={currentInsight}
           show={insightVisible}
           dissolveDir="down"
+          popMs={INSIGHT_POP_MS}
+          staggerMs={INSIGHT_STAGGER_MS}
+          exitMs={INSIGHT_EXIT_MS}
           className="font-fraunces font-semibold text-[40px] leading-[1.1] tracking-[-0.01em] text-light-foreground text-center max-w-[15ch]"
         />
       </div>

--- a/src/components/layout/ScrollContainer.tsx
+++ b/src/components/layout/ScrollContainer.tsx
@@ -1,19 +1,38 @@
 "use client";
 
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+
 /**
  * Root viewport wrapper — owns 100dvh height and a single hidden scroll
  * axis. Pages render inside this container so the scroll bar is always
  * at the same place and the iOS PWA never gets a phantom Safari URL bar
  * eating into the bottom.
  *
+ * It lives in the ROOT layout, so it persists across client navigations —
+ * which means the scroll element is `#app-scroll`, NOT `window`, and its
+ * scroll position would otherwise carry from one page straight into the next.
+ * The pathname effect resets it to the top on every route change so a tall
+ * page always opens at the top. (In-flow brew step changes aren't route
+ * changes — LightFlowShell resets this same element by id on step change.)
+ *
  * Pages that need bottom-anchored UI (e.g. the brew flow's footer CTAs)
  * handle their own safe-area accounting via env(safe-area-inset-bottom).
- * No global bottom-padding reserve here — the legacy BottomNav was
- * retired with the last of the Light migration (PR #136).
  */
+export const SCROLL_CONTAINER_ID = "app-scroll";
+
 export default function ScrollContainer({ children }: { children: React.ReactNode }) {
+  const ref = useRef<HTMLDivElement>(null);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    ref.current?.scrollTo({ top: 0, behavior: "instant" });
+  }, [pathname]);
+
   return (
     <div
+      ref={ref}
+      id={SCROLL_CONTAINER_ID}
       style={{
         height: "100dvh",
         overflowY: "auto",

--- a/src/components/ui/light/LightFlowShell.tsx
+++ b/src/components/ui/light/LightFlowShell.tsx
@@ -6,6 +6,7 @@ import { ChevronLeft } from "lucide-react";
 import { useFlowStore, type FlowStep } from "@/store/flowStore";
 import { useFieldConfig } from "@/lib/field/FieldContext";
 import { DEFAULT_FIELD_ZONES } from "@/lib/field/defaultZones";
+import { SCROLL_CONTAINER_ID } from "@/components/layout/ScrollContainer";
 import CTA from "./CTA";
 
 /**
@@ -79,12 +80,16 @@ export default function LightFlowShell({
   useFieldConfig(fieldConfig);
 
   // Reset scroll to the top on every step transition. Without this,
-  // tapping Continue from a long Scan screen lands the user
-  // mid-Context with the eyebrow off-screen. Each step is a fresh
-  // page in the user's mental model — they should always see the
-  // Hero first. `instant` avoids the smooth animation that would
-  // jar the field rotation transition.
+  // tapping Continue from a long Scan screen lands the user mid-Context
+  // with the eyebrow off-screen (most jarring on "How was it?", which
+  // opens right after the tall brew-timer screen). Each step is a fresh
+  // page in the user's mental model — they should always see the Hero
+  // first. The app scrolls inside ScrollContainer (a 100dvh overflow div),
+  // NOT the window, so reset THAT element; the window call is a fallback
+  // for any context where the window is the scroller. `instant` avoids the
+  // smooth animation that would jar the field rotation transition.
   useEffect(() => {
+    document.getElementById(SCROLL_CONTAINER_ID)?.scrollTo({ top: 0, behavior: "instant" });
     window.scrollTo({ top: 0, behavior: "instant" });
   }, [step]);
 

--- a/src/components/ui/light/LiquidHeadline.tsx
+++ b/src/components/ui/light/LiquidHeadline.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, type CSSProperties } from "react";
 import { usePresence } from "@/hooks/usePresence";
 
 /**
@@ -10,10 +10,15 @@ import { usePresence } from "@/hooks/usePresence";
  *
  * Each word is an inline-block span that springs in from a scattered,
  * non-left-to-right order with an overshoot (`lh-pop-*`). When `show` flips
- * false the whole line dissolves and then unmounts (via `usePresence`):
- *   - `dissolveDir="up"`   mirrors the welcome haiku (blur + float up + grow).
- *   - `dissolveDir="down"` is the OPPOSITE (blur + sink + shrink) — used by the
- *     recipe screen so a finished insight leaves the way it didn't arrive.
+ * false the line leaves THE SAME WAY IN REVERSE: each word retreats one after
+ * another (the assembly played backwards — last word in, first word out),
+ * scattered + staggered, NOT a one-shot whole-line fade. `dissolveDir` only
+ * sets where the words drift as they go: "up" floats + grows (like the haiku),
+ * "down" sinks + shrinks (the opposite — used by the recipe screen).
+ *
+ * Timings are props (`popMs` / `staggerMs` / `exitMs`) so a calm, slow surface
+ * (the rotating recipe insight) and a snappy one (the Hero) can differ. Defaults
+ * keep the Hero at its original speed.
  *
  * Keyframes are co-located here (styled-jsx global), NOT in globals.css — the
  * installed PWA serves a stale cached globals.css, so iterated keyframes there
@@ -21,18 +26,26 @@ import { usePresence } from "@/hooks/usePresence";
  * in the same block. No touch-lens (that stays haiku-only).
  */
 
-export const LH_POP_MS = 770; // each word's spring duration
-export const LH_STAGGER_MS = 64; // gap between word pops
-export const LH_EXIT_MS = 360; // dissolve duration
+export const LH_POP_MS = 770; // default per-word entrance duration
+export const LH_STAGGER_MS = 64; // default gap between words
 
-/** Total time from mount until the whole line has settled, for a given word count. */
-export function liquidEntranceMs(wordCount: number): number {
-  return wordCount * LH_STAGGER_MS + LH_POP_MS;
+/** Time from mount until the whole line has settled, for a given word count. */
+export function liquidEntranceMs(
+  wordCount: number,
+  popMs = LH_POP_MS,
+  staggerMs = LH_STAGGER_MS,
+): number {
+  return wordCount * staggerMs + popMs;
+}
+
+/** Time from `show=false` until the whole line has left (drives `usePresence`). */
+export function liquidExitMs(wordCount: number, exitMs: number, staggerMs = LH_STAGGER_MS): number {
+  return Math.max(0, wordCount - 1) * staggerMs + exitMs;
 }
 
 // Deterministic scatter: a shuffled (LCG) per-word delay so words pop in a
 // non-typewriter order. Same text → same scatter. Mirrors HaikuStarter.
-function scatterDelays(n: number): number[] {
+function scatterDelays(n: number, staggerMs: number): number[] {
   const order = Array.from({ length: n }, (_, i) => i);
   let seed = 1337;
   for (let i = n - 1; i > 0; i--) {
@@ -44,21 +57,27 @@ function scatterDelays(n: number): number[] {
   }
   const delay = new Array<number>(n);
   order.forEach((origIdx, pos) => {
-    delay[origIdx] = pos * LH_STAGGER_MS;
+    delay[origIdx] = pos * staggerMs;
   });
   return delay;
 }
 
 interface LiquidHeadlineProps {
   text: string;
-  /** When this flips false the line dissolves, then unmounts. Default true. */
+  /** When this flips false the line leaves (per-word, reversed), then unmounts. Default true. */
   show?: boolean;
-  /** Dissolve direction. "up" = like the haiku; "down" = the opposite. */
+  /** Where words drift as they leave. "up" = like the haiku; "down" = the opposite. */
   dissolveDir?: "up" | "down";
   /** Element tag — "h1" for a page hero (keeps heading semantics), else "p". */
   as?: "h1" | "p";
   /** Classes for the line (typography, alignment). */
   className?: string;
+  /** Per-word entrance duration (ms). */
+  popMs?: number;
+  /** Gap between words for both entrance and exit (ms). */
+  staggerMs?: number;
+  /** Per-word exit duration (ms). Defaults to `popMs`. */
+  exitMs?: number;
 }
 
 export default function LiquidHeadline({
@@ -67,16 +86,25 @@ export default function LiquidHeadline({
   dissolveDir = "up",
   as: Tag = "p",
   className,
+  popMs = LH_POP_MS,
+  staggerMs = LH_STAGGER_MS,
+  exitMs,
 }: LiquidHeadlineProps) {
-  const { mounted, state } = usePresence(show, LH_EXIT_MS);
-  const exiting = state === "exit";
+  const resolvedExitMs = exitMs ?? popMs;
   const tokens = useMemo(() => text.split(/(\s+)/), [text]);
   const wordCount = useMemo(() => tokens.filter((t) => t.trim() !== "").length, [tokens]);
-  const delays = useMemo(() => scatterDelays(wordCount), [wordCount]);
+  const enterDelays = useMemo(() => scatterDelays(wordCount, staggerMs), [wordCount, staggerMs]);
+  // Exit plays the assembly in reverse: the last word to arrive leaves first.
+  const maxEnter = enterDelays.length ? Math.max(...enterDelays) : 0;
+  const exitDelays = useMemo(
+    () => enterDelays.map((d) => maxEnter - d),
+    [enterDelays, maxEnter],
+  );
 
-  const dissolveClass = dissolveDir === "down" ? "lh-dissolve-down" : "lh-dissolve-up";
+  const { mounted, state } = usePresence(show, liquidExitMs(wordCount, resolvedExitMs, staggerMs));
+  const exiting = state === "exit";
+
   let wi = -1;
-
   return (
     <>
       <style jsx global>{`
@@ -95,31 +123,55 @@ export default function LiquidHeadline({
           62% { opacity: 1; filter: blur(0); transform: translateY(-3px) scale(1.05); }
           100% { opacity: 1; filter: blur(0); transform: translateY(0) scale(1); }
         }
-        @keyframes lh-dissolve-up {
-          from { opacity: 1; filter: blur(0); transform: translateY(0) scale(1); }
-          to { opacity: 0; filter: blur(10px); transform: translateY(-8px) scale(1.03); }
+        /* Exit = the entrance in reverse: settle → slight anticipation → scatter out. */
+        @keyframes lh-out-1-down {
+          0% { opacity: 1; filter: blur(0); transform: translate(0, 0) scale(1) rotate(0deg); }
+          35% { opacity: 1; filter: blur(0); transform: translate(1px, -3px) scale(1.05) rotate(1deg); }
+          100% { opacity: 0; filter: blur(10px); transform: translate(-6px, 22px) scale(0.84) rotate(-3deg); }
         }
-        @keyframes lh-dissolve-down {
-          from { opacity: 1; filter: blur(0); transform: translateY(0) scale(1); }
-          to { opacity: 0; filter: blur(10px); transform: translateY(14px) scale(0.95); }
+        @keyframes lh-out-2-down {
+          0% { opacity: 1; filter: blur(0); transform: translate(0, 0) scale(1) rotate(0deg); }
+          35% { opacity: 1; filter: blur(0); transform: translate(-1px, -3px) scale(1.06) rotate(-1deg); }
+          100% { opacity: 0; filter: blur(12px); transform: translate(7px, 24px) scale(0.8) rotate(4deg); }
         }
-        .lh-word { animation-fill-mode: both; }
+        @keyframes lh-out-3-down {
+          0% { opacity: 1; filter: blur(0); transform: translateY(0) scale(1); }
+          35% { opacity: 1; filter: blur(0); transform: translateY(-4px) scale(1.05); }
+          100% { opacity: 0; filter: blur(9px); transform: translateY(26px) scale(0.9); }
+        }
+        @keyframes lh-out-1-up {
+          0% { opacity: 1; filter: blur(0); transform: translate(0, 0) scale(1) rotate(0deg); }
+          35% { opacity: 1; filter: blur(0); transform: translate(1px, 3px) scale(1.05) rotate(1deg); }
+          100% { opacity: 0; filter: blur(10px); transform: translate(-6px, -20px) scale(1.08) rotate(-3deg); }
+        }
+        @keyframes lh-out-2-up {
+          0% { opacity: 1; filter: blur(0); transform: translate(0, 0) scale(1) rotate(0deg); }
+          35% { opacity: 1; filter: blur(0); transform: translate(-1px, 3px) scale(1.06) rotate(-1deg); }
+          100% { opacity: 0; filter: blur(12px); transform: translate(7px, -22px) scale(1.06) rotate(4deg); }
+        }
+        @keyframes lh-out-3-up {
+          0% { opacity: 1; filter: blur(0); transform: translateY(0) scale(1); }
+          35% { opacity: 1; filter: blur(0); transform: translateY(4px) scale(1.05); }
+          100% { opacity: 0; filter: blur(9px); transform: translateY(-24px) scale(1.05); }
+        }
+        .lh-word {
+          animation-fill-mode: both;
+          animation-duration: var(--lh-dur, ${LH_POP_MS}ms);
+        }
+        .lh-pop-1, .lh-pop-2, .lh-pop-3 { animation-timing-function: ease-out; }
+        .lh-out-1-down, .lh-out-2-down, .lh-out-3-down,
+        .lh-out-1-up, .lh-out-2-up, .lh-out-3-up { animation-timing-function: ease-in; }
         .lh-pop-1 { animation-name: lh-pop-1; }
         .lh-pop-2 { animation-name: lh-pop-2; }
         .lh-pop-3 { animation-name: lh-pop-3; }
-        .lh-pop-1, .lh-pop-2, .lh-pop-3 {
-          animation-duration: ${LH_POP_MS}ms;
-          animation-timing-function: ease-out;
-        }
-        .lh-dissolve-up, .lh-dissolve-down {
-          animation-duration: ${LH_EXIT_MS}ms;
-          animation-timing-function: ease-in;
-          animation-fill-mode: forwards;
-        }
-        .lh-dissolve-up { animation-name: lh-dissolve-up; }
-        .lh-dissolve-down { animation-name: lh-dissolve-down; }
+        .lh-out-1-down { animation-name: lh-out-1-down; }
+        .lh-out-2-down { animation-name: lh-out-2-down; }
+        .lh-out-3-down { animation-name: lh-out-3-down; }
+        .lh-out-1-up { animation-name: lh-out-1-up; }
+        .lh-out-2-up { animation-name: lh-out-2-up; }
+        .lh-out-3-up { animation-name: lh-out-3-up; }
         @media (prefers-reduced-motion: reduce) {
-          .lh-word, .lh-dissolve-up, .lh-dissolve-down {
+          .lh-word {
             animation: none !important;
             opacity: 1 !important;
             filter: none !important;
@@ -129,16 +181,24 @@ export default function LiquidHeadline({
       `}</style>
       {mounted && (
         // Key on text so a new headline always remounts → replays the entrance.
-        <Tag key={text} className={`${exiting ? dissolveClass : ""}${className ? ` ${className}` : ""}`}>
+        <Tag key={text} className={className}>
           {tokens.map((w, i) => {
             if (w.trim() === "") return <span key={i}>{w}</span>;
             wi += 1;
             const variant = (wi % 3) + 1;
+            const cls = exiting ? `lh-out-${variant}-${dissolveDir}` : `lh-pop-${variant}`;
+            const dur = exiting ? resolvedExitMs : popMs;
+            const delay = exiting ? exitDelays[wi] : enterDelays[wi];
             return (
               <span
                 key={i}
-                className={`lh-word lh-pop-${variant} inline-block`}
-                style={{ animationDelay: `${delays[wi] ?? 0}ms` }}
+                className={`lh-word ${cls} inline-block`}
+                style={
+                  {
+                    "--lh-dur": `${dur}ms`,
+                    animationDelay: `${delay ?? 0}ms`,
+                  } as CSSProperties
+                }
               >
                 {w}
               </span>


### PR DESCRIPTION
Two things from using it: the recipe insight animation was stressful, and steps opened scrolled down.

## 1. Recipe insight — slower, per-word reverse exit, longer hold
- **Slower** entrance *and* exit (the old pace felt rushed).
- **The dissolve now mirrors the setup, in reverse** — instead of the whole line fading at once, each word leaves one after another (last word in, first word out), scattered + staggered, sinking down. `LiquidHeadline`'s exit is now the entrance played backwards.
- **Holds much longer** before it starts to leave.

Timings are now prop-driven (a `--lh-dur` CSS var) so the **Hero questions keep their snappy speed** while the recipe insight is calm: `pop 1000 / stagger 110 / exit 850`, held `4800ms` fully settled (was ~2600 + a 360ms whole-line fade). `liquidExitMs()` makes the rotation wait until every word has actually gone. All four are one-number dials in `LightStepRecommend`.

## 2. Every page / step opens at the top
"How was it?" (and other steps) opened at the previous screen's scroll offset — you had to scroll up. Root cause: the app scrolls inside `ScrollContainer` (a `100dvh` overflow div in the root layout), **not** the window, so `LightFlowShell`'s `window.scrollTo(0)` was a no-op. Now `ScrollContainer` resets itself to the top on every route change (`usePathname`) and `LightFlowShell` resets that element by id on step change. Fixes it app-wide, not just the flow.

## Verification
- `tsc --noEmit` clean; `node --test` green (62/62). Best confirmed on device (force-quit & reopen the PWA first): the insight should feel calm and disassemble word-by-word, and every screen should open at the top.

https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR)_