### PR TITLE
fix(watch): physical-therapy extended-runtime session + notifyUser (build 17)

### DIFF
--- a/native/ios/App/App/BrewWatchPlugin.swift
+++ b/native/ios/App/App/BrewWatchPlugin.swift
@@ -3,71 +3,73 @@ import Capacitor
 import WatchConnectivity
 
 /**
- BrewWatch — phone-side bridge between the watch and the WKWebView (JS).
+ BrewWatch — phone-side bridge from the WKWebView (JS) to the Apple Watch app.
 
- New model (build 13): the watch is a push receiver. It registers for remote
- notifications and sends its APNs device token to the phone over
- WatchConnectivity. This plugin receives that token and surfaces it to JS — the
- web layer (`src/lib/native/watchPush.ts`) registers it with the server, which
- then pushes one alert to the watch per brew step. The phone no longer sends a
- schedule to the watch; per-step pushes go web → server → APNs.
+ The web layer (`src/lib/native/brewWatch.ts`) calls `startBrew` once when a
+ brew's timer hits zero, handing over the WHOLE step schedule as absolute
+ epoch-ms fire times. We forward it to the watch over WatchConnectivity; the
+ watch app runs the timeline itself and buzzes the wrist at each step via a
+ physical-therapy extended-runtime session (the only thing that buzzes the wrist
+ while the iPhone screen is ON).
+
+ Delivery: `sendMessage` for immediacy when the watch app is reachable
+ (foreground — it is, the user opened it at brew start), plus
+ `updateApplicationContext` as a durable fallback.
  */
 @objc(BrewWatchPlugin)
 public class BrewWatchPlugin: CAPPlugin, CAPBridgedPlugin {
     public let identifier = "BrewWatchPlugin"
     public let jsName = "BrewWatch"
     public let pluginMethods: [CAPPluginMethod] = [
-        CAPPluginMethod(name: "getWatchToken", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "startBrew", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "endBrew", returnType: CAPPluginReturnPromise),
     ]
 
     private var session: WCSession?
-    private var lastToken: String?
 
     override public func load() {
         guard WCSession.isSupported() else { return }
-        WatchSessionForwarder.shared.onToken = { [weak self] token in
-            self?.lastToken = token
-            self?.notifyListeners("watchToken", data: ["token": token])
-        }
         let s = WCSession.default
         s.delegate = WatchSessionForwarder.shared
         s.activate()
         session = s
     }
 
-    /// Return the latest watch APNs token the phone has received (or "").
-    @objc func getWatchToken(_ call: CAPPluginCall) {
-        call.resolve(["token": lastToken ?? ""])
+    @objc func startBrew(_ call: CAPPluginCall) {
+        guard WCSession.isSupported() else { call.resolve(); return }
+        let recipeName = call.getString("recipeName") ?? "Brew"
+        let firesIn = call.getArray("fires", JSObject.self) ?? []
+        var fires: [[String: Any]] = []
+        for f in firesIn {
+            guard let atMs = f["atMs"] as? Double ?? (f["atMs"] as? NSNumber)?.doubleValue else { continue }
+            let label = f["label"] as? String ?? "Next step"
+            fires.append(["atMs": atMs, "label": label])
+        }
+        send(["type": "start", "recipeName": recipeName, "fires": fires])
+        call.resolve()
+    }
+
+    @objc func endBrew(_ call: CAPPluginCall) {
+        send(["type": "end"])
+        call.resolve()
+    }
+
+    private func send(_ payload: [String: Any]) {
+        guard let s = session, s.activationState == .activated else { return }
+        if s.isReachable {
+            s.sendMessage(payload, replyHandler: nil, errorHandler: nil)
+        }
+        try? s.updateApplicationContext(payload)
     }
 }
 
 /**
- WCSession delegate that forwards the watch's APNs token to the plugin. A
- delegate is mandatory for the session to activate; the multi-device
- reactivation stubs are required by iOS.
+ Minimal WCSessionDelegate — the phone only SENDS for this feature, so the
+ callbacks are no-ops, but a delegate is mandatory for the session to activate.
  */
 final class WatchSessionForwarder: NSObject, WCSessionDelegate {
     static let shared = WatchSessionForwarder()
-    var onToken: ((String) -> Void)?
-
-    private func handle(_ message: [String: Any]) {
-        guard (message["type"] as? String) == "watchToken",
-              let token = message["token"] as? String, !token.isEmpty
-        else { return }
-        DispatchQueue.main.async { self.onToken?(token) }
-    }
-
-    func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
-        handle(message)
-    }
-
-    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
-        handle(applicationContext)
-    }
-
     func session(_ session: WCSession, activationDidCompleteWith state: WCSessionActivationState, error: Error?) {}
     func sessionDidBecomeInactive(_ session: WCSession) {}
-    func sessionDidDeactivate(_ session: WCSession) {
-        session.activate()
-    }
+    func sessionDidDeactivate(_ session: WCSession) { session.activate() }
 }

--- a/native/ios/App/BTTSWatch/BTTSWatch.entitlements
+++ b/native/ios/App/BTTSWatch/BTTSWatch.entitlements
@@ -2,9 +2,5 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>aps-environment</key>
-	<string>production</string>
-	<key>com.apple.developer.usernotifications.time-sensitive</key>
-	<true/>
 </dict>
 </plist>

--- a/native/ios/App/BTTSWatch/BTTSWatchApp.swift
+++ b/native/ios/App/BTTSWatch/BTTSWatchApp.swift
@@ -1,41 +1,14 @@
 import SwiftUI
-import UserNotifications
-import WatchKit
 
 /**
- BTTS Apple Watch companion — APNs push receiver.
+ BTTS Apple Watch companion — single-target SwiftUI watch app.
 
- The app delegate registers for remote notifications on launch and forwards the
- device token to the phone (BrewWatchModel). From then on the wrist buzzes from
- push alerts the server sends per brew step — this app does not need to be open.
+ Open it at brew start: the phone hands over the step schedule, the app starts a
+ physical-therapy extended-runtime session (so it stays alive in the background)
+ and buzzes the wrist at each step — screen off, wrist down. See BrewWatchModel.
  */
-class WatchAppDelegate: NSObject, WKApplicationDelegate, UNUserNotificationCenterDelegate {
-    func applicationDidFinishLaunching() {
-        UNUserNotificationCenter.current().delegate = self
-        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
-        WKApplication.shared().registerForRemoteNotifications()
-    }
-
-    func didRegisterForRemoteNotifications(withDeviceToken deviceToken: Data) {
-        let hex = deviceToken.map { String(format: "%02x", $0) }.joined()
-        BrewWatchModel.shared.sendToken(hex)
-    }
-
-    func didFailToRegisterForRemoteNotificationsWithError(_ error: Error) {}
-
-    // Show the cue (with its haptic) even if the watch app happens to be foreground.
-    func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        willPresent notification: UNNotification,
-        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
-    ) {
-        completionHandler([.banner, .sound, .list])
-    }
-}
-
 @main
 struct BTTSWatchApp: App {
-    @WKApplicationDelegateAdaptor(WatchAppDelegate.self) private var appDelegate
     @StateObject private var model = BrewWatchModel.shared
 
     init() {

--- a/native/ios/App/BTTSWatch/BrewWatchModel.swift
+++ b/native/ios/App/BTTSWatch/BrewWatchModel.swift
@@ -1,61 +1,187 @@
 import Foundation
 import WatchConnectivity
+import WatchKit
 
 /**
- BTTS watch app — APNs push receiver.
+ BTTS watch app — runs the brew timeline locally and buzzes the wrist at each
+ step, even with the screen off / wrist down, while the iPhone is active.
 
- New model (build 13): the watch no longer runs the brew timeline. It registers
- for remote notifications, gets an APNs device token, and hands it to the phone
- over WatchConnectivity. The phone then fires one APNs push per brew step (via
- the server), and the OS buzzes the wrist — at the exact step, synced to the
- phone, with this app CLOSED. No Timer, no schedule, no HealthKit, no workout
- session: the OS owns delivery, so nothing can stall or dump a backlog.
+ WHY THIS WORKS (after several wrong turns):
+ - watchOS will NOT play `WKInterfaceDevice.play()` haptics for a backgrounded
+   app (that was build 8-11's bug), and it DELAYS notifications to the watch
+   while the phone is active (that was build 12-16, ~15 s late).
+ - The fix is a `WKExtendedRuntimeSession` of type **physical-therapy** (declared
+   in Info.plist `WKBackgroundModes`). Physical-therapy sessions RUN IN THE
+   BACKGROUND and keep the app alive, and the session's own
+   `notifyUser(hapticType:)` plays a haptic that fires wrist-down / screen-off —
+   directly on the watch, with no notification routing and no delay.
 
- This object's only job is to ship the device token to the phone (immediately
- when reachable, durably via application-context otherwise) and re-ship it if
- the session reactivates.
+ The iPhone hands over the whole step schedule (absolute epoch-ms fire times)
+ over WatchConnectivity when the brew starts (the user opens this app once at
+ brew start, so the session can be started while foreground — required). The
+ watch then runs the timeline itself: a phone↔watch hiccup can't drop a buzz.
  */
 final class BrewWatchModel: NSObject, ObservableObject {
     static let shared = BrewWatchModel()
 
-    @Published var tokenReady = false
+    struct Fire: Identifiable {
+        let id = UUID()
+        let at: Date
+        let label: String
+        var fired = false
+    }
 
-    private var session: WCSession?
-    private var pendingToken: String?
+    @Published var isBrewing = false
+    @Published var recipeName = "BTTS"
+    @Published var currentLabel = ""
+    @Published var nextLabel: String?
+    @Published var nextFireAt: Date?
+
+    private var fires: [Fire] = []
+    private var ticker: Timer?
+    private var runtimeSession: WKExtendedRuntimeSession?
 
     func activateSession() {
         guard WCSession.isSupported() else { return }
         let s = WCSession.default
         s.delegate = self
         s.activate()
-        session = s
     }
 
-    /// Called by the app delegate when APNs hands us a device token (hex string).
-    func sendToken(_ hex: String) {
-        pendingToken = hex
-        DispatchQueue.main.async { self.tokenReady = true }
-        flushToken()
+    // MARK: - Brew lifecycle
+
+    private func startBrew(recipeName: String, fires incoming: [Fire]) {
+        let now = Date()
+        let sorted = incoming.sorted { $0.at < $1.at }
+        self.fires = sorted.map { var f = $0; if $0.at <= now { f.fired = true }; return f }
+        self.recipeName = recipeName
+        self.isBrewing = true
+        self.currentLabel = "Brewing"
+        startRuntimeSession() // keeps the app alive in the background for the brew
+        startTicker()
+        refreshLabels(now: now)
     }
 
-    private func flushToken() {
-        guard let token = pendingToken, let s = session, s.activationState == .activated else { return }
-        let payload: [String: Any] = ["type": "watchToken", "token": token]
-        if s.isReachable {
-            s.sendMessage(payload, replyHandler: nil, errorHandler: nil)
+    private func endBrew() {
+        isBrewing = false
+        currentLabel = ""
+        nextLabel = nil
+        nextFireAt = nil
+        fires = []
+        ticker?.invalidate()
+        ticker = nil
+        runtimeSession?.invalidate()
+        runtimeSession = nil
+    }
+
+    // MARK: - Extended runtime session (physical-therapy → background-running)
+
+    private func startRuntimeSession() {
+        runtimeSession?.invalidate()
+        let session = WKExtendedRuntimeSession()
+        session.delegate = self
+        // Must be started while the app is foreground — it is, the user just
+        // opened the watch app at brew start.
+        session.start()
+        runtimeSession = session
+    }
+
+    // MARK: - Timeline ticker + haptics
+
+    private func startTicker() {
+        ticker?.invalidate()
+        let t = Timer(timeInterval: 0.2, repeats: true) { [weak self] _ in self?.tick() }
+        RunLoop.main.add(t, forMode: .common)
+        ticker = t
+    }
+
+    private func tick() {
+        guard isBrewing else { return }
+        let now = Date()
+        var advanced = false
+        for i in fires.indices where !fires[i].fired && fires[i].at <= now {
+            let late = now.timeIntervalSince(fires[i].at)
+            fires[i].fired = true
+            currentLabel = fires[i].label
+            advanced = true
+            // Late-skip guard: if we somehow caught up after a stall, don't dump
+            // a backlog of buzzes — only fire if this step is essentially on time.
+            if late <= 3 { buzz() }
         }
-        // Durable path: delivered to the phone whenever it next processes context.
-        try? s.updateApplicationContext(payload)
+        if advanced { refreshLabels(now: now) }
+        // Wind down a few seconds after the last step so the session doesn't
+        // hold longer than needed.
+        if let last = fires.last?.at, now.timeIntervalSince(last) > 8 {
+            endBrew()
+        }
+    }
+
+    /// The wrist cue — the SESSION's haptic, which fires in the background /
+    /// wrist-down (unlike WKInterfaceDevice.play()).
+    private func buzz() {
+        guard let s = runtimeSession, s.state == .running else { return }
+        s.notifyUser(hapticType: .notification, repeatHandler: nil)
+    }
+
+    private func refreshLabels(now: Date) {
+        if let next = fires.first(where: { !$0.fired }) {
+            nextLabel = next.label
+            nextFireAt = next.at
+        } else {
+            nextLabel = nil
+            nextFireAt = nil
+        }
+    }
+
+    // MARK: - Payload parsing
+
+    fileprivate func handle(_ payload: [String: Any]) {
+        DispatchQueue.main.async {
+            let type = payload["type"] as? String ?? ""
+            switch type {
+            case "start":
+                let name = payload["recipeName"] as? String ?? "Brew"
+                let raw = payload["fires"] as? [[String: Any]] ?? []
+                let parsed: [Fire] = raw.compactMap { dict in
+                    guard let atMs = dict["atMs"] as? Double ?? (dict["atMs"] as? NSNumber)?.doubleValue
+                    else { return nil }
+                    let label = dict["label"] as? String ?? "Next step"
+                    return Fire(at: Date(timeIntervalSince1970: atMs / 1000.0), label: label)
+                }
+                guard !parsed.isEmpty else { return }
+                self.startBrew(recipeName: name, fires: parsed)
+            case "end":
+                self.endBrew()
+            default:
+                break
+            }
+        }
     }
 }
 
+// MARK: - WCSessionDelegate
+
 extension BrewWatchModel: WCSessionDelegate {
-    func session(
-        _ session: WCSession,
-        activationDidCompleteWith state: WCSessionActivationState,
+    func session(_ session: WCSession, activationDidCompleteWith state: WCSessionActivationState, error: Error?) {}
+    func session(_ session: WCSession, didReceiveMessage message: [String: Any]) { handle(message) }
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) { handle(applicationContext) }
+}
+
+// MARK: - WKExtendedRuntimeSessionDelegate
+
+extension BrewWatchModel: WKExtendedRuntimeSessionDelegate {
+    func extendedRuntimeSessionDidStart(_ extendedRuntimeSession: WKExtendedRuntimeSession) {
+        // A confirmation tap that the wrist took over the brew.
+        extendedRuntimeSession.notifyUser(hapticType: .start, repeatHandler: nil)
+    }
+
+    func extendedRuntimeSessionWillExpire(_ extendedRuntimeSession: WKExtendedRuntimeSession) {}
+
+    func extendedRuntimeSession(
+        _ extendedRuntimeSession: WKExtendedRuntimeSession,
+        didInvalidateWith reason: WKExtendedRuntimeSessionInvalidationReason,
         error: Error?
     ) {
-        // If the token arrived before the session activated, send it now.
-        flushToken()
+        if runtimeSession === extendedRuntimeSession { runtimeSession = nil }
     }
 }

--- a/native/ios/App/BTTSWatch/ContentView.swift
+++ b/native/ios/App/BTTSWatch/ContentView.swift
@@ -1,23 +1,45 @@
 import SwiftUI
 
 /**
- Glance UI for the watch app. The wrist haptic (delivered by push) is the
- product — this screen is just a one-line reassurance. BTTS voice: pragmatic,
+ Glance UI for the watch app. The wrist haptic is the product; this screen shows
+ what's brewing + what's next when you raise your wrist. BTTS voice: pragmatic,
  no hype, no emoji.
  */
 struct ContentView: View {
     @EnvironmentObject var model: BrewWatchModel
 
     var body: some View {
-        VStack(spacing: 8) {
-            Text("BTTS")
-                .font(.headline)
-            Text("Brew on your phone. Each step buzzes your wrist — you don't need to keep this open.")
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
+        VStack(alignment: .leading, spacing: 8) {
+            if model.isBrewing {
+                Text(model.recipeName)
+                    .font(.headline)
+                    .lineLimit(1)
+                if let next = model.nextLabel, let at = model.nextFireAt {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Next")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Text(next)
+                            .font(.body)
+                            .lineLimit(2)
+                        Text(at, style: .timer)
+                            .font(.system(.title3, design: .rounded).monospacedDigit())
+                    }
+                } else {
+                    Text(model.currentLabel.isEmpty ? "Brewing" : model.currentLabel)
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Text("BTTS")
+                    .font(.headline)
+                Text("Open this at brew start — each step buzzes your wrist, screen off.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(.horizontal, 6)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 4)
     }
 }

--- a/native/ios/App/BTTSWatch/Info.plist
+++ b/native/ios/App/BTTSWatch/Info.plist
@@ -24,5 +24,9 @@
 	<true/>
 	<key>WKCompanionAppBundleIdentifier</key>
 	<string>com.roitsch.btts</string>
+	<key>WKBackgroundModes</key>
+	<array>
+		<string>physical-therapy</string>
+	</array>
 </dict>
 </plist>

--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -15,8 +15,7 @@ import { buildBrewTimeline, type BrewTimeline } from "@/lib/brew/timeline";
 import type { BrewStepAction } from "@/lib/types/session";
 import { basedOnReference } from "@/lib/utils/resolveRecipe";
 import { useBrewStepHaptics } from "@/hooks/useBrewStepHaptics";
-import { useBrewStepWatchPush } from "@/hooks/useBrewStepWatchPush";
-import { initWatchTokenRelay } from "@/lib/native/watchPush";
+import { useBrewStepWatch } from "@/hooks/useBrewStepWatch";
 import { boundariesFromTimeline } from "@/lib/native/brewNotifications";
 import { ScalePanel } from "@/components/flow/ScalePanel";
 import { useAcaiaScale } from "@/hooks/useAcaiaScale";
@@ -124,11 +123,6 @@ export default function LightStepBrew() {
     }
   }, [elapsed]);
 
-  // Relay the watch's APNs push token to the server (the build-13+ watch hands
-  // its token to the phone; we register it so per-step pushes can target the
-  // watch). No-op off the native shell.
-  useEffect(() => initWatchTokenRelay(), []);
-
   // The current timeline, in a ref, so handleDone can analyse without being
   // re-created every render (timeline is a fresh object each render).
   const timelineRef = useRef<BrewTimeline | null>(null);
@@ -200,11 +194,11 @@ export default function LightStepBrew() {
   // Live pour-flow comparison. Off the native shell / immersion / no weight yet
   // → cue "none", so the coach UI renders nothing (no-scale path unchanged).
   const coach = coachFlow(timeline, elapsed, started, scale.weight, samplesRef.current);
-  // The decisive cue on the wrist: at each step, the phone fires an APNs push to
-  // the watch (via the server) at the same instant it buzzes itself — so the
-  // watch buzzes synced to the phone, with the watch app CLOSED. Native-only
-  // no-op; the server no-ops without an APNs config / registered token.
-  useBrewStepWatchPush(boundaries, elapsed, started);
+  // Hand the whole step schedule to the paired Apple Watch at brew start; the
+  // watch app runs the timeline and buzzes the wrist per step via a
+  // physical-therapy extended-runtime session (fires screen-off / wrist-down,
+  // directly on the watch — no notification delay). Native-only no-op.
+  useBrewStepWatch(boundaries, elapsed, started, recipeName ?? "Brew");
 
   return (
     <LightFlowShell

--- a/src/hooks/useBrewStepWatch.ts
+++ b/src/hooks/useBrewStepWatch.ts
@@ -1,0 +1,60 @@
+"use client";
+import { useEffect, useRef } from "react";
+import { type BrewBoundary } from "@/lib/native/brewNotifications";
+import { startBrewOnWatch, endBrewOnWatch, isNativeWatch } from "@/lib/native/brewWatch";
+
+/**
+ * Hand the whole step schedule to the paired Apple Watch at brew start, so the
+ * watch app runs the timeline itself and buzzes the wrist per step (even with
+ * the iPhone screen on). We send ONCE at start (not per step), so a phone↔watch
+ * hiccup can't drop a single buzz — the watch holds every fire time.
+ *
+ * Resends only if the wall-clock anchor drifts > 1.5 s (a Stop→Resume or
+ * visibilitychange snap). Ends the brew on the watch on Reset and on unmount.
+ * Native-shell-only; a clean no-op in the browser.
+ */
+export function useBrewStepWatch(
+  boundaries: BrewBoundary[],
+  elapsed: number,
+  started: boolean,
+  recipeName: string,
+): void {
+  const boundariesRef = useRef(boundaries);
+  const recipeNameRef = useRef(recipeName);
+  useEffect(() => {
+    boundariesRef.current = boundaries;
+    recipeNameRef.current = recipeName;
+  }, [boundaries, recipeName]);
+
+  const sentAnchorRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!isNativeWatch()) return;
+
+    // Reset → tell the watch to stop and clear our anchor.
+    if (!started || elapsed === 0) {
+      if (sentAnchorRef.current !== null) {
+        sentAnchorRef.current = null;
+        endBrewOnWatch();
+      }
+      return;
+    }
+    if (elapsed < 1) return;
+
+    const impliedStartMs = Date.now() - elapsed * 1000;
+    if (
+      sentAnchorRef.current === null ||
+      Math.abs(impliedStartMs - sentAnchorRef.current) > 1500
+    ) {
+      sentAnchorRef.current = impliedStartMs;
+      startBrewOnWatch(boundariesRef.current, impliedStartMs, recipeNameRef.current);
+    }
+  }, [elapsed, started, boundaries]);
+
+  // End the brew on the watch if the screen unmounts mid-brew.
+  useEffect(() => {
+    return () => {
+      if (isNativeWatch()) endBrewOnWatch();
+    };
+  }, []);
+}

--- a/src/lib/native/brewWatch.ts
+++ b/src/lib/native/brewWatch.ts
@@ -1,0 +1,72 @@
+/**
+ * Brew-step Apple Watch bridge — hands the whole step schedule to the watch at
+ * brew start, so the watch app runs the timeline locally and buzzes the wrist
+ * at each step (via a physical-therapy extended-runtime session — the only thing
+ * that buzzes the wrist while the iPhone screen is ON during a wake-locked brew).
+ *
+ * Absolute epoch-ms fire times mean a slightly-late delivery self-corrects: the
+ * watch schedules `atMs - Date.now()` for each remaining boundary and drops any
+ * already in the past.
+ *
+ * Pure-web module, ZERO `@capacitor/*` imports (ambient types only). Off the
+ * native shell every export is a silent no-op.
+ */
+import type { BrewBoundary } from "@/lib/native/brewNotifications";
+
+export interface WatchFire {
+  /** Epoch milliseconds at which the watch should buzz. */
+  atMs: number;
+  /** Short label shown on the watch face for this step. */
+  label: string;
+}
+
+interface BrewWatchPluginLike {
+  startBrew(options: { recipeName: string; fires: WatchFire[] }): Promise<void>;
+  endBrew(): Promise<void>;
+}
+
+interface CapacitorLike {
+  isNativePlatform?: () => boolean;
+  Plugins?: { BrewWatch?: BrewWatchPluginLike };
+}
+
+function getPlugin(): BrewWatchPluginLike | null {
+  try {
+    if (typeof window === "undefined") return null;
+    const cap = (window as unknown as { Capacitor?: CapacitorLike }).Capacitor;
+    if (!cap?.isNativePlatform?.()) return null;
+    return cap.Plugins?.BrewWatch ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** True only inside the Capacitor shell with the BrewWatch plugin present. */
+export function isNativeWatch(): boolean {
+  return getPlugin() !== null;
+}
+
+/** Convert the brew's relative-second boundaries into absolute epoch-ms fires. */
+export function boundariesToFires(boundaries: BrewBoundary[], startedAtMs: number): WatchFire[] {
+  return boundaries.map((b) => ({ atMs: startedAtMs + Math.round(b.atSec * 1000), label: b.title }));
+}
+
+/** Hand the watch the full schedule at brew start. No-op off the native shell. */
+export function startBrewOnWatch(
+  boundaries: BrewBoundary[],
+  startedAtMs: number,
+  recipeName: string,
+): void {
+  const plugin = getPlugin();
+  if (!plugin) return;
+  const fires = boundariesToFires(boundaries, startedAtMs);
+  if (fires.length === 0) return;
+  void plugin.startBrew({ recipeName, fires }).catch(() => {});
+}
+
+/** Tell the watch the brew ended / reset. No-op off the native shell. */
+export function endBrewOnWatch(): void {
+  const plugin = getPlugin();
+  if (!plugin) return;
+  void plugin.endBrew().catch(() => {});
+}


### PR DESCRIPTION
The real fix: watch buzzes via a physical-therapy WKExtendedRuntimeSession + notifyUser(hapticType:) — fires screen-off/wrist-down directly on the watch (no notification delay). Reverts the APNs path to the WCSession schedule handoff. Build 17.