### PR TITLE
revert(watch): drop time-sensitive entitlement (90163)

### DIFF
--- a/native/ios/App/BTTSWatch/BTTSWatch.entitlements
+++ b/native/ios/App/BTTSWatch/BTTSWatch.entitlements
@@ -4,7 +4,5 @@
 <dict>
 	<key>aps-environment</key>
 	<string>production</string>
-	<key>com.apple.developer.usernotifications.time-sensitive</key>
-	<true/>
 </dict>
 </plist>

--- a/native/scripts/mac-build-upload.sh
+++ b/native/scripts/mac-build-upload.sh
@@ -112,13 +112,6 @@ cp "$WATCH_PROFILE" "$WATCH/embedded.mobileprovision"
 security cms -D -i "$APP_PROFILE"   | plutil -extract Entitlements xml1 -o "$WORK/app.ent"   -
 security cms -D -i "$WATCH_PROFILE" | plutil -extract Entitlements xml1 -o "$WORK/watch.ent" -
 
-# Add the Time Sensitive Notifications entitlement so watchOS delivers each
-# step push IMMEDIATELY instead of batching it (~15 s late otherwise). It's a
-# registration-free entitlement (not an App-ID capability), so it signs through
-# on top of the profile's aps-environment.
-/usr/libexec/PlistBuddy -c "Add :com.apple.developer.usernotifications.time-sensitive bool true" "$WORK/watch.ent" 2>/dev/null \
-  || /usr/libexec/PlistBuddy -c "Set :com.apple.developer.usernotifications.time-sensitive true" "$WORK/watch.ent"
-
 sign() { codesign -f -s "$IDENTITY" --timestamp "$@"; }
 
 # Bottom-up: nested frameworks first, then the watch app, then the iOS app.
@@ -132,8 +125,8 @@ say "Verify"
 codesign -v --deep --strict "$APP"
 echo "Payload root (must be App.app ONLY):"; ls "$WORK/Payload"
 echo "Watch embedded:"; ls "$APP/Watch"
-echo "watch push entitlements (want aps-environment + time-sensitive, NO healthkit):"
-codesign -d --entitlements - "$WATCH" 2>/dev/null | grep -iE "aps-environment|time-sensitive" || echo "  (MISSING — check signing)"
+echo "watch push entitlements (want aps-environment, NO healthkit):"
+codesign -d --entitlements - "$WATCH" 2>/dev/null | grep -iE "aps-environment" || echo "  (MISSING — check signing)"
 codesign -d --entitlements - "$WATCH" 2>/dev/null | grep -qi healthkit && echo "  WARNING: healthkit still present (will be rejected 90683)" || true
 echo "iOS build:"; /usr/libexec/PlistBuddy -c 'Print CFBundleVersion' "$APP/Info.plist"
 echo "watch build:"; /usr/libexec/PlistBuddy -c 'Print CFBundleVersion' "$WATCH/Info.plist"


### PR DESCRIPTION
time-sensitive must be in the profile; the ASC API can't add it (only Xcode). Revert to push-only so builds upload. Latency fix needs a different signing path.