### PR TITLE
fix(docker): install curl in the runner image (unbreaks in-container crons)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,14 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# curl is required by the in-container scheduled jobs that POST to localhost:
+# deploy/ofelia.ini (research / conversations-cleanup / coffees-compact) and the
+# "Refresh loading insights" GitHub Actions workflow all run
+# `docker compose exec app curl …`. node:alpine ships without curl, so without
+# this those crons silently fail with "curl: not found". Installed as root,
+# before the USER switch below.
+RUN apk add --no-cache curl
+
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 


### PR DESCRIPTION
The "Refresh loading insights" run failed with `sh: curl: not found`. Root cause: the runner image is `node:20-alpine`, which ships **without `curl`** — and the Dockerfile never adds it.

This is bigger than the new workflow: the in-container scheduled jobs in `deploy/ofelia.ini` (`/api/research`, `/api/conversations/cleanup`, `/api/coffees/compact`) **also** run `curl` inside this same container, so they have very likely been **silently failing** the same way (Ofelia only reports errors to Slack, which isn't configured, so it went unnoticed).

**Fix:** install `curl` in the runner stage (as root, before the `USER nextjs` switch). One line, repairs everything:
- the loading-insights refresh workflow (already merged) starts working;
- the existing Ofelia crons start working **on their next scheduled run** once this image deploys — Ofelia execs into the app container, so no Ofelia restart is needed.

After this deploys (~3 min on merge), the failed workflow run can be re-run (**Re-run jobs**) — or just **Run workflow** again — and it'll go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR)_