### PR TITLE
docs: loading-screen insight agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,8 @@ Removed routes: legacy Dark `page.tsx` (replaced by `(light)/page.tsx`), `match/
 | `insights` | ★ Coach observations over the full session corpus. **Opus** (`src/lib/claude/insights.ts`). GET = cache-aware Opus regeneration + full list for /taste (client-side status filtering); a `?status=` filtered read exists but currently has no UI consumer (both per-coffee surfaces read `/api/coffees/[id]/insight` since migration 0015). PATCH `{ id, status }` advances an insight through a **two-stage** workflow (migration 0017): **New** (`new` → Save to try / Confirmed / Doesn't apply) then **Saved** (`trying` → It helped=`confirmed` / Didn't help=`doesnt-apply` / Skip=`snoozed`). `snoozed` rows set `snoozed_until` (default +7 days) and are hidden until it passes, then resurface and regen treats them like `new` — EXCEPT `source='user-confirmed'` rows, which regeneration never deletes (June 2026 fix; previously Save → Skip → 7 days could silently delete a hand-saved note, because PATCH also used to reset `source` to `'opus'` on snooze). Confirm is the only transition that changes `source` (→ `user-confirmed`). The regeneration only replaces `status='new'` (and expired-snooze opus) rows; user-acted rows are preserved and re-emitted similar observations inherit the existing status (text-match on first 80 chars). **POST** writes a chat-authored coach note (tap-to-save from the home chat's `remember_advice` pill, and the post-brew Summary insight card) to **two** places: (a) an insights row (`status='trying'` or `'confirmed'` / `source='user-confirmed'`), deduped on the first 80 chars and anchored to the current corpus `latestSessionMs` so it never freezes regeneration; and (b) the targeted coffee's `coach_insight` column so the note becomes that bag's card on `/coffees/[id]` — a precise per-coffee write that supersedes the auto-generated per-coffee insight (rotation-gated card; a note saved for an out-of-rotation bag won't render a card). The two copies' statuses are NOT synced (see explore-agent row caveat). (PR #215, migrations 0014 + 0017) |
 | `coffees/[id]/insight` | GET / PATCH — the **per-coffee** coach card (`coffees.coach_insight`, migration 0015, **Opus** via `src/lib/claude/coffeeInsight.ts`). GET returns the cached insight, regenerating when this coffee has a newer session AND status is `new`/`doesnt-apply` (never while `trying`/`confirmed` — don't move the card under the user). PATCH advances the card's own status. Consumed by `CoffeeCoachCard` (/coffees/[id]) and the /brew/new Context reminder pill. |
 | `admin/prewarm-coffee-insights` | POST (CRON_SECRET bearer) — one-shot Opus pre-warm of per-coffee insights for every rotation coffee, so /coffees/[id] cards appear instantly after migration 0015 / a rotation batch. Preserves `trying`/`confirmed` cards. |
+| `loading-insights` | GET — live rows of the **auto-refreshed loading-screen insight pool** shown during the recipe-crafting wait (`LightStepRecommend`). Defensive: returns `[]` on any failure (incl. pre-migration) so the static `COFFEE_HINTS` seed always covers it. requireAuth-gated. |
+| `loading-insights/refresh` | ★ POST (CRON_SECRET) — the **insight agent**. Generates short headline lines grounded in the verified corpus (recipes/varieties/techniques) + brew aggregates + live `web_search` (each web line must carry a verbatim quote), runs every candidate through a deterministic gate (`src/lib/insights/loadingInsightLint.ts`) **and** a model claim-check, inserts survivors, retires oldest over a 150 cap. Full-auto, **NO human review** — the machine gate replaces it so nothing ungrounded reaches the screen (the "never fabricate" rule). Table self-bootstraps (`CREATE TABLE IF NOT EXISTS`). Monthly via `.github/workflows/loading-insights-refresh.yml` (SSH → `docker compose exec app curl`, reuses deploy key). **Full reference: `docs/loading-insights.md`.** |
 | `coach-question` | POST — post-rating micro-dialogue (Sonnet). Called by `LightStepLog` only when a client-side ambiguity heuristic fires (`shouldAskCoach`); returns one short question + 3 answer chips, stored as `tasteResult.coachAnswer` and read downstream by /recommend + /insights. |
 | `hints` | GET contextual brewing hints |
 | `news` | GET coffee news feed |
@@ -167,7 +169,9 @@ Removed during the Light cleanup (PR #137): `BottomNav`, Dark `Chip`, `RadarChar
 
 ```
 lib/
-├── coffeeHints.ts          # Static contextual brewing hints used by /api/hints
+├── coffeeHints.ts          # ★ COFFEE_HINTS — static seed + offline floor for the recipe-screen insight pool (docs/loading-insights.md)
+├── insights/
+│   └── loadingInsightLint.ts  # ★ Deterministic gate for the loading-screen insight agent — shared SoT (agent + read route + screen + CI)
 ├── auth/
 │   ├── requireAuth.ts      # Server helper: throws if no valid session cookie
 │   └── session.ts          # JWT session cookie create/verify (jose)
@@ -214,7 +218,8 @@ lib/
 │   ├── 0014_add_insight_status.sql         # status workflow column on insights (`new`/`trying`/`confirmed`/`doesnt-apply`), PR #215
 │   ├── 0015_add_coffee_coach_insight.sql    # coffees.coach_insight jsonb — per-coffee Opus insight (CoffeeCoachCard source)
 │   ├── 0016_add_drip_bags.sql               # drip_bags table — single-serve drip-bag documentation records, isolated from the corpus
-│   └── 0017_add_insight_snooze.sql          # insights.snoozed_until + 'snoozed' status (two-stage coach workflow, +7-day skip)
+│   ├── 0017_add_insight_snooze.sql          # insights.snoozed_until + 'snoozed' status (two-stage coach workflow, +7-day skip)
+│   └── 0018_add_loading_insights.sql        # loading_insights table — auto-refreshed loading-screen insight pool (also self-bootstrapped by the refresh route)
 │   # NOTE: 0001+ are applied manually via `psql` on the VPS — Drizzle journal does not track them.
 │   # Applying schema/code that references a new column BEFORE running the migration on the VPS
 │   # makes Drizzle SELECT 500 (column-strict). Always migrate VPS first, deploy code second.
@@ -283,7 +288,7 @@ lib/
 
 ### Database tables (Drizzle + Postgres)
 
-`sessions`, `coffees`, `auth_credentials`, `auth_challenges`, `preferences`, `roasters`, `knowledge`, `coffee_alerts`, `places`, `conversations`, `conversation_messages`, `cafe_visits`, `insights`, `drip_bags` (14 tables; `lessons` from PR #210 also exists but is read-by-nothing post-#211 — its `/lessons` page, `/api/lessons` route, and `src/lib/claude/lessons.ts` distiller were all removed, only the table + migrations 0012/0013_add_lesson_questions remain as dead schema).
+`sessions`, `coffees`, `auth_credentials`, `auth_challenges`, `preferences`, `roasters`, `knowledge`, `coffee_alerts`, `places`, `conversations`, `conversation_messages`, `cafe_visits`, `insights`, `drip_bags`, `loading_insights` (15 tables; `lessons` from PR #210 also exists but is read-by-nothing post-#211 — its `/lessons` page, `/api/lessons` route, and `src/lib/claude/lessons.ts` distiller were all removed, only the table + migrations 0012/0013_add_lesson_questions remain as dead schema).
 
 Recent additions:
 - `coffees.field_zones jsonb` (migration 0008) — persisted Field composition per coffee
@@ -320,6 +325,13 @@ All migrations applied manually on the VPS — see migration NOTE above.
 ## Current Status — Snapshot June 2026
 
 ### ✅ Done
+
+**Auto-refreshed loading-screen insight agent (June 2026, PRs #342 / #345 / #346 / #347)**
+- The recipe-crafting loading screen (`LightStepRecommend`) rotated a static `COFFEE_HINTS` array; now a scheduled agent grows/swaps the pool **monthly, full-auto, no human review**. Because the owner chose no review and "never fabricate" is non-negotiable, a **machine gate replaces the human one**: every candidate — from the verified corpus, brew aggregates, AND live `web_search` — must be grounded in a cited source (numbers + mid-line proper nouns must appear in it), pass `src/lib/insights/loadingInsightLint.ts` + a model claim-check, before insert. Web lines carry a verbatim quote as their grounding; residual web-fabrication risk is accepted for this low-stakes surface.
+- `loading_insights` table (migration 0018, **also self-bootstrapped** via `CREATE TABLE IF NOT EXISTS` in the refresh route — the integration can't dispatch the migration workflow, `403`). GET `/api/loading-insights` is defensive (→ seed on any failure); `LightStepRecommend` merges pool + seed, and the seed is the unbreakable floor (instant, offline-safe, never regresses).
+- Runs via `.github/workflows/loading-insights-refresh.yml` (monthly cron + `workflow_dispatch`): SSHes in with the **deploy key** and triggers `docker compose exec -T app curl` from inside the container — zero new secrets, reads the container's own `CRON_SECRET`, no Ofelia restart.
+- **The Dockerfile now installs `curl`** (`node:20-alpine` shipped without it). This ALSO unbroke the existing Ofelia crons (`/api/research`, `/api/conversations/cleanup`, `/api/coffees/compact`), which had been silently failing on `curl: not found` (Ofelia only Slacks on error, which isn't wired). Don't remove curl.
+- Full reference: **`docs/loading-insights.md`** (architecture, the gate, the sources, ops, tuning dials). Tests: `tests/dataflow/loading-insight-lint.test.mjs`.
 
 **Recipe-fidelity system + extraction-budget framework + primary-source audit + deploy fix (June 2026, PRs #265–#278)**
 - **Recipe fidelity (two layers).** (1) Prompt rule in `recommend.ts` (#265): when a candidate is `basedOn` a documented recipe, preserve its grind/cadence/temp/total-time and scale ONLY the grams — adding 50ml must never add 1:15. (2) Deterministic backstop `src/lib/claude/recipeFidelity.ts` (#266): `reconcileToReference()` runs after parsing and snaps a drifted candidate's mechanics back to the VERIFIED scaled corpus recipe. Verified-refs only, 0.5–2.5× scale only, skips iced/bypass. Tests: `tests/dataflow/recipe-fidelity.test.mjs`. Root cause was the Kasuya Super-Coarse "+50ml→+1:15 / lost super-coarse grind" mangle (the model rewrote the recipe at generation time; the timing math was innocent).

--- a/docs/loading-insights.md
+++ b/docs/loading-insights.md
@@ -1,0 +1,211 @@
+# Loading-screen insight agent
+
+> **Source of truth:** the code under `src/app/api/loading-insights/`,
+> `src/lib/insights/loadingInsightLint.ts`, and the seed `src/lib/coffeeHints.ts`.
+> This doc mirrors them for humans — if a constant changes, update the code, then this file.
+
+The recipe-creation loading screen (`LightStepRecommend`, shown while `/api/recommend`
+builds the recipe) rotates short, headline-sized coffee insights in the big Fraunces-40
+treatment. They used to be a **static** hand-written array (`COFFEE_HINTS`, 59 lines). This
+feature adds an **agent that grows and swaps that pool automatically, ~monthly, with no human
+in the loop** — while guaranteeing nothing fabricated reaches the screen.
+
+---
+
+## The one decision that shapes everything: full-auto, no review
+
+The owner chose **full-auto with no human review**. The project's strongest, explicitly
+carved-out rule is **"never fabricate coffee facts"** (CLAUDE.md). Those reconcile exactly one
+way: the human reviewer is **replaced by a machine gate**. The owner asked for *no manual work*,
+not for *fabrications* — so the review became code instead of a person, and an ungrounded line
+physically cannot be inserted.
+
+Every candidate line, from every source, must clear **both**:
+
+1. **The deterministic gate** (`loadingInsightLint.ts`) — format + dedupe + **source-grounding**.
+2. **A model claim-check** — a second cheap call confirming the line is fully supported by its
+   cited source.
+
+Only survivors of both are written.
+
+---
+
+## Architecture
+
+```
+            ┌─ corpus  (recipes / varieties / techniques)  → snippet = the verified entry text
+ sources ──┼─ brews   (your session aggregates)            → snippet = buildHistorySummary()
+            └─ web     (live web_search)                    → snippet = a model-supplied verbatim quote
+                         │
+                         ▼  one candidate line per snippet, grounded in that snippet
+              ┌──────────────────────┐
+              │ deterministic gate   │  ≤80 chars · ≤15 words · no emoji · no "!" ·
+              │ (loadingInsightLint) │  dedupe · every number/proper-noun must be IN the source
+              └──────────┬───────────┘
+                         ▼
+              ┌──────────────────────┐
+              │ model claim-check    │  "is this line fully supported by its source? y/n"
+              └──────────┬───────────┘
+                         ▼
+              insert survivors (status='live')  ·  retire oldest over the 150 cap
+                         │
+                         ▼
+   GET /api/loading-insights  ──►  screen merges live rows + the static seed  ──►  shuffle 12
+```
+
+**The static seed is an unbreakable floor.** The screen always merges the DB pool with
+`COFFEE_HINTS` and falls back to seed-only on any fetch failure (offline, error, or before the
+first run). So the pool can only ever *add* to what's shown today — it can't regress or empty.
+
+### Why each source is safe
+
+- **corpus** — the generator is told to *restate a fact from the given snippet*, and that snippet
+  is a verified corpus entry (`recipes` / `varieties` / `techniques`). Grounded by construction.
+- **brews** — observations computed from *your own real sessions* (`buildHistorySummary`). They're
+  facts about your data, not coffee-science claims the model could invent.
+- **web** — the freshest and the riskiest. The model must attach a **verbatim quote** from a page
+  it actually found; that quote becomes the grounding `sourceText`, so web rides the exact same
+  gate. Residual risk (a fabricated quote) is accepted for this low-stakes surface and minimised
+  by the "prefer the general principle; no numbers/names unless they're in the quote" rule — which
+  the deterministic specifics-check then enforces.
+
+---
+
+## The gate (`src/lib/insights/loadingInsightLint.ts`)
+
+Pure module, zero dependencies — the single source of truth shared by the agent, the read route,
+the screen merge, and the CI test. `lintLoadingInsight(line, { sourceText?, existing? })` returns
+`{ ok, reasons[] }`. Rejection reasons:
+
+| reason | rule |
+|---|---|
+| `empty` | blank after trim |
+| `too-long:<n>` | `> MAX_CHARS` (80) |
+| `too-many-words:<n>` | `> MAX_WORDS` (15) |
+| `emoji` | any emoji / pictograph |
+| `exclamation` | contains `!` (brand voice) |
+| `duplicate` | normalized form already in the `existing` set |
+| `ungrounded:<token>` | a **factual token** not found in the cited `sourceText` |
+
+**Factual tokens** (`factualTokens()`) = anything containing a digit (years, ppm, °C, ratios) +
+any capitalized word that is *not* sentence-initial (a mid-line proper noun: a person, place, or
+cultivar). Sentence-initial capitals are ordinary English and exempt. This is the riggel that
+stops the web source from slipping an attributed specific ("Hendon's 2014 paper…") onto the
+screen unless a real fetched quote backs it. (ASCII-based — a name opening with a non-ASCII
+capital isn't flagged; an accepted under-catch, since the claim-check + prompt are the other two
+layers.) The hand-verified seed is checked for format + dedupe only, never grounding.
+
+`tests/dataflow/loading-insight-lint.test.mjs` bundles the real module + the real seed and asserts
+(a) every seed line satisfies the mechanical contract and (b) the gate rejects/accepts as intended.
+
+---
+
+## Data model
+
+`loading_insights` (migration `0018`, but the refresh route also `CREATE TABLE IF NOT EXISTS`-es
+it, so it's self-bootstrapping — see below):
+
+| column | meaning |
+|---|---|
+| `id` | uuid |
+| `text` | the insight line |
+| `source` | `corpus` \| `brews` \| `web` |
+| `source_ref` | corpus entry id / `brews:summary` / the source url |
+| `status` | `live` \| `retired` |
+| `score` | reserved (all `1` today) |
+| `created_at` / `created_at_ms` | timestamps |
+| `verified_at_ms` | when it passed the gate |
+
+A **unique index on `lower(text)`** is a DB-level dedup backstop on top of the agent's own
+normalized dedup. `live` rows are what the screen reads; over the 150 cap the oldest are flipped
+to `retired` (never deleted).
+
+---
+
+## Files
+
+| File | Role |
+|---|---|
+| `src/lib/coffeeHints.ts` | `COFFEE_HINTS` — the static seed + offline floor (hand-verified) |
+| `src/lib/insights/loadingInsightLint.ts` | the deterministic gate (shared SoT) |
+| `src/app/api/loading-insights/route.ts` | `GET` — live rows for the screen; defensive (returns `[]` on any failure, incl. pre-migration) |
+| `src/app/api/loading-insights/refresh/route.ts` | `POST` (CRON_SECRET) — the agent: ensureTable → generate (corpus+brews+web) → gate → claim-check → insert → retire |
+| `src/components/flow/LightStepRecommend.tsx` | merges the fetched pool with the seed, length-capped, `shuffleSubset(…, 12)` |
+| `src/middleware.ts` | `/api/loading-insights` added to `PUBLIC_PATHS` (refresh = CRON_SECRET-gated, GET = requireAuth-gated) |
+| `src/lib/db/migrations/0018_add_loading_insights.sql` | canonical schema record |
+| `.github/workflows/loading-insights-refresh.yml` | the monthly trigger |
+| `tests/dataflow/loading-insight-lint.test.mjs` | gate + seed-contract tests |
+
+Models: generation `claude-sonnet-4-6`, web `claude-sonnet-4-6` (+ `web_search` tool), claim-check
+`claude-haiku-4-5`.
+
+---
+
+## How it runs (the monthly trigger)
+
+`.github/workflows/loading-insights-refresh.yml` — `schedule: "0 5 1 * *"` (05:00 UTC, 1st of each
+month) + `workflow_dispatch`. It **SSHes into the VPS with the same deploy key the Deploy workflow
+uses**, then triggers the refresh **from inside the app container**:
+
+```
+docker compose exec -T app sh -c 'curl -fsS -X POST http://localhost:3000/api/loading-insights/refresh -H "Authorization: Bearer $CRON_SECRET"'
+```
+
+This means **zero owner setup**: it reuses the existing `DEPLOY_*` secrets, reads the container's
+own `CRON_SECRET` (never exposed to GitHub), and needs no new GitHub secret and no Ofelia restart.
+A missed run is harmless (seed floor).
+
+- **Run it now:** Actions → "Refresh loading insights" → **Run workflow** (or **Re-run jobs** on a
+  past run). Otherwise it fires monthly on its own.
+- **Reading a run:** the `refresh` step prints the JSON the route returns, e.g.
+  `{"snippets":27,"web":8,"candidates":35,"gated":22,"inserted":22,"retired":0}` —
+  snippets pulled · web lines returned · total candidates · passed the gate+check · inserted ·
+  retired over the cap. A big gap between `candidates` and `gated` means the gate is being strict.
+
+> **`curl` dependency:** the app image is `node:20-alpine`, which has **no curl** by default. The
+> Dockerfile (`runner` stage) installs it (`apk add --no-cache curl`) because the in-container
+> trigger above — and the existing Ofelia crons in `deploy/ofelia.ini` — all shell out to curl.
+> Before that fix those crons were silently failing with `curl: not found`; don't remove curl.
+
+---
+
+## Self-bootstrapping table
+
+Because the GitHub integration can't dispatch the SQL-migration workflow (`403`), the refresh route
+runs `CREATE TABLE IF NOT EXISTS loading_insights (…)` + indexes at the top of every run
+(`ensureTable()`). So the agent is self-healing whether or not migration `0018` was applied on the
+VPS; `0018` stays as the canonical schema record / fresh-install path. The `GET` read is defensive
+regardless (missing table → `[]` → seed shows).
+
+---
+
+## Tuning dials
+
+All in `src/app/api/loading-insights/refresh/route.ts` unless noted. Change the number, ship.
+
+| Want | Dial | Now |
+|---|---|---|
+| More/fewer corpus lines per run | `N_RECIPES` / `N_VARIETIES` / `N_TECHNIQUES` | 10 / 8 / 8 |
+| Bigger/smaller live pool before retiring | `POOL_CAP` | 150 |
+| Brews source on/off threshold | `MIN_SESSIONS_FOR_BREWS` | 4 |
+| More/fewer web searches per run | `web_search` `max_uses` | 5 |
+| Web lines requested | the `generateWebCandidates` user prompt | "6–10" |
+| Line length / word ceiling | `MAX_CHARS` / `MAX_WORDS` (`loadingInsightLint.ts`) | 80 / 15 |
+| Run cadence | `cron` in the workflow | 1st of month, 05:00 UTC |
+| On-screen pacing (read time / in-out speed) | `INSIGHT_READ_MS` / `INSIGHT_POP_MS` / `INSIGHT_EXIT_MS` (`LightStepRecommend.tsx`) | 4800 / 1000 / 850 ms |
+
+Per-insight on-screen rhythm and the seed's character budget are documented in
+`docs/liquid-design.md` (the recipe-crafting insight deck) — the seed sits at 41–80 chars / 8–15
+words, and the gate enforces that ceiling on every generated line.
+
+---
+
+## Known limitations / residual risk
+
+- **Web fabrication.** A line is grounded in a *model-supplied* quote, so a determined hallucination
+  (fake quote + matching fake specific) could pass. Accepted for this surface; the
+  "prefer general, no specifics unless in the quote" rule + the specifics-check + the claim-check
+  make it unlikely and low-impact. Attributed web facts verbatim belong in the news feed, not here.
+- **No live-DB visibility from a Claude session.** Production rows can't be read from a session —
+  judge output from a run's `inserted` count and from the brew screen, or ask the owner.
+- **Statuses aren't synced anywhere else.** This pool is independent of the coach `insights` table.


### PR DESCRIPTION
Documentation for the loading-screen insight agent (PRs #342/#345/#346/#347).

- **`docs/loading-insights.md`** (new) — the full reference: the no-review / machine-gate safety model and why it's there, the three sources (corpus / brews / web), the deterministic gate + claim-check, the data model, a file map, how the monthly trigger runs (SSH + in-container `curl`), ops + how to read a run's JSON counts, the tuning dials, the `curl`/Dockerfile note (and the Ofelia-cron discovery), and known residual risks.
- **`CLAUDE.md`** — inventory + status entries so future sessions discover it: the two API routes, migration `0018`, the `loading_insights` table (count → 15), the `insights/loadingInsightLint.ts` lib entry (+ corrected the stale `coffeeHints.ts` note), and a "Done" entry pointing at the new doc.

Docs-only — no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR)_