### PR TITLE
Crafting status = real per-bean factor walk; coffee-detail controls above the photo

### DIFF
--- a/docs/liquid-design.md
+++ b/docs/liquid-design.md
@@ -142,7 +142,7 @@ dissolve). Swapping to a single text node mid-life re-wraps the line and hyphena
 | `src/components/ui/light/HaikuStarter.tsx` | Shimmer → entrance → dissolve → touch lens; owns the `haiku-pop-*` keyframes (co-located). Home welcome-haiku ONLY (it has the touch-lens). | `STAGGER_MS`, `POP_MS` (entrance speed), `EXIT_MS` (dissolve), `DISTURB_MAX_BLUR`, `DISTURB_FALLOFF` (lens) |
 | `src/components/ui/light/LiquidHeadline.tsx` | The haiku's per-word scatter entrance, extracted + reusable (NO touch-lens). Owns `lh-pop-*` + `lh-out-*-up/down` keyframes (co-located) + reduced-motion gate. **Exit is the entrance in REVERSE** — each word retreats one after another (last word in, first out), scattered + staggered, NOT a whole-line fade; `dissolveDir` only sets where they drift ("down" sinks/shrinks = the opposite of the haiku's up-float). Per-word duration via the `--lh-dur` CSS var so timings are prop-driven. Used by `Hero` (entrance only, `as="h1"`) and the recipe-crafting insight. Keyed on `text` so it replays the entrance whenever the headline changes. | props `popMs` / `staggerMs` / `exitMs` (per-instance speed); `LH_POP_MS` / `LH_STAGGER_MS` (Hero defaults); `liquidEntranceMs` / `liquidExitMs` helpers; the `lh-out-*` translate/scale (the "opposite" feel) |
 | `src/components/flow/LightStepRecommend.tsx` | Recipe-crafting loading screen: a `LiquidHeadline` insight deck (shuffled `COFFEE_HINTS`) shown big (Fraunces 40), one at a time — scatter-in, hold to read, leave word-by-word in reverse (sinking down), next sets up. Slow + calm on purpose. Pinned-top status is `<CraftingStatus>` (replaced the bean glow + the uppercase-grey "CRAFTING…" / "Did you know?" eyebrow). | `INSIGHT_POP_MS` 1000 / `INSIGHT_STAGGER_MS` 110 / `INSIGHT_EXIT_MS` 850 / `INSIGHT_READ_MS` 4800 (the settled read time); the deck size (`shuffleSubset(…, 12)`); `max-w-[15ch]` (wrap width) |
-| `src/components/ui/light/CraftingStatus.tsx` | Recipe-screen status line — black, sentence-case (card-title style), cycling phases ("Reading your context" → … → "Adapting it to your beans", holds on the last) + an animated 1-2-3 ellipsis. Co-located styled-jsx keyframes + reduced-motion gate. | `PHASES` (the phrases), `PHASE_MS` 2400 (advance speed), the `craft-d1/2/3` dot keyframes |
+| `src/components/ui/light/CraftingStatus.tsx` | Recipe-screen status line — black, sentence-case (card-title style) + animated 1-2-3 ellipsis. Cycles a `phases` list (passed in) and HOLDS on the last; the list is the **real per-bean factors** (`buildCraftingPhases` in `src/lib/craftingPhases.ts` — origin/process/variety/roast/freshness/mood/time/water/method → reference recipes → grind+temp → pours → "Adapting it to your beans"), personalized to the scanned coffee's own values, generic fallback otherwise (never fabricated). Paced to span the real ~minute, not 7s. Co-located styled-jsx keyframes + reduced-motion gate. | `buildCraftingPhases` (the walk + wording), `PHASE_MS` 4800 (advance speed), the `craft-d1/2/3` dot keyframes |
 | `src/components/ui/light/Hero.tsx` | Page hero — animates the question via `LiquidHeadline` when it's a plain string. The scan / context / log questions now **vary between visits** (`nextHeroQuestion` in `src/lib/heroQuestions.ts`, localStorage rotation; set in a mount effect so SSR stays stable and the scatter-in plays once). | whether a hero animates (string vs JSX); the variant lists in `heroQuestions.ts` |
 | `src/hooks/usePresence.ts` | Generic delayed-unmount `(present, exitMs) → {mounted, state}`. Replaces framer-motion AnimatePresence. Backs both `HaikuStarter` and `LiquidHeadline`. | — |
 | `src/app/(light)/page.tsx` | Renders the haiku as an absolute overlay over `ChatThread`; `showStarter = messages.length===0 && !composing` (declarative — NOT a one-way latch, so the haiku returns when a draft clears). | when the haiku shows / dissolves (the `composing` flag) |
@@ -407,4 +407,27 @@ When adding any new motion, add its selector to that globals.css block in the sa
   `PHASES`/`PHASE_MS`, the hero variant wording, the map `saturate`/`hue-rotate`.
 - **Traps found:** the hero pick must run in a mount effect, not render — `localStorage`/random in
   render causes an SSR hydration mismatch + a double scatter-in.
+- **PRs this session:** (number assigned on open)
+
+### 2026-06-12 — crafting status = real per-bean factor walk (not fake steps) + coffee-detail controls off the photo
+- **Done (status):** the recipe wait is ONE blocking Opus call (~30–60s, no streamed sub-steps —
+  `recommend.ts:983`, `max_tokens 5000`), so the old 4 generic phases raced through in ~7s on the 2.4s
+  timer then hung on "Adapting it to your beans" for the rest. Owner's call: not streaming, not
+  stretching the same four — **walk the real factors that build the two recipes for THIS bean**. New
+  pure `src/lib/craftingPhases.ts` `buildCraftingPhases(coffee, context)` returns an ordered list using
+  the coffee's OWN stored values (origin/region/process/variety/roast/freshness/mood/occasion/time/
+  water/method) with generic fallbacks on empty/"Unknown"/"Other" (no fabrication), then the real build
+  steps (pull reference recipes → grind+temp → pours → hold on "Adapting it to your beans").
+  `CraftingStatus` now takes a `phases` prop and `PHASE_MS` 2400→**4800** so the walk spans the real
+  minute; `LightStepRecommend` memoizes the list from `draft.coffee`/`draft.context`. Test:
+  `tests/dataflow/crafting-phases.test.mjs` (bundles the real helper — personalization, fallbacks,
+  freshness, the held tail).
+- **Done (coffee detail):** the back + burger were overlaid ON the rounded bag photo (#303). Moved them
+  into a flex header row ABOVE the photo, over the Field, and onto the standard dark header treatment
+  (`bg-light-foreground`/`text-light-text-on-dark`/`shadow-light-float`, `w-11 h-11`) for legibility +
+  consistency with every other `(light)` route. Photo sits below.
+- **Open / next:** on device, tune `craftingPhases` wording / `PHASE_MS`; confirm the detail header
+  spacing. The broader "less cream" pass still pending.
+- **Traps found:** — (`buildCraftingPhases` only ever shows stored values; placeholder guard prevents
+  "the Other process" / "Unknown variety" leaking).
 - **PRs this session:** (number assigned on open)

--- a/src/app/(light)/coffees/[id]/page.tsx
+++ b/src/app/(light)/coffees/[id]/page.tsx
@@ -200,9 +200,32 @@ export default function CoffeeDetailPage() {
 
   return (
     <div className="min-h-svh bg-transparent flex flex-col">
-      {/* Hero — rounded-inset bag photo (shared BagPhoto treatment), with the
-          back / menu controls and the title overlaid on the rounded image. */}
-      <div className="relative px-5" style={{ paddingTop: "calc(env(safe-area-inset-top) + 0.75rem)" }}>
+      {/* Hero — back / menu in a header row OVER the Field, ABOVE the
+          rounded-inset bag photo, so the controls no longer sit on the image. */}
+      <div className="px-5" style={{ paddingTop: "calc(env(safe-area-inset-top) + 1rem)" }}>
+        <div className="flex items-center justify-between mb-3">
+          {/* Back button — return to /coffees list */}
+          <button
+            onClick={() => router.push("/coffees")}
+            aria-label="Back to library"
+            className="w-11 h-11 rounded-full bg-light-foreground text-light-text-on-dark shadow-light-float flex items-center justify-center active:scale-95 transition-transform"
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
+
+          {/* Burger menu — opens NavigationOverlay (every Light surface has it). */}
+          <button
+            type="button"
+            onClick={() => setMenuOpen(true)}
+            aria-label="Open menu"
+            className="w-11 h-11 rounded-full bg-light-foreground text-light-text-on-dark shadow-light-float flex items-center justify-center active:scale-95 transition-transform"
+          >
+            <Menu className="w-5 h-5" strokeWidth={1.5} />
+          </button>
+        </div>
+
         {coffee.bagPhotoUrl ? (
           <BagPhoto url={coffee.bagPhotoUrl} alt={coffee.name}>
             <div className="absolute bottom-0 left-0 right-0 p-5">
@@ -240,28 +263,6 @@ export default function CoffeeDetailPage() {
           </>
         )}
 
-        {/* Back button — return to /coffees list */}
-        <button
-          onClick={() => router.push("/coffees")}
-          aria-label="Back to library"
-          className="absolute z-10 left-8 w-10 h-10 rounded-full bg-light-card-default/85 backdrop-blur-light-card backdrop-blur-sm flex items-center justify-center text-light-foreground"
-          style={{ top: "calc(env(safe-area-inset-top) + 1.5rem)" }}
-        >
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-          </svg>
-        </button>
-
-        {/* Burger menu — opens NavigationOverlay (every Light surface has it). */}
-        <button
-          type="button"
-          onClick={() => setMenuOpen(true)}
-          aria-label="Open menu"
-          className="absolute z-10 right-8 w-10 h-10 rounded-full bg-light-card-default/85 backdrop-blur-light-card backdrop-blur-sm flex items-center justify-center text-light-foreground active:scale-95 transition-transform"
-          style={{ top: "calc(env(safe-area-inset-top) + 1.5rem)" }}
-        >
-          <Menu className="w-5 h-5" strokeWidth={1.5} />
-        </button>
       </div>
 
       {/* Stats row */}

--- a/src/components/flow/LightStepRecommend.tsx
+++ b/src/components/flow/LightStepRecommend.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useFlowStore } from "@/store/flowStore";
 import LightFlowShell from "@/components/ui/light/LightFlowShell";
 import Section from "@/components/ui/light/Section";
@@ -10,6 +10,7 @@ import { formatSeconds } from "@/lib/utils/formatTime";
 import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
 import LiquidHeadline, { liquidEntranceMs, liquidExitMs } from "@/components/ui/light/LiquidHeadline";
 import CraftingStatus from "@/components/ui/light/CraftingStatus";
+import { buildCraftingPhases } from "@/lib/craftingPhases";
 import { COFFEE_HINTS } from "@/lib/coffeeHints";
 import { useWakeLock } from "@/hooks/useWakeLock";
 import type { RecommendationCandidate, CandidateRole, CandidateConfidence } from "@/lib/types/session";
@@ -67,6 +68,12 @@ const CONFIDENCE_LABELS: Record<CandidateConfidence, string> = {
 export default function LightStepRecommend() {
   const { draft, setStep, isRecommending, recommendError, setBrew } = useFlowStore();
   const rec = draft.recommendation;
+  // Status walk for the loading screen — the real factors going into the recipe
+  // for THIS coffee/context (personalized where the scanned bag has the data).
+  const craftingPhases = useMemo(
+    () => buildCraftingPhases(draft.coffee, draft.context),
+    [draft.coffee, draft.context],
+  );
   const [selectedIdx, setSelectedIdx] = useState(0);
 
   const { enableWakeLock, disableWakeLock } = useWakeLock();
@@ -133,7 +140,7 @@ export default function LightStepRecommend() {
           className="absolute left-0 right-0 flex justify-center px-8"
           style={{ top: "calc(env(safe-area-inset-top) + 1.75rem)" }}
         >
-          <CraftingStatus className="text-center" />
+          <CraftingStatus phases={craftingPhases} className="text-center" />
         </div>
         <LiquidHeadline
           text={currentInsight}

--- a/src/components/ui/light/CraftingStatus.tsx
+++ b/src/components/ui/light/CraftingStatus.tsx
@@ -1,37 +1,42 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { buildCraftingPhases } from "@/lib/craftingPhases";
 
 /**
  * Recipe-crafting status line — replaces the old static uppercase-grey
  * "CRAFTING YOUR RECIPE…" eyebrow. Black, sentence-case, in the card-title
  * style (Chivo 15/500 anthracite — see CardTitle in Card.tsx), with an animated
- * 1-2-3 ellipsis and a cycling phase telling you roughly what's happening.
+ * 1-2-3 ellipsis and a cycling phase that walks the REAL factors going into the
+ * recipe for this bean (passed in via `phases` — see buildCraftingPhases).
  *
- * The recipe is a single /recommend request, so the phases are indicative
- * (timed), not live progress. It advances through them and HOLDS on the last,
- * so a long wait doesn't loop back to "Reading your context".
+ * The recipe is a single /recommend Opus call with no streamed sub-steps, so
+ * the walk is paced (not live progress): it advances through the factors and
+ * HOLDS on the last ("Adapting it to your beans") so a long wait doesn't loop.
+ * PHASE_MS is sized so the walk spans the real ~minute rather than racing.
  *
  * Keyframes co-located (styled-jsx) per the PWA-cache rule; reduced motion
  * freezes the dots and swaps phases instantly.
  */
 
-const PHASES = [
-  "Reading your context",
-  "Looking through the recipes",
-  "Lining up a couple of options",
-  "Adapting it to your beans",
-];
-const PHASE_MS = 2400;
+const DEFAULT_PHASES = buildCraftingPhases();
+const PHASE_MS = 4800;
 
-export default function CraftingStatus({ className }: { className?: string }) {
+export default function CraftingStatus({
+  phases = DEFAULT_PHASES,
+  className,
+}: {
+  phases?: string[];
+  className?: string;
+}) {
   const [i, setI] = useState(0);
+  const last = Math.max(phases.length - 1, 0);
 
   useEffect(() => {
-    if (i >= PHASES.length - 1) return; // hold on the final phase
-    const t = setTimeout(() => setI((n) => Math.min(n + 1, PHASES.length - 1)), PHASE_MS);
+    if (i >= last) return; // hold on the final factor
+    const t = setTimeout(() => setI((n) => Math.min(n + 1, last)), PHASE_MS);
     return () => clearTimeout(t);
-  }, [i]);
+  }, [i, last]);
 
   return (
     <p
@@ -39,7 +44,7 @@ export default function CraftingStatus({ className }: { className?: string }) {
       className={`font-chivo text-[15px] font-medium leading-tight text-light-foreground ${className ?? ""}`}
     >
       <span key={i} className="craft-phrase">
-        {PHASES[i]}
+        {phases[i] ?? ""}
       </span>
       <span className="craft-dots" aria-hidden>
         <span>.</span>

--- a/src/lib/craftingPhases.ts
+++ b/src/lib/craftingPhases.ts
@@ -1,0 +1,108 @@
+import type { CoffeeIdentity, SessionContext } from "@/lib/types/session";
+
+/**
+ * Builds the ordered status walk shown on the recipe-crafting screen.
+ *
+ * The recipe is ONE blocking Opus call with no streamed sub-steps, so a
+ * truthful progress bar isn't available. Instead we narrate the **real factors
+ * that go into building the two recipes for THIS bean** — the same inputs the
+ * recommender weighs (origin / process / variety / roast / freshness / mood /
+ * occasion / time / water / method → recipe selection → grind+temp → pours).
+ * Each line uses the coffee's OWN stored value when present (never invents one
+ * — see the no-fabrication Hard Rule); a missing/placeholder value falls back
+ * to a generic phrasing. Only the sequential pacing is simulated.
+ *
+ * `CraftingStatus` cycles this list and holds on the final entry.
+ */
+
+/** A stored string we can actually show (not empty / placeholder). */
+function real(v?: string | null): v is string {
+  if (!v) return false;
+  const s = v.trim().toLowerCase();
+  return s !== "" && s !== "unknown" && s !== "other" && s !== "n/a" && s !== "none";
+}
+
+const OCCASION_LABELS: Record<string, string> = {
+  "morning-ritual": "morning ritual",
+  focus: "focus session",
+  experiment: "experiment",
+  "after-dinner": "after-dinner cup",
+  social: "social pour",
+};
+
+const TIME_LABELS: Record<string, string> = {
+  quick: "quick window",
+  normal: "~5-minute window",
+  unhurried: "unhurried window",
+};
+
+const WATER_LABELS: Record<string, string> = {
+  championship: "clarity-blend water",
+  tap: "filtered water",
+};
+
+function freshnessPhrase(roastDate?: string): string | null {
+  if (!real(roastDate)) return null;
+  const t = Date.parse(roastDate);
+  if (Number.isNaN(t)) return null;
+  const days = Math.floor((Date.now() - t) / 86_400_000);
+  if (days < 0) return null; // future-dated — skip rather than show nonsense
+  if (days < 7) return "Accounting for a fresh bag";
+  const weeks = Math.round(days / 7);
+  return `Accounting for a ${weeks}-week-rested bag`;
+}
+
+export function buildCraftingPhases(
+  coffee?: Partial<CoffeeIdentity> | null,
+  context?: Partial<SessionContext> | null,
+): string[] {
+  const phases: string[] = [];
+
+  // 1. Origin (+ region when known)
+  if (real(coffee?.region) && real(coffee?.origin)) {
+    phases.push(`Analyzing ${coffee.region}, ${coffee.origin}`);
+  } else if (real(coffee?.origin)) {
+    phases.push(`Analyzing the ${coffee.origin} origin`);
+  } else {
+    phases.push("Analyzing the bean's origin");
+  }
+
+  // 2. Process
+  phases.push(real(coffee?.process) ? `Reading the ${coffee.process} process` : "Reading the process");
+
+  // 3. Variety (only when known)
+  if (real(coffee?.variety)) phases.push(`Balancing the ${coffee.variety} variety`);
+
+  // 4. Roast
+  if (real(coffee?.roastLevel)) phases.push(`Factoring the ${coffee.roastLevel} roast`);
+
+  // 5. Freshness
+  const fresh = freshnessPhrase(coffee?.roastDate ?? undefined);
+  if (fresh) phases.push(fresh);
+
+  // 6. Mood
+  phases.push(real(context?.moodPreference) ? `Processing your ${context.moodPreference} mood` : "Processing your mood");
+
+  // 7. Occasion (named ones only)
+  const occ = real(context?.occasion) ? OCCASION_LABELS[context.occasion] : undefined;
+  if (occ) phases.push(`Reading the ${occ}`);
+
+  // 8. Time
+  const time = real(context?.timeAvailable) ? TIME_LABELS[context.timeAvailable] : undefined;
+  phases.push(time ? `Sizing the ${time}` : "Considering the time");
+
+  // 9. Water (when chosen)
+  const water = real(context?.waterSource) ? WATER_LABELS[context.waterSource] : undefined;
+  if (water) phases.push(`Matching your ${water}`);
+
+  // 10. Method
+  phases.push(real(context?.preferredMethod) ? `Building it for your ${context.preferredMethod}` : "Evaluating the best brewing method");
+
+  // 11–14. The build itself — real work the engine + Opus do, in order
+  phases.push("Pulling the reference recipes");
+  phases.push("Dialing grind and temperature");
+  phases.push("Shaping the pour sequence");
+  phases.push("Adapting it to your beans");
+
+  return phases;
+}

--- a/tests/dataflow/crafting-phases.test.mjs
+++ b/tests/dataflow/crafting-phases.test.mjs
@@ -1,0 +1,85 @@
+// Crafting-status phase tests. Bundles the REAL buildCraftingPhases() with
+// esbuild so the asserted walk is the one the recipe screen actually shows.
+//
+//   node --test tests/dataflow/crafting-phases.test.mjs
+//
+// What's locked down: the loading walk narrates the coffee's OWN stored values
+// when present (origin / process / variety / roast / mood / method), falls back
+// to generic phrasing on empty / "Unknown" / "Other" so NO placeholder leaks
+// and nothing is fabricated (the no-fabrication Hard Rule), and always ends on
+// the four build steps holding at "Adapting it to your beans".
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const entry = `export { buildCraftingPhases } from ${JSON.stringify(
+  path.join(ROOT, "src/lib/craftingPhases.ts"),
+)};`;
+const dir = await mkdtemp(join(tmpdir(), "craftphases-"));
+const out = join(dir, "c.mjs");
+await build({
+  stdin: { contents: entry, resolveDir: ROOT, loader: "ts" },
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  outfile: out,
+  logLevel: "silent",
+});
+const { buildCraftingPhases } = await import(pathToFileURL(out).href);
+
+const TAIL = [
+  "Pulling the reference recipes",
+  "Dialing grind and temperature",
+  "Shaping the pour sequence",
+  "Adapting it to your beans",
+];
+
+test("personalizes with the bag's real values", () => {
+  const phases = buildCraftingPhases(
+    { origin: "Ethiopia", region: "Yirgacheffe", variety: "Heirloom", process: "Washed", roastLevel: "Light" },
+    { moodPreference: "balanced", timeAvailable: "normal", preferredMethod: "V60" },
+  );
+  assert.ok(phases.includes("Analyzing Yirgacheffe, Ethiopia"));
+  assert.ok(phases.includes("Reading the Washed process"));
+  assert.ok(phases.includes("Balancing the Heirloom variety"));
+  assert.ok(phases.includes("Factoring the Light roast"));
+  assert.ok(phases.includes("Processing your balanced mood"));
+  assert.ok(phases.includes("Building it for your V60"));
+});
+
+test("always ends with the four build steps, holding on 'Adapting it to your beans'", () => {
+  const phases = buildCraftingPhases();
+  assert.deepEqual(phases.slice(-4), TAIL);
+  assert.equal(phases.at(-1), "Adapting it to your beans");
+});
+
+test("falls back generically on empty / placeholder values (no fabrication)", () => {
+  const phases = buildCraftingPhases(
+    { origin: "", variety: "Unknown", process: "Other", roastLevel: "" },
+    { moodPreference: "" },
+  );
+  assert.ok(phases.includes("Analyzing the bean's origin"));
+  assert.ok(phases.includes("Reading the process")); // "Other" → generic, not "the Other process"
+  assert.ok(phases.includes("Processing your mood"));
+  assert.ok(!phases.some((p) => p.includes("Unknown")));
+  assert.ok(!phases.some((p) => p.includes("Other")));
+  assert.ok(!phases.some((p) => /variety/i.test(p))); // unknown variety → line skipped
+  assert.ok(!phases.some((p) => /roast/i.test(p))); // empty roast → line skipped
+});
+
+test("freshness line derives from roastDate, and a future date shows nothing", () => {
+  const tenDaysAgo = new Date(Date.now() - 10 * 86_400_000).toISOString().slice(0, 10);
+  const fresh = buildCraftingPhases({ origin: "Kenya", process: "Washed", roastLevel: "Light", roastDate: tenDaysAgo });
+  assert.ok(fresh.some((p) => /rested bag/.test(p)));
+
+  const future = new Date(Date.now() + 30 * 86_400_000).toISOString().slice(0, 10);
+  const phases = buildCraftingPhases({ origin: "Kenya", process: "Washed", roastLevel: "Light", roastDate: future });
+  assert.ok(!phases.some((p) => /rested bag|fresh bag/.test(p)));
+});


### PR DESCRIPTION
Two fixes from the live app.

## 1. The "Crafting…" screen now narrates what's actually being weighed

You were right that it was bad. The recipe wait is **one blocking Opus call** (~30–60s, no streamed sub-steps), so the four generic phases raced through in ~7s on a 2.4s timer and then hung on "Adapting it to your beans" for the rest of the minute.

Instead of streaming (overkill) or stretching the same four words, the screen now **walks the real factors that go into building the two recipes for this specific bean**, paced across the real wait:

> Analyzing *Yirgacheffe, Ethiopia* → Reading the *Washed* process → Balancing the *Heirloom* variety → Factoring the *Light* roast → Accounting for a *2-week-rested* bag → Processing your *balanced* mood → Sizing the *~5-minute* window → Matching your *clarity-blend* water → Building it for your *V60* → Pulling the reference recipes → Dialing grind and temperature → Shaping the pour sequence → **Adapting it to your beans** (holds here)

It pulls the coffee's **own stored values** where the bag has them (italicised above), falls back to generic phrasing on missing/placeholder values so nothing is ever invented, and these *are* the real inputs the recommender weighs (origin/process/variety/roast/freshness/mood/time/water/method → recipe selection → grind/temp → pours). Only the sequential pacing is simulated. `PHASE_MS` 2400 → 4800 so it spans the real minute and rests on the last line instead of racing then hanging.

New pure `src/lib/craftingPhases.ts` + a test (`crafting-phases.test.mjs`) locking the personalization, the no-placeholder-leak fallbacks, freshness, and the held tail.

## 2. Coffee-detail: back + burger now sit above the photo

In #303 the controls were overlaid *on* the rounded bag photo. They're now in a header row **above** it (over the background), and on the standard dark header treatment every other `(light)` route uses — legible over the colourful Field and consistent. The photo drops below them.

## Verification
- `tsc --noEmit` clean; `node --test` green (66/66, ＋4 new). Best judged on device (force-quit & reopen first).

https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR)_