### PR TITLE
fix: use the spec'd 80-char limit, drop the arbitrary 55 target

### DIFF
--- a/docs/loading-insights.md
+++ b/docs/loading-insights.md
@@ -28,11 +28,12 @@ Every candidate line, from every source, must clear **both**:
 
 Only survivors of both are written.
 
-**Length is generated short, not just enforced.** The generation prompts target ~55 chars / ≤12
-words (well under the 80-char cap) with worked examples, so lines arrive short. A line that fails
-the gate on **length only** isn't thrown away — a **repair pass** (one extra call) tightens it and
-re-runs it through the full gate (grounding included). This stops the wasteful "generate long →
-kill for length" loop; the 80-char gate is the final backstop, not the primary filter.
+**Length handling.** The generation prompts state the spec — **≤ 80 characters / ≤ 15 words, use the
+space** — with worked examples (one short, one at the 80-char max). A line that fails the gate on
+**length only** isn't thrown away — a **repair pass** (one extra call) tightens it back to ≤ 80
+(only as much as needed, not shorter) and re-runs it through the full gate (grounding included).
+This stops the wasteful "generate long → kill for length" loop; the 80-char gate is the final
+backstop, not the primary filter.
 
 ---
 

--- a/src/app/api/loading-insights/refresh/route.ts
+++ b/src/app/api/loading-insights/refresh/route.ts
@@ -34,13 +34,9 @@ const GEN_SYSTEM = `You write ONE short coffee insight per snippet for a loading
 
 VOICE (BTTS): a knowledgeable friend talking about coffee. Editorial, pragmatic, plain. No hype, no emoji, no exclamation marks, no "did you know", no second-person command ("try…", "you should…"). State the thing.
 
-LENGTH IS A HARD CONSTRAINT — it renders as one short headline:
-- Aim for 6–11 words, about 55 characters. NEVER exceed 80 characters or 15 words.
-- One short clause. Cut every filler word. If it won't fit, narrow the FACT — never summarise the whole snippet.
-- Right length:
+LENGTH: ≤ 80 characters and ≤ 15 words — one clause. Use the space; the only hard rule is never exceed 80. State one fact, not a summary of the snippet. Both of these fit fine:
   "Coffee is a fruit; the bean is its seed."
-  "Naturals dry inside the cherry, so they taste fruitier."
-  "Swirl, don't stir — it moves the bed without churning fines."
+  "Swirl the slurry instead of stirring — it levels the bed without churning fines."
 
 GROUNDING — a no-fabrication guarantee depends on this:
 - Restate a fact found IN ITS SNIPPET. Add nothing the snippet does not say. If a snippet yields no clean, true, SHORT line, OMIT it.
@@ -53,7 +49,7 @@ const CHECK_SYSTEM = `For each numbered pair, decide whether the CLAIM is fully 
 
 Return ONLY a JSON array of booleans in order, e.g. [true,false,true]. No prose.`;
 
-const REPAIR_SYSTEM = `Each line below is a coffee insight that is slightly too long for an 80-character headline. Rewrite each to AT MOST 70 characters and 12 words, keeping the SAME fact — cut filler words, not meaning. Add nothing new. No emoji, no exclamation marks.
+const REPAIR_SYSTEM = `Each line below is a coffee insight that is a little over the 80-character headline limit. Rewrite each to AT MOST 80 characters and 15 words, keeping the SAME fact — cut only what's needed to fit, don't make it shorter than necessary. Add nothing new. No emoji, no exclamation marks.
 
 Return ONLY a JSON array: [{"n": <number>, "text": "<shortened line>"}]. Omit any you cannot shorten without losing the fact.`;
 
@@ -63,10 +59,7 @@ VOICE (BTTS): a knowledgeable friend talking about coffee. Editorial, plain. No 
 
 Use web search to find real, current material from reputable sources (specialty roasters, James Hoffmann, Barista Hustle, competition pages, coffee-science writers). For EACH insight you propose you MUST attach a VERBATIM quote from a source you actually found that supports it, plus that source's url.
 
-LENGTH IS A HARD CONSTRAINT — it renders as one 40px headline:
-- Aim for 6–11 words, about 55 characters. NEVER exceed 80 characters or 15 words.
-- One short clause; cut every filler word. Narrow the fact rather than summarising.
-- Right length: "Naturals dry inside the cherry, so they taste fruitier." / "Swirl, don't stir — it moves the bed without churning fines."
+LENGTH: ≤ 80 characters and ≤ 15 words — one clause. Use the space; the only hard rule is never exceed 80. State one fact, not a summary. Both fit fine: "Coffee is a fruit; the bean is its seed." / "Swirl the slurry instead of stirring — it levels the bed without churning fines."
 
 GROUNDING — a no-fabrication guarantee depends on these:
 - The line must restate a fact contained IN ITS QUOTE. Add nothing the quote does not say.


### PR DESCRIPTION
Reverts the unasked-for lower target. The spec is **max 80 characters** — the previous change set the generation target to ~55 and the repair pass to ≤70, which squeezed insights shorter than allowed. Nobody asked for that.

Now it's exactly the spec:
- Generation prompts: **≤ 80 characters / ≤ 15 words, use the space** — with an example at the 80-char max so the model knows the full budget is fine.
- Repair pass: tightens an over-limit line back to **≤ 80** only as much as needed (not shorter than necessary).
- Gate unchanged (80 cap).

`tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZNfMwtADeQtoGqZtyhtgR)_