### PR TITLE
feat(watch): rewrite the watch app as an APNs push receiver (build 13)

### DIFF
--- a/native/ios/App/App/BrewWatchPlugin.swift
+++ b/native/ios/App/App/BrewWatchPlugin.swift
@@ -3,90 +3,71 @@ import Capacitor
 import WatchConnectivity
 
 /**
- BrewWatch — phone-side bridge from the WKWebView (JS) to the Apple Watch app.
+ BrewWatch — phone-side bridge between the watch and the WKWebView (JS).
 
- The web layer (`src/lib/native/brewWatch.ts`) calls `startBrew` once when a
- brew's timer hits zero, handing over the WHOLE step schedule as absolute
- epoch-ms fire times. We forward it to the watch over WatchConnectivity. The
- watch app then runs the timeline itself and buzzes the wrist at each step —
- which is the only way to alert the wrist while the iPhone screen is ON (during
- a wake-locked brew iOS will not mirror notifications to the watch).
-
- Delivery strategy: `sendMessage` for immediacy when the watch app is reachable
- (foreground), AND `updateApplicationContext` always, so a watch app opened a
- moment later still picks up the in-progress brew. We never message per step —
- the watch owns the timeline, so no single buzz can be dropped by a flaky link.
+ New model (build 13): the watch is a push receiver. It registers for remote
+ notifications and sends its APNs device token to the phone over
+ WatchConnectivity. This plugin receives that token and surfaces it to JS — the
+ web layer (`src/lib/native/watchPush.ts`) registers it with the server, which
+ then pushes one alert to the watch per brew step. The phone no longer sends a
+ schedule to the watch; per-step pushes go web → server → APNs.
  */
 @objc(BrewWatchPlugin)
 public class BrewWatchPlugin: CAPPlugin, CAPBridgedPlugin {
     public let identifier = "BrewWatchPlugin"
     public let jsName = "BrewWatch"
     public let pluginMethods: [CAPPluginMethod] = [
-        CAPPluginMethod(name: "startBrew", returnType: CAPPluginReturnPromise),
-        CAPPluginMethod(name: "endBrew", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "getWatchToken", returnType: CAPPluginReturnPromise),
     ]
 
     private var session: WCSession?
+    private var lastToken: String?
 
     override public func load() {
         guard WCSession.isSupported() else { return }
+        WatchSessionForwarder.shared.onToken = { [weak self] token in
+            self?.lastToken = token
+            self?.notifyListeners("watchToken", data: ["token": token])
+        }
         let s = WCSession.default
         s.delegate = WatchSessionForwarder.shared
         s.activate()
         session = s
     }
 
-    @objc func startBrew(_ call: CAPPluginCall) {
-        guard WCSession.isSupported() else { call.resolve(); return }
-
-        let recipeName = call.getString("recipeName") ?? "Brew"
-        let firesIn = call.getArray("fires", JSObject.self) ?? []
-        var fires: [[String: Any]] = []
-        for f in firesIn {
-            // atMs arrives as a JS number → NSNumber; keep it as a plist-safe Double.
-            guard let atMs = f["atMs"] as? Double ?? (f["atMs"] as? NSNumber)?.doubleValue else { continue }
-            let label = f["label"] as? String ?? "Next step"
-            fires.append(["atMs": atMs, "label": label])
-        }
-
-        let payload: [String: Any] = [
-            "type": "start",
-            "recipeName": recipeName,
-            "fires": fires,
-        ]
-        send(payload)
-        call.resolve()
-    }
-
-    @objc func endBrew(_ call: CAPPluginCall) {
-        send(["type": "end"])
-        call.resolve()
-    }
-
-    private func send(_ payload: [String: Any]) {
-        guard let s = session, s.activationState == .activated else { return }
-        // Immediate path when the watch app is in the foreground.
-        if s.isReachable {
-            s.sendMessage(payload, replyHandler: nil, errorHandler: nil)
-        }
-        // Durable "latest brew state" path — delivered whenever the watch app
-        // next becomes active, so a slightly-late open still gets the brew.
-        try? s.updateApplicationContext(payload)
+    /// Return the latest watch APNs token the phone has received (or "").
+    @objc func getWatchToken(_ call: CAPPluginCall) {
+        call.resolve(["token": lastToken ?? ""])
     }
 }
 
 /**
- A minimal WCSessionDelegate. The phone only SENDS to the watch for this
- feature, so the callbacks are no-ops — but a delegate is mandatory for the
- session to activate, and iOS requires the multi-device reactivation stubs.
+ WCSession delegate that forwards the watch's APNs token to the plugin. A
+ delegate is mandatory for the session to activate; the multi-device
+ reactivation stubs are required by iOS.
  */
 final class WatchSessionForwarder: NSObject, WCSessionDelegate {
     static let shared = WatchSessionForwarder()
+    var onToken: ((String) -> Void)?
+
+    private func handle(_ message: [String: Any]) {
+        guard (message["type"] as? String) == "watchToken",
+              let token = message["token"] as? String, !token.isEmpty
+        else { return }
+        DispatchQueue.main.async { self.onToken?(token) }
+    }
+
+    func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
+        handle(message)
+    }
+
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
+        handle(applicationContext)
+    }
 
     func session(_ session: WCSession, activationDidCompleteWith state: WCSessionActivationState, error: Error?) {}
     func sessionDidBecomeInactive(_ session: WCSession) {}
     func sessionDidDeactivate(_ session: WCSession) {
-        // Re-activate for a newly-paired watch.
         session.activate()
     }
 }

--- a/native/ios/App/BTTSWatch/BTTSWatch.entitlements
+++ b/native/ios/App/BTTSWatch/BTTSWatch.entitlements
@@ -2,9 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.healthkit</key>
-	<true/>
-	<key>com.apple.developer.healthkit.access</key>
-	<array/>
+	<key>aps-environment</key>
+	<string>production</string>
 </dict>
 </plist>

--- a/native/ios/App/BTTSWatch/BTTSWatchApp.swift
+++ b/native/ios/App/BTTSWatch/BTTSWatchApp.swift
@@ -1,15 +1,41 @@
 import SwiftUI
+import UserNotifications
+import WatchKit
 
 /**
- BTTS Apple Watch companion — single-target SwiftUI watch app.
+ BTTS Apple Watch companion — APNs push receiver.
 
- Purpose: buzz the wrist at each brew step. It carries no brew UI of its own
- beyond a status glance; the iPhone drives everything and hands the schedule
- over at brew start (see BrewWatchModel). Open it before you brew and the wrist
- takes over the step cues, even with the phone screen on.
+ The app delegate registers for remote notifications on launch and forwards the
+ device token to the phone (BrewWatchModel). From then on the wrist buzzes from
+ push alerts the server sends per brew step — this app does not need to be open.
  */
+class WatchAppDelegate: NSObject, WKApplicationDelegate, UNUserNotificationCenterDelegate {
+    func applicationDidFinishLaunching() {
+        UNUserNotificationCenter.current().delegate = self
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
+        WKApplication.shared().registerForRemoteNotifications()
+    }
+
+    func didRegisterForRemoteNotifications(withDeviceToken deviceToken: Data) {
+        let hex = deviceToken.map { String(format: "%02x", $0) }.joined()
+        BrewWatchModel.shared.sendToken(hex)
+    }
+
+    func didFailToRegisterForRemoteNotificationsWithError(_ error: Error) {}
+
+    // Show the cue (with its haptic) even if the watch app happens to be foreground.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound, .list])
+    }
+}
+
 @main
 struct BTTSWatchApp: App {
+    @WKApplicationDelegateAdaptor(WatchAppDelegate.self) private var appDelegate
     @StateObject private var model = BrewWatchModel.shared
 
     init() {

--- a/native/ios/App/BTTSWatch/BrewWatchModel.swift
+++ b/native/ios/App/BTTSWatch/BrewWatchModel.swift
@@ -1,273 +1,61 @@
 import Foundation
-import HealthKit
-import UserNotifications
 import WatchConnectivity
-import WatchKit
 
 /**
- The brain of the BTTS watch app.
+ BTTS watch app — APNs push receiver.
 
- The iPhone hands us the whole brew schedule once at brew start (absolute
- epoch-ms STEP fire times). We hold it locally so a phone↔watch hiccup mid-brew
- can't drop a cue.
+ New model (build 13): the watch no longer runs the brew timeline. It registers
+ for remote notifications, gets an APNs device token, and hands it to the phone
+ over WatchConnectivity. The phone then fires one APNs push per brew step (via
+ the server), and the OS buzzes the wrist — at the exact step, synced to the
+ phone, with this app CLOSED. No Timer, no schedule, no HealthKit, no workout
+ session: the OS owns delivery, so nothing can stall or dump a backlog.
 
- HOW THE WRIST CUES FIRE — the load-bearing decision.
- watchOS aggressively suspends a backgrounded app when the wrist drops. The
- earlier approach (a repeating `Timer` that called `WKInterfaceDevice.play()`)
- fought that and lost: wrist-down the timer stalled, then on wrist-raise it
- "caught up" and dumped every missed buzz at once — useless. So cues are now
- delivered as **scheduled local notifications** (`UNUserNotificationCenter`),
- which the OS fires at the exact time with a haptic regardless of app state —
- the same mechanism alarm/timer apps rely on. For each step we schedule a
- "Get ready" pre-cue a few seconds before, plus a cue AT the step.
-
- The `HKWorkoutSession` is kept only to keep the app alive so the on-screen
- current/next labels stay live when you raise your wrist mid-brew — it no longer
- carries the haptics. The ticker updates labels only; it never buzzes, so it
- can't dump a backlog.
+ This object's only job is to ship the device token to the phone (immediately
+ when reachable, durably via application-context otherwise) and re-ship it if
+ the session reactivates.
  */
 final class BrewWatchModel: NSObject, ObservableObject {
     static let shared = BrewWatchModel()
 
-    /// Seconds before a step to fire the "get ready" pre-cue.
-    private static let readyLead: TimeInterval = 5
+    @Published var tokenReady = false
 
-    struct Fire: Identifiable {
-        let id = UUID()
-        let at: Date
-        let label: String
-        var fired = false
-    }
-
-    @Published var isBrewing = false
-    @Published var recipeName = "BTTS"
-    @Published var currentLabel = ""
-    @Published var nextLabel: String?
-    @Published var nextFireAt: Date?
-
-    private var fires: [Fire] = []
-    private var ticker: Timer?
-    private let healthStore = HKHealthStore()
-    private var workoutSession: HKWorkoutSession?
-
-    // MARK: - Lifecycle
+    private var session: WCSession?
+    private var pendingToken: String?
 
     func activateSession() {
-        if WCSession.isSupported() {
-            let s = WCSession.default
-            s.delegate = self
-            s.activate()
+        guard WCSession.isSupported() else { return }
+        let s = WCSession.default
+        s.delegate = self
+        s.activate()
+        session = s
+    }
+
+    /// Called by the app delegate when APNs hands us a device token (hex string).
+    func sendToken(_ hex: String) {
+        pendingToken = hex
+        DispatchQueue.main.async { self.tokenReady = true }
+        flushToken()
+    }
+
+    private func flushToken() {
+        guard let token = pendingToken, let s = session, s.activationState == .activated else { return }
+        let payload: [String: Any] = ["type": "watchToken", "token": token]
+        if s.isReachable {
+            s.sendMessage(payload, replyHandler: nil, errorHandler: nil)
         }
-        UNUserNotificationCenter.current().delegate = self
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
-        requestWorkoutAuthorization()
-    }
-
-    /// Ask once for permission to record a workout. We only need this to keep
-    /// the app alive (live labels) — no health data is recorded beyond the bare
-    /// session. Prompt appears the first time the watch app launches.
-    private func requestWorkoutAuthorization() {
-        guard HKHealthStore.isHealthDataAvailable() else { return }
-        healthStore.requestAuthorization(toShare: [HKObjectType.workoutType()], read: []) { _, _ in }
-    }
-
-    // MARK: - Schedule control (always called on the main thread)
-
-    private func startBrew(recipeName: String, fires incoming: [Fire]) {
-        let now = Date()
-        let sorted = incoming.sorted { $0.at < $1.at }
-        // Keep the whole schedule for the on-screen labels; past fires can't alert.
-        self.fires = sorted.map { var f = $0; if $0.at <= now { f.fired = true }; return f }
-        self.recipeName = recipeName
-        self.isBrewing = true
-        self.currentLabel = "Brewing"
-        scheduleNotifications(for: sorted, now: now) // the reliable wrist-down cues
-        startWorkoutSession() // keeps the live screen alive on wrist-raise
-        startTicker() // on-screen labels only — NO haptics
-        refreshLabels(now: now)
-        WKInterfaceDevice.current().play(.start) // brew handed over to the wrist
-    }
-
-    private func endBrew() {
-        isBrewing = false
-        currentLabel = ""
-        nextLabel = nil
-        nextFireAt = nil
-        fires = []
-        ticker?.invalidate()
-        ticker = nil
-        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
-        endWorkoutSession()
-    }
-
-    // MARK: - Local notifications (the actual wrist cues)
-
-    /// Schedule a "Get ready" pre-cue (`readyLead` s before) + a cue AT each
-    /// step. The OS fires these with a haptic at the exact time even when the
-    /// app is suspended / the wrist is down — no catch-up, no backlog.
-    private func scheduleNotifications(for steps: [Fire], now: Date) {
-        let center = UNUserNotificationCenter.current()
-        center.removeAllPendingNotificationRequests()
-        var requests: [UNNotificationRequest] = []
-        for (i, step) in steps.enumerated() {
-            let readyAt = step.at.addingTimeInterval(-Self.readyLead)
-            if readyAt.timeIntervalSince(now) > 1.5 {
-                requests.append(
-                    makeNotification(
-                        id: "btts-ready-\(i)", title: "Get ready", body: step.label, fireAt: readyAt,
-                        now: now))
-            }
-            if step.at.timeIntervalSince(now) > 1.0 {
-                requests.append(
-                    makeNotification(
-                        id: "btts-now-\(i)", title: step.label, body: "Now", fireAt: step.at, now: now))
-            }
-        }
-        for r in requests { center.add(r) }
-    }
-
-    private func makeNotification(
-        id: String, title: String, body: String, fireAt: Date, now: Date
-    ) -> UNNotificationRequest {
-        let content = UNMutableNotificationContent()
-        content.title = title
-        content.body = body
-        content.sound = .default
-        if #available(watchOS 9.0, *) { content.interruptionLevel = .timeSensitive }
-        let interval = max(1, fireAt.timeIntervalSince(now))
-        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: interval, repeats: false)
-        return UNNotificationRequest(identifier: id, content: content, trigger: trigger)
-    }
-
-    // MARK: - On-screen label ticker (no haptics)
-
-    private func startTicker() {
-        ticker?.invalidate()
-        let t = Timer(timeInterval: 0.5, repeats: true) { [weak self] _ in
-            self?.tick()
-        }
-        RunLoop.main.add(t, forMode: .common)
-        ticker = t
-    }
-
-    private func tick() {
-        guard isBrewing else { return }
-        let now = Date()
-        var advanced = false
-        for i in fires.indices where !fires[i].fired && fires[i].at <= now {
-            fires[i].fired = true
-            currentLabel = fires[i].label
-            advanced = true
-        }
-        if advanced { refreshLabels(now: now) }
-        // Auto-wind-down a few seconds after the last step, so a forgotten brew
-        // doesn't hold the workout session open indefinitely.
-        if let last = fires.last?.at, now.timeIntervalSince(last) > 8 {
-            endBrew()
-        }
-    }
-
-    private func refreshLabels(now: Date) {
-        if let next = fires.first(where: { !$0.fired }) {
-            nextLabel = next.label
-            nextFireAt = next.at
-        } else {
-            nextLabel = nil
-            nextFireAt = nil
-        }
-    }
-
-    // MARK: - Workout session (keeps the app alive for the live labels)
-
-    private func startWorkoutSession() {
-        guard workoutSession == nil, HKHealthStore.isHealthDataAvailable() else { return }
-        let config = HKWorkoutConfiguration()
-        config.activityType = .other
-        config.locationType = .indoor
-        do {
-            let session = try HKWorkoutSession(healthStore: healthStore, configuration: config)
-            session.delegate = self
-            session.startActivity(with: Date())
-            workoutSession = session
-        } catch {
-            workoutSession = nil // labels just won't update in the background; cues still fire
-        }
-    }
-
-    private func endWorkoutSession() {
-        workoutSession?.end()
-        workoutSession = nil
-    }
-
-    // MARK: - Payload parsing
-
-    fileprivate func handle(_ payload: [String: Any]) {
-        DispatchQueue.main.async {
-            let type = payload["type"] as? String ?? ""
-            switch type {
-            case "start":
-                let name = payload["recipeName"] as? String ?? "Brew"
-                let raw = payload["fires"] as? [[String: Any]] ?? []
-                let parsed: [Fire] = raw.compactMap { dict in
-                    guard let atMs = dict["atMs"] as? Double ?? (dict["atMs"] as? NSNumber)?.doubleValue
-                    else { return nil }
-                    let label = dict["label"] as? String ?? "Next step"
-                    return Fire(at: Date(timeIntervalSince1970: atMs / 1000.0), label: label)
-                }
-                guard !parsed.isEmpty else { return }
-                self.startBrew(recipeName: name, fires: parsed)
-            case "end":
-                self.endBrew()
-            default:
-                break
-            }
-        }
+        // Durable path: delivered to the phone whenever it next processes context.
+        try? s.updateApplicationContext(payload)
     }
 }
-
-// MARK: - WCSessionDelegate
 
 extension BrewWatchModel: WCSessionDelegate {
-    func session(_ session: WCSession, activationDidCompleteWith state: WCSessionActivationState, error: Error?) {}
-
-    func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
-        handle(message)
-    }
-
-    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
-        handle(applicationContext)
-    }
-}
-
-// MARK: - UNUserNotificationCenterDelegate (so cues alert + haptic in the foreground too)
-
-extension BrewWatchModel: UNUserNotificationCenterDelegate {
-    func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        willPresent notification: UNNotification,
-        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    func session(
+        _ session: WCSession,
+        activationDidCompleteWith state: WCSessionActivationState,
+        error: Error?
     ) {
-        if #available(watchOS 9.0, *) {
-            completionHandler([.banner, .sound, .list])
-        } else {
-            completionHandler([.alert, .sound])
-        }
-    }
-}
-
-// MARK: - HKWorkoutSessionDelegate
-
-extension BrewWatchModel: HKWorkoutSessionDelegate {
-    func workoutSession(
-        _ workoutSession: HKWorkoutSession,
-        didChangeTo toState: HKWorkoutSessionState,
-        from fromState: HKWorkoutSessionState,
-        date: Date
-    ) {}
-
-    func workoutSession(_ workoutSession: HKWorkoutSession, didFailWithError error: Error) {
-        DispatchQueue.main.async { [weak self] in
-            if self?.workoutSession === workoutSession { self?.workoutSession = nil }
-        }
+        // If the token arrived before the session activated, send it now.
+        flushToken()
     }
 }

--- a/native/ios/App/BTTSWatch/ContentView.swift
+++ b/native/ios/App/BTTSWatch/ContentView.swift
@@ -1,46 +1,23 @@
 import SwiftUI
 
 /**
- Glance UI for the watch app. Deliberately minimal — the wrist haptic is the
- product; this screen just confirms a brew is mirrored and shows what's next.
- Copy follows the BTTS voice: knowledgeable, pragmatic, no hype, no emoji.
+ Glance UI for the watch app. The wrist haptic (delivered by push) is the
+ product — this screen is just a one-line reassurance. BTTS voice: pragmatic,
+ no hype, no emoji.
  */
 struct ContentView: View {
     @EnvironmentObject var model: BrewWatchModel
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            if model.isBrewing {
-                Text(model.recipeName)
-                    .font(.headline)
-                    .lineLimit(1)
-
-                if let next = model.nextLabel, let at = model.nextFireAt {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Next")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                        Text(next)
-                            .font(.body)
-                            .lineLimit(2)
-                        Text(at, style: .timer)
-                            .font(.system(.title3, design: .rounded).monospacedDigit())
-                    }
-                } else {
-                    Text(model.currentLabel.isEmpty ? "Brewing" : model.currentLabel)
-                        .font(.body)
-                        .foregroundStyle(.secondary)
-                }
-            } else {
-                Text("BTTS")
-                    .font(.headline)
-                Text("Start a brew on your phone — each step buzzes here.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            }
-            Spacer(minLength: 0)
+        VStack(spacing: 8) {
+            Text("BTTS")
+                .font(.headline)
+            Text("Brew on your phone. Each step buzzes your wrist — you don't need to keep this open.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 4)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, 6)
     }
 }

--- a/native/ios/App/BTTSWatch/Info.plist
+++ b/native/ios/App/BTTSWatch/Info.plist
@@ -24,13 +24,5 @@
 	<true/>
 	<key>WKCompanionAppBundleIdentifier</key>
 	<string>com.roitsch.btts</string>
-	<key>WKBackgroundModes</key>
-	<array>
-		<string>workout-processing</string>
-	</array>
-	<key>NSHealthUpdateUsageDescription</key>
-	<string>BTTS runs a brief workout session during a brew so your wrist keeps getting each step's haptic cue while the screen is off. No health data is recorded beyond the session itself.</string>
-	<key>NSHealthShareUsageDescription</key>
-	<string>BTTS runs a brief workout session during a brew so your wrist keeps getting each step's haptic cue while the screen is off. No health data is read.</string>
 </dict>
 </plist>


### PR DESCRIPTION
The watch becomes a push receiver: registers for remote notifications, hands its APNs token to the phone, buzzes from server pushes per step (closed app, synced to phone). Strips Timer/schedule/HealthKit/workout. Entitlements swap HealthKit → aps-environment. Signing (Push capability + profile) handled in the build-13 re-sign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)