### PR TITLE
feat(brew): swirl/stir/tap as discrete flow-rate-timed steps + foreground haptics

### DIFF
--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -11,12 +11,14 @@ import {
   buildGuideSteps,
   hasImmersionShape,
   getActiveIdx,
+  isAgitationPourAction,
   type PourStep,
   type GuideStep,
 } from "@/lib/utils/pourSequence";
 import type { BrewStepAction } from "@/lib/types/session";
 import { basedOnReference } from "@/lib/utils/resolveRecipe";
 import { useBrewStepNotifications } from "@/hooks/useBrewStepNotifications";
+import { useBrewStepHaptics } from "@/hooks/useBrewStepHaptics";
 import { buildBrewBoundaries } from "@/lib/native/brewNotifications";
 
 /**
@@ -61,14 +63,6 @@ export default function LightStepBrew() {
   const recipeName = selectedCandidate?.title;
   const basedOn = basedOnReference(selectedCandidate?.basedOn, selectedCandidate?.title);
 
-  // Belt-and-suspenders: even if the structured steps aren't explicit, a recipe
-  // that describes itself as minimal/reduced agitation must never show a swirl
-  // affordance. Scans the candidate's own words + any step notes.
-  const suppressAgitation = /minimal agitation|reduced agitation|no swirl|no stir|no agitation|without agitation/i.test(
-    `${selectedCandidate?.title ?? ""} ${selectedCandidate?.whyChosen ?? ""} ${(recipe?.pourSteps ?? [])
-      .map((s) => s.notes ?? "")
-      .join(" ")}`,
-  );
 
   const [elapsed, setElapsed] = useState(0);
   const [started, setStarted] = useState(false);
@@ -144,6 +138,12 @@ export default function LightStepBrew() {
     started,
   );
 
+  // iOS shell: real foreground Taptic cues — a 3-2-1 countdown then a strong
+  // buzz at every step boundary, fired live while the app is awake + foreground
+  // (where lock-screen notifications never show and navigator.vibrate is dead).
+  // Native-only no-op elsewhere.
+  useBrewStepHaptics(boundaries, elapsed, started);
+
   return (
     <LightFlowShell
       onNext={() => {
@@ -193,8 +193,6 @@ export default function LightStepBrew() {
             elapsed={elapsed}
             targetTimeSec={recipe.targetTimeSec}
             started={started}
-            process={draft.coffee?.process}
-            suppressAgitation={suppressAgitation}
           />
         )}
 
@@ -213,60 +211,50 @@ interface LivePourSequenceProps {
   elapsed: number;
   targetTimeSec: number;
   started: boolean;
-  process?: string;
-  /** Recipe is minimal/reduced agitation — never show a swirl/stir affordance. */
-  suppressAgitation?: boolean;
 }
 
-/**
- * Decide whether (and how) to offer an agitation tap for a pour — RECIPE-DRIVEN.
- * Explicit `agitation` from the structured recipe wins (`null` = none). When the
- * recipe is silent (legacy grams string, `agitation === undefined`), default to
- * a bloom-only swirl/stir; NO default agitation on mid or final pours — that
- * stray "Swirl" on the drawdown card was the reported bug.
- */
-function resolveAgitation(
-  step: PourStep,
-  isWashed: boolean,
-  suppress: boolean,
-): { isStir: boolean; label: string } | null {
-  if (suppress) return null;
-  if (step.agitation === null) return null;
-  if (step.agitation === "stir") return { isStir: true, label: "Stir" };
-  if (step.agitation === "swirl") return { isStir: false, label: "Swirl" };
-  if (step.action === "bloom") return { isStir: isWashed, label: isWashed ? "Stir" : "Swirl" };
-  return null;
+/** Short SwirlButton label for an agitation step. */
+function agitationButtonLabel(action: PourStep["action"]): string {
+  return action === "stir" ? "Stir" : action === "tap" ? "Tap" : "Swirl";
 }
 
-function LivePourSequence({
-  steps,
-  elapsed,
-  targetTimeSec,
-  started,
-  process,
-  suppressAgitation = false,
-}: LivePourSequenceProps) {
+function LivePourSequence({ steps, elapsed, targetTimeSec, started }: LivePourSequenceProps) {
   const activeIdx = started ? getActiveIdx(elapsed, steps) : -1;
   const activeStep = activeIdx >= 0 ? steps[activeIdx] : null;
   const nextStep = activeIdx >= 0 && activeIdx < steps.length - 1 ? steps[activeIdx + 1] : null;
-  const isWashed = process?.toLowerCase() === "washed";
-  const bloomCueActive =
-    started && activeStep?.action === "bloom" && elapsed >= 20 && elapsed < 40;
-  const finalStep = steps[steps.length - 1];
-  const finalCueActive =
-    started &&
-    activeStep?.action === "final" &&
-    elapsed >= finalStep.startTimeSec + 28 &&
-    elapsed < finalStep.startTimeSec + 55;
   const nextCountdown = nextStep ? Math.max(0, nextStep.startTimeSec - elapsed) : null;
-  const lastPourStart = steps[steps.length - 1].startTimeSec;
-  const pourGraceSec = Math.min(20, Math.round((targetTimeSec - lastPourStart) * 0.35));
-  const allPoursDone = started && elapsed >= lastPourStart + pourGraceSec;
+  // The last step is the final pour OR a trailing tap/swirl after it — either
+  // way, draining begins once we're a grace beyond it.
+  const lastStepStart = steps[steps.length - 1].startTimeSec;
+  const pourGraceSec = Math.min(20, Math.round((targetTimeSec - lastStepStart) * 0.35));
+  const allPoursDone = started && elapsed >= lastStepStart + pourGraceSec;
 
   const [flashKey, setFlashKey] = useState(0);
   useEffect(() => {
     if (activeIdx > 0) setFlashKey((k) => k + 1);
   }, [activeIdx]);
+
+  // Countdown footer ("Swirl in 0:05") — shared by the pour + agitation cards.
+  const countdownFooter =
+    nextStep && nextCountdown !== null && nextCountdown <= 20 && nextCountdown > 0 ? (
+      <div className="mt-3 pt-3 border-t border-light-foreground/15 flex items-center justify-between">
+        <span className="text-[12px] text-light-muted-foreground">{nextStep.label}</span>
+        <span
+          // key={nextCountdown} so React replaces the DOM node on every tick.
+          // Otherwise the infinite opacity pulse can be mid-cycle when the digit
+          // changes (6 → 5), and iOS Safari leaves the previous glyph faintly
+          // visible behind the new one.
+          key={nextCountdown}
+          className={`font-mono-num text-[14px] ${
+            nextCountdown <= 5
+              ? "font-bold text-light-foreground animate-countdown-pulse"
+              : "font-medium text-light-muted-foreground"
+          }`}
+        >
+          in 0:{String(nextCountdown).padStart(2, "0")}
+        </span>
+      </div>
+    ) : null;
 
   if (!started) {
     return (
@@ -281,34 +269,27 @@ function LivePourSequence({
             isLast={false}
           />
 
-          {steps.map((step, i) => {
-            const ag = resolveAgitation(step, isWashed, suppressAgitation);
-            const agitation = ag ? (ag.isStir ? "Stir to agitate" : "Gentle swirl") : null;
-            return (
-              <TimelineRow
-                key={i}
-                time={step.startTimeSec === 0 ? "0:00" : formatSeconds(step.startTimeSec)}
-                label={
-                  <div>
-                    <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-                      <span className="text-[14px] font-medium text-light-foreground">{step.label}</span>
-                      <span className="font-mono-num text-[12px] font-semibold text-light-foreground">+{step.pourGrams}g</span>
-                      <span className="font-mono-num text-[12px] text-light-muted-foreground">→ {step.cumulativeGrams}g</span>
-                      {step.temperatureC != null && (
-                        <span className="font-mono-num text-[12px] text-light-muted-foreground">· {step.temperatureC}°C</span>
-                      )}
-                    </div>
-                    {agitation && (
-                      <span className="text-[12px] text-light-muted-foreground block mt-0.5">
-                        {agitation}
-                      </span>
+          {steps.map((step, i) => (
+            <TimelineRow
+              key={i}
+              time={step.startTimeSec === 0 ? "0:00" : formatSeconds(step.startTimeSec)}
+              label={
+                isAgitationPourAction(step.action) ? (
+                  <span className="text-[14px] font-medium text-light-foreground">{step.label}</span>
+                ) : (
+                  <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                    <span className="text-[14px] font-medium text-light-foreground">{step.label}</span>
+                    <span className="font-mono-num text-[12px] font-semibold text-light-foreground">+{step.pourGrams}g</span>
+                    <span className="font-mono-num text-[12px] text-light-muted-foreground">→ {step.cumulativeGrams}g</span>
+                    {step.temperatureC != null && (
+                      <span className="font-mono-num text-[12px] text-light-muted-foreground">· {step.temperatureC}°C</span>
                     )}
                   </div>
-                }
-                isLast={i === steps.length - 1}
-              />
-            );
-          })}
+                )
+              }
+              isLast={i === steps.length - 1}
+            />
+          ))}
 
           <TimelineRow
             time={formatSeconds(targetTimeSec)}
@@ -322,7 +303,34 @@ function LivePourSequence({
 
   return (
     <div className="space-y-3">
-      {activeStep && !allPoursDone && (
+      {activeStep && !allPoursDone && isAgitationPourAction(activeStep.action) && (
+        // Agitation step — its own prominent moment (the cue the 3-2-1 buzz lands on).
+        <div
+          key={`step-${flashKey}`}
+          className="rounded-3xl bg-light-card-selected backdrop-blur-light-card backdrop-saturate-150 shadow-light-card-pressed p-4 animate-step-activate"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex-1 min-w-0">
+              <p className="label-eyebrow mb-1">Now</p>
+              <p className="font-fraunces text-[24px] leading-tight text-light-foreground">
+                {activeStep.label}
+              </p>
+              <p className="text-[12px] text-light-muted-foreground mt-2">
+                {activeStep.notes ?? defaultPourNote(activeStep.action)}
+              </p>
+            </div>
+            <SwirlButton
+              isStir={activeStep.action === "stir"}
+              label={agitationButtonLabel(activeStep.action)}
+              cueActive
+            />
+          </div>
+          {countdownFooter}
+        </div>
+      )}
+
+      {activeStep && !allPoursDone && !isAgitationPourAction(activeStep.action) && (
+        // Pour step — grams only; agitation is now a discrete step of its own.
         <div
           key={`step-${flashKey}`}
           className="rounded-3xl bg-light-card-selected backdrop-blur-light-card backdrop-saturate-150 shadow-light-card-pressed p-4 animate-step-activate"
@@ -348,45 +356,8 @@ function LivePourSequence({
                 {activeStep.notes ?? defaultPourNote(activeStep.action)}
               </p>
             </div>
-
-            {(() => {
-              const ag = resolveAgitation(activeStep, isWashed, suppressAgitation);
-              if (!ag) return null;
-              return (
-                <SwirlButton
-                  isStir={ag.isStir}
-                  label={ag.label}
-                  cueActive={
-                    activeStep.action === "bloom"
-                      ? bloomCueActive
-                      : activeStep.action === "final"
-                        ? finalCueActive
-                        : false
-                  }
-                />
-              );
-            })()}
           </div>
-
-          {nextCountdown !== null && nextCountdown <= 20 && nextCountdown > 0 && (
-            <div className="mt-3 pt-3 border-t border-light-foreground/15 flex items-center justify-between">
-              <span className="text-[12px] text-light-muted-foreground">{nextStep!.label}</span>
-              <span
-                // key={nextCountdown} so React replaces the DOM node on every
-                // tick. Otherwise the infinite opacity pulse can be mid-cycle
-                // when the digit changes (6 → 5), and iOS Safari leaves the
-                // previous glyph faintly visible behind the new one.
-                key={nextCountdown}
-                className={`font-mono-num text-[14px] ${
-                  nextCountdown <= 5
-                    ? "font-bold text-light-foreground animate-countdown-pulse"
-                    : "font-medium text-light-muted-foreground"
-                }`}
-              >
-                in 0:{String(nextCountdown).padStart(2, "0")}
-              </span>
-            </div>
-          )}
+          {countdownFooter}
         </div>
       )}
 
@@ -402,10 +373,6 @@ function LivePourSequence({
                 Target finish: {formatSeconds(targetTimeSec)}
               </p>
             </div>
-            {(() => {
-              const ag = resolveAgitation(steps[steps.length - 1], isWashed, suppressAgitation);
-              return ag ? <SwirlButton isStir={ag.isStir} label={ag.label} /> : null;
-            })()}
           </div>
         </div>
       )}
@@ -460,10 +427,20 @@ function StepDots({
   activeIdx: number;
   allDone: boolean;
 }) {
-  const pourLabels = steps.map((_, i) =>
-    i === 0 ? "Bloom" : i === steps.length - 1 ? "Final" : `P${i + 1}`,
-  );
-  const labels = ["Ready", ...pourLabels, "Drain"];
+  // Label each dot by its action: agitation steps get their own short tag,
+  // pours are numbered among the pours only (so an interleaved swirl doesn't
+  // bump the pour count).
+  let pourNo = 0;
+  const stepLabels = steps.map((step) => {
+    if (isAgitationPourAction(step.action)) {
+      return step.action === "stir" ? "Stir" : step.action === "tap" ? "Tap" : "Swirl";
+    }
+    pourNo += 1;
+    if (step.action === "bloom") return "Bloom";
+    if (step.action === "final") return "Final";
+    return `P${pourNo}`;
+  });
+  const labels = ["Ready", ...stepLabels, "Drain"];
   const total = labels.length;
   const currentPos = allDone ? total - 1 : activeIdx === -1 ? 0 : activeIdx + 1;
   const fillPct = total > 1 ? (currentPos / (total - 1)) * 100 : 0;
@@ -510,7 +487,13 @@ function defaultPourNote(action: PourStep["action"]): string {
     case "bloom":
       return "Pour in slow circles from centre outward";
     case "final":
-      return "Last pour — swirl gently after";
+      return "Last pour";
+    case "swirl":
+      return "Gentle swirl to even the bed";
+    case "stir":
+      return "Stir evenly to settle the bed";
+    case "tap":
+      return "Tap to settle and level the bed";
     default:
       return "Slow spiral from centre outward";
   }

--- a/src/hooks/useBrewStepHaptics.ts
+++ b/src/hooks/useBrewStepHaptics.ts
@@ -1,0 +1,75 @@
+"use client";
+import { useEffect, useRef } from "react";
+import { type BrewBoundary } from "@/lib/native/brewNotifications";
+import { COUNTDOWN_SECONDS, countdownTap, stepBuzz, isNativeHaptics } from "@/lib/native/brewHaptics";
+
+/**
+ * Foreground Taptic cues for an active brew (iOS shell). Pure no-op in browsers
+ * and on the lock-screen-notification path — see brewHaptics.ts for why this is
+ * native-only and separate from notifications.
+ *
+ * Unlike notifications (scheduled once, fired by iOS even when JS is frozen),
+ * haptics must fire LIVE at the moment — so this runs off the timer's own
+ * integer-second `elapsed`. The app is foregrounded + wake-locked during a
+ * brew, so the tick keeps coming and JS is alive to fire each cue.
+ *
+ * For every step boundary it fires: a short MEDIUM tap at t-3 / t-2 / t-1 (the
+ * 3-2-1 countdown), then a strong, longer buzz AT the boundary ("act now").
+ *
+ * A cue fires only when `elapsed` lands on (or within 1 s late of) its moment.
+ * If `elapsed` jumps forward — a visibilitychange snap after a tab switch /
+ * Stop→Resume — the skipped cues are marked done WITHOUT buzzing, so the phone
+ * never machine-guns a backlog of stale taps.
+ */
+export function useBrewStepHaptics(
+  boundaries: BrewBoundary[],
+  elapsed: number,
+  started: boolean,
+): void {
+  const boundariesRef = useRef(boundaries);
+  useEffect(() => {
+    boundariesRef.current = boundaries;
+  }, [boundaries]);
+
+  const firedRef = useRef<Set<string>>(new Set());
+  const prevElapsedRef = useRef(-1);
+
+  // Reset the fired-set whenever the brew resets (Reset emits elapsed 0) or
+  // hasn't started — so a re-brew in the same mounted component replays cues.
+  if (!started || elapsed === 0) {
+    if (firedRef.current.size > 0) firedRef.current.clear();
+    prevElapsedRef.current = elapsed;
+  }
+
+  useEffect(() => {
+    if (!started || elapsed < 1) return;
+    if (!isNativeHaptics()) return;
+    // Act only on genuine ticks — a re-render with no elapsed change must not
+    // re-evaluate (and an integer that repeats across two 500 ms syncs is fine,
+    // the fired-set guards each cue anyway).
+    if (elapsed === prevElapsedRef.current) return;
+    prevElapsedRef.current = elapsed;
+
+    const LATE_TOLERANCE = 1; // seconds: still fire if we're at most 1 s late
+
+    for (const b of boundariesRef.current) {
+      // 3-2-1 countdown taps.
+      for (const lead of COUNTDOWN_SECONDS) {
+        const at = b.atSec - lead;
+        if (at <= 0) continue;
+        const key = `t@${at}`;
+        if (firedRef.current.has(key)) continue;
+        if (elapsed >= at) {
+          firedRef.current.add(key);
+          if (elapsed - at <= LATE_TOLERANCE) countdownTap();
+        }
+      }
+      // Strong "act now" buzz at the boundary.
+      const key = `b@${b.atSec}`;
+      if (!firedRef.current.has(key) && elapsed >= b.atSec) {
+        firedRef.current.add(key);
+        if (elapsed - b.atSec <= LATE_TOLERANCE) stepBuzz();
+      }
+    }
+  }, [elapsed, started, boundaries]);
+}

--- a/src/lib/native/brewHaptics.ts
+++ b/src/lib/native/brewHaptics.ts
@@ -1,0 +1,85 @@
+/**
+ * Brew-step HAPTICS — foreground Taptic cues for the iOS shell.
+ *
+ * Why this exists separately from brewNotifications.ts: during an active brew
+ * the screen is held awake (wake lock), so the phone is NEVER on its lock
+ * screen — the lock-screen notifications never show. The user is looking at
+ * (or distracted near) an unlocked, foregrounded app. The only thing that can
+ * refocus them then is a real vibration, and `navigator.vibrate()` — which the
+ * timer already calls — is silently IGNORED by iOS inside a WKWebView. So this
+ * module drives the native `@capacitor/haptics` plugin instead, which IS able
+ * to fire Taptic feedback in the foreground.
+ *
+ * Pure-web module, ZERO `@capacitor/*` imports (strict-TS clean, ambient types
+ * only). In any non-shell context (Safari PWA, desktop, CI Chromium) every
+ * export is a silent no-op — the plugin is absent, so `getHaptics()` returns
+ * null. Native-only by design: the existing `navigator.vibrate` path keeps
+ * serving Android, and we don't want a double buzz there.
+ *
+ * Cue design (driven live by useBrewStepHaptics on the timer's tick — haptics
+ * CANNOT be pre-scheduled like notifications; they must fire at the moment):
+ *   - the last 3 seconds before a step: three short MEDIUM impact taps (3-2-1),
+ *   - at the step boundary: one strong, longer continuous buzz.
+ */
+
+// ── Ambient bridge types (no @capacitor/* imports) ──────────────────────────
+
+interface HapticsLike {
+  impact(options: { style: string }): Promise<void>;
+  vibrate(options: { duration: number }): Promise<void>;
+}
+
+interface CapacitorLike {
+  isNativePlatform?: () => boolean;
+  Plugins?: { Haptics?: HapticsLike };
+}
+
+// NB: we do NOT augment `Window.Capacitor` here — brewNotifications.ts already
+// declares it with a different Plugins shape, and two global augmentations of
+// the same property collide. Read it through a local cast instead.
+
+// ── Cue tuning ───────────────────────────────────────────────────────────────
+
+/** Seconds before a step boundary at which the 3-2-1 countdown taps fire. */
+export const COUNTDOWN_SECONDS = [3, 2, 1] as const;
+
+/** iOS UIImpactFeedbackStyle for a countdown tap — short + clearly felt. */
+const TICK_STYLE = "MEDIUM";
+
+/** Strong "act now" buzz at the step boundary. The plugin maps `vibrate` to a
+ * full-intensity Core Haptics continuous event of this duration (ms) — a long,
+ * unmistakable buzz, distinct from the short countdown taps. */
+const STEP_BUZZ_MS = 650;
+
+// ── Native bridge access ─────────────────────────────────────────────────────
+
+function getHaptics(): HapticsLike | null {
+  try {
+    if (typeof window === "undefined") return null;
+    const cap = (window as unknown as { Capacitor?: CapacitorLike }).Capacitor;
+    if (!cap?.isNativePlatform?.()) return null;
+    return cap.Plugins?.Haptics ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** True only inside the Capacitor shell with the Haptics plugin present. */
+export function isNativeHaptics(): boolean {
+  return getHaptics() !== null;
+}
+
+/** One short countdown tap (t-3 / t-2 / t-1). No-op off the native shell. */
+export function countdownTap(): void {
+  const h = getHaptics();
+  if (!h) return;
+  // Fire-and-forget; a bridge hiccup must never disturb the brew loop.
+  void h.impact({ style: TICK_STYLE }).catch(() => {});
+}
+
+/** The strong "do the step now" buzz at a boundary. No-op off the shell. */
+export function stepBuzz(): void {
+  const h = getHaptics();
+  if (!h) return;
+  void h.vibrate({ duration: STEP_BUZZ_MS }).catch(() => {});
+}

--- a/src/lib/native/brewNotifications.ts
+++ b/src/lib/native/brewNotifications.ts
@@ -24,6 +24,7 @@
  */
 
 import type { PourStep, GuideStep } from "@/lib/utils/pourSequence";
+import { isAgitationPourAction } from "@/lib/utils/pourSequence";
 
 // ── Ambient bridge types (no @capacitor/* imports — strict-TS clean) ────────
 
@@ -103,9 +104,19 @@ export function buildBrewBoundaries(
   const out: BrewBoundary[] = [];
 
   if (steps && steps.length > 0) {
-    // Percolation (V60/Orea/Kalita/Chemex) — cumulative-grams pours.
+    // Percolation (V60/Orea/Kalita/Chemex) — cumulative-grams pours plus
+    // discrete agitation steps (swirl/stir/tap), each timed to its own moment.
     for (const s of steps) {
       if (s.startTimeSec <= 0) continue;
+      if (isAgitationPourAction(s.action)) {
+        // Agitation step: no grams — the cue IS the action.
+        out.push({
+          atSec: s.startTimeSec,
+          title: s.label,
+          body: s.notes ?? "after the pour",
+        });
+        continue;
+      }
       const parts = [`→ ${s.cumulativeGrams}g total`];
       if (s.temperatureC != null) parts.push(`${s.temperatureC}°C`);
       out.push({

--- a/src/lib/utils/pourSequence.test.mjs
+++ b/src/lib/utils/pourSequence.test.mjs
@@ -1,159 +1,48 @@
-// Unit tests for the pour-over timing formula. Pure math, zero dependencies —
-// run with:  node --test src/lib/utils/pourSequence.test.mjs
+// Unit tests for the pour-over timing + step model.
+// Run with:  node --test src/lib/utils/pourSequence.test.mjs
 //
-// The tests duplicate the logic instead of importing from the .ts module so
-// this file runs under plain Node with no TypeScript loader. If the math in
-// pourSequence.ts ever changes, update this file too — the point of the tests
-// is that the formula keeps producing the exact milestones documented below.
+// These bundle the REAL src/lib/utils/pourSequence.ts with esbuild (same harness
+// as brew-notifications.test.mjs) so they assert the actual shipped logic — no
+// duplicated copy to drift out of sync. (The resolveBrewedRecipe section lower
+// down still re-declares its logic — that's a different module, unchanged here.)
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import path from "node:path";
 
-// ── Re-declared pure logic (MUST stay in sync with src/lib/utils/pourSequence.ts) ──
-
-function getBloomDuration(roastDate, now = Date.now()) {
-  if (roastDate) {
-    const daysOld = Math.floor((now - new Date(roastDate).getTime()) / 86_400_000);
-    if (daysOld < 7) return 50;
-    if (daysOld < 22) return 45;
-    return 30;
-  }
-  return 45;
-}
-
-function leadingGrams(token) {
-  const m = token.match(/^\s*(\d+)/);
-  return m ? Number(m[1]) : null;
-}
-
-function tokenTemperature(token) {
-  const t = token.match(/[@(]\s*@?\s*(\d{2,3})\s*°?\s*[cC]?/);
-  return t ? Number(t[1]) : undefined;
-}
-
-function tokenNote(token) {
-  const s = token
-    .replace(/^\s*\d+\s*/, "")
-    .replace(/[@(]\s*@?\s*\d{2,3}\s*°?\s*[cC]?\s*\)?/g, "")
-    .replace(/[()]/g, "")
-    .trim();
-  return s.length > 0 ? s : undefined;
-}
-
-function buildPourOver(milestones, targetTimeSec, roastDate, now = Date.now()) {
-  const n = milestones.length;
-  if (n < 2) return null;
-  const bloomDur = getBloomDuration(roastDate, now);
-  const drawdownReserve = Math.round(targetTimeSec * 0.33);
-  const remaining = targetTimeSec - bloomDur - drawdownReserve;
-  const interval = n > 2 ? remaining / (n - 2) : 0;
-  return milestones.map((m, i) => ({
-    index: i,
-    label: i === 0 ? "Bloom" : i === n - 1 ? "Final pour" : `Pour ${i + 1}`,
-    cumulativeGrams: m.grams,
-    pourGrams: i === 0 ? m.grams : m.grams - milestones[i - 1].grams,
-    startTimeSec: i === 0 ? 0 : Math.round(bloomDur + (i - 1) * interval),
-    action: i === 0 ? "bloom" : i === n - 1 ? "final" : "pour",
-    temperatureC: m.temperatureC,
-    notes: m.notes,
-    agitation: m.agitation,
-  }));
-}
-
-function parsePourSteps(sequence, targetTimeSec, roastDate, now = Date.now()) {
-  const parts = sequence.split(/\s*[–—\-]\s*/).map((s) => s.trim());
-  const grams = parts.map(leadingGrams);
-  if (parts.length < 2 || grams.some((g) => g === null)) return null;
-  const milestones = parts.map((p, i) => ({
-    grams: grams[i],
-    temperatureC: tokenTemperature(p),
-    notes: tokenNote(p),
-  }));
-  return buildPourOver(milestones, targetTimeSec, roastDate, now);
-}
-
-function defaultDuration(action) {
-  switch (action) {
-    case "press": return 25;
-    case "wait": return 60;
-    case "stir":
-    case "swirl":
-    case "agitate-bed": return 10;
-    case "drain": return 30;
-    case "bypass": return 5;
-    case "invert":
-    case "flip": return 0;
-    default: return 10;
-  }
-}
-
-function isSetupAction(action, label) {
-  if (action === "invert") return true;
-  return /^\s*(assemble|position|set.?up|load|rinse|place)\b/i.test(label);
-}
-
-function buildGuideSteps(recipe) {
-  const src = recipe.pourSteps;
-  if (!src || src.length === 0) return null;
-  let clock = 0;
-  return src.map((step, i) => {
-    const action = step.action;
-    const isSetup = isSetupAction(action, step.label);
-    const durationSec = step.durationSec ?? defaultDuration(action);
-    const startTimeSec = isSetup ? 0 : clock;
-    if (!isSetup) clock += durationSec;
-    return {
-      index: i,
-      label: step.label,
-      action,
-      startTimeSec,
-      durationSec,
-      temperatureC: step.temperatureC,
-      notes: step.notes,
-      cumulativeGrams: step.waterGramsAtEnd,
-      isSetup,
-    };
-  });
-}
-
-const isAgitationStep = (a) => a === "swirl" || a === "stir" || a === "agitate-bed";
-
-function pourStepsFromStructured(recipe, roastDate, now = Date.now()) {
-  const src = recipe.pourSteps;
-  if (!src || src.length === 0) return null;
-  const milestones = [];
-  let last = -1;
-  for (const s of src) {
-    if (s.waterGramsAtEnd != null) {
-      milestones.push({ grams: s.waterGramsAtEnd, temperatureC: s.temperatureC, notes: s.notes, agitation: null });
-      last = milestones.length - 1;
-    } else if (isAgitationStep(s.action) && last >= 0) {
-      milestones[last].agitation = s.action === "swirl" ? "swirl" : "stir";
-    }
-  }
-  return buildPourOver(milestones, recipe.targetTimeSec, roastDate, now);
-}
-
-function hasImmersionShape(recipe) {
-  const src = recipe.pourSteps;
-  if (!src || src.length === 0) return false;
-  return src.some(
-    (s) =>
-      s.action === "invert" ||
-      s.action === "flip" ||
-      s.action === "press" ||
-      s.action === "bypass" ||
-      (s.action === "wait" && (s.durationSec ?? 0) >= 45),
-  );
-}
-
-function getActiveIdx(elapsed, steps) {
-  let idx = 0;
-  for (let i = 0; i < steps.length; i++) {
-    if (elapsed >= steps[i].startTimeSec) idx = i;
-  }
-  return idx;
-}
+const ROOT = process.cwd();
+const entry = `
+export {
+  getBloomDuration, parsePourSteps, pourStepsFromStructured, buildGuideSteps,
+  hasImmersionShape, getActiveIdx, isAgitationPourAction, pourDurationSec, POUR_RATE_GPS,
+} from ${JSON.stringify(path.join(ROOT, "src/lib/utils/pourSequence.ts"))};
+`;
+const dir = await mkdtemp(join(tmpdir(), "pourseq-"));
+const out = join(dir, "p.mjs");
+await build({
+  stdin: { contents: entry, resolveDir: ROOT, loader: "ts" },
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  outfile: out,
+  logLevel: "silent",
+});
+const {
+  getBloomDuration,
+  parsePourSteps,
+  pourStepsFromStructured,
+  buildGuideSteps,
+  hasImmersionShape,
+  getActiveIdx,
+  isAgitationPourAction,
+  pourDurationSec,
+  POUR_RATE_GPS,
+} = await import(pathToFileURL(out).href);
 
 // Fixed clock: Apr 17 2026. Lets roast-date branches be exercised deterministically.
 const NOW = new Date("2026-04-17T00:00:00Z").getTime();
@@ -418,9 +307,16 @@ test("getActiveIdx: advances exactly at each step's startTime", () => {
   assert.equal(getActiveIdx(500, steps), 3); // stays on final after target time
 });
 
-// ── pourStepsFromStructured: agitation is recipe-driven ─────────────────────
+// ── pourStepsFromStructured: agitation is a discrete, flow-rate-timed step ───
 
-test("pourStepsFromStructured: attaches swirl/stir only where the recipe agitates", () => {
+test("pourDurationSec / POUR_RATE_GPS: pour time = grams ÷ rate", () => {
+  assert.equal(POUR_RATE_GPS, 4);
+  assert.equal(pourDurationSec(100), 25); // 100g ÷ 4 g/s
+  assert.equal(pourDurationSec(50), 13); // 12.5 → 13
+  assert.equal(pourDurationSec(0), 1); // floor of 1s, never 0
+});
+
+test("pourStepsFromStructured: swirl/stir become their own steps, timed AFTER the pour", () => {
   const recipe = {
     targetTimeSec: 240,
     pourSteps: [
@@ -434,12 +330,49 @@ test("pourStepsFromStructured: attaches swirl/stir only where the recipe agitate
   };
   const steps = pourStepsFromStructured(recipe, peakRoast, NOW);
   assert.ok(steps);
-  assert.deepEqual(steps.map((s) => s.agitation), ["stir", null, "swirl"]);
+  // Pours @0/45/161 (peak bloom 45, drawdown reserve 79, one 116s interval).
+  // Stir lands at bloom-start 0 + pourDuration(50g)=13. Swirl at final-start
+  // 161 + pourDuration(100g)=25 = 186.
+  assert.deepEqual(
+    steps.map((s) => [s.action, s.startTimeSec]),
+    [
+      ["bloom", 0],
+      ["stir", 13],
+      ["pour", 45],
+      ["final", 161],
+      ["swirl", 186],
+    ],
+  );
+  // Agitation steps carry no grams and inherit the preceding pour's total.
+  const stir = steps.find((s) => s.action === "stir");
+  const swirl = steps.find((s) => s.action === "swirl");
+  assert.equal(stir.pourGrams, 0);
+  assert.equal(stir.cumulativeGrams, 50);
+  assert.equal(swirl.pourGrams, 0);
+  assert.equal(swirl.cumulativeGrams, 300);
 });
 
-test("pourStepsFromStructured: reduced-agitation recipe shows NO agitation", () => {
-  // The screenshot bug: a recipe with no swirl/stir steps must yield agitation
-  // null everywhere — no stray Swirl button on the final pour / drawdown.
+test("pourStepsFromStructured: agitate-bed maps to a 'tap' step", () => {
+  const recipe = {
+    targetTimeSec: 210,
+    pourSteps: [
+      { label: "Bloom", action: "bloom", waterGramsAtEnd: 40 },
+      { label: "Pour", action: "pour", waterGramsAtEnd: 250 },
+      { label: "Tap to level", action: "agitate-bed" },
+      { label: "Drawdown", action: "drain", durationSec: 40 },
+    ],
+  };
+  const steps = pourStepsFromStructured(recipe, peakRoast, NOW);
+  assert.ok(steps);
+  const tap = steps.find((s) => s.action === "tap");
+  assert.ok(tap, "agitate-bed → tap step");
+  assert.ok(isAgitationPourAction(tap.action));
+  assert.equal(tap.label, "Tap to level");
+});
+
+test("pourStepsFromStructured: reduced-agitation recipe yields NO agitation steps", () => {
+  // A recipe with no swirl/stir/tap steps must produce zero agitation steps —
+  // no stray Swirl on the final pour / drawdown.
   const recipe = {
     targetTimeSec: 270,
     pourSteps: [
@@ -451,7 +384,8 @@ test("pourStepsFromStructured: reduced-agitation recipe shows NO agitation", () 
   };
   const steps = pourStepsFromStructured(recipe, peakRoast, NOW);
   assert.ok(steps);
-  assert.ok(steps.every((s) => s.agitation === null), "every milestone agitation is null");
+  assert.equal(steps.length, 3, "bloom + pour + final, nothing inserted");
+  assert.ok(steps.every((s) => !isAgitationPourAction(s.action)), "no agitation steps");
 });
 
 // ── resolveBrewedRecipe: read the SELECTED candidate, not primary ───────────

--- a/src/lib/utils/pourSequence.ts
+++ b/src/lib/utils/pourSequence.ts
@@ -28,21 +28,47 @@
 
 import type { BrewRecipe, BrewPourStep, BrewStepAction } from "@/lib/types/session";
 
+/**
+ * Pour rate (grams/second) at which the user pours from the kettle — the rate
+ * of the POUR itself, NOT the drip-through flow rate. Used to place an agitation
+ * step at the moment a pour FINISHES: a pour of `g` grams takes `g / POUR_RATE`
+ * seconds, so a swirl/stir/tap called for "after the pour" lands at
+ * `pourStart + g / POUR_RATE`.
+ *
+ * Owner-set 2026-06-15: ~4 g/s (a gentle, controlled gooseneck pour on the
+ * Fellow Stagg EKG — matches the silky/floral house style). This is the ONE
+ * place to change it; re-measure (pour 100 g, time it) and update here.
+ */
+export const POUR_RATE_GPS = 4;
+
+/** Seconds to physically pour `grams` at POUR_RATE_GPS (≥1s, rounded). */
+export function pourDurationSec(grams: number): number {
+  return Math.max(1, Math.round(grams / POUR_RATE_GPS));
+}
+
+/** Discrete agitation actions that now get their OWN timed step in the
+ * percolation timeline (instead of being folded onto a pour as an attribute). */
+export type AgitationAction = "swirl" | "stir" | "tap";
+
 export interface PourStep {
   index: number;
   label: string;
   cumulativeGrams: number;
   pourGrams: number;
   startTimeSec: number;
-  action: "bloom" | "pour" | "final";
+  /** Water-bearing actions (bloom/pour/final) plus discrete agitation actions
+   * (swirl/stir/tap) — agitation is now a real step, timed to land right after
+   * the pour it follows finishes pouring. */
+  action: "bloom" | "pour" | "final" | AgitationAction;
   /** Per-pour temperature for staged-temperature recipes (Hsu, Peng). */
   temperatureC?: number;
   /** Free-text hint shown alongside the active pour. */
   notes?: string;
-  /** Agitation the recipe calls for AT this pour. Explicit `"stir"`/`"swirl"`
-   * shows the button; explicit `null` suppresses it (minimal-agitation recipe);
-   * `undefined` = unknown (legacy grams string) → renderer applies its default. */
-  agitation?: "stir" | "swirl" | null;
+}
+
+/** True for the discrete agitation step actions (swirl/stir/tap). */
+export function isAgitationPourAction(a: PourStep["action"]): a is AgitationAction {
+  return a === "swirl" || a === "stir" || a === "tap";
 }
 
 /** A timed, action-aware step for non-percolation methods (immersion,
@@ -108,13 +134,24 @@ function tokenNote(token: string): string | undefined {
   return stripped.length > 0 ? stripped : undefined;
 }
 
-/** One cumulative-grams milestone, with optional per-pour temperature/note. */
+/** One cumulative-grams milestone, with optional per-pour temperature/note and
+ * an agitation the recipe calls for AFTER this pour (becomes its own step). */
 interface Milestone {
   grams: number;
   temperatureC?: number;
   notes?: string;
-  agitation?: "stir" | "swirl" | null;
+  /** Agitation to perform right after this pour finishes — emitted as a
+   * discrete, flow-rate-timed step. `undefined`/absent = none. */
+  agitationAfter?: AgitationAction;
+  /** Optional note carried onto the agitation step. */
+  agitationNote?: string;
 }
+
+const AGITATION_LABEL: Record<AgitationAction, string> = {
+  swirl: "Swirl",
+  stir: "Stir",
+  tap: "Tap to level",
+};
 
 /**
  * Time a set of cumulative-grams milestones with the drawdown-reserve formula:
@@ -122,6 +159,12 @@ interface Milestone {
  * (n − 2) intervals so the final pour lands at (target − reserve). Shared by the
  * string parser and the structured-percolation builder so both produce an
  * identical schedule.
+ *
+ * Agitation is now a DISCRETE step: when a milestone carries `agitationAfter`,
+ * a swirl/stir/tap step is inserted at `pourStart + pourDurationSec(pourGrams)`
+ * — i.e. the instant that pour finishes pouring at the user's pour rate —
+ * clamped to land before the next pour (or, for the final pour, before target).
+ * So "swirl after the pour" is timed by physics, not guessed.
  */
 function buildPourOver(
   milestones: Milestone[],
@@ -137,17 +180,47 @@ function buildPourOver(
   const remaining = targetTimeSec - bloomDur - drawdownReserve;
   const interval = n > 2 ? remaining / (n - 2) : 0;
 
-  return milestones.map((m, i) => ({
-    index: i,
-    label: i === 0 ? "Bloom" : i === n - 1 ? "Final pour" : `Pour ${i + 1}`,
-    cumulativeGrams: m.grams,
-    pourGrams: i === 0 ? m.grams : m.grams - milestones[i - 1].grams,
-    startTimeSec: i === 0 ? 0 : Math.round(bloomDur + (i - 1) * interval),
-    action: (i === 0 ? "bloom" : i === n - 1 ? "final" : "pour") as PourStep["action"],
-    temperatureC: m.temperatureC,
-    notes: m.notes,
-    agitation: m.agitation,
-  }));
+  const pourStartSec = (i: number) => (i === 0 ? 0 : Math.round(bloomDur + (i - 1) * interval));
+
+  const out: PourStep[] = [];
+  milestones.forEach((m, i) => {
+    const pourGrams = i === 0 ? m.grams : m.grams - milestones[i - 1].grams;
+    const start = pourStartSec(i);
+    out.push({
+      index: 0, // re-indexed after interleaving
+      label: i === 0 ? "Bloom" : i === n - 1 ? "Final pour" : `Pour ${i + 1}`,
+      cumulativeGrams: m.grams,
+      pourGrams,
+      startTimeSec: start,
+      action: i === 0 ? "bloom" : i === n - 1 ? "final" : "pour",
+      temperatureC: m.temperatureC,
+      notes: m.notes,
+    });
+
+    if (m.agitationAfter) {
+      // The pour finishes pouring `pourGrams` after `pourDurationSec` seconds.
+      // Clamp so the agitation always lands before the next pour starts (or,
+      // on the final pour, before the target finish) — never overlapping.
+      const ceiling = (i < n - 1 ? pourStartSec(i + 1) : targetTimeSec) - 1;
+      const agStart = Math.min(start + pourDurationSec(pourGrams), Math.max(start + 1, ceiling));
+      out.push({
+        index: 0,
+        label: AGITATION_LABEL[m.agitationAfter],
+        cumulativeGrams: m.grams,
+        pourGrams: 0,
+        startTimeSec: agStart,
+        action: m.agitationAfter,
+        notes: m.agitationNote,
+      });
+    }
+  });
+
+  // Stable-sort by start time (agitation already lands inside its pour's gap,
+  // but the explicit sort keeps getActiveIdx / StepDots strictly monotonic) and
+  // re-index in timeline order.
+  out.sort((a, b) => a.startTimeSec - b.startTimeSec);
+  out.forEach((s, i) => (s.index = i));
+  return out;
 }
 
 /**
@@ -207,12 +280,14 @@ export function pourStepsFromStructured(
         grams: s.waterGramsAtEnd,
         temperatureC: s.temperatureC,
         notes: s.notes,
-        agitation: null,
       });
       last = milestones.length - 1;
     } else if (isAgitationStep(s.action) && last >= 0) {
-      // Attach this agitation to the pour it follows (bloom-stir, post-pour swirl).
-      milestones[last].agitation = s.action === "swirl" ? "swirl" : "stir";
+      // Attach this agitation to the pour it follows (bloom-stir, post-pour
+      // swirl, tap-to-level) — it becomes its own flow-rate-timed step.
+      milestones[last].agitationAfter =
+        s.action === "swirl" ? "swirl" : s.action === "agitate-bed" ? "tap" : "stir";
+      milestones[last].agitationNote = s.notes;
     }
   }
   return buildPourOver(milestones, recipe.targetTimeSec, roastDate, now);

--- a/tests/dataflow/brew-notifications.test.mjs
+++ b/tests/dataflow/brew-notifications.test.mjs
@@ -25,7 +25,7 @@ const entry = `
 export { buildBrewBoundaries } from ${JSON.stringify(
   path.join(ROOT, "src/lib/native/brewNotifications.ts"),
 )};
-export { parsePourSteps, buildGuideSteps } from ${JSON.stringify(
+export { parsePourSteps, buildGuideSteps, pourStepsFromStructured } from ${JSON.stringify(
   path.join(ROOT, "src/lib/utils/pourSequence.ts"),
 )};
 `;
@@ -39,9 +39,8 @@ await build({
   outfile: out,
   logLevel: "silent",
 });
-const { buildBrewBoundaries, parsePourSteps, buildGuideSteps } = await import(
-  pathToFileURL(out).href
-);
+const { buildBrewBoundaries, parsePourSteps, buildGuideSteps, pourStepsFromStructured } =
+  await import(pathToFileURL(out).href);
 
 // ── Percolation (V60 grams string → PourStep[]) ─────────────────────────────
 
@@ -77,6 +76,40 @@ test("percolation: per-pour temperature annotation lands in the body", () => {
   const boundaries = buildBrewBoundaries(steps, null, 240);
   // Bloom carries the 70°C but is skipped; later pours have no temp → plain body.
   assert.equal(boundaries[0].body, "→ 220g total");
+});
+
+// ── Percolation agitation: swirl/stir/tap get their own timed boundary ──────
+
+test("percolation: a recipe's swirl becomes its own notification boundary", () => {
+  // Bloom 60g, stir after bloom, pour to 250, final to 420, swirl after final.
+  const recipe = {
+    targetTimeSec: 240,
+    pourSteps: [
+      { label: "Bloom", action: "bloom", waterGramsAtEnd: 60 },
+      { label: "Stir", action: "stir" },
+      { label: "Pour 2", action: "pour", waterGramsAtEnd: 250 },
+      { label: "Final", action: "final", waterGramsAtEnd: 420 },
+      { label: "Swirl", action: "swirl" },
+    ],
+  };
+  // No roastDate → default 45s bloom (matches buildBrewBoundaries' own path).
+  const steps = pourStepsFromStructured(recipe, undefined, Date.parse("2026-04-17T00:00:00Z"));
+  assert.ok(steps);
+
+  const boundaries = buildBrewBoundaries(steps, null, 240);
+  // Agitation steps must appear as boundaries titled by the action (NOT "+0g").
+  const titles = boundaries.map((b) => b.title);
+  assert.ok(titles.includes("Stir"), "stir boundary present");
+  assert.ok(titles.includes("Swirl"), "swirl boundary present");
+  // The stir boundary lands at the bloom step's agitation time, and its body is
+  // the action hint — never a grams string.
+  const stir = boundaries.find((b) => b.title === "Stir");
+  assert.equal(stir.body, "after the pour");
+  // Boundaries stay in chronological order.
+  assert.deepEqual(
+    boundaries.map((b) => b.atSec),
+    [...boundaries.map((b) => b.atSec)].sort((a, b) => a - b),
+  );
 });
 
 // ── Immersion / AeroPress (structured steps → GuideStep[]) ──────────────────


### PR DESCRIPTION
## What
Rebuilds the brew step model so **every action is a real, timed step** and adds **real foreground vibration** for the iOS shell.

### 1. Swirl / Stir / Tap are discrete, flow-rate-timed steps
Previously agitation was an *attribute* folded onto a pour (no time of its own). Now, in the percolation model, each swirl/stir/tap the recipe calls for is its **own timeline step**, placed at the moment the preceding pour **finishes pouring**:

`pourStart + pourDurationSec(pourGrams)`, where pour duration = `grams ÷ POUR_RATE_GPS`.

- **POUR_RATE_GPS = 4 g/s** (owner-set — a gentle Stagg EKG pour; one constant, easy to retune).
- Clamped to land before the next pour / target — never overlapping.
- `agitate-bed` → a **tap** step.
- Each agitation gets its own active card, its own progress dot, and its own **notification + haptic boundary**.
- Still fully recipe-driven: a recipe with no agitation steps shows none (the old stray-Swirl bug stays fixed).
- Immersion/AeroPress already had discrete steps — unchanged.

### 2. Foreground Taptic haptics (iOS shell)
During a brew the screen is wake-locked → the phone is never on its lock screen, so the lock-screen notifications never show, and `navigator.vibrate` is dead in WKWebView. New `brewHaptics.ts` + `useBrewStepHaptics` drive the native Haptics plugin **live**: three MEDIUM taps at **t-3 / t-2 / t-1** (the 3-2-1 countdown) then a **strong ~650 ms buzz** at each step boundary. Native-only no-op everywhere else (feature-detected; the plugin ships in the shell separately — this web code is harmless until then).

## Why no rebuild for part 1
The step model + renderer are web code on the live site → deploys immediately, visible on the PWA. Part 2's haptics need the native Haptics plugin in a TestFlight build (separate, in progress).

## Tests
- `pourSequence.test.mjs` **converted to bundle the REAL module** via esbuild (it was a duplicated copy that had silently drifted — false green) + new discrete-agitation + flow-rate-timing cases.
- `brew-notifications.test.mjs` gains a real-code agitation-boundary case.
- `tsc --noEmit` clean; src 36/36, tests 33/33 green (CI's exact invocation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)