### PR TITLE
Stop button on the home chat — X returns while loading and aborts the reply

### DIFF
--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -119,6 +119,7 @@ export default function HomePage() {
   // lands, which is better UX than flashing a generic "Welcome…" string.
   const [starter, setStarter] = useState<string>("");
   const conversationIdRef = useRef<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
   const voice = useVoicePlayback();
 
   // Recent sessions for the agent's personal-context block.
@@ -282,6 +283,8 @@ export default function HomePage() {
         return { role: m.role, content: m.content };
       });
 
+      const controller = new AbortController();
+      abortRef.current = controller;
       const res = await fetch("/api/explore-agent", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -290,6 +293,7 @@ export default function HomePage() {
           recentSessions,
           ...(imageUrl ? { attachedImageUrl: imageUrl } : {}),
         }),
+        signal: controller.signal,
       });
 
       if (!res.ok || !res.body) {
@@ -403,14 +407,34 @@ export default function HomePage() {
           ...(assistantActions ? { actions: assistantActions } : {}),
         });
       }
-    } catch {
-      setMessages((prev) => [
-        ...prev,
-        { role: "assistant", content: "Couldn't reach BTTS. Check your connection." },
-      ]);
+    } catch (err) {
+      // Stop button aborted the request — keep whatever streamed, no error bubble.
+      const aborted = err instanceof DOMException && err.name === "AbortError";
+      if (!aborted) {
+        setMessages((prev) => [
+          ...prev,
+          { role: "assistant", content: "Couldn't reach BTTS. Check your connection." },
+        ]);
+      } else {
+        // Stopped before any text arrived — drop the empty assistant bubble.
+        setMessages((prev) => {
+          const last = prev[prev.length - 1];
+          if (last && last.role === "assistant" && !last.content && !last.actions) {
+            return prev.slice(0, -1);
+          }
+          return prev;
+        });
+      }
     } finally {
+      abortRef.current = null;
       setLoading(false);
     }
+  };
+
+  // Stop button while a reply streams — abort the request and silence any TTS.
+  const handleStop = () => {
+    abortRef.current?.abort();
+    voice.cancel();
   };
 
   return (
@@ -444,6 +468,7 @@ export default function HomePage() {
         <ChatInput
           loading={loading}
           onSend={handleSend}
+          onStop={handleStop}
           onComposingChange={setComposing}
           assistantSpeaking={voice.speaking}
           onCancelSpeak={voice.cancel}

--- a/src/components/ui/light/ChatInput.tsx
+++ b/src/components/ui/light/ChatInput.tsx
@@ -41,6 +41,8 @@ export interface SendPayload {
 interface ChatInputProps {
   loading: boolean;
   onSend: (payload: SendPayload) => void;
+  /** Abort the in-flight reply — wired to the Stop (X) button shown while loading. */
+  onStop?: () => void;
   /**
    * Live composition state: true when a draft exists (text / photo / coffee
    * ref / uploading), false when idle. NOT triggered by a bare mic tap or an
@@ -77,6 +79,7 @@ async function uploadPhoto(file: File): Promise<string> {
 export default function ChatInput({
   loading,
   onSend,
+  onStop,
   onComposingChange,
   assistantSpeaking = false,
   onCancelSpeak,
@@ -347,6 +350,15 @@ export default function ChatInput({
             >
               <X className="h-5 w-5" strokeWidth={1.5} />
             </button>
+          ) : loading ? (
+            <button
+              type="button"
+              onClick={() => onStop?.()}
+              aria-label="Stop"
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-light-foreground text-light-text-on-dark shadow-light-float active:scale-95 transition-transform"
+            >
+              <X className="h-5 w-5" strokeWidth={1.5} />
+            </button>
           ) : assistantSpeaking && !isCompositionActive ? (
             <button
               type="button"
@@ -356,7 +368,7 @@ export default function ChatInput({
             >
               <X className="h-5 w-5" strokeWidth={1.5} />
             </button>
-          ) : loading ? null : isCompositionActive ? (
+          ) : isCompositionActive ? (
             <button
               type="button"
               onClick={clearComposition}


### PR DESCRIPTION
I removed the X from the busy state in #305 but left no way to stop a streaming reply. This brings it back as a real **Stop**: while a reply generates, the left control is an enabled **X** in the dark chrome (not dimmed) that aborts the request. The dark dots pill stays.

- `page.tsx`: an `AbortController` per send, its `signal` passed to the explore-agent fetch; `handleStop()` aborts it and silences any TTS. The catch distinguishes `AbortError` (no error bubble — keep whatever already streamed) and drops a trailing empty assistant bubble if you stop before any text arrives.
- `ChatInput.tsx`: new `onStop` prop; the loading branch renders the X (Stop) ahead of the assistant-speaking branch so one tap stops generation.

`tsc --noEmit` clean; `node --test` green.

https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR)_