### PR TITLE
ci(watch): one-click workflow to set APNs secrets on the VPS

### DIFF
--- a/.github/workflows/set-apns-secrets.yml
+++ b/.github/workflows/set-apns-secrets.yml
@@ -1,0 +1,75 @@
+name: Set APNs secrets on VPS
+
+# Writes the APNs push secrets onto the VPS `.env` (the file docker compose
+# reads), then recreates the app container so it picks them up — so the owner
+# never has to SSH or edit a file. Driven entirely from the web UI:
+#   1. Add the repo secrets (Settings → Secrets and variables → Actions):
+#        APNS_KEY_P8     the full .p8 file contents (BEGIN/END lines included)
+#        APNS_KEY_ID     the APNs key id (10 chars)
+#        APNS_TEAM_ID    the Developer Program team id (10 chars)
+#        APNS_BUNDLE_ID  (optional) defaults to com.roitsch.btts.watchkitapp
+#   2. Actions tab → "Set APNs secrets on VPS" → Run workflow.
+#
+# Idempotent: strips any existing APNS_ lines from .env, then appends the
+# current values. The multiline .p8 is stored as a single line with \n escapes
+# (apnsPush.ts un-escapes them).
+
+on:
+  workflow_dispatch:
+
+jobs:
+  set-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write APNs secrets to the VPS .env
+        env:
+          APNS_KEY_P8: ${{ secrets.APNS_KEY_P8 }}
+          APNS_KEY_ID: ${{ secrets.APNS_KEY_ID }}
+          APNS_TEAM_ID: ${{ secrets.APNS_TEAM_ID }}
+          APNS_BUNDLE_ID: ${{ secrets.APNS_BUNDLE_ID }}
+        run: |
+          set -e
+          # Fail early + clearly if a required secret is missing.
+          missing=""
+          [ -z "$APNS_KEY_P8" ] && missing="$missing APNS_KEY_P8"
+          [ -z "$APNS_KEY_ID" ] && missing="$missing APNS_KEY_ID"
+          [ -z "$APNS_TEAM_ID" ] && missing="$missing APNS_TEAM_ID"
+          if [ -n "$missing" ]; then
+            echo "Missing repo secret(s):$missing"
+            echo "Add them under Settings → Secrets and variables → Actions, then re-run."
+            exit 1
+          fi
+
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts
+
+          # Collapse the multiline .p8 to one line with literal \n separators.
+          P8_ESCAPED=$(printf '%s' "$APNS_KEY_P8" | awk 'BEGIN{ORS="\\n"}{print}')
+          BUNDLE="${APNS_BUNDLE_ID:-com.roitsch.btts.watchkitapp}"
+
+          {
+            printf 'APNS_KEY_P8=%s\n' "$P8_ESCAPED"
+            printf 'APNS_KEY_ID=%s\n' "$APNS_KEY_ID"
+            printf 'APNS_TEAM_ID=%s\n' "$APNS_TEAM_ID"
+            printf 'APNS_BUNDLE_ID=%s\n' "$BUNDLE"
+          } > /tmp/apns.env
+
+          scp -i ~/.ssh/deploy_key /tmp/apns.env \
+            ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }}:/tmp/apns.env
+          rm -f /tmp/apns.env
+
+          ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} bash <<'REMOTE'
+            set -e
+            cd ${{ secrets.DEPLOY_PATH }}
+            touch .env
+            # Strip any prior APNS_ lines, append the fresh ones.
+            grep -v '^APNS_' .env > .env.next 2>/dev/null || true
+            cat /tmp/apns.env >> .env.next
+            mv .env.next .env
+            rm -f /tmp/apns.env
+            # Recreate only the app so it reads the new env (postgres/caddy/ofelia untouched).
+            docker compose up -d --force-recreate --no-deps app
+            echo "APNs env written; app recreated."
+          REMOTE


### PR DESCRIPTION
Web-UI-driven workflow so the owner never SSHes: add the APNS_* repo secrets, run this workflow, it writes them onto the VPS and recreates the app. Pairs with the compose vars (#335) and the push server (#334).

🤖 Generated with [Claude Code](https://claude.com/claude-code)