### PR TITLE
Home chat: brew pill for recipes, dark-chrome busy state, ~20% shorter answers

### DIFF
--- a/src/app/api/explore-agent/route.ts
+++ b/src/app/api/explore-agent/route.ts
@@ -93,7 +93,7 @@ Mention capabilities only when relevant — don't pitch them unprompted.
 
 | Situation | Destination |
 |-----------|-------------|
-| You mention a specific coffee **bag** from the user's library | coffee_detail (use the coffee's id from context) |
+| You mention a specific coffee **bag** from the user's library (but did NOT just write a full recipe for it — if you did, use **start_brew**, not a link) | coffee_detail (use the coffee's id from context) |
 | The user explicitly wants to **brew a specific bag again** — "brew the Jaime Sanchez again", "make me the cherry one", "I want the DAK Bourbon" | brew_again (use the coffee's id from context) — this lands the user in Step 3 (Context) of the brew flow with the bag already selected |
 | You reference several of their coffee bags, or suggest browsing their bag collection | coffee_library |
 | You recommend visiting a specific **café, roastery, or physical place** | cafe_detail — opens the Explore Nearby map |
@@ -107,7 +107,7 @@ Do NOT call suggest_navigation for trivial mentions. Only when navigation would 
 
 ## When to call start_brew
 
-When you have just written out a COMPLETE, ready-to-brew recipe for a specific bag in the user's library (you have its id), offer **start_brew** so they can brew it immediately — straight into the timer, without re-entering context (which would re-generate a possibly different recipe). This is the common "I've only got a few grams left, how would you brew it?" case. Do NOT use brew_again for this — brew_again throws your recipe away and re-asks context.
+When you have just written out a COMPLETE, ready-to-brew recipe for a specific bag in the user's library (you have its id), **start_brew is the PRIMARY action** — emit it INSTEAD of a suggest_navigation coffee_detail/coffee_library link for that bag. A library link is never the call-to-action for a recipe you just wrote: don't offer "View X in library" as the button — offer "Brew X" and build the pourSteps from the sequence you wrote. start_brew drops them straight into the timer, without re-entering context (which would re-generate a possibly different recipe). This is the common "I've only got a few grams left, how would you brew it?" case. Do NOT use brew_again for this — brew_again throws your recipe away and re-asks context.
 
 Non-negotiable rules:
 - The recipe in the start_brew call MUST be exactly the one in your message — same dose, water (hot water only for iced; put the ice in iceGrams), temperature, grind, total time, and the SAME pour-by-pour sequence. Never round or restate it differently. If they don't match, the user brews different numbers than they just read — a hard failure.
@@ -237,7 +237,7 @@ Be confident through the documented recipe, not apologetic. Never tell the user 
 
 ## Response Style
 
-- **Brevity first.** For shopping picks: one structured block per coffee. For conversation: 3–6 sentences max.
+- **Brevity first — about 20% tighter than your instinct.** Lead with the answer; cut opening pleasantries ("Great choice", "Let me think this through") and closing remarks. For conversation: 3–5 sentences. For a recipe or shopping pick: the structured recipe block plus at most one tight sentence each for agitation / water / any comparison. Trim words, never the reasoning or the numbers.
 - **No markdown headers** (no #, ##). Use **bold** for key terms.
 - Direct, confident. Reference real people, origins, varietals by name.
 - **Show your reasoning when you compare or pick.** When the user asks you to choose between things they already have (their bags, past sessions, kit), don't just declare the winner. Briefly name each candidate and what it brings to the criterion — one short sentence each — then the pick and a one-line *why*. "Direct" means every sentence does work, not "skip the reasoning".

--- a/src/components/ui/ThinkingDots.tsx
+++ b/src/components/ui/ThinkingDots.tsx
@@ -5,12 +5,19 @@
  * spinner per spec §6.2. Used inline where the next assistant message
  * will appear; left-aligned, no bubble, no avatar.
  */
-export default function ThinkingDots({ className = "" }: { className?: string }) {
+export default function ThinkingDots({
+  className = "",
+  color,
+}: {
+  className?: string;
+  /** Dot colour. Omit to keep the default `var(--text-secondary)` (Dark-era chat thread). */
+  color?: string;
+}) {
   return (
     <div className={`flex items-center gap-1.5 ${className}`} aria-label="Thinking">
-      <span className="thinking-dot" />
-      <span className="thinking-dot" style={{ animationDelay: "120ms" }} />
-      <span className="thinking-dot" style={{ animationDelay: "240ms" }} />
+      <span className="thinking-dot" style={{ background: color }} />
+      <span className="thinking-dot" style={{ background: color, animationDelay: "120ms" }} />
+      <span className="thinking-dot" style={{ background: color, animationDelay: "240ms" }} />
       <style jsx>{`
         .thinking-dot {
           width: 6px;

--- a/src/components/ui/light/ChatInput.tsx
+++ b/src/components/ui/light/ChatInput.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { Plus, X, AudioLines, ArrowUp, Square, Loader2, Coffee as CoffeeIcon } from "lucide-react";
 import { useVoiceCapture } from "@/hooks/useVoiceCapture";
 import WaveformBars from "@/components/ui/WaveformBars";
+import ThinkingDots from "@/components/ui/ThinkingDots";
 import AttachmentSheet from "@/components/ui/light/AttachmentSheet";
 import ReferenceCoffeePicker, { type CompactCoffee } from "@/components/ui/light/ReferenceCoffeePicker";
 
@@ -355,12 +356,12 @@ export default function ChatInput({
             >
               <X className="h-5 w-5" strokeWidth={1.5} />
             </button>
-          ) : isCompositionActive || loading ? (
+          ) : loading ? null : isCompositionActive ? (
             <button
               type="button"
               onClick={clearComposition}
-              disabled={loading || uploadingImage}
-              aria-label={loading ? "Sending" : "Clear"}
+              disabled={uploadingImage}
+              aria-label="Clear"
               className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-light-foreground text-light-text-on-dark shadow-light-float disabled:opacity-50"
             >
               <X className="h-5 w-5" strokeWidth={1.5} />
@@ -377,7 +378,9 @@ export default function ChatInput({
           )}
 
           {loading ? (
-            <div className="h-11 flex-1 rounded-full bg-light-foreground shadow-light-float" />
+            <div className="flex min-h-11 flex-1 items-center rounded-3xl bg-light-foreground pl-5 pr-5 shadow-light-float">
+              <ThinkingDots color="hsl(36 55% 96%)" />
+            </div>
           ) : isVoiceActive ? (
             <div className="flex h-11 flex-1 items-center gap-2 rounded-full bg-light-foreground pl-5 pr-1.5 shadow-light-float">
               <WaveformBars


### PR DESCRIPTION
Three fixes from using the live home chat (screenshots).

## 1. Recipe → brew pill, not a library link
When the chat writes a complete recipe for a bag in your library it was ending with a **"View … in library"** navigation pill instead of a **brew** pill. The `start_brew` action (drops you straight into the timer with that exact recipe) already works end-to-end — the agent just wasn't choosing it, because the `suggest_navigation` table said "mention a bag → coffee_detail" with no precedence rule. Added the precedence: a complete recipe for a library bag → `start_brew` is the primary action, emitted **instead** of a library/detail link for that bag. So the pill now reads **"Brew …"** and lands you in the timer.

## 2. Busy state matches the dark chrome
While a reply generated, the input row showed a dimmed gray **X** and an **empty all-black pill** — it read as unfinished. Now the loading pill mirrors the resting input pill (`rounded-3xl`, `bg-light-foreground`, `shadow-light-float`) with animated **cream `ThinkingDots`**, and the dimmed X is gone (the dots pill fills the row). `ThinkingDots` gained an optional `color` prop; the existing chat-thread usage is unchanged.

## 3. ~20% shorter answers
Tightened the Response Style brevity rule — cut preamble/filler ("Great choice", "Let me think this through", closing remarks), conversation cap 3–6 → 3–5 sentences, and one tight sentence per recipe note (agitation / water / comparison). The reasoning and the numbers are explicitly preserved (the "show your reasoning when you pick" rule is untouched). `max_tokens` left at 2000 so a long recipe never truncates mid-stream.

A functional Stop-to-cancel button (would touch the streaming logic) was deliberately left out of scope.

## Verification
- `tsc --noEmit` clean; `node --test` green. Best judged on device (force-quit & reopen first): ask for a recipe on a rotation bag → "Brew …" pill into the timer; send a message → clean dark dots pill while it works; answers read tighter without losing the recipe or the reasoning.

https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR)_