### PR TITLE
refactor(brew): canonical brew timeline (one intended flow)

### DIFF
--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -6,20 +6,17 @@ import LightCircularTimer from "@/components/ui/light/CircularTimer";
 import { formatSeconds } from "@/lib/utils/formatTime";
 import { useWakeLock } from "@/hooks/useWakeLock";
 import {
-  parsePourSteps,
-  pourStepsFromStructured,
-  buildGuideSteps,
-  hasImmersionShape,
   getActiveIdx,
   isAgitationPourAction,
   type PourStep,
   type GuideStep,
 } from "@/lib/utils/pourSequence";
+import { buildBrewTimeline } from "@/lib/brew/timeline";
 import type { BrewStepAction } from "@/lib/types/session";
 import { basedOnReference } from "@/lib/utils/resolveRecipe";
 import { useBrewStepHaptics } from "@/hooks/useBrewStepHaptics";
 import { useBrewStepWatch } from "@/hooks/useBrewStepWatch";
-import { buildBrewBoundaries } from "@/lib/native/brewNotifications";
+import { boundariesFromTimeline } from "@/lib/native/brewNotifications";
 import { ScalePanel } from "@/components/flow/ScalePanel";
 
 /**
@@ -116,31 +113,25 @@ export default function LightStepBrew() {
 
   const roastDate = draft.coffee?.roastDate;
 
-  // Immersion / AeroPress / staged routines (steep, flip, press, bypass) →
-  // action-aware step guide built from the recipe's structured steps.
-  const guideSteps = recipe && hasImmersionShape(recipe) ? buildGuideSteps(recipe) : null;
+  // The canonical "intended flow" for this recipe — one builder that lowers both
+  // percolation and immersion into a single model (the source of truth the live
+  // flow coach compares the actual pour against). It also exposes the SAME
+  // renderer-ready arrays the two renderers always consumed, so the brew guide is
+  // unchanged. See src/lib/brew/timeline.ts.
+  const timeline = recipe ? buildBrewTimeline(recipe, roastDate) : null;
 
-  // Percolation → cumulative-grams pour-over renderer. Prefer structured steps
-  // (they carry per-pour temperature + notes); fall back to the legacy grams
-  // string. Either way the drawdown-reserve timing is identical.
-  const steps =
-    !guideSteps && recipe
-      ? pourStepsFromStructured(recipe, roastDate) ??
-        (recipe.pourSequence && recipe.targetTimeSec
-          ? parsePourSteps(recipe.pourSequence, recipe.targetTimeSec, roastDate)
-          : null)
-      : null;
-
-  // Genuine prose immersion ("·"-separated string, no structured steps) — the
-  // legacy path for older recommendations.
-  const proseSequence = !guideSteps && !steps && recipe?.pourSequence ? recipe.pourSequence : null;
+  // Percolation → cumulative-grams pour-over renderer; immersion → action-aware
+  // step guide; prose → legacy "·"-separated string. All derived once above.
+  const steps = timeline?.pourSteps ?? null;
+  const guideSteps = timeline?.guideSteps ?? null;
+  const proseSequence = timeline?.proseSequence ?? null;
 
   // The step cue schedule (one entry per pour + agitation step). Lock-screen
   // notifications were removed (they only ever orphaned after a force-quit — see
   // brewNotifications.ts); these boundaries now drive the foreground Taptic
   // haptics only — a 3-2-1 countdown then a strong buzz at each step, fired live
   // while the app is awake. Native-only no-op elsewhere.
-  const boundaries = buildBrewBoundaries(steps, guideSteps, recipe?.targetTimeSec);
+  const boundaries = timeline ? boundariesFromTimeline(timeline) : [];
   useBrewStepHaptics(boundaries, elapsed, started);
   // The decisive cue: hand the whole schedule to a paired Apple Watch at brew
   // start so the wrist buzzes per step even while the phone screen is on (the

--- a/src/lib/brew/timeline.ts
+++ b/src/lib/brew/timeline.ts
@@ -1,0 +1,219 @@
+/**
+ * Canonical brew timeline — the SINGLE "intended flow" for a recipe.
+ *
+ * Before this module the intended flow was split in two: percolation
+ * (`PourStep[]`, cumulative-grams) vs immersion (`GuideStep[]`, action-driven),
+ * derived inline in LightStepBrew with the active-step logic duplicated. That
+ * made "compare the live pour to the plan" impossible — there was no one thing
+ * to compare against.
+ *
+ * `buildBrewTimeline` is a NORMALIZE LAYER over the existing, tested builders in
+ * `pourSequence.ts` (`buildGuideSteps` / `pourStepsFromStructured` / `parsePourSteps`).
+ * It does NOT re-implement any timing math — it calls them and lowers their
+ * output into one shape. It returns BOTH:
+ *   - the renderer-ready `pourSteps`/`guideSteps`/`proseSequence` (the existing
+ *     types, byte-identical to what the two brew renderers always consumed), and
+ *   - a normalized `steps: TimelineStep[]` + `expectedGramsAt` + `activeStepAt`,
+ *     the canonical model the flow coach (live pour comparison) builds on.
+ *
+ * The selection logic mirrors LightStepBrew's old inline block exactly; the
+ * golden-equivalence test (tests/dataflow/brew-timeline.test.mjs) locks that the
+ * renderer arrays and the cue boundaries are unchanged across the recipe corpus.
+ */
+import type { BrewRecipe, BrewStepAction } from "@/lib/types/session";
+import {
+  buildGuideSteps,
+  hasImmersionShape,
+  isAgitationPourAction,
+  parsePourSteps,
+  pourDurationSec,
+  pourStepsFromStructured,
+  type AgitationAction,
+  type GuideStep,
+  type PourStep,
+} from "@/lib/utils/pourSequence";
+
+export type BrewMethodShape = "percolation" | "immersion" | "prose";
+
+/** One normalized step on the canonical timeline. Carries everything the flow
+ * coach needs without caring which renderer the brew uses. */
+export interface TimelineStep {
+  index: number;
+  label: string;
+  action: BrewStepAction | AgitationAction;
+  /** Seconds since brew start when this step begins. */
+  startSec: number;
+  /** Seconds since brew start when this step ends (next step's start, or
+   * targetTimeSec for the last percolation step; start+duration for immersion). */
+  endSec: number;
+  /** Cumulative water in the brewer at the end of this step, when known. */
+  targetCumulativeGrams?: number;
+  /** Water added by THIS step (percolation pours only). */
+  pourGrams?: number;
+  /** Pre-brew handling (immersion invert/load/assemble) — excluded from `steps`. */
+  isSetup: boolean;
+  /** Swirl / stir / tap / agitate-bed. */
+  isAgitation: boolean;
+  temperatureC?: number;
+  notes?: string;
+}
+
+export interface BrewTimeline {
+  shape: BrewMethodShape;
+  // ── Renderer-ready arrays (existing types, unchanged) ──
+  pourSteps: PourStep[] | null;
+  guideSteps: GuideStep[] | null;
+  proseSequence: string | null;
+  // ── Canonical normalized model ──
+  /** Timeline-ordered steps with setup excluded. The single "intended flow". */
+  steps: TimelineStep[];
+  /** Immersion pre-brew steps (invert/load); empty for percolation. */
+  setupSteps: TimelineStep[];
+  targetTimeSec: number;
+  /** True when grams-over-time comparison is meaningful (percolation). Immersion
+   * only has sparse checkpoints, so live grams-comparison degrades to timing. */
+  hasGramsCurve: boolean;
+}
+
+const isAgitationGuideAction = (a: BrewStepAction): boolean =>
+  a === "stir" || a === "swirl" || a === "agitate-bed";
+
+function fromGuideStep(g: GuideStep): TimelineStep {
+  return {
+    index: g.index,
+    label: g.label,
+    action: g.action,
+    startSec: g.startTimeSec,
+    endSec: g.startTimeSec + g.durationSec,
+    targetCumulativeGrams: g.cumulativeGrams,
+    isSetup: g.isSetup,
+    isAgitation: isAgitationGuideAction(g.action),
+    temperatureC: g.temperatureC,
+    notes: g.notes,
+  };
+}
+
+function fromPourStep(p: PourStep, all: PourStep[], i: number, targetTimeSec: number): TimelineStep {
+  const endSec = i < all.length - 1 ? all[i + 1].startTimeSec : targetTimeSec;
+  return {
+    index: p.index,
+    label: p.label,
+    action: p.action,
+    startSec: p.startTimeSec,
+    endSec,
+    targetCumulativeGrams: p.cumulativeGrams,
+    pourGrams: p.pourGrams,
+    isSetup: false,
+    isAgitation: isAgitationPourAction(p.action),
+    temperatureC: p.temperatureC,
+    notes: p.notes,
+  };
+}
+
+/**
+ * Build the canonical timeline for a recipe. Mirrors LightStepBrew's old inline
+ * derivation exactly: immersion shape → guide steps; else structured/percolation
+ * pour steps; else a genuine prose sequence; else nothing.
+ */
+export function buildBrewTimeline(
+  recipe: BrewRecipe,
+  roastDate?: string,
+  now: number = Date.now(),
+): BrewTimeline {
+  const targetTimeSec = recipe.targetTimeSec;
+
+  const guideSteps = hasImmersionShape(recipe) ? buildGuideSteps(recipe) : null;
+  if (guideSteps) {
+    const normalized = guideSteps.map(fromGuideStep);
+    return {
+      shape: "immersion",
+      pourSteps: null,
+      guideSteps,
+      proseSequence: null,
+      steps: normalized.filter((s) => !s.isSetup),
+      setupSteps: normalized.filter((s) => s.isSetup),
+      targetTimeSec,
+      hasGramsCurve: false,
+    };
+  }
+
+  const pourSteps =
+    pourStepsFromStructured(recipe, roastDate, now) ??
+    (recipe.pourSequence && recipe.targetTimeSec
+      ? parsePourSteps(recipe.pourSequence, recipe.targetTimeSec, roastDate, now)
+      : null);
+  if (pourSteps) {
+    return {
+      shape: "percolation",
+      pourSteps,
+      guideSteps: null,
+      proseSequence: null,
+      steps: pourSteps.map((p, i) => fromPourStep(p, pourSteps, i, targetTimeSec)),
+      setupSteps: [],
+      targetTimeSec,
+      hasGramsCurve: true,
+    };
+  }
+
+  const proseSequence = recipe.pourSequence ? recipe.pourSequence : null;
+  return {
+    shape: "prose",
+    pourSteps: null,
+    guideSteps: null,
+    proseSequence,
+    steps: [],
+    setupSteps: [],
+    targetTimeSec,
+    hasGramsCurve: false,
+  };
+}
+
+/**
+ * Expected cumulative water (grams) at time `tSec`, interpolated from the
+ * intended flow. Percolation: water rises linearly from the previous cumulative
+ * to each pour's target over the pour's physical duration (`pourDurationSec` at
+ * `POUR_RATE_GPS`), then holds flat until the next pour — so the "expected" curve
+ * matches the same pour-rate model the timeline is built on. Returns null when
+ * there's no meaningful grams curve (immersion / prose).
+ */
+export function expectedGramsAt(timeline: BrewTimeline, tSec: number): number | null {
+  if (!timeline.hasGramsCurve) return null;
+  const pours = timeline.steps.filter(
+    (s) => !s.isAgitation && s.targetCumulativeGrams != null,
+  );
+  if (pours.length === 0) return null;
+
+  let prevC = 0;
+  for (const s of pours) {
+    const c = s.targetCumulativeGrams as number;
+    const pourGrams = s.pourGrams ?? c - prevC;
+    const dur = pourDurationSec(Math.max(1, pourGrams));
+    const pourEnd = s.startSec + dur;
+    if (tSec < s.startSec) {
+      return prevC; // resting between the previous pour's end and this pour
+    }
+    if (tSec < pourEnd) {
+      const frac = (tSec - s.startSec) / Math.max(1, dur);
+      return prevC + (c - prevC) * frac;
+    }
+    prevC = c; // this pour is fully complete
+  }
+  return prevC; // past the last pour
+}
+
+/**
+ * The active step index on the canonical timeline at `elapsed` seconds, or -1
+ * before the brew starts. The ONE active-step selector — wraps the existing
+ * `getActiveIdx` so the duplicated inline scans in the two renderers can converge
+ * on it (and the flow coach reads the same notion of "current step").
+ */
+export function activeStepAt(timeline: BrewTimeline, elapsed: number, started: boolean): number {
+  if (!started || timeline.steps.length === 0) return -1;
+  // Same scan as getActiveIdx, over the normalized `startSec` field — the most
+  // recent step that has started by `elapsed`.
+  let idx = 0;
+  for (let i = 0; i < timeline.steps.length; i++) {
+    if (elapsed >= timeline.steps[i].startSec) idx = i;
+  }
+  return idx;
+}

--- a/src/lib/native/brewNotifications.ts
+++ b/src/lib/native/brewNotifications.ts
@@ -21,6 +21,7 @@
 
 import type { PourStep, GuideStep } from "@/lib/utils/pourSequence";
 import { isAgitationPourAction } from "@/lib/utils/pourSequence";
+import type { BrewTimeline } from "@/lib/brew/timeline";
 
 // ── Ambient bridge types (no @capacitor/* imports — strict-TS clean) ────────
 
@@ -129,6 +130,17 @@ export function buildBrewBoundaries(
   }
 
   return out; // prose-only legacy sequence — no machine-readable boundaries
+}
+
+/**
+ * The cue schedule for a canonical {@link BrewTimeline}. A thin wrapper over
+ * `buildBrewBoundaries` using the timeline's own renderer arrays, so the haptic
+ * + watch schedule is provably IDENTICAL to the pre-timeline code (the
+ * golden-equivalence test asserts the deep-equal). The single call site for
+ * "boundaries from the intended flow".
+ */
+export function boundariesFromTimeline(timeline: BrewTimeline): BrewBoundary[] {
+  return buildBrewBoundaries(timeline.pourSteps, timeline.guideSteps, timeline.targetTimeSec);
 }
 
 // ── Native bridge access ─────────────────────────────────────────────────────

--- a/tests/dataflow/brew-timeline.test.mjs
+++ b/tests/dataflow/brew-timeline.test.mjs
@@ -1,0 +1,201 @@
+// Golden-equivalence test for the canonical brew timeline (PR 1, refactor-only).
+//
+//   node --test tests/dataflow/brew-timeline.test.mjs
+//
+// THE GATE: buildBrewTimeline is a normalize layer over the existing pour-math
+// builders. This test bundles the REAL timeline.ts + pourSequence.ts +
+// brewNotifications.ts and asserts, across a recipe corpus, that:
+//   1. timeline.pourSteps / guideSteps / proseSequence are byte-identical to the
+//      legacy inline derivation the brew screen used (so the two renderers get
+//      the exact same data),
+//   2. boundariesFromTimeline(timeline) deep-equals buildBrewBoundaries(...)
+//      (so the haptic + Apple Watch cue schedule is provably unchanged),
+//   3. activeStepAt matches the renderers' getActiveIdx scan, and
+//   4. expectedGramsAt is a sane monotonic curve (0 at start → final at end).
+// If any of these drift, the daily brew timer/cues changed — fail loudly.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const entry = `
+export { buildBrewTimeline, expectedGramsAt, activeStepAt } from ${JSON.stringify(
+  path.join(ROOT, "src/lib/brew/timeline.ts"),
+)};
+export { buildBrewBoundaries, boundariesFromTimeline } from ${JSON.stringify(
+  path.join(ROOT, "src/lib/native/brewNotifications.ts"),
+)};
+export { pourStepsFromStructured, parsePourSteps, buildGuideSteps, hasImmersionShape, getActiveIdx } from ${JSON.stringify(
+  path.join(ROOT, "src/lib/utils/pourSequence.ts"),
+)};
+`;
+const dir = await mkdtemp(join(tmpdir(), "brewtl-"));
+const out = join(dir, "tl.mjs");
+await build({
+  stdin: { contents: entry, resolveDir: ROOT, loader: "ts" },
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  outfile: out,
+  logLevel: "silent",
+});
+const {
+  buildBrewTimeline,
+  expectedGramsAt,
+  activeStepAt,
+  buildBrewBoundaries,
+  boundariesFromTimeline,
+  pourStepsFromStructured,
+  parsePourSteps,
+  buildGuideSteps,
+  hasImmersionShape,
+  getActiveIdx,
+} = await import(pathToFileURL(out).href);
+
+// Fixed clock + roast date so the bloom-duration math is deterministic.
+const ROAST = "2026-06-01";
+const NOW = new Date("2026-06-16T08:00:00Z").getTime(); // ~15 days → 45s bloom
+
+const base = { doseGrams: 15, waterGrams: 250, waterTempC: 94, grindSize: "medium" };
+
+const RECIPES = {
+  "percolation-structured-with-agitation": {
+    ...base,
+    targetTimeSec: 180,
+    pourSteps: [
+      { label: "Bloom", action: "bloom", waterGramsAtEnd: 45, durationSec: 45, notes: "swirl" },
+      { label: "Swirl", action: "swirl" },
+      { label: "Pour 2", action: "pour", waterGramsAtEnd: 150 },
+      { label: "Final pour", action: "final", waterGramsAtEnd: 250 },
+    ],
+  },
+  "percolation-grams-string": {
+    ...base,
+    targetTimeSec: 210,
+    pourSequence: "50 – 180 – 320 – 500",
+    waterGrams: 500,
+  },
+  "immersion-inverted-aeropress": {
+    ...base,
+    targetTimeSec: 150,
+    pourSteps: [
+      { label: "Invert AeroPress", action: "invert" },
+      { label: "Add coffee + water", action: "pour", waterGramsAtEnd: 200, durationSec: 15 },
+      { label: "Steep", action: "wait", durationSec: 60 },
+      { label: "Flip onto cup", action: "flip" },
+      { label: "Press", action: "press", durationSec: 25 },
+    ],
+  },
+  "immersion-clever": {
+    ...base,
+    targetTimeSec: 240,
+    pourSteps: [
+      { label: "Add all water", action: "pour", waterGramsAtEnd: 300, durationSec: 20 },
+      { label: "Steep", action: "wait", durationSec: 120 },
+      { label: "Drain onto cup", action: "drain", durationSec: 30 },
+    ],
+  },
+  "prose-only": {
+    ...base,
+    targetTimeSec: 180,
+    pourSequence: "bloom then pour slowly in spirals",
+  },
+};
+
+// Recompute the legacy inline derivation (mirrors LightStepBrew pre-refactor).
+function legacy(r) {
+  const guideSteps = hasImmersionShape(r) ? buildGuideSteps(r) : null;
+  const pourSteps = !guideSteps
+    ? pourStepsFromStructured(r, ROAST, NOW) ??
+      (r.pourSequence && r.targetTimeSec
+        ? parsePourSteps(r.pourSequence, r.targetTimeSec, ROAST, NOW)
+        : null)
+    : null;
+  const proseSequence = !guideSteps && !pourSteps && r.pourSequence ? r.pourSequence : null;
+  return { guideSteps, pourSteps, proseSequence };
+}
+
+for (const [name, recipe] of Object.entries(RECIPES)) {
+  test(`${name}: renderer arrays are byte-identical to the legacy derivation`, () => {
+    const tl = buildBrewTimeline(recipe, ROAST, NOW);
+    const leg = legacy(recipe);
+    assert.deepEqual(tl.pourSteps, leg.pourSteps, "pourSteps drift");
+    assert.deepEqual(tl.guideSteps, leg.guideSteps, "guideSteps drift");
+    assert.equal(tl.proseSequence, leg.proseSequence, "proseSequence drift");
+  });
+
+  test(`${name}: cue boundaries are provably unchanged`, () => {
+    const tl = buildBrewTimeline(recipe, ROAST, NOW);
+    const leg = legacy(recipe);
+    const fromTimeline = boundariesFromTimeline(tl);
+    const fromLegacy = buildBrewBoundaries(leg.pourSteps, leg.guideSteps, recipe.targetTimeSec);
+    assert.deepEqual(fromTimeline, fromLegacy, "boundary schedule changed — haptics/watch would drift");
+  });
+
+  test(`${name}: activeStepAt matches the renderer getActiveIdx scan`, () => {
+    const tl = buildBrewTimeline(recipe, ROAST, NOW);
+    const rendererArray =
+      tl.shape === "percolation"
+        ? tl.pourSteps
+        : tl.shape === "immersion"
+          ? tl.guideSteps.filter((s) => !s.isSetup)
+          : [];
+    if (rendererArray.length === 0) {
+      assert.equal(activeStepAt(tl, 30, true), -1);
+      return;
+    }
+    for (let e = 0; e <= recipe.targetTimeSec; e++) {
+      assert.equal(
+        activeStepAt(tl, e, true),
+        getActiveIdx(e, rendererArray),
+        `active step mismatch at ${e}s`,
+      );
+    }
+    assert.equal(activeStepAt(tl, 30, false), -1, "not started → -1");
+  });
+}
+
+test("percolation: expectedGramsAt is monotonic 0 → final", () => {
+  const tl = buildBrewTimeline(RECIPES["percolation-grams-string"], ROAST, NOW);
+  assert.equal(tl.hasGramsCurve, true);
+  assert.equal(expectedGramsAt(tl, 0), 0, "0 grams at t=0");
+
+  let prev = -1;
+  for (let e = 0; e <= tl.targetTimeSec; e++) {
+    const g = expectedGramsAt(tl, e);
+    assert.ok(g >= prev - 1e-9, `not monotonic at ${e}s (${g} < ${prev})`);
+    prev = g;
+  }
+  // Past the last pour → final cumulative (500g for this recipe).
+  assert.equal(expectedGramsAt(tl, tl.targetTimeSec), 500);
+});
+
+test("percolation: expectedGramsAt interpolates mid-bloom", () => {
+  // Structured: bloom 45g starting at t=0. pourDurationSec(45) = round(45/4) = 11s.
+  // At t=5: 45 * 5/11 ≈ 20.45g.
+  const tl = buildBrewTimeline(RECIPES["percolation-structured-with-agitation"], ROAST, NOW);
+  const g = expectedGramsAt(tl, 5);
+  assert.ok(Math.abs(g - (45 * 5) / 11) < 0.01, `mid-bloom interpolation off: ${g}`);
+});
+
+test("immersion + prose: no grams curve (expectedGramsAt null)", () => {
+  for (const name of ["immersion-inverted-aeropress", "immersion-clever", "prose-only"]) {
+    const tl = buildBrewTimeline(RECIPES[name], ROAST, NOW);
+    assert.equal(tl.hasGramsCurve, false, `${name} should have no grams curve`);
+    assert.equal(expectedGramsAt(tl, 30), null, `${name} expectedGramsAt should be null`);
+  }
+});
+
+test("shapes are classified correctly", () => {
+  assert.equal(buildBrewTimeline(RECIPES["percolation-structured-with-agitation"], ROAST, NOW).shape, "percolation");
+  assert.equal(buildBrewTimeline(RECIPES["percolation-grams-string"], ROAST, NOW).shape, "percolation");
+  assert.equal(buildBrewTimeline(RECIPES["immersion-inverted-aeropress"], ROAST, NOW).shape, "immersion");
+  assert.equal(buildBrewTimeline(RECIPES["immersion-clever"], ROAST, NOW).shape, "immersion");
+  assert.equal(buildBrewTimeline(RECIPES["prose-only"], ROAST, NOW).shape, "prose");
+});


### PR DESCRIPTION
**PR 1 of the brew-flow coaching arc** (the "tidy up the step-by-step guide" the owner asked for). Refactor-only — zero behavior change, locked by a golden test.

### Why
The intended flow was split: percolation `PourStep[]` (grams-over-time) vs immersion `GuideStep[]` (action-only), derived inline in `LightStepBrew` with the active-step scan duplicated across the two renderers. There was no single "intended flow" to compare a live pour against.

### What
- **`src/lib/brew/timeline.ts`** — a normalize layer over the existing tested builders (`buildGuideSteps`/`pourStepsFromStructured`/`parsePourSteps`); no timing math reimplemented. `buildBrewTimeline` returns the **byte-identical renderer arrays** AND a canonical `steps[]` + `expectedGramsAt(t)` + `activeStepAt()`.
- **`boundariesFromTimeline`** in `brewNotifications.ts` — thin wrapper over `buildBrewBoundaries`, so the haptic + Apple Watch cue schedule is provably unchanged.
- **`LightStepBrew`** derives the timeline once and feeds the renderers + cues from it.

### Safety
The golden-equivalence test bundles the real modules and asserts, across a recipe corpus (structured percolation w/ agitation, grams-string, inverted AeroPress, Clever, prose-legacy), that the renderer arrays and cue boundaries **deep-equal** the legacy derivation — plus `activeStepAt` parity and `expectedGramsAt` correctness. `tsc` + full `next build` clean; 19 new tests; no scale code.

Foundation for PR 2 (live pour-flow coaching) and PR 3 (post-brew analysis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)