### PR TITLE
feat: per-line refresh audit (proposed / killed-with-reasons / passed)

### DIFF
--- a/.github/workflows/loading-insights-refresh.yml
+++ b/.github/workflows/loading-insights-refresh.yml
@@ -29,13 +29,37 @@ jobs:
           mkdir -p ~/.ssh
           printf '%s\n' "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts
-          ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} bash <<'REMOTE'
-            set -e
-            cd ${{ secrets.DEPLOY_PATH }}
-            # Trigger from inside the app container so $CRON_SECRET expands from
-            # the container's own env (single quotes keep the host/SSH shells from
-            # touching it). -fsS makes curl exit non-zero on an HTTP error, so a
-            # failed refresh fails this job loudly.
-            docker compose exec -T app sh -c 'curl -fsS -X POST http://localhost:3000/api/loading-insights/refresh -H "Authorization: Bearer $CRON_SECRET"'
+          ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+          # Trigger from inside the app container so $CRON_SECRET expands from the
+          # container's own env (single quotes keep the host/SSH shells off it).
+          # -fsS makes curl non-zero on an HTTP error. Capture the JSON body to a
+          # file so we can print a readable per-line audit (proposed/killed/passed).
+          set +e
+          ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} bash <<'REMOTE' > /tmp/resp.json 2>/tmp/resp.err
+          cd ${{ secrets.DEPLOY_PATH }}
+          docker compose exec -T app sh -c 'curl -fsS -X POST http://localhost:3000/api/loading-insights/refresh -H "Authorization: Bearer $CRON_SECRET"'
           REMOTE
+          rc=$?
+          set -e
+
+          echo "----- raw response -----"
+          cat /tmp/resp.json
+
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::refresh failed (ssh/curl exit $rc)"
+            cat /tmp/resp.err
+            exit 1
+          fi
+
+          echo
+          echo "----- audit -----"
+          jq -r '
+            "counts: \(.candidates) proposed · \(.inserted) inserted · \(.killed | length) killed",
+            "",
+            "PASSED (\(.passed | length)):",
+            (.passed[] | "  + [\(.source)] \(.text)"),
+            "",
+            "KILLED (\(.killed | length)):",
+            (.killed[] | "  - [\(.source)] \(.text)  -> \(.reasons | join(\", \"))")
+          ' /tmp/resp.json || echo "(could not format JSON; see raw response above)"

--- a/src/app/api/loading-insights/refresh/route.ts
+++ b/src/app/api/loading-insights/refresh/route.ts
@@ -272,13 +272,18 @@ export async function POST(req: NextRequest) {
     }
 
     // 4. Deterministic gate — each candidate grounded against its OWN source.
+    // `killed` records every rejected line + WHY, so a run is fully auditable.
+    const killed: { source: LoadingInsightSource; text: string; reasons: string[] }[] = [];
     const gated: { text: string; snippet: Snippet }[] = [];
     for (const cand of rawCandidates) {
-      const { ok } = lintLoadingInsight(cand.text, {
+      const { ok, reasons } = lintLoadingInsight(cand.text, {
         sourceText: cand.snippet.sourceText,
         existing,
       });
-      if (!ok) continue;
+      if (!ok) {
+        killed.push({ source: cand.snippet.source, text: cand.text, reasons });
+        continue;
+      }
       existing.add(normalizeForDedupe(cand.text)); // catch intra-batch dups
       gated.push(cand);
     }
@@ -300,7 +305,11 @@ export async function POST(req: NextRequest) {
         });
         const verdicts = extractJsonArray(textOf(checkResp));
         if (verdicts && verdicts.length === gated.length) {
-          survivors = gated.filter((_, i) => verdicts[i] === true);
+          survivors = [];
+          gated.forEach((g, i) => {
+            if (verdicts[i] === true) survivors.push(g);
+            else killed.push({ source: g.snippet.source, text: g.text, reasons: ["claim-check"] });
+          });
         }
       } catch {
         /* keep gate survivors on claim-check failure */
@@ -346,6 +355,9 @@ export async function POST(req: NextRequest) {
       gated: gated.length,
       inserted: newRows.length,
       retired,
+      // Full per-line audit so a run shows what passed and what was killed (+why).
+      passed: survivors.map((s) => ({ source: s.snippet.source, text: s.text })),
+      killed,
     });
   } catch (err) {
     console.error("loading-insights refresh failed", err);


### PR DESCRIPTION
Right now a refresh run only shows counts (`{"snippets":27,"web":10,"candidates":27,"gated":15,"inserted":15,"retired":0}`). You can't see **what** was proposed, **what** got killed, or **why**.

This makes every run fully auditable:

- **Route returns the lines, not just counts.** `passed` = the lines that made it. `killed` = the lines that didn't, each with its rejection reasons (`too-long:<n>`, `ungrounded:<token>`, `duplicate`, `emoji`, `exclamation`, `claim-check`, …). Lines that failed the *model claim-check* are now recorded with reason `claim-check` so they appear in the kill list too.
- **Workflow prints a readable audit** through `jq`, e.g.:

  ```
  counts: 27 proposed · 15 inserted · 12 killed

  PASSED (15):
    + [corpus] Geisha made its name in Panama.
    + [web]    Naturals lock fruit into the bean during drying.
    …

  KILLED (12):
    - [web]    Hendon proved magnesium matters in 2014.  -> ungrounded:Hendon, ungrounded:2014
    - [corpus] Always swirl, never stir!                  -> exclamation
    …
  ```

So you open the next workflow run, expand the step, and see exactly what the agent proposed, what passed, and what was dropped (with the rule that killed it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR)_