### PR TITLE
fix(ios): mic/camera/photo permissions for the native shell (Build 4)

### DIFF
--- a/native/ios/App/App/Info.plist
+++ b/native/ios/App/App/Info.plist
@@ -26,6 +26,12 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>BTTS uses the camera to scan coffee bags and read their details.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>BTTS uses the microphone for voice chat — talk to your coffee assistant instead of typing.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>BTTS uses your photos to read a coffee bag you have already photographed.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>


### PR DESCRIPTION
WKWebView blocks `getUserMedia` / camera / photo access silently without Info.plist usage strings → voice chat + bag scanner + photo upload were dead in the TestFlight app (fine in the Safari PWA). Adds the three usage strings. Built + uploaded as **Build 4** (Delivery UUID `eea531a0-…`).

⚠️ Touches `native/**` → triggers the known-broken `ios-testflight` CI (red, expected — Mac build is the path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)