### PR TITLE
docs(ios): build 11 uploaded (watch 3-2-1 countdown)

### DIFF
--- a/docs/ios-shell-roadmap.md
+++ b/docs/ios-shell-roadmap.md
@@ -404,8 +404,8 @@ Owner-brainstormed June 2026 — what the shell unlocks beyond the G1–G4 miles
 - **Next entry-point:** owner installs build 9 + runs the spike. If grams stream → wire pour auto-advance. If not → debug iOS connect in `manager.ts`/`acaia.ts` (connection mode + the 150 ms sleep).
 - **PRs / commits this session:** #324 (diagnostic removal), #325 (BLE shell), #326 (build script), + this branch `feat/acaia-decoder-port` (web decoder + UI).
 
-### 2026-06-16 — Watch: 3-2-1 countdown BEFORE each step (build 11 pending)
+### 2026-06-16 — Watch: 3-2-1 countdown BEFORE each step (build 11 UPLOADED)
 - **Done:** the watch buzzed only AT each step (the strong 5× train), which is too late to react — the owner needs "3, 2, 1, POUR". The phone already does this (useBrewStepHaptics: light taps at −3/−2/−1 + strong buzz at the step). Fixed the watch WATCH-SIDE ONLY (no web change, no version-skew): `BrewWatchModel.swift` now expands each incoming STEP fire into a 3-2-1 countdown (light `.click` taps at −3/−2/−1 s) plus the strong `.notification` step buzz AT the step. Added `FireKind {countdown, step}`; `tick()` plays `buzzCountdown()` (light) vs `buzz()` (strong) per kind; `refreshLabels` tracks the next STEP only; `handle()` parses incoming as `.step`. The web (`brewWatch.ts`) still sends one fire per boundary — the watch generates the countdown locally from the step times it already holds, so build 9 → build 11 just changes how the watch renders the same schedule.
-- **Open / blocked:** needs **build 11** (Mac): `native/scripts/mac-build-upload.sh 11`. On-device: confirm the wrist ticks 3-2-1 then a strong POUR buzz before each pour.
-- **Next entry-point:** owner runs build 11 → verify the countdown on the wrist.
-- **PRs / commits this session:** branch `feat/watch-321-countdown`.
+- **Open / blocked:** **build 11 UPLOADED 2026-06-16** (Delivery UUID `b6b87f79-9235-47ff-b500-0647c35de321`) via `native/scripts/mac-build-upload.sh 11`. On-device: confirm the wrist ticks 3-2-1 then a strong POUR buzz before each pour.
+- **Next entry-point:** owner installs build 11 → verify the countdown on the wrist.
+- **PRs / commits this session:** #329 (`feat/watch-321-countdown`); build 11.


### PR DESCRIPTION
Roadmap status: build 11 uploaded to TestFlight (Delivery UUID b6b87f79). Doc-only.