### PR TITLE
Drop the welcome-haiku loading skeleton

### DIFF
--- a/src/components/ui/light/HaikuStarter.tsx
+++ b/src/components/ui/light/HaikuStarter.tsx
@@ -32,17 +32,6 @@ function scatterDelays(n: number): number[] {
   return delay;
 }
 
-function HaikuSkeleton() {
-  const widths = ["72%", "90%", "54%"];
-  return (
-    <div aria-hidden className="w-full space-y-3.5">
-      {widths.map((w, i) => (
-        <div key={i} className="haiku-shimmer h-7 rounded-full" style={{ width: w }} />
-      ))}
-    </div>
-  );
-}
-
 /**
  * Home welcome-haiku (fluidity pass §E). Shimmer while it loads → a LIQUID
  * per-word entrance (words spring in from different directions with an
@@ -167,9 +156,7 @@ export default function HaikuStarter({ text, show }: { text: string; show: boole
           100% { opacity: 1; filter: blur(0); transform: translateY(0) scale(1); }
         }
       `}</style>
-      {loading ? (
-        <HaikuSkeleton />
-      ) : (
+      {loading ? null : (
         <p
           ref={pRef}
           className={exiting ? `${P_CLASS} haiku-exit` : P_CLASS}


### PR DESCRIPTION
The three shimmer bars you saw before the welcome haiku are a **loading skeleton** — `HaikuStarter` renders them while the daily greeting is still being fetched from `/api/greeting` (generated by the model, cached per time-of-day). Once the text lands, the haiku scatters in over them.

You don't want it, so this renders **nothing** while loading — the haiku simply scatters in when its text is ready, with nothing before it. Removed the now-unused `HaikuSkeleton`.

(If the greeting is cached it appears almost instantly; on a cold fetch there's just a brief blank where the bars used to be, then the haiku.)

## Verification
- `tsc --noEmit` clean; `node --test` green. Confirm on device (force-quit & reopen): opening Home should go straight from blank to the haiku scattering in — no shimmer bars.

https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR)_