### PR TITLE
Auto-refreshed loading-screen insight pool — slice 1 (corpus + brews)

### DIFF
--- a/src/app/api/loading-insights/refresh/route.ts
+++ b/src/app/api/loading-insights/refresh/route.ts
@@ -1,0 +1,248 @@
+import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+import Anthropic from "@anthropic-ai/sdk";
+import { asc, desc, eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { loadingInsights, sessions } from "@/lib/db/schema";
+import type { LoadingInsightSource, NewLoadingInsightRow } from "@/lib/db/schema";
+import { rowToSession } from "@/lib/db/helpers";
+import { ALL_RECIPES } from "@/lib/knowledge/recipes";
+import { VARIETY_PRIORS } from "@/lib/knowledge/varieties";
+import { TECHNIQUES } from "@/lib/knowledge/techniques";
+import { buildHistorySummary } from "@/lib/claude/historyUtils";
+import { lintLoadingInsight, normalizeForDedupe } from "@/lib/insights/loadingInsightLint";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 120;
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+// How many of each verified-corpus source to sample per run. Random each time,
+// so the pool drifts across the whole corpus over months.
+const N_RECIPES = 10;
+const N_VARIETIES = 8;
+const N_TECHNIQUES = 8;
+// Live-pool ceiling — over this, the oldest live rows are retired (the static
+// COFFEE_HINTS seed is always merged in by the screen, so the floor is fixed
+// regardless of how many DB rows exist).
+const POOL_CAP = 150;
+// Brews source only kicks in once there's enough signal — mirrors the coach's
+// "needs a few rated sessions" bar.
+const MIN_SESSIONS_FOR_BREWS = 4;
+
+const GEN_SYSTEM = `You write ONE short coffee insight per snippet for a loading screen — a big Fraunces headline shown while a brew recipe is generated.
+
+VOICE (BTTS): a knowledgeable friend talking about coffee. Editorial, pragmatic, plain. No hype, no emoji, no exclamation marks, no "did you know", no second-person command ("try…", "you should…"). State the thing.
+
+HARD RULES — these protect a no-fabrication guarantee, follow them exactly:
+- Each line must restate a fact found IN ITS SNIPPET. Add nothing the snippet does not say. If a snippet yields no clean, true, interesting line, OMIT it.
+- Prefer the general principle over trivia. Avoid naming competitions, years, or people UNLESS the fact is meaningless without the name. A cultivar name ("Pink Bourbon", "Geisha") is fine; "won the 2016 World Brewers Cup" is not.
+- No numbers, ppm, temperatures, ratios, or dates UNLESS they appear verbatim in the snippet.
+- ≤ 80 characters. ≤ 15 words. One sentence. A trailing period is optional.
+
+Return ONLY a JSON array: [{"n": <snippet number>, "text": "<line>"}]. Omit any snippet you cannot serve well. No prose around the JSON.`;
+
+const CHECK_SYSTEM = `For each numbered pair, decide whether the CLAIM is fully supported by its SOURCE — i.e. every fact asserted in the claim is stated or directly implied by the source, with nothing invented.
+
+Return ONLY a JSON array of booleans in order, e.g. [true,false,true]. No prose.`;
+
+interface Snippet {
+  source: LoadingInsightSource;
+  ref: string;
+  sourceText: string;
+}
+
+function sample<T>(arr: readonly T[], n: number): T[] {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy.slice(0, n);
+}
+
+function extractJsonArray(s: string): unknown[] | null {
+  const start = s.indexOf("[");
+  const end = s.lastIndexOf("]");
+  if (start === -1 || end === -1 || end < start) return null;
+  try {
+    const parsed = JSON.parse(s.slice(start, end + 1));
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function textOf(resp: Anthropic.Message): string {
+  const block = resp.content.find((b) => b.type === "text");
+  return block && "text" in block ? block.text : "";
+}
+
+/**
+ * POST (CRON_SECRET bearer) — refresh the loading-screen insight pool.
+ *
+ * Generates candidate lines grounded in the user's own VERIFIED knowledge
+ * corpus (recipes / varieties / techniques) and brewing aggregates, then runs
+ * every candidate through the deterministic gate (loadingInsightLint) AND a
+ * model claim-check before inserting. This machine review REPLACES the human
+ * review the user chose to skip — nothing ungrounded reaches the screen.
+ *
+ * Slice 1: corpus + brews only. The (riskier) web source lands in slice 2
+ * behind the same gate.
+ */
+export async function POST(req: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  const auth = req.headers.get("authorization");
+  if (!secret || auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    // 1. Existing live texts → dedup set (and a DB-level unique index backs it).
+    const liveRows = await db
+      .select({ text: loadingInsights.text })
+      .from(loadingInsights)
+      .where(eq(loadingInsights.status, "live"));
+    const existing = new Set(liveRows.map((r) => normalizeForDedupe(r.text)));
+
+    // 2. Build grounded snippets from the verified corpus.
+    const snippets: Snippet[] = [];
+    for (const r of sample(ALL_RECIPES, N_RECIPES)) {
+      snippets.push({
+        source: "corpus",
+        ref: `recipe:${r.id}`,
+        sourceText: `${r.name}. ${r.teaches} ${r.science}`,
+      });
+    }
+    for (const v of sample(VARIETY_PRIORS, N_VARIETIES)) {
+      snippets.push({
+        source: "corpus",
+        ref: `variety:${v.name}`,
+        sourceText: `${v.name} — ${v.origin}. ${v.cupSignature}`,
+      });
+    }
+    for (const t of sample(TECHNIQUES, N_TECHNIQUES)) {
+      snippets.push({
+        source: "corpus",
+        ref: `technique:${t.id}`,
+        sourceText: `${t.name}: ${t.description} ${t.mechanism}`,
+      });
+    }
+
+    // Brews snippet — aggregates over the user's own sessions (grounded in real
+    // data, so safe). One snippet; the model may draw a couple of lines from it.
+    try {
+      const rows = await db
+        .select()
+        .from(sessions)
+        .orderBy(desc(sessions.createdAtMs))
+        .limit(40);
+      if (rows.length >= MIN_SESSIONS_FOR_BREWS) {
+        const summary = buildHistorySummary(rows.map(rowToSession), 12);
+        if (summary.trim() !== "") {
+          snippets.push({ source: "brews", ref: "brews:summary", sourceText: summary });
+        }
+      }
+    } catch {
+      /* brews source is optional — never block the run on it */
+    }
+
+    if (snippets.length === 0) {
+      return NextResponse.json({ generated: 0, inserted: 0, reason: "no-snippets" });
+    }
+
+    // 3. Generate one candidate line per snippet.
+    const snippetBlock = snippets
+      .map((s, i) => `[${i + 1}] ${s.sourceText}`)
+      .join("\n\n");
+    const genResp = await client.messages.create({
+      model: "claude-sonnet-4-6",
+      max_tokens: 1500,
+      system: GEN_SYSTEM,
+      messages: [{ role: "user", content: `SNIPPETS:\n\n${snippetBlock}` }],
+    });
+    const genItems = extractJsonArray(textOf(genResp)) ?? [];
+
+    // 4. Deterministic gate — grounded against the candidate's OWN snippet.
+    const gated: { text: string; snippet: Snippet }[] = [];
+    for (const item of genItems) {
+      if (typeof item !== "object" || item === null) continue;
+      const rec = item as { n?: unknown; text?: unknown };
+      const n = typeof rec.n === "number" ? rec.n : NaN;
+      const text = typeof rec.text === "string" ? rec.text.trim() : "";
+      const snippet = snippets[n - 1];
+      if (!snippet || text === "") continue;
+      const { ok } = lintLoadingInsight(text, { sourceText: snippet.sourceText, existing });
+      if (!ok) continue;
+      existing.add(normalizeForDedupe(text)); // catch intra-batch dups
+      gated.push({ text, snippet });
+    }
+
+    // 5. Model claim-check — semantic backstop the regex can't do. If it can't
+    // be parsed (transient hiccup), accept the gate survivors: they are already
+    // token-grounded against their own corpus snippet by construction.
+    let survivors = gated;
+    if (gated.length > 0) {
+      try {
+        const pairs = gated
+          .map((g, i) => `[${i + 1}] CLAIM: ${g.text}\nSOURCE: ${g.snippet.sourceText}`)
+          .join("\n\n");
+        const checkResp = await client.messages.create({
+          model: "claude-haiku-4-5",
+          max_tokens: 400,
+          system: CHECK_SYSTEM,
+          messages: [{ role: "user", content: pairs }],
+        });
+        const verdicts = extractJsonArray(textOf(checkResp));
+        if (verdicts && verdicts.length === gated.length) {
+          survivors = gated.filter((_, i) => verdicts[i] === true);
+        }
+      } catch {
+        /* keep gate survivors on claim-check failure */
+      }
+    }
+
+    // 6. Insert survivors.
+    const now = Date.now();
+    const newRows: NewLoadingInsightRow[] = survivors.map((s) => ({
+      id: randomUUID(),
+      text: s.text,
+      source: s.snippet.source,
+      sourceRef: s.snippet.ref,
+      status: "live",
+      score: "1",
+      createdAtMs: now,
+      verifiedAtMs: now,
+    }));
+    if (newRows.length > 0) {
+      await db.insert(loadingInsights).values(newRows).onConflictDoNothing();
+    }
+
+    // 7. Retire the oldest live rows beyond the cap.
+    let retired = 0;
+    const allLive = await db
+      .select({ id: loadingInsights.id })
+      .from(loadingInsights)
+      .where(eq(loadingInsights.status, "live"))
+      .orderBy(asc(loadingInsights.createdAtMs));
+    if (allLive.length > POOL_CAP) {
+      const toRetire = allLive.slice(0, allLive.length - POOL_CAP).map((r) => r.id);
+      await db
+        .update(loadingInsights)
+        .set({ status: "retired" })
+        .where(inArray(loadingInsights.id, toRetire));
+      retired = toRetire.length;
+    }
+
+    return NextResponse.json({
+      snippets: snippets.length,
+      generated: genItems.length,
+      gated: gated.length,
+      inserted: newRows.length,
+      retired,
+    });
+  } catch (err) {
+    console.error("loading-insights refresh failed", err);
+    return NextResponse.json({ error: "refresh-failed" }, { status: 500 });
+  }
+}

--- a/src/app/api/loading-insights/route.ts
+++ b/src/app/api/loading-insights/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { requireAuth } from "@/lib/auth/requireAuth";
+import { db } from "@/lib/db/client";
+import { loadingInsights } from "@/lib/db/schema";
+import { MAX_CHARS, MAX_WORDS, wordCount } from "@/lib/insights/loadingInsightLint";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET — live loading-screen insights for the recipe-creation wait.
+ *
+ * Returns `{ insights: string[] }`. The screen merges these with the static
+ * COFFEE_HINTS seed, so this endpoint is purely additive: returning [] (incl.
+ * before the migration has run, or on any DB error) just means the screen
+ * shows the seed. It must NEVER throw the screen into an error state — every
+ * failure path returns an empty list.
+ */
+export async function GET(req: NextRequest) {
+  const authError = await requireAuth(req);
+  if (authError) return authError;
+
+  try {
+    const rows = await db
+      .select({ text: loadingInsights.text })
+      .from(loadingInsights)
+      .where(eq(loadingInsights.status, "live"));
+
+    // Defensive: a stored row must never break the 40px headline layout, even
+    // if it somehow got in past the gate. Cheap to re-check here.
+    const insights = rows
+      .map((r) => r.text)
+      .filter((t) => t.length <= MAX_CHARS && wordCount(t) <= MAX_WORDS);
+
+    const res = NextResponse.json({ insights });
+    // Short private cache — the pool changes ~monthly; the screen re-fetches
+    // on each mount but doesn't need a fresh DB hit every time.
+    res.headers.set("Cache-Control", "private, max-age=300");
+    return res;
+  } catch {
+    return NextResponse.json({ insights: [] });
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -289,18 +289,6 @@
   [data-light-scope] [data-brew-method-icon] {
     filter: brightness(0);
   }
-
-  /* Light System — COLOUR the Leaflet (Positron) tile pane on /cafes/map.
-   * Positron ships cold gray. Instead of washing it cream (old-school),
-   * push it toward the Field's soft rose/peach: a deeper hue-rotate + more
-   * saturation so the map picks up the app's fruity/floral palette while
-   * streets/labels stay legible. Cautious by design — tune the four numbers
-   * on device (raise saturate / push hue-rotate more negative for more
-   * colour). Scoped to leaflet-tile-pane (under [data-light-scope]) so it
-   * doesn't touch markers / labels / popups, which stay anthracite. */
-  [data-light-scope] .leaflet-tile-pane {
-    filter: sepia(0.4) hue-rotate(-25deg) saturate(0.95) brightness(1.03);
-  }
 }
 
 /*

--- a/src/components/cafes/CafeMap.tsx
+++ b/src/components/cafes/CafeMap.tsx
@@ -45,38 +45,40 @@ async function geocafe(name: string, location?: string): Promise<{ lat: number; 
 }
 
 /* ── Marker palette ────────────────────────────────────────────
- * Anthracite (#242424 ≈ light-foreground hsl(0 0% 14%)) + cream
- * (#FAF3ED ≈ hsl(36 55% 96%)) so pins read against Positron's neutral
- * light-gray tiles without needing a brand-color accent.
+ * Pins colour-coded by type, in the app's warm rose→coral→mauve Field
+ * family (cream dot #FAF3ED ≈ hsl(36 55% 96%)). They read true on the
+ * warm-graded Voyager tiles because the tile filter is scoped to the
+ * tile pane only, never the markers.
  *
- *   visited default  → solid anthracite body, cream dot
- *   visited selected → cream body, anthracite ring + dot, slightly larger
- *   ghost default    → outline-only anthracite (unvisited curated places)
- *   ghost selected   → cream fill, anthracite outline + solid dot
+ *   visited default  → coral fill (#E07A4E) + cream dot, soft shadow
+ *   visited selected → deep terracotta (#C6502E) + cream ring/dot — pops
+ *   ghost default    → muted-rose outline (#B07C84), unvisited curated places
+ *   ghost selected   → muted-rose fill + cream ring/dot
+ *   you-are-here     → mauve dot (#C8A6C0) + cream border + mauve pulse
  */
-const PIN_HTML = `<svg width="28" height="36" viewBox="0 0 28 36" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="#242424"/>
+const PIN_HTML = `<svg width="28" height="36" viewBox="0 0 28 36" fill="none" xmlns="http://www.w3.org/2000/svg" style="filter:drop-shadow(0 2px 2px rgba(70,30,15,0.35))">
+  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="#E07A4E"/>
   <circle cx="14" cy="14" r="5" fill="#FAF3ED"/>
 </svg>`;
 
-const PIN_SELECTED_HTML = `<svg width="32" height="40" viewBox="-2 -2 32 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="#FAF3ED" stroke="#242424" stroke-width="2.5"/>
-  <circle cx="14" cy="14" r="5" fill="#242424"/>
+const PIN_SELECTED_HTML = `<svg width="32" height="40" viewBox="-2 -2 32 40" fill="none" xmlns="http://www.w3.org/2000/svg" style="filter:drop-shadow(0 3px 4px rgba(70,30,15,0.4))">
+  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="#C6502E" stroke="#FAF3ED" stroke-width="2.5"/>
+  <circle cx="14" cy="14" r="5" fill="#FAF3ED"/>
 </svg>`;
 
 const GHOST_PIN_HTML = `<svg width="24" height="31" viewBox="-2 -2 32 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="none" stroke="#242424" stroke-width="2.5"/>
-  <circle cx="14" cy="14" r="4" fill="none" stroke="#242424" stroke-width="2"/>
+  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="none" stroke="#B07C84" stroke-width="2.5"/>
+  <circle cx="14" cy="14" r="4" fill="none" stroke="#B07C84" stroke-width="2"/>
 </svg>`;
 
-const GHOST_PIN_SELECTED_HTML = `<svg width="28" height="36" viewBox="-2 -2 32 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="#FAF3ED" stroke="#242424" stroke-width="2.5"/>
-  <circle cx="14" cy="14" r="4" fill="#242424"/>
+const GHOST_PIN_SELECTED_HTML = `<svg width="28" height="36" viewBox="-2 -2 32 40" fill="none" xmlns="http://www.w3.org/2000/svg" style="filter:drop-shadow(0 2px 3px rgba(70,30,15,0.32))">
+  <path d="M14 0C6.268 0 0 6.268 0 14C0 24.5 14 36 14 36C14 36 28 24.5 28 14C28 6.268 21.732 0 14 0Z" fill="#B07C84" stroke="#FAF3ED" stroke-width="2.5"/>
+  <circle cx="14" cy="14" r="4" fill="#FAF3ED"/>
 </svg>`;
 
 const YOU_ARE_HERE_HTML = `
-<style>@keyframes ect-pulse{0%,100%{box-shadow:0 0 0 5px rgba(36,36,36,0.28)}50%{box-shadow:0 0 0 10px rgba(36,36,36,0.08)}}</style>
-<div style="width:12px;height:12px;border-radius:50%;background:#242424;border:2px solid #FAF3ED;box-shadow:0 0 0 5px rgba(36,36,36,0.28);animation:ect-pulse 1.8s ease-in-out infinite"></div>`;
+<style>@keyframes ect-pulse{0%,100%{box-shadow:0 0 0 5px rgba(200,166,192,0.40)}50%{box-shadow:0 0 0 10px rgba(200,166,192,0.10)}}</style>
+<div style="width:13px;height:13px;border-radius:50%;background:#C8A6C0;border:2px solid #FAF3ED;box-shadow:0 0 0 5px rgba(200,166,192,0.40);animation:ect-pulse 1.8s ease-in-out infinite"></div>`;
 
 function normalizeName(s: string): string {
   return s.trim().toLowerCase();
@@ -192,9 +194,10 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
       const map = L.map(containerRef.current, { zoomControl: false, attributionControl: false });
       mapRef.current = map;
 
-      // Positron — Carto's neutral light-gray tile set. Sits cleanly behind
-      // anthracite markers + cream cards without competing for attention.
-      L.tileLayer("https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png", {
+      // Voyager — Carto's colourful basemap (green parks, blue water, warm
+      // roads). Real colour, graded warm toward the app's Field palette by the
+      // tile-pane filter co-located in this component's <style jsx global>.
+      L.tileLayer("https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png", {
         maxZoom: 19,
         detectRetina: true,
       }).addTo(map);
@@ -507,6 +510,16 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
 
   return (
     <div className="relative w-full h-full">
+      {/* Warm grade for the Voyager tiles — co-located here, NOT in globals.css,
+          so the installed PWA can't serve it stale (the documented cache trap).
+          Scoped to the tile pane only, so the coloured pins/labels stay true.
+          The four numbers are dials: more saturate / more-negative hue-rotate
+          = more colour; more sepia = warmer/creamier. */}
+      <style jsx global>{`
+        [data-light-scope] .leaflet-tile-pane {
+          filter: sepia(0.1) saturate(1.15) hue-rotate(-8deg) brightness(1.02);
+        }
+      `}</style>
       <div ref={containerRef} className="absolute inset-0" />
 
       {/* Search input — pushed below the floating page header (Nearby +

--- a/src/components/flow/LightStepRecommend.tsx
+++ b/src/components/flow/LightStepRecommend.tsx
@@ -12,6 +12,7 @@ import LiquidHeadline, { liquidEntranceMs, liquidExitMs } from "@/components/ui/
 import CraftingStatus from "@/components/ui/light/CraftingStatus";
 import { buildCraftingPhases } from "@/lib/craftingPhases";
 import { COFFEE_HINTS } from "@/lib/coffeeHints";
+import { MAX_CHARS } from "@/lib/insights/loadingInsightLint";
 import { useWakeLock } from "@/hooks/useWakeLock";
 import type { RecommendationCandidate, CandidateRole, CandidateConfidence } from "@/lib/types/session";
 import { basedOnReference } from "@/lib/utils/resolveRecipe";
@@ -85,11 +86,39 @@ export default function LightStepRecommend() {
   // Rotating insight deck for the crafting screen: a shuffled subset shown one
   // at a time — big (Fraunces 40, like the welcome haiku), scattered-in, held
   // long enough to read, then dissolved the OPPOSITE way (down) before the next
-  // sets up. Pulled straight from the code-canonical short COFFEE_HINTS so the
-  // big format always fits (no /api/hints round-trip, no risk of a long string).
-  const [insights] = useState<string[]>(() => shuffleSubset(COFFEE_HINTS, 12));
+  // sets up. Seeded synchronously from the code-canonical short COFFEE_HINTS so
+  // the big format always fits and the first frame paints instantly (offline
+  // too); the auto-refreshed pool is merged in below, purely additive.
+  const [insights, setInsights] = useState<string[]>(() => shuffleSubset(COFFEE_HINTS, 12));
   const [insightIdx, setInsightIdx] = useState(0);
   const [insightVisible, setInsightVisible] = useState(true);
+
+  // Merge the auto-refreshed insight pool (/api/loading-insights) with the
+  // static seed. The seed is the floor — always present, instant, offline-safe
+  // — so DB rows only add, and any fetch failure leaves the seed-only shuffle
+  // in place. Length-capped defensively so a bad row can't break the headline.
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/loading-insights")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: { insights?: string[] } | null) => {
+        if (cancelled || !data?.insights?.length) return;
+        const seen = new Set<string>();
+        const merged: string[] = [];
+        for (const s of [...data.insights, ...COFFEE_HINTS]) {
+          const key = s.trim().toLowerCase();
+          if (s.length <= MAX_CHARS && !seen.has(key)) {
+            seen.add(key);
+            merged.push(s);
+          }
+        }
+        if (merged.length > 0) setInsights(shuffleSubset(merged, 12));
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const currentInsight = insights[insightIdx] ?? "";
   const insightWordCount = currentInsight.trim() === "" ? 0 : currentInsight.trim().split(/\s+/).length;

--- a/src/lib/db/migrations/0018_add_loading_insights.sql
+++ b/src/lib/db/migrations/0018_add_loading_insights.sql
@@ -1,0 +1,43 @@
+-- 0018 — Loading-screen insight pool (auto-refreshed)
+--
+-- The recipe-creation loading screen rotates short, headline-sized coffee
+-- insights (Fraunces 40px) while Claude builds the recipe. They were a static
+-- code array (src/lib/coffeeHints.ts → COFFEE_HINTS); this table lets a
+-- scheduled agent grow and refresh the pool automatically, with no human in
+-- the loop.
+--
+-- Because there is no human review, NOTHING ungrounded may reach the screen:
+-- every row carries the source it was grounded in (source = 'corpus' | 'brews'
+-- | 'web', source_ref = the corpus entry id / brew-metric key / fetched URL),
+-- and the agent only inserts a line after it passes the deterministic gate in
+-- src/lib/insights/loadingInsightLint.ts plus a model claim-check. See
+-- src/app/api/loading-insights/refresh/route.ts (the agent) and
+-- src/app/api/loading-insights/route.ts (the read the screen consumes).
+--
+-- The static COFFEE_HINTS array stays as the synchronous fallback + seed, so
+-- the screen is never empty and never worse than today, even offline / before
+-- the first refresh has run.
+--
+-- Run with:
+--   cat src/lib/db/migrations/0018_add_loading_insights.sql | docker compose exec -T postgres psql -U brewlog -d brewlog
+
+CREATE TABLE IF NOT EXISTS loading_insights (
+  id              text PRIMARY KEY,
+  text            text NOT NULL,
+  source          text NOT NULL,                 -- 'corpus' | 'brews' | 'web'
+  source_ref      text,                          -- corpus id / metric key / url
+  status          text NOT NULL DEFAULT 'live',  -- 'live' | 'retired'
+  score           numeric NOT NULL DEFAULT 1,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  created_at_ms   bigint NOT NULL,
+  verified_at_ms  bigint
+);
+
+-- Case-insensitive uniqueness on the line itself — a DB-level dedup backstop
+-- in addition to the agent's own normalized dedup.
+CREATE UNIQUE INDEX IF NOT EXISTS loading_insights_text_lower_idx
+  ON loading_insights (lower(text));
+CREATE INDEX IF NOT EXISTS loading_insights_status_idx
+  ON loading_insights (status);
+CREATE INDEX IF NOT EXISTS loading_insights_created_at_ms_idx
+  ON loading_insights (created_at_ms DESC);

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -295,3 +295,34 @@ export type NewSessionRow = typeof sessions.$inferInsert;
 export type CoffeeRow = typeof coffees.$inferSelect;
 export type NewCoffeeRow = typeof coffees.$inferInsert;
 export type PlaceRow = typeof places.$inferSelect;
+
+// ── Loading-screen insight pool (migration 0018) ─────────────────────────
+// Auto-refreshed pool of short headline insights for the recipe-creation
+// loading screen. Grown/swapped by the scheduled agent in
+// /api/loading-insights/refresh; read by /api/loading-insights. Every row is
+// grounded in a source (see the migration header). The static COFFEE_HINTS
+// array remains the synchronous seed + offline fallback.
+export type LoadingInsightSource = "corpus" | "brews" | "web";
+export type LoadingInsightStatus = "live" | "retired";
+
+export const loadingInsights = pgTable(
+  "loading_insights",
+  {
+    id: text("id").primaryKey(),
+    text: text("text").notNull(),
+    source: text("source").$type<LoadingInsightSource>().notNull(),
+    sourceRef: text("source_ref"),
+    status: text("status").$type<LoadingInsightStatus>().notNull().default("live"),
+    score: numeric("score").notNull().default("1"),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    createdAtMs: bigint("created_at_ms", { mode: "number" }).notNull(),
+    verifiedAtMs: bigint("verified_at_ms", { mode: "number" }),
+  },
+  (t) => ({
+    statusIdx: index("loading_insights_status_idx").on(t.status),
+    createdAtMsIdx: index("loading_insights_created_at_ms_idx").on(t.createdAtMs.desc()),
+  })
+);
+
+export type LoadingInsightRow = typeof loadingInsights.$inferSelect;
+export type NewLoadingInsightRow = typeof loadingInsights.$inferInsert;

--- a/src/lib/insights/loadingInsightLint.ts
+++ b/src/lib/insights/loadingInsightLint.ts
@@ -1,0 +1,109 @@
+// Deterministic gate for loading-screen insights.
+//
+// This is the machine reviewer that REPLACES a human reviewer on the
+// auto-refreshed loading-insight pool (the user chose full-auto, no PR). It is
+// the load-bearing reason an agent can write to that screen without breaking
+// the "never fabricate" Hard Rule: a generated line only ships if it passes
+// here AND a model claim-check.
+//
+// Pure module — no DB, no Anthropic, no Node-only APIs — so it is the SINGLE
+// source of truth shared by:
+//   • the refresh agent (src/app/api/loading-insights/refresh/route.ts) — full
+//     gate incl. source-grounding,
+//   • the GET read (src/app/api/loading-insights/route.ts) — defensive length,
+//   • the screen merge (LightStepRecommend) — length floor,
+//   • the CI test (tests/dataflow/loading-insight-lint.test.mjs) — asserts the
+//     static COFFEE_HINTS seed satisfies the mechanical contract.
+
+// The Fraunces-40 headline format. 80 chars / 15 words is the validated ceiling
+// the static seed already lives within (its longest line is exactly 80 chars).
+export const MAX_CHARS = 80;
+export const MAX_WORDS = 15;
+
+// Emoji / pictographic ranges (arrows, dingbats, misc symbols, the VS16
+// selector, and any astral-plane char via its high surrogate — where the
+// modern emoji live). Plain BMP ranges + a surrogate range so it works without
+// the `u` flag (the project's TS target predates it). The brand forbids emoji.
+const EMOJI_RE = /[\u2190-\u21FF\u2300-\u27BF\u2B00-\u2BFF\uFE0F\uD800-\uDBFF]/;
+
+export function wordCount(s: string): number {
+  const t = s.trim();
+  return t === "" ? 0 : t.split(/\s+/).length;
+}
+
+export function hasEmoji(s: string): boolean {
+  return EMOJI_RE.test(s);
+}
+
+// Normalized key for dedup — case- and punctuation-insensitive.
+export function normalizeForDedupe(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+// Tokens in a line that assert a checkable specific — and therefore must be
+// present in the cited source for the line to count as grounded:
+//   • anything containing a digit (years, ppm, °C, ratios, percentages), and
+//   • a capitalized word that is NOT sentence-initial (a proper noun mid-line:
+//     a person, place, cultivar, roaster).
+// Sentence-initial capitals are ordinary English and exempt. This is what
+// stops the (slice-2) web source from smuggling an attributed specific
+// ("Hendon's 2014 paper…") onto the screen unless a fetched source backs it.
+// ASCII-based (no `u` flag / `\p{}` — see the TS-target note on EMOJI_RE). This
+// means a proper noun opening with a non-ASCII capital (Š, É) isn't flagged —
+// an acceptable under-catch; the model claim-check + the "prefer general, avoid
+// names" generation prompt are the other two layers. Only `.!?` reset the
+// sentence (a colon often precedes the very name we want to check).
+export function factualTokens(line: string): string[] {
+  const out: string[] = [];
+  let sentenceStart = true;
+  for (const raw of line.split(/\s+/)) {
+    if (raw === "") continue;
+    const w = raw.replace(/^[^A-Za-z0-9]+/, "").replace(/[^A-Za-z0-9%°]+$/, "");
+    if (w !== "") {
+      if (/\d/.test(w)) out.push(w);
+      else if (!sentenceStart && /^[A-Z][a-z]/.test(w)) out.push(w);
+    }
+    sentenceStart = /[.!?]$/.test(raw);
+  }
+  return out;
+}
+
+export interface LintOptions {
+  // When provided, every factual token in the line must appear in this text
+  // (the cited source). Omit for the hand-verified static seed.
+  sourceText?: string;
+  // When provided, a line whose normalized form is already present is rejected.
+  existing?: Set<string>;
+}
+
+export interface LintResult {
+  ok: boolean;
+  reasons: string[];
+}
+
+export function lintLoadingInsight(line: string, opts: LintOptions = {}): LintResult {
+  const reasons: string[] = [];
+  const trimmed = line.trim();
+
+  if (trimmed === "") reasons.push("empty");
+  if (trimmed.length > MAX_CHARS) reasons.push(`too-long:${trimmed.length}`);
+  if (wordCount(trimmed) > MAX_WORDS) reasons.push(`too-many-words:${wordCount(trimmed)}`);
+  if (hasEmoji(trimmed)) reasons.push("emoji");
+  if (trimmed.includes("!")) reasons.push("exclamation");
+
+  if (opts.existing && opts.existing.has(normalizeForDedupe(trimmed))) {
+    reasons.push("duplicate");
+  }
+
+  if (opts.sourceText !== undefined) {
+    const src = opts.sourceText.toLowerCase();
+    for (const tok of factualTokens(trimmed)) {
+      if (!src.includes(tok.toLowerCase())) reasons.push(`ungrounded:${tok}`);
+    }
+  }
+
+  return { ok: reasons.length === 0, reasons };
+}

--- a/tests/dataflow/loading-insight-lint.test.mjs
+++ b/tests/dataflow/loading-insight-lint.test.mjs
@@ -1,0 +1,96 @@
+// Loading-insight gate tests. Bundles the REAL loadingInsightLint.ts AND the
+// REAL COFFEE_HINTS seed with esbuild, so the test tracks the actual data.
+//
+//   node --test tests/dataflow/loading-insight-lint.test.mjs
+//
+// Two jobs:
+//   1. Contract: every line in the static COFFEE_HINTS seed must satisfy the
+//      mechanical rules (≤80 chars, ≤15 words, no emoji, no "!", unique). This
+//      is the format contract the auto-refresh agent must also meet — if a new
+//      hand-added seed line breaks it, CI fails here.
+//   2. Gate behaviour: length / words / emoji / "!" / dedupe / source-grounding
+//      all reject as intended (the grounding check is what keeps the slice-2
+//      web source from smuggling unattributed specifics onto the screen).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const entry = `
+export { lintLoadingInsight, normalizeForDedupe, factualTokens, wordCount, MAX_CHARS, MAX_WORDS }
+  from ${JSON.stringify(path.join(ROOT, "src/lib/insights/loadingInsightLint.ts"))};
+export { COFFEE_HINTS } from ${JSON.stringify(path.join(ROOT, "src/lib/coffeeHints.ts"))};
+`;
+const dir = await mkdtemp(join(tmpdir(), "loading-insight-"));
+const out = join(dir, "b.mjs");
+await build({
+  stdin: { contents: entry, resolveDir: ROOT, loader: "ts" },
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  outfile: out,
+  logLevel: "silent",
+});
+const {
+  lintLoadingInsight,
+  normalizeForDedupe,
+  factualTokens,
+  COFFEE_HINTS,
+  MAX_CHARS,
+  MAX_WORDS,
+} = await import(pathToFileURL(out).href);
+
+test("static seed satisfies the mechanical contract", () => {
+  assert.ok(COFFEE_HINTS.length > 0, "seed should not be empty");
+  const seen = new Set();
+  for (const line of COFFEE_HINTS) {
+    // No sourceText — the seed is hand-verified; we only check format + dedupe.
+    const { ok, reasons } = lintLoadingInsight(line, { existing: seen });
+    assert.ok(ok, `seed line failed gate (${reasons.join(", ")}): ${line}`);
+    seen.add(normalizeForDedupe(line));
+  }
+});
+
+test("rejects over-length and over-word lines", () => {
+  const long = "x".repeat(MAX_CHARS + 1);
+  assert.ok(!lintLoadingInsight(long).ok);
+  const wordy = Array.from({ length: MAX_WORDS + 1 }, () => "a").join(" ");
+  assert.ok(!lintLoadingInsight(wordy).ok);
+});
+
+test("rejects emoji and exclamation marks", () => {
+  assert.ok(lintLoadingInsight("Coffee is a fruit ☕").reasons.includes("emoji"));
+  assert.ok(lintLoadingInsight("Coffee is a fruit!").reasons.includes("exclamation"));
+});
+
+test("dedupes case- and punctuation-insensitively", () => {
+  const existing = new Set([normalizeForDedupe("Coffee is a fruit — the bean is its seed.")]);
+  const dup = lintLoadingInsight("coffee is a fruit, the bean is its seed", { existing });
+  assert.ok(dup.reasons.includes("duplicate"));
+});
+
+test("factualTokens flags mid-sentence proper nouns and numbers, not sentence starts", () => {
+  // "Hendon" + "2014" must be caught; leading "Water" must NOT.
+  const toks = factualTokens("Water chemistry: Hendon showed it in 2014.");
+  assert.ok(toks.includes("Hendon"));
+  assert.ok(toks.includes("2014"));
+  assert.ok(!toks.includes("Water"));
+});
+
+test("grounding gate rejects a specific absent from the source, accepts one present", () => {
+  const ungrounded = lintLoadingInsight("Hendon proved magnesium matters in 2014.", {
+    sourceText: "Water chemistry shapes extraction.",
+  });
+  assert.ok(ungrounded.reasons.some((r) => r.startsWith("ungrounded:")));
+
+  const grounded = lintLoadingInsight("Geisha made its name in Panama.", {
+    sourceText: "Geisha came from Ethiopia and made its name in Panama in the 1960s.",
+  });
+  assert.ok(grounded.ok, `expected grounded line to pass: ${grounded.reasons.join(", ")}`);
+});


### PR DESCRIPTION
Slice 1 of the agent that grows/refreshes the recipe-creation loading-screen insights automatically (the screen that rotated the static `COFFEE_HINTS`).

**The design driver:** the owner chose full-auto, *no human review*. The project's strongest, explicitly carved-out rule is "never fabricate coffee facts." Those reconcile only one way — the human review you skip is **replaced by a machine gate**, so nothing ungrounded can reach the screen. The owner asked for *no manual work*, not for *fabrications*; this keeps both.

### What's here (slice 1: corpus + brews)
- **`loading_insights` table** (migration `0018`) + Drizzle schema. Every row carries the source it was grounded in (`corpus` id / `brews` metric / `web` url).
- **`loadingInsightLint.ts`** — the deterministic gate, the single source of truth shared by the agent, the read route, the screen and CI: `≤80` chars, `≤15` words, no emoji, no `!`, dedupe, and a **source-grounding check** (every number / mid-line proper noun must appear in the cited source — the riggel that stops the slice-2 web source from smuggling attributed specifics onto the screen).
- **`GET /api/loading-insights`** — what the screen reads. Defensive: returns `[]` on any failure (incl. before the migration runs), so the static seed always covers it. **No way for this to break the screen.**
- **`POST /api/loading-insights/refresh`** (CRON_SECRET) — the agent. Generates one line per snippet grounded in the verified corpus (recipes / varieties / techniques) + brew aggregates, runs the deterministic gate **then a model claim-check**, inserts survivors, retires oldest over a 150 cap.
- **`LightStepRecommend`** merges the pool with the static seed — seed stays the instant, offline-safe floor; DB rows are purely additive and length-capped.
- **CI test** locks the static seed to the mechanical contract and exercises the gate.

`tsc` clean; full `node --test` suite green (72/72).

### Dormant until slice 2
This is safe to merge but shows **no visible change yet** — the screen renders the same seed. It activates when slice 2 lands: the **web source** (behind the same gate) + the **monthly Ofelia trigger**, at which point migration `0018` gets applied to prod (the table is only needed once the agent actually runs). I'll handle the migration with slice 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR)_