### PR TITLE
fix(ios): brew-step notifications now buzz — sound + haptic + Apple Watch

### DIFF
--- a/src/lib/native/brewNotifications.ts
+++ b/src/lib/native/brewNotifications.ts
@@ -32,6 +32,19 @@ interface LocalNotificationLike {
   title: string;
   body: string;
   schedule: { at: Date };
+  /** iOS: setting ANY non-nil sound flips the notification from passively
+   * delivered (silent banner, no haptic) to "alerting" — it then plays a sound
+   * AND fires the default vibration on the iPhone + mirrors the haptic to a
+   * paired Apple Watch (when the phone is locked/asleep). A missing custom file
+   * falls back to the system default tone. Omitting this field is why early
+   * builds buzzed nothing. */
+  sound?: string;
+  /** iOS interruption level. `timeSensitive` lets a pour cue break through a
+   * Focus / Do-Not-Disturb mode and reads as urgent — the right semantic for a
+   * live brew timer. (Breaking through Focus also needs the Time-Sensitive
+   * entitlement on the App ID; without it this degrades gracefully to a normal
+   * alert.) */
+  interruptionLevel?: "passive" | "active" | "timeSensitive" | "critical";
 }
 
 interface LocalNotificationsLike {
@@ -197,7 +210,18 @@ export async function scheduleBrew(boundaries: BrewBoundary[], anchorMs: number)
     const notifications = boundaries.slice(0, ID_RANGE).flatMap((b, i) => {
       const at = new Date(anchorMs + b.atSec * 1000);
       if (at.getTime() - now < MIN_LEAD_MS) return [];
-      return [{ id: ID_BASE + i, title: b.title, body: b.body, schedule: { at } }];
+      return [
+        {
+          id: ID_BASE + i,
+          title: b.title,
+          body: b.body,
+          schedule: { at },
+          // Make the cue alerting, not passive — sound + iPhone vibration +
+          // Apple Watch haptic on a locked phone. See LocalNotificationLike.
+          sound: "default",
+          interruptionLevel: "timeSensitive" as const,
+        },
+      ];
     });
     if (notifications.length > 0) await plugin.schedule({ notifications });
   } catch {


### PR DESCRIPTION
## Problem
On-device test of the TestFlight build: lock-screen pour notifications **appear** (e.g. "Final Pour") but are **silent** — no sound, and crucially **no vibration on the iPhone or the paired Apple Watch**.

## Cause
iOS delivers a local notification with no `sound` set **passively**: banner only, no alert tone, no haptic, and it is **not mirrored to the Apple Watch**. The Phase-1 brew bridge scheduled every boundary with just `id/title/body/schedule` — no `sound` — so every cue was passive.

## Fix
`src/lib/native/brewNotifications.ts` now schedules each notification with:
- `sound: "default"` — any non-nil sound flips the notification to *alerting*: it plays a tone, fires the iPhone's default vibration, and mirrors the haptic to a paired Apple Watch (when the phone is locked/asleep — Apple's routing rule).
- `interruptionLevel: "timeSensitive"` — a pour cue can break through a Focus / Do-Not-Disturb mode (fully effective once the Time-Sensitive entitlement is added to the App ID; degrades to a normal alert without it).

## Why no rebuild
The notification bridge is **web code on the live site** the Capacitor shell loads via `server.url`. Merging → auto-deploy to Hetzner → the **existing** installed TestFlight build picks it up on next launch. No new TestFlight build needed.

## Verification
- `tsc --noEmit` clean; `tests/dataflow/brew-notifications.test.mjs` 5/5 green (boundary schedule unchanged — only the native payload gained sound/interruption fields).
- On-device re-test pending after deploy: lock phone → each pour cue should now sound + vibrate on iPhone + Watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)