### PR TITLE
fix(brew): Done Brewing button does nothing — couldn't log brews (#320 regression)

### DIFF
--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -82,11 +82,18 @@ export default function LightStepBrew() {
   const handleDone = useCallback(
     (actualSec?: number) => {
       disableWakeLock();
+      // Guard the arg: if a click event leaks in via onNext={handleDone} it is
+      // truthy, so `actualSec ?? elapsed` would store the (non-serializable)
+      // event as actualTimeSec — which threw inside the localStorage-persisted
+      // store and left the brew stuck on this screen, unable to log (#320
+      // regression). Coerce anything that isn't a finite number to elapsed.
+      const finalSec =
+        typeof actualSec === "number" && Number.isFinite(actualSec) ? actualSec : elapsed;
       setBrew({
         ...draft.brew,
         methodUsed: method,
         followedRecipe: true,
-        actualTimeSec: actualSec ?? elapsed,
+        actualTimeSec: finalSec,
       });
       setStep("log");
     },
@@ -136,7 +143,7 @@ export default function LightStepBrew() {
 
   return (
     <LightFlowShell
-      onNext={handleDone}
+      onNext={() => handleDone()}
       nextLabel="Done Brewing"
     >
       <div className="flex flex-col gap-5">


### PR DESCRIPTION
## Bug

Tapping **Done Brewing** did nothing — the brew couldn't be logged (reported by the owner this morning).

## Cause

#320 changed the Done CTA wiring from `onNext={() => handleDone()}` to `onNext={handleDone}`. The shared `CTA` forwards its click `SyntheticEvent` straight to `onNext`, so `handleDone(actualSec)` received the **event object**. `actualSec ?? elapsed` keeps it (it's truthy), so `actualTimeSec` became a SyntheticEvent — which the **localStorage-persisted** flow store can't `JSON.stringify` (circular refs). `setBrew` threw, so `setStep("log")` never ran. The screen stayed on the brew step.

## Fix (two layers)

1. Restore `onNext={() => handleDone()}` — the event never reaches the handler (exactly what #289 and earlier had).
2. Coerce `actualSec` to `elapsed` unless it's a finite number, so a future re-wiring can't reintroduce a non-number `actualTimeSec`.

Verified the other steps' `onNext` handlers (`confirmPlace`, both `handleNext`) take no args, so they were unaffected. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)