### PR TITLE
feat(brew): live pour-flow coaching from the Acaia scale (PR 2)

### DIFF
--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -18,6 +18,8 @@ import { useBrewStepHaptics } from "@/hooks/useBrewStepHaptics";
 import { useBrewStepWatch } from "@/hooks/useBrewStepWatch";
 import { boundariesFromTimeline } from "@/lib/native/brewNotifications";
 import { ScalePanel } from "@/components/flow/ScalePanel";
+import { useAcaiaScale } from "@/hooks/useAcaiaScale";
+import { coachFlow, type WeightSample, type FlowComparison } from "@/lib/brew/flowCoach";
 
 /**
  * Light System fork of /components/flow/StepBrew.tsx.
@@ -78,6 +80,27 @@ export default function LightStepBrew() {
     [enableWakeLock],
   );
 
+  // ── Live scale (Acaia) ─────────────────────────────────────────────────────
+  // The brew screen owns the scale so the live flow coach reads the SAME weight
+  // + sample stream the ScalePanel shows. Downsample the ~10–20 Hz BLE stream to
+  // ~5 Hz into a rolling ~6 s window — a ref, so samples never trigger renders.
+  const samplesRef = useRef<WeightSample[]>([]);
+  const lastSampleMsRef = useRef(0);
+  const pushSample = useCallback((grams: number, atMs: number) => {
+    if (atMs - lastSampleMsRef.current < 200) return;
+    lastSampleMsRef.current = atMs;
+    const buf = samplesRef.current;
+    buf.push({ atMs, grams });
+    const cutoff = atMs - 6000;
+    while (buf.length > 0 && buf[0].atMs < cutoff) buf.shift();
+  }, []);
+  const scale = useAcaiaScale({ onSample: pushSample });
+
+  // Clear the sample window on reset so a re-brew never coaches off stale pours.
+  useEffect(() => {
+    if (elapsed === 0) samplesRef.current = [];
+  }, [elapsed]);
+
   const handleDone = useCallback(
     (actualSec?: number) => {
       disableWakeLock();
@@ -133,6 +156,10 @@ export default function LightStepBrew() {
   // while the app is awake. Native-only no-op elsewhere.
   const boundaries = timeline ? boundariesFromTimeline(timeline) : [];
   useBrewStepHaptics(boundaries, elapsed, started);
+
+  // Live pour-flow comparison. Off the native shell / immersion / no weight yet
+  // → cue "none", so the coach UI renders nothing (no-scale path unchanged).
+  const coach = coachFlow(timeline, elapsed, started, scale.weight, samplesRef.current);
   // The decisive cue: hand the whole schedule to a paired Apple Watch at brew
   // start so the wrist buzzes per step even while the phone screen is on (the
   // wake-locked brew case, where iOS won't mirror notifications). Native-only
@@ -145,7 +172,7 @@ export default function LightStepBrew() {
       nextLabel="Done Brewing"
     >
       <div className="flex flex-col gap-5">
-        <ScalePanel />
+        <ScalePanel {...scale} />
         {recipe && (
           <div className="rounded-3xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 p-4">
             <div className="mb-3">
@@ -186,6 +213,7 @@ export default function LightStepBrew() {
             elapsed={elapsed}
             targetTimeSec={recipe.targetTimeSec}
             started={started}
+            coach={coach}
           />
         )}
 
@@ -204,6 +232,42 @@ interface LivePourSequenceProps {
   elapsed: number;
   targetTimeSec: number;
   started: boolean;
+  /** Live pour-flow comparison (scale connected). Null/"none" → nothing renders. */
+  coach?: FlowComparison | null;
+}
+
+/** Live "pour slower / faster / keep the flow" cue on the active pour card.
+ * Renders only when the scale is connected and on a grams-curve (percolation). */
+function CoachCue({ coach }: { coach: FlowComparison }) {
+  const color =
+    coach.state === "on-track"
+      ? "text-light-success"
+      : coach.state === "ahead" || coach.state === "behind"
+        ? "text-light-accent-overtime"
+        : "text-light-foreground";
+  return (
+    <div
+      key={coach.cue}
+      className="mt-3 rounded-2xl bg-[hsl(36_55%_96%/0.5)] px-3 py-2 animate-step-activate"
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <span className={`font-fraunces text-[20px] leading-none ${color}`}>{coach.message}</span>
+        {coach.liveGrams != null && (
+          <span className="font-mono-num text-[15px] font-semibold text-light-foreground">
+            {Math.round(coach.liveGrams)}g
+          </span>
+        )}
+      </div>
+      {coach.detail && (
+        <p className="font-mono-num text-[11px] text-light-muted-foreground mt-1">{coach.detail}</p>
+      )}
+    </div>
+  );
+}
+
+/** Whether a coach result is worth surfacing on the pour card. */
+function showsCoach(coach?: FlowComparison | null): coach is FlowComparison {
+  return !!coach && coach.cue !== "none" && coach.cue !== "agitate";
 }
 
 /** Short SwirlButton label for an agitation step. */
@@ -211,7 +275,7 @@ function agitationButtonLabel(action: PourStep["action"]): string {
   return action === "stir" ? "Stir" : action === "tap" ? "Tap" : "Swirl";
 }
 
-function LivePourSequence({ steps, elapsed, targetTimeSec, started }: LivePourSequenceProps) {
+function LivePourSequence({ steps, elapsed, targetTimeSec, started, coach }: LivePourSequenceProps) {
   const activeIdx = started ? getActiveIdx(elapsed, steps) : -1;
   const activeStep = activeIdx >= 0 ? steps[activeIdx] : null;
   const nextStep = activeIdx >= 0 && activeIdx < steps.length - 1 ? steps[activeIdx + 1] : null;
@@ -350,6 +414,7 @@ function LivePourSequence({ steps, elapsed, targetTimeSec, started }: LivePourSe
               </p>
             </div>
           </div>
+          {showsCoach(coach) && <CoachCue coach={coach} />}
           {countdownFooter}
         </div>
       )}

--- a/src/components/flow/ScalePanel.tsx
+++ b/src/components/flow/ScalePanel.tsx
@@ -8,11 +8,21 @@
  * In the shell it offers a Connect action, then shows live grams + Tare while
  * connected. v1: read-only weight + tare; pour auto-advance comes later.
  */
-import { useAcaiaScale } from "@/hooks/useAcaiaScale";
+import type { UseAcaiaScale } from "@/hooks/useAcaiaScale";
 
-export function ScalePanel() {
-  const { available, status, weight, connect, disconnect, tare } = useAcaiaScale();
-
+/**
+ * Presentational scale card — the brew screen owns the `useAcaiaScale` state
+ * (so the live flow coach can read the same weight + sample stream) and passes
+ * it in. Renders nothing off the native shell (`available` false).
+ */
+export function ScalePanel({
+  available,
+  status,
+  weight,
+  connect,
+  disconnect,
+  tare,
+}: UseAcaiaScale) {
   if (!available) return null;
 
   const connected = status === "connected";

--- a/src/hooks/useAcaiaScale.ts
+++ b/src/hooks/useAcaiaScale.ts
@@ -30,7 +30,15 @@ export interface UseAcaiaScale {
   tare: () => void;
 }
 
-export function useAcaiaScale(): UseAcaiaScale {
+export interface UseAcaiaScaleOptions {
+  /** Called on every weight sample with a wall-clock timestamp — feeds the live
+   * flow coach's rolling window. Additive; no effect off the native shell. */
+  onSample?: (grams: number, atMs: number) => void;
+}
+
+export function useAcaiaScale(opts: UseAcaiaScaleOptions = {}): UseAcaiaScale {
+  const onSampleRef = useRef(opts.onSample);
+  onSampleRef.current = opts.onSample;
   // Resolve capability after mount so SSR markup stays stable (server = false).
   const [available, setAvailable] = useState(false);
   const [status, setStatus] = useState<AcaiaUiStatus>("idle");
@@ -45,7 +53,10 @@ export function useAcaiaScale(): UseAcaiaScale {
     if (!acaiaCapable() || handleRef.current) return;
     try {
       const handle = await connectAcaia({
-        onWeight: (grams) => setWeight(grams),
+        onWeight: (grams) => {
+          setWeight(grams);
+          onSampleRef.current?.(grams, Date.now());
+        },
         onStatus: (s) => setStatus(s),
       });
       handleRef.current = handle;

--- a/src/lib/brew/flowCoach.ts
+++ b/src/lib/brew/flowCoach.ts
@@ -1,0 +1,218 @@
+/**
+ * Live pour-flow coach — compares the Acaia weight stream to the recipe's
+ * intended flow and emits a single teaching cue ("Pour slower", "Keep the
+ * flow", "Ease off"…). Pure + deterministic; the brew screen renders whatever
+ * this returns. No BLE here — it takes a weight + a short sample window.
+ *
+ * Grounded in the research (docs/plan): the scale (under the whole brewer)
+ * measures water ADDED, so the live signal is your POUR RATE (slope of weight
+ * over time) and your progress toward each pour's target. The intended pour
+ * rate is ~POUR_RATE_GPS (4 g/s — within the practical 3–5 g/s band); we coach
+ * toward it with a tolerance band, sanity-capped. Drawdown rate is NOT visible
+ * to the scale (mass is conserved when you're not pouring) → that's a post-brew
+ * judgment from total time, handled elsewhere.
+ *
+ * Bands are STARTING DEFAULTS, tunable on-device — exact g/s is practical
+ * guidance, never presented as hard law.
+ */
+import { activeStepAt, expectedGramsAt, type BrewTimeline } from "@/lib/brew/timeline";
+import { pourDurationSec } from "@/lib/utils/pourSequence";
+
+export interface WeightSample {
+  /** Wall-clock ms when the sample was read. */
+  atMs: number;
+  grams: number;
+}
+
+export type FlowCue =
+  | "none"
+  | "bloom"
+  | "pour-slower"
+  | "pour-faster"
+  | "keep-flow"
+  | "ease-off"
+  | "steady"
+  | "overshot"
+  | "hold"
+  | "agitate";
+
+export interface FlowComparison {
+  cue: FlowCue;
+  /** Short imperative coach line (BTTS voice). Empty when cue is "none". */
+  message: string;
+  /** Secondary line, e.g. "16g to go · 6.2 g/s". */
+  detail?: string;
+  liveGrams: number | null;
+  /** Where you should be right now (interpolated). */
+  targetGramsNow: number | null;
+  /** The active step's cumulative target. */
+  currentStepTargetG: number | null;
+  /** target − live (positive = more to pour). */
+  remainingToTargetG: number | null;
+  liveRateGPS: number | null;
+  targetRateGPS: number | null;
+  /** For colour: pouring too fast = "ahead", too slow/stalled = "behind". */
+  state: "ahead" | "behind" | "on-track" | "no-data";
+}
+
+// ── Tuning bands (starting defaults; refine on-device) ───────────────────────
+const TOL_G = 3; // within this of a pour's target = "reached"
+const EASE_OFF_G = 15; // start easing off this many grams before target
+const STALL_RATE = 0.4; // g/s — below this mid-pour = stalled
+const FAST_ABS = 6; // g/s — hard "too fast" cap
+const SLOW_ABS = 1.5; // g/s — hard "too slow" floor (while pouring)
+const FAST_MULT = 1.4; // or this × the intended rate
+const SLOW_MULT = 0.6;
+
+const NO_DATA: FlowComparison = {
+  cue: "none",
+  message: "",
+  liveGrams: null,
+  targetGramsNow: null,
+  currentStepTargetG: null,
+  remainingToTargetG: null,
+  liveRateGPS: null,
+  targetRateGPS: null,
+  state: "no-data",
+};
+
+/**
+ * Pour rate (g/s) = least-squares slope of weight over the trailing `windowMs`.
+ * Least-squares (not a 2-point diff) so BLE jitter doesn't make the number jump.
+ * Null until there are ≥2 samples spanning the window.
+ */
+export function flowRateGPS(samples: WeightSample[], windowMs = 1500): number | null {
+  if (samples.length < 2) return null;
+  const latest = samples[samples.length - 1].atMs;
+  const win = samples.filter((s) => latest - s.atMs <= windowMs);
+  if (win.length < 2) return null;
+
+  const t0 = win[0].atMs;
+  let n = 0;
+  let sx = 0;
+  let sy = 0;
+  let sxx = 0;
+  let sxy = 0;
+  for (const s of win) {
+    const x = (s.atMs - t0) / 1000;
+    const y = s.grams;
+    n += 1;
+    sx += x;
+    sy += y;
+    sxx += x * x;
+    sxy += x * y;
+  }
+  const denom = n * sxx - sx * sx;
+  if (Math.abs(denom) < 1e-9) return null;
+  return (n * sxy - sx * sy) / denom;
+}
+
+function fmtDetail(remaining: number, rate: number | null): string {
+  const left = `${Math.max(0, Math.round(remaining))}g to go`;
+  return rate != null ? `${left} · ${rate.toFixed(1)} g/s` : left;
+}
+
+/**
+ * Compare the live pour to the intended flow at this instant. Returns a single
+ * cue + the numbers behind it. Degrades to "no-data" off the grams curve
+ * (immersion) or before there's a weight reading.
+ */
+export function coachFlow(
+  timeline: BrewTimeline | null,
+  elapsed: number,
+  started: boolean,
+  liveGrams: number | null,
+  samples: WeightSample[],
+): FlowComparison {
+  if (!timeline || !started || liveGrams == null || !timeline.hasGramsCurve) {
+    return { ...NO_DATA, liveGrams };
+  }
+
+  const targetGramsNow = expectedGramsAt(timeline, elapsed);
+  const rate = flowRateGPS(samples);
+  const idx = activeStepAt(timeline, elapsed, started);
+  const step = idx >= 0 ? timeline.steps[idx] : null;
+  if (!step) {
+    return { ...NO_DATA, liveGrams, targetGramsNow, liveRateGPS: rate };
+  }
+
+  // Agitation step → cue the swirl/stir, no flow coaching (no water added).
+  if (step.isAgitation) {
+    return {
+      cue: "agitate",
+      message: step.label,
+      liveGrams,
+      targetGramsNow,
+      currentStepTargetG: step.targetCumulativeGrams ?? null,
+      remainingToTargetG: null,
+      liveRateGPS: rate,
+      targetRateGPS: null,
+      state: "on-track",
+    };
+  }
+
+  const stepTarget = step.targetCumulativeGrams ?? null;
+  if (stepTarget == null) {
+    return { ...NO_DATA, liveGrams, targetGramsNow, liveRateGPS: rate };
+  }
+
+  const remaining = stepTarget - liveGrams;
+  const isBloom = step.action === "bloom";
+  const pourGrams = step.pourGrams != null && step.pourGrams > 0 ? step.pourGrams : stepTarget;
+  const targetRate = pourGrams / pourDurationSec(Math.max(1, pourGrams)); // ≈ 4 g/s
+
+  const partial: Omit<FlowComparison, "cue" | "message" | "detail" | "state"> = {
+    liveGrams,
+    targetGramsNow,
+    currentStepTargetG: stepTarget,
+    remainingToTargetG: remaining,
+    liveRateGPS: rate,
+    targetRateGPS: targetRate,
+  };
+
+  // Past the target → overshot.
+  if (remaining < -TOL_G) {
+    return {
+      ...partial,
+      cue: "overshot",
+      message: "Overshot",
+      detail: `+${Math.round(-remaining)}g`,
+      state: "ahead",
+    };
+  }
+  // Reached the target (within tolerance) → hold for the next pour.
+  if (remaining <= TOL_G) {
+    return {
+      ...partial,
+      cue: "hold",
+      message: isBloom ? "Bloom set — swirl & wait" : "Hold — let it draw down",
+      state: "on-track",
+    };
+  }
+
+  // Still pouring toward the target — coach the rate.
+  const r = rate ?? 0;
+  let cue: FlowCue = isBloom ? "bloom" : "steady";
+  let message = isBloom ? "Bloom — gentle" : "Steady";
+  let state: FlowComparison["state"] = "on-track";
+
+  if (r < STALL_RATE) {
+    cue = "keep-flow";
+    message = "Keep the flow going";
+    state = "behind";
+  } else if (r > Math.max(targetRate * FAST_MULT, FAST_ABS)) {
+    cue = "pour-slower";
+    message = "Pour slower";
+    state = "ahead";
+  } else if (r < Math.min(targetRate * SLOW_MULT, SLOW_ABS) && remaining > EASE_OFF_G) {
+    cue = "pour-faster";
+    message = "Pour faster";
+    state = "behind";
+  } else if (remaining <= EASE_OFF_G) {
+    cue = "ease-off";
+    message = "Ease off";
+    state = "on-track";
+  }
+
+  return { ...partial, cue, message, detail: fmtDetail(remaining, rate), state };
+}

--- a/tests/dataflow/brew-flowcoach.test.mjs
+++ b/tests/dataflow/brew-flowcoach.test.mjs
@@ -1,0 +1,128 @@
+// Live pour-flow coach tests. Bundles the REAL flowCoach.ts + timeline.ts and
+// asserts each teaching cue fires on the right weight/rate situation.
+//
+//   node --test tests/dataflow/brew-flowcoach.test.mjs
+//
+// Locked: least-squares flow rate from a noisy-ish sample window; and the cue
+// boundaries — pour-slower (too fast), keep-flow (stalled mid-pour), pour-faster
+// (too slow), ease-off (near target), overshot, hold (reached), steady; plus
+// graceful no-data on the immersion path.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const entry = `
+export { coachFlow, flowRateGPS } from ${JSON.stringify(path.join(ROOT, "src/lib/brew/flowCoach.ts"))};
+export { buildBrewTimeline } from ${JSON.stringify(path.join(ROOT, "src/lib/brew/timeline.ts"))};
+`;
+const dir = await mkdtemp(join(tmpdir(), "flowcoach-"));
+const out = join(dir, "fc.mjs");
+await build({
+  stdin: { contents: entry, resolveDir: ROOT, loader: "ts" },
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  outfile: out,
+  logLevel: "silent",
+});
+const { coachFlow, flowRateGPS, buildBrewTimeline } = await import(pathToFileURL(out).href);
+
+const ROAST = "2026-06-01";
+const NOW = new Date("2026-06-16T08:00:00Z").getTime();
+
+// "50 – 180 – 320 – 500" @210s → bloom@0(50), pour@45(180), pour@93(320), final@141(500).
+const PERC = buildBrewTimeline(
+  { doseGrams: 15, waterGrams: 500, waterTempC: 94, grindSize: "medium", targetTimeSec: 210, pourSequence: "50 – 180 – 320 – 500" },
+  ROAST,
+  NOW,
+);
+const IMMERSION = buildBrewTimeline(
+  {
+    doseGrams: 15, waterGrams: 250, waterTempC: 94, grindSize: "medium", targetTimeSec: 150,
+    pourSteps: [
+      { label: "Add water", action: "pour", waterGramsAtEnd: 200, durationSec: 15 },
+      { label: "Steep", action: "wait", durationSec: 90 },
+      { label: "Press", action: "press", durationSec: 25 },
+    ],
+  },
+  ROAST,
+  NOW,
+);
+
+// Samples that encode a given pour rate (g/s) over a 1.4s window.
+function ramp(rateGPS) {
+  const out = [];
+  for (let i = 0; i < 8; i++) out.push({ atMs: 100000 + i * 200, grams: 50 + i * 0.2 * rateGPS });
+  return out;
+}
+
+test("flowRateGPS = least-squares slope of the sample window", () => {
+  assert.ok(Math.abs(flowRateGPS(ramp(8)) - 8) < 0.01);
+  assert.ok(Math.abs(flowRateGPS(ramp(4)) - 4) < 0.01);
+  assert.equal(flowRateGPS([{ atMs: 1, grams: 5 }]), null); // need ≥2
+});
+
+// Mid-pour on step 1 (target 180g): elapsed in [45,93), plenty remaining.
+const ELAPSED_MID = 60;
+
+test("too fast → pour-slower", () => {
+  const c = coachFlow(PERC, ELAPSED_MID, true, 90, ramp(8));
+  assert.equal(c.cue, "pour-slower");
+  assert.equal(c.state, "ahead");
+});
+
+test("stalled mid-pour → keep-flow", () => {
+  const c = coachFlow(PERC, ELAPSED_MID, true, 90, ramp(0));
+  assert.equal(c.cue, "keep-flow");
+  assert.equal(c.state, "behind");
+});
+
+test("too slow (but moving) → pour-faster", () => {
+  const c = coachFlow(PERC, ELAPSED_MID, true, 90, ramp(1));
+  assert.equal(c.cue, "pour-faster");
+  assert.equal(c.state, "behind");
+});
+
+test("good rate → steady", () => {
+  const c = coachFlow(PERC, ELAPSED_MID, true, 90, ramp(4));
+  assert.equal(c.cue, "steady");
+  assert.equal(c.state, "on-track");
+});
+
+test("near the target → ease-off", () => {
+  // target 180, live 172 → 8g remaining (≤15) at a fine rate.
+  const c = coachFlow(PERC, ELAPSED_MID, true, 172, ramp(4));
+  assert.equal(c.cue, "ease-off");
+});
+
+test("reached the target → hold", () => {
+  const c = coachFlow(PERC, ELAPSED_MID, true, 180, ramp(0));
+  assert.equal(c.cue, "hold");
+  assert.match(c.message, /draw/i);
+});
+
+test("past the target → overshot with +Xg", () => {
+  const c = coachFlow(PERC, ELAPSED_MID, true, 192, ramp(0));
+  assert.equal(c.cue, "overshot");
+  assert.equal(c.detail, "+12g");
+  assert.equal(c.state, "ahead");
+});
+
+test("detail shows grams-to-go and rate", () => {
+  const c = coachFlow(PERC, ELAPSED_MID, true, 90, ramp(4));
+  assert.match(c.detail, /90g to go · 4\.0 g\/s/);
+});
+
+test("immersion / no scale → no-data, no cue", () => {
+  assert.equal(coachFlow(IMMERSION, 30, true, 100, ramp(4)).cue, "none");
+  assert.equal(coachFlow(IMMERSION, 30, true, 100, ramp(4)).state, "no-data");
+  assert.equal(coachFlow(PERC, 60, true, null, []).cue, "none"); // no weight yet
+  assert.equal(coachFlow(PERC, 60, false, 90, ramp(4)).cue, "none"); // not started
+});


### PR DESCRIPTION
**PR 2 of the brew-flow coaching arc.** When the scale is connected, the brew screen teaches the pour in real time.

### The cues
"Pour slower" / "Pour faster" / "Keep the flow going" (stalled mid-pour) / "Ease off" (near target) / "Overshot +Xg" / "Hold — let it draw down" / "Steady". Each with the numbers behind it (grams to go · live g/s).

### Grounded in the research
The scale (under the whole brewer) measures water **added**, so the live signal is your **pour rate** — the least-squares slope of weight over a ~1.5 s window — and your progress toward each pour's target. We coach toward the recipe's intended ~4 g/s (within the practical 3–5 g/s band), sanity-capped. Drawdown rate isn't visible to the scale (mass conserved) → that's PR 3's post-brew job.

### What's here
- **`src/lib/brew/flowCoach.ts`** — pure engine (`flowRateGPS` + `coachFlow`), built on the canonical `BrewTimeline` (`expectedGramsAt` / `activeStepAt`). Degrades to "no-data" on immersion / before a reading.
- **`LightStepBrew`** owns `useAcaiaScale` + a downsampled (~5 Hz) ~6 s rolling sample ring buffer (a ref — samples don't trigger renders); renders a `CoachCue` on the active pour card. `ScalePanel` is now presentational.
- **`useAcaiaScale`** gains an additive `onSample(grams, atMs)`.

### Safety
No-scale path unchanged — every coach element is gated on a live weight + the grams curve, so off the shell / on immersion nothing new renders. Step advance + the watch/haptic schedule stay time-driven. `tsc` + full `next build` clean; 10 new tests.

Ships behind the build-9 BLE shell already on the phone. Bands are starting defaults, tunable on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)