### PR TITLE
feat(brew): post-brew pour analysis + measured flow grade (PR 3)

### DIFF
--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -11,7 +11,7 @@ import {
   type PourStep,
   type GuideStep,
 } from "@/lib/utils/pourSequence";
-import { buildBrewTimeline } from "@/lib/brew/timeline";
+import { buildBrewTimeline, type BrewTimeline } from "@/lib/brew/timeline";
 import type { BrewStepAction } from "@/lib/types/session";
 import { basedOnReference } from "@/lib/utils/resolveRecipe";
 import { useBrewStepHaptics } from "@/hooks/useBrewStepHaptics";
@@ -20,6 +20,7 @@ import { boundariesFromTimeline } from "@/lib/native/brewNotifications";
 import { ScalePanel } from "@/components/flow/ScalePanel";
 import { useAcaiaScale } from "@/hooks/useAcaiaScale";
 import { coachFlow, type WeightSample, type FlowComparison } from "@/lib/brew/flowCoach";
+import { analyzeFlow, type FlowCurvePoint } from "@/lib/brew/flowAnalysis";
 
 /**
  * Light System fork of /components/flow/StepBrew.tsx.
@@ -75,6 +76,7 @@ export default function LightStepBrew() {
       if (e === 1) {
         setStarted(true);
         enableWakeLock();
+        brewStartMsRef.current = Date.now() - 1000; // elapsed=1 ≈ 1 s after start
       }
     },
     [enableWakeLock],
@@ -84,22 +86,46 @@ export default function LightStepBrew() {
   // The brew screen owns the scale so the live flow coach reads the SAME weight
   // + sample stream the ScalePanel shows. Downsample the ~10–20 Hz BLE stream to
   // ~5 Hz into a rolling ~6 s window — a ref, so samples never trigger renders.
-  const samplesRef = useRef<WeightSample[]>([]);
+  const samplesRef = useRef<WeightSample[]>([]); // ~6 s rolling window for the live coach
+  const fullCurveRef = useRef<FlowCurvePoint[]>([]); // whole-brew curve for post-brew analysis
+  const brewStartMsRef = useRef(0);
   const lastSampleMsRef = useRef(0);
+  const lastCurveMsRef = useRef(0);
   const pushSample = useCallback((grams: number, atMs: number) => {
-    if (atMs - lastSampleMsRef.current < 200) return;
-    lastSampleMsRef.current = atMs;
-    const buf = samplesRef.current;
-    buf.push({ atMs, grams });
-    const cutoff = atMs - 6000;
-    while (buf.length > 0 && buf[0].atMs < cutoff) buf.shift();
+    // Live-coach window: ~5 Hz, keep the last 6 s.
+    if (atMs - lastSampleMsRef.current >= 200) {
+      lastSampleMsRef.current = atMs;
+      const buf = samplesRef.current;
+      buf.push({ atMs, grams });
+      const cutoff = atMs - 6000;
+      while (buf.length > 0 && buf[0].atMs < cutoff) buf.shift();
+    }
+    // Whole-brew curve: ~2 Hz, in brew-relative seconds, for the post-brew report.
+    if (brewStartMsRef.current > 0 && atMs - lastCurveMsRef.current >= 500) {
+      lastCurveMsRef.current = atMs;
+      const tSec = (atMs - brewStartMsRef.current) / 1000;
+      if (tSec >= 0) {
+        const curve = fullCurveRef.current;
+        curve.push({ tSec, grams });
+        if (curve.length > 600) curve.shift(); // safety cap (~5 min @ 2 Hz)
+      }
+    }
   }, []);
   const scale = useAcaiaScale({ onSample: pushSample });
 
-  // Clear the sample window on reset so a re-brew never coaches off stale pours.
+  // Clear capture on reset so a re-brew never coaches/analyses off stale pours.
   useEffect(() => {
-    if (elapsed === 0) samplesRef.current = [];
+    if (elapsed === 0) {
+      samplesRef.current = [];
+      fullCurveRef.current = [];
+      brewStartMsRef.current = 0;
+      lastCurveMsRef.current = 0;
+    }
   }, [elapsed]);
+
+  // The current timeline, in a ref, so handleDone can analyse without being
+  // re-created every render (timeline is a fresh object each render).
+  const timelineRef = useRef<BrewTimeline | null>(null);
 
   const handleDone = useCallback(
     (actualSec?: number) => {
@@ -111,11 +137,18 @@ export default function LightStepBrew() {
       // regression). Coerce anything that isn't a finite number to elapsed.
       const finalSec =
         typeof actualSec === "number" && Number.isFinite(actualSec) ? actualSec : elapsed;
+      // If a scale captured the pour, derive the objective flow analysis and let
+      // it drive the flow grade (so the log screen needn't ask). Null off-scale /
+      // on immersion → nothing changes.
+      const analysis = analyzeFlow(timelineRef.current, fullCurveRef.current, finalSec);
       setBrew({
         ...draft.brew,
         methodUsed: method,
         followedRecipe: true,
         actualTimeSec: finalSec,
+        ...(analysis
+          ? { flowAnalysis: analysis, flowSource: "measured", flow: analysis.derivedFlow }
+          : {}),
       });
       setStep("log");
     },
@@ -148,6 +181,7 @@ export default function LightStepBrew() {
   const steps = timeline?.pourSteps ?? null;
   const guideSteps = timeline?.guideSteps ?? null;
   const proseSequence = timeline?.proseSequence ?? null;
+  timelineRef.current = timeline;
 
   // The step cue schedule (one entry per pour + agitation step). Lock-screen
   // notifications were removed (they only ever orphaned after a force-quit — see

--- a/src/components/flow/LightStepLog.tsx
+++ b/src/components/flow/LightStepLog.tsx
@@ -396,12 +396,24 @@ export default function LightStepLog() {
         {!isExternal && (
           <Section eyebrow="How it brewed">
             <div className="space-y-4">
-              <SensoryRow
-                label="Flow"
-                options={FLOW_OPTIONS.map((o) => ({ id: o, label: FLOW_LABELS[o] }))}
-                value={flow}
-                onChange={setFlow}
-              />
+              {draft.brew?.flowSource === "measured" && draft.brew.flow ? (
+                // The scale measured the pour — show the grade read-only instead
+                // of asking, so the user can't overwrite the measured flow.
+                <div className="flex items-center justify-between">
+                  <span className="text-[13px] text-light-muted-foreground">Flow</span>
+                  <span className="text-[14px] text-light-foreground">
+                    {FLOW_LABELS[draft.brew.flow]}{" "}
+                    <span className="text-light-muted-foreground">· measured</span>
+                  </span>
+                </div>
+              ) : (
+                <SensoryRow
+                  label="Flow"
+                  options={FLOW_OPTIONS.map((o) => ({ id: o, label: FLOW_LABELS[o] }))}
+                  value={flow}
+                  onChange={setFlow}
+                />
+              )}
               <SensoryRow
                 label="Timing"
                 options={TIMING_OPTIONS.map((o) => ({ id: o, label: TIMING_LABELS[o] }))}

--- a/src/components/flow/LightStepSummary.tsx
+++ b/src/components/flow/LightStepSummary.tsx
@@ -10,6 +10,7 @@ import LightStarRating from "@/components/ui/light/StarRating";
 import CoffeeBeanGlow from "@/components/ui/light/CoffeeBeanGlow";
 import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
 import Chip from "@/components/ui/light/Chip";
+import type { FlowAnalysis } from "@/lib/brew/flowAnalysis";
 
 /**
  * Light System fork of /components/flow/StepSummary.tsx.
@@ -282,6 +283,8 @@ export default function LightStepSummary() {
           </div>
         ) : null}
 
+        {brew?.flowAnalysis && <PourAnalysisCard analysis={brew.flowAnalysis} />}
+
         {(insightLoading || terrain || adjustment) && (
           <div className="rounded-3xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 p-4 space-y-3">
             {insightLoading ? (
@@ -418,6 +421,73 @@ function InfoRow({ label, value }: { label: string; value: string }) {
     <div className="flex items-baseline justify-between gap-4">
       <span className="text-[13px] text-light-muted-foreground shrink-0">{label}</span>
       <span className="text-[14px] text-light-foreground text-right">{value}</span>
+    </div>
+  );
+}
+
+// ── Pour analysis (measured from a connected Acaia scale) ────────────────────
+
+function mmss(sec: number): string {
+  const s = Math.max(0, Math.round(sec));
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
+}
+
+function AnalysisStat({ label, value, accent }: { label: string; value: string; accent?: string }) {
+  return (
+    <div className="rounded-2xl bg-[hsl(36_55%_96%/0.5)] px-3 py-2">
+      <p className="text-[10px] uppercase tracking-wide text-light-muted-foreground">{label}</p>
+      <p className={`font-mono-num text-[15px] mt-0.5 ${accent ?? "text-light-foreground"}`}>{value}</p>
+    </div>
+  );
+}
+
+function PourAnalysisCard({ analysis }: { analysis: FlowAnalysis }) {
+  const gradeLabel =
+    analysis.derivedFlow === "perfect"
+      ? "On target"
+      : analysis.derivedFlow === "too-fast"
+        ? "Ran fast"
+        : "Ran slow";
+  const gradeColor =
+    analysis.derivedFlow === "perfect" ? "text-light-success" : "text-light-accent-overtime";
+
+  // The pour that drifted furthest from its scheduled time (worth a teaching line).
+  const drifted = analysis.perPour
+    .filter((p) => p.errorSec != null)
+    .sort((a, b) => Math.abs(b.errorSec as number) - Math.abs(a.errorSec as number))[0];
+  const steady =
+    analysis.pourSteadiness == null ? null : analysis.pourSteadiness < 0.3 ? "Steady" : "Uneven";
+
+  return (
+    <div className="rounded-3xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 p-4">
+      <div className="flex items-center justify-between mb-3">
+        <p className="label-eyebrow">Pour analysis</p>
+        <span className="text-[10px] uppercase tracking-wide text-light-muted-foreground">measured</span>
+      </div>
+      <div className="grid grid-cols-2 gap-2">
+        <AnalysisStat
+          label="Total"
+          value={`${mmss(analysis.totalTimeSec)} / ${mmss(analysis.targetTimeSec)}`}
+          accent={gradeColor}
+        />
+        <AnalysisStat label="Flow" value={gradeLabel} accent={gradeColor} />
+        {analysis.avgFlowRateGPS != null && (
+          <AnalysisStat label="Avg pour" value={`${analysis.avgFlowRateGPS} g/s`} />
+        )}
+        {analysis.overshootG != null && analysis.overshootG > 2 && (
+          <AnalysisStat label="Overshoot" value={`+${analysis.overshootG}g`} />
+        )}
+        {steady && <AnalysisStat label="Stream" value={steady} />}
+      </div>
+      {drifted && Math.abs(drifted.errorSec as number) >= 3 && (
+        <p className="text-[12px] text-light-muted-foreground mt-3">
+          {drifted.label} hit {drifted.targetGrams}g{" "}
+          {(drifted.errorSec as number) > 0
+            ? `${Math.round(drifted.errorSec as number)}s late`
+            : `${Math.abs(Math.round(drifted.errorSec as number))}s early`}
+          .
+        </p>
+      )}
     </div>
   );
 }

--- a/src/lib/brew/flowAnalysis.ts
+++ b/src/lib/brew/flowAnalysis.ts
@@ -1,0 +1,155 @@
+/**
+ * Post-brew flow analysis — turns the captured weight curve into objective
+ * numbers that teach: did each pour land on time, was the pour steady or jerky
+ * (channeling risk), did you overshoot, and was the whole brew too fast / too
+ * slow. The total-time judgment is the classic grind signal (the scale can't
+ * see drawdown rate directly — mass is conserved when you're not pouring — so
+ * total time vs target is how "drawdown too slow/fast" is diagnosed).
+ *
+ * Pure + deterministic. Consumes the canonical BrewTimeline + a {tSec,grams}
+ * curve sampled across the whole brew. `derivedFlow` populates the existing
+ * BrewLog.flow field so /recommend, /api/brew-insight and brewSignature pick up
+ * the MEASURED grade automatically — no self-report needed.
+ */
+import { expectedGramsAt, type BrewTimeline } from "@/lib/brew/timeline";
+import { pourDurationSec } from "@/lib/utils/pourSequence";
+
+export interface FlowCurvePoint {
+  /** Seconds since brew start. */
+  tSec: number;
+  grams: number;
+}
+
+export interface PourTiming {
+  index: number;
+  label: string;
+  /** Cumulative target for this pour. */
+  targetGrams: number;
+  /** When the pour SHOULD have finished (start + pour duration at the intended rate). */
+  targetSec: number;
+  /** When the curve actually reached the target, or null if never. */
+  actualSec: number | null;
+  /** actualSec − targetSec; positive = late. Null if never reached. */
+  errorSec: number | null;
+}
+
+export interface FlowAnalysis {
+  totalTimeSec: number;
+  targetTimeSec: number;
+  finalGrams: number | null;
+  perPour: PourTiming[];
+  /** Mean of the per-pour observed pour rates (g/s). */
+  avgFlowRateGPS: number | null;
+  peakFlowRateGPS: number | null;
+  /** Coefficient of variation of per-pour rates — lower = steadier (channeling risk when high). */
+  pourSteadiness: number | null;
+  /** Max amount the actual curve ran ahead of the intended curve (g). */
+  overshootG: number | null;
+  /** Measured total-time grade, replacing the self-reported flow. */
+  derivedFlow: "too-fast" | "perfect" | "too-slow";
+  /** Downsampled curve for storage / a sparkline. Capped. */
+  samples: FlowCurvePoint[];
+}
+
+const REACH_TOL_G = 1.5; // treat the target as "reached" within this many grams
+const MAX_STORED_POINTS = 80;
+
+/** First time the curve reaches `grams` (within tolerance), or null. */
+function timeToReach(curve: FlowCurvePoint[], grams: number): number | null {
+  for (const p of curve) {
+    if (p.grams >= grams - REACH_TOL_G) return p.tSec;
+  }
+  return null;
+}
+
+/** Evenly downsample a curve to at most `max` points (keeps first + last). */
+function downsample(curve: FlowCurvePoint[], max = MAX_STORED_POINTS): FlowCurvePoint[] {
+  if (curve.length <= max) return curve.slice();
+  const step = (curve.length - 1) / (max - 1);
+  const out: FlowCurvePoint[] = [];
+  for (let i = 0; i < max; i++) out.push(curve[Math.round(i * step)]);
+  return out;
+}
+
+function gradeFromTime(totalSec: number, targetSec: number): FlowAnalysis["derivedFlow"] {
+  if (targetSec <= 0) return "perfect";
+  const ratio = totalSec / targetSec;
+  if (ratio < 0.85) return "too-fast";
+  if (ratio > 1.15) return "too-slow";
+  return "perfect";
+}
+
+/**
+ * Analyze a completed brew. `curve` is the whole-brew {tSec,grams} capture;
+ * `actualTimeSec` is the timer's final elapsed. Returns null when there's no
+ * usable grams curve (immersion / no scale / too few points).
+ */
+export function analyzeFlow(
+  timeline: BrewTimeline | null,
+  curve: FlowCurvePoint[],
+  actualTimeSec: number,
+): FlowAnalysis | null {
+  if (!timeline || !timeline.hasGramsCurve || curve.length < 3) return null;
+
+  const pours = timeline.steps.filter((s) => !s.isAgitation && s.targetCumulativeGrams != null);
+  if (pours.length === 0) return null;
+
+  const finalGrams = curve.reduce((m, p) => Math.max(m, p.grams), 0);
+
+  // Per-pour timing + observed rate.
+  const perPour: PourTiming[] = [];
+  const rates: number[] = [];
+  let prevTarget = 0;
+  let prevReachSec = 0;
+  for (const step of pours) {
+    const target = step.targetCumulativeGrams as number;
+    const pourGrams = step.pourGrams != null && step.pourGrams > 0 ? step.pourGrams : target - prevTarget;
+    const targetSec = step.startSec + pourDurationSec(Math.max(1, pourGrams));
+    const actualSec = timeToReach(curve, target);
+    perPour.push({
+      index: step.index,
+      label: step.label,
+      targetGrams: target,
+      targetSec,
+      actualSec,
+      errorSec: actualSec != null ? Math.round((actualSec - targetSec) * 10) / 10 : null,
+    });
+    if (actualSec != null && actualSec > prevReachSec && pourGrams > 0) {
+      const rate = pourGrams / (actualSec - prevReachSec);
+      if (Number.isFinite(rate) && rate > 0) rates.push(rate);
+      prevReachSec = actualSec;
+    }
+    prevTarget = target;
+  }
+
+  const avgFlowRateGPS = rates.length ? rates.reduce((a, b) => a + b, 0) / rates.length : null;
+  const peakFlowRateGPS = rates.length ? Math.max(...rates) : null;
+  let pourSteadiness: number | null = null;
+  if (rates.length >= 2 && avgFlowRateGPS) {
+    const variance = rates.reduce((a, r) => a + (r - avgFlowRateGPS) ** 2, 0) / rates.length;
+    pourSteadiness = Math.sqrt(variance) / avgFlowRateGPS; // coefficient of variation
+  }
+
+  // Max amount the actual curve ran ahead of the intended curve.
+  let overshootG: number | null = null;
+  for (const p of curve) {
+    const expected = expectedGramsAt(timeline, p.tSec);
+    if (expected == null) continue;
+    const ahead = p.grams - expected;
+    if (overshootG == null || ahead > overshootG) overshootG = ahead;
+  }
+  if (overshootG != null) overshootG = Math.round(overshootG * 10) / 10;
+
+  return {
+    totalTimeSec: actualTimeSec,
+    targetTimeSec: timeline.targetTimeSec,
+    finalGrams: Math.round(finalGrams),
+    perPour,
+    avgFlowRateGPS: avgFlowRateGPS != null ? Math.round(avgFlowRateGPS * 10) / 10 : null,
+    peakFlowRateGPS: peakFlowRateGPS != null ? Math.round(peakFlowRateGPS * 10) / 10 : null,
+    pourSteadiness: pourSteadiness != null ? Math.round(pourSteadiness * 100) / 100 : null,
+    overshootG,
+    derivedFlow: gradeFromTime(actualTimeSec, timeline.targetTimeSec),
+    samples: downsample(curve),
+  };
+}

--- a/src/lib/types/session.ts
+++ b/src/lib/types/session.ts
@@ -1,3 +1,5 @@
+import type { FlowAnalysis } from "@/lib/brew/flowAnalysis";
+
 export type SessionMode = "home" | "external";
 export type SessionType = "coffee" | "wine";
 
@@ -159,6 +161,12 @@ export interface BrewLog {
   actualTempC?: number;              // actual temp used (pre-filled, editable)
   followedAgitation?: "yes" | "partially" | "no";
   agitationNote?: string;            // free text: what I actually did
+  /** Objective pour analysis from a connected Acaia scale (nested in this JSONB
+   * column — no migration). Present only when a weight curve was captured. */
+  flowAnalysis?: FlowAnalysis;
+  /** Whether `flow` came from the scale curve or the user's self-report. When
+   * "measured", flow = flowAnalysis.derivedFlow. */
+  flowSource?: "measured" | "self-report";
 }
 
 export interface TasteResult {

--- a/tests/dataflow/brew-flow-analysis.test.mjs
+++ b/tests/dataflow/brew-flow-analysis.test.mjs
@@ -1,0 +1,107 @@
+// Post-brew flow-analysis tests. Bundles the REAL flowAnalysis.ts + timeline.ts
+// and asserts the measured grade, per-pour timing, overshoot, steadiness, and
+// the sample cap on synthetic weight curves.
+//
+//   node --test tests/dataflow/brew-flow-analysis.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const entry = `
+export { analyzeFlow } from ${JSON.stringify(path.join(ROOT, "src/lib/brew/flowAnalysis.ts"))};
+export { buildBrewTimeline } from ${JSON.stringify(path.join(ROOT, "src/lib/brew/timeline.ts"))};
+`;
+const dir = await mkdtemp(join(tmpdir(), "flowan-"));
+const out = join(dir, "fa.mjs");
+await build({
+  stdin: { contents: entry, resolveDir: ROOT, loader: "ts" },
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  outfile: out,
+  logLevel: "silent",
+});
+const { analyzeFlow, buildBrewTimeline } = await import(pathToFileURL(out).href);
+
+const ROAST = "2026-06-01";
+const NOW = new Date("2026-06-16T08:00:00Z").getTime();
+
+// "50 – 180 – 320 – 500" @210 → milestones at 50/180/320/500g.
+const PERC = buildBrewTimeline(
+  { doseGrams: 15, waterGrams: 500, waterTempC: 94, grindSize: "medium", targetTimeSec: 210, pourSequence: "50 – 180 – 320 – 500" },
+  ROAST,
+  NOW,
+);
+const IMMERSION = buildBrewTimeline(
+  {
+    doseGrams: 15, waterGrams: 250, waterTempC: 94, grindSize: "medium", targetTimeSec: 150,
+    pourSteps: [
+      { label: "Add water", action: "pour", waterGramsAtEnd: 200, durationSec: 15 },
+      { label: "Steep", action: "wait", durationSec: 90 },
+      { label: "Press", action: "press", durationSec: 25 },
+    ],
+  },
+  ROAST,
+  NOW,
+);
+
+// A curve that hits each cumulative target at the given times.
+const CURVE = [
+  { tSec: 0, grams: 0 },
+  { tSec: 10, grams: 50 },
+  { tSec: 70, grams: 180 },
+  { tSec: 120, grams: 320 },
+  { tSec: 180, grams: 500 },
+];
+
+test("derivedFlow grades total time vs target", () => {
+  assert.equal(analyzeFlow(PERC, CURVE, 210).derivedFlow, "perfect");
+  assert.equal(analyzeFlow(PERC, CURVE, 160).derivedFlow, "too-fast");
+  assert.equal(analyzeFlow(PERC, CURVE, 260).derivedFlow, "too-slow");
+});
+
+test("per-pour timing: target reach times + error", () => {
+  const a = analyzeFlow(PERC, CURVE, 210);
+  assert.equal(a.perPour.length, 4);
+  assert.equal(a.perPour[0].targetGrams, 50);
+  assert.equal(a.perPour[0].actualSec, 10);
+  assert.equal(a.perPour[3].targetGrams, 500);
+  assert.equal(a.perPour[3].actualSec, 180);
+  // Each errorSec is a finite number (late/early offset).
+  for (const p of a.perPour) assert.equal(typeof p.errorSec, "number");
+});
+
+test("flow-rate + steadiness are computed", () => {
+  const a = analyzeFlow(PERC, CURVE, 210);
+  assert.ok(a.avgFlowRateGPS > 0);
+  assert.ok(a.peakFlowRateGPS >= a.avgFlowRateGPS);
+  assert.ok(a.pourSteadiness != null && a.pourSteadiness >= 0);
+  assert.equal(a.finalGrams, 500);
+});
+
+test("overshoot is positive when the pour runs ahead of plan", () => {
+  // CURVE reaches each milestone earlier than the intended schedule → ahead.
+  const a = analyzeFlow(PERC, CURVE, 210);
+  assert.ok(a.overshootG > 0, `expected positive overshoot, got ${a.overshootG}`);
+});
+
+test("samples are capped at 80", () => {
+  const big = Array.from({ length: 500 }, (_, i) => ({ tSec: i * 0.4, grams: i }));
+  const a = analyzeFlow(PERC, big, 200);
+  assert.ok(a.samples.length <= 80);
+  assert.equal(a.samples[0].tSec, 0); // keeps first
+  assert.equal(a.samples[a.samples.length - 1].grams, 499); // keeps last
+});
+
+test("immersion / too-few-points → null", () => {
+  assert.equal(analyzeFlow(IMMERSION, CURVE, 150), null);
+  assert.equal(analyzeFlow(PERC, [{ tSec: 0, grams: 0 }], 210), null);
+  assert.equal(analyzeFlow(null, CURVE, 210), null);
+});


### PR DESCRIPTION
**PR 3 — the final piece of the brew-flow coaching arc.** When the Acaia captured the pour, the brew closes the loop with objective numbers instead of a self-report.

### What's here
- **`src/lib/brew/flowAnalysis.ts`** — pure `analyzeFlow(timeline, curve, actualTime)`: per-pour timing error, avg/peak pour rate, **pour steadiness** (CV of pour rates → channeling risk), **overshoot** vs the intended curve, and **`derivedFlow`** (too-fast/perfect/too-slow) from total time vs target — the classic grind signal (the scale can't see drawdown rate; total time is how that's diagnosed). Null off the grams curve.
- **`LightStepBrew`** captures the **whole-brew** `{tSec,grams}` curve (~2 Hz, separate from the coach's 6 s window) and, on Done, runs `analyzeFlow` → stores it + sets `flow = derivedFlow`, `flowSource = "measured"`.
- **Migration-free storage** — `flowAnalysis` + `flowSource` nest in the existing `sessions.brew` JSONB column.
- **`LightStepSummary`** shows a "Pour analysis" card (total vs target, avg pour rate, overshoot, stream steadiness, the pour that drifted most).
- **`LightStepLog`** shows the measured grade read-only instead of asking — so it can't be overwritten. The measured flow feeds `/api/brew-insight`, `/recommend` and `brewSignature` automatically via the same `brew.flow` field.

### Safety
No migration. Off-scale / immersion → `analyzeFlow` returns null, nothing changes (self-report path intact). `tsc` + full `next build` clean; 6 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)