### PR TITLE
fix(watch): robust phone→watch handoff + on-watch diagnostic (build 18)

### DIFF
--- a/native/ios/App/App/BrewWatchPlugin.swift
+++ b/native/ios/App/App/BrewWatchPlugin.swift
@@ -1,20 +1,25 @@
 import Foundation
 import Capacitor
 import WatchConnectivity
+import os
+
+private let plog = Logger(subsystem: "com.roitsch.btts", category: "brewwatch")
 
 /**
  BrewWatch — phone-side bridge from the WKWebView (JS) to the Apple Watch app.
 
- The web layer (`src/lib/native/brewWatch.ts`) calls `startBrew` once when a
- brew's timer hits zero, handing over the WHOLE step schedule as absolute
- epoch-ms fire times. We forward it to the watch over WatchConnectivity; the
- watch app runs the timeline itself and buzzes the wrist at each step via a
- physical-therapy extended-runtime session (the only thing that buzzes the wrist
- while the iPhone screen is ON).
+ The web layer (`src/lib/native/brewWatch.ts`) calls `startBrew` repeatedly
+ (every ~3 s) during a brew, handing over the WHOLE step schedule as absolute
+ epoch-ms fire times plus a stable `brewId`. We forward it to the watch over
+ WatchConnectivity; the watch app runs the timeline itself and buzzes the wrist
+ at each step via a physical-therapy extended-runtime session (the only thing
+ that buzzes the wrist while the iPhone screen is ON).
 
- Delivery: `sendMessage` for immediacy when the watch app is reachable
- (foreground — it is, the user opened it at brew start), plus
- `updateApplicationContext` as a durable fallback.
+ Delivery (build 18): `sendMessage` for immediacy when the watch app is
+ reachable, PLUS `transferUserInfo` (a durable FIFO queue that delivers even
+ when the watch app is backgrounded) AND `updateApplicationContext` (latest
+ state on next launch). The watch dedupes on `brewId`, so the periodic re-send
+ is free — whenever the watch next becomes reachable it picks the brew up.
  */
 @objc(BrewWatchPlugin)
 public class BrewWatchPlugin: CAPPlugin, CAPBridgedPlugin {
@@ -33,11 +38,13 @@ public class BrewWatchPlugin: CAPPlugin, CAPBridgedPlugin {
         s.delegate = WatchSessionForwarder.shared
         s.activate()
         session = s
+        plog.log("plugin load() — WCSession activate()")
     }
 
     @objc func startBrew(_ call: CAPPluginCall) {
         guard WCSession.isSupported() else { call.resolve(); return }
         let recipeName = call.getString("recipeName") ?? "Brew"
+        let brewId = call.getDouble("brewId") ?? 0
         let firesIn = call.getArray("fires", JSObject.self) ?? []
         var fires: [[String: Any]] = []
         for f in firesIn {
@@ -45,7 +52,7 @@ public class BrewWatchPlugin: CAPPlugin, CAPBridgedPlugin {
             let label = f["label"] as? String ?? "Next step"
             fires.append(["atMs": atMs, "label": label])
         }
-        send(["type": "start", "recipeName": recipeName, "fires": fires])
+        send(["type": "start", "recipeName": recipeName, "brewId": brewId, "fires": fires])
         call.resolve()
     }
 
@@ -55,10 +62,21 @@ public class BrewWatchPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     private func send(_ payload: [String: Any]) {
-        guard let s = session, s.activationState == .activated else { return }
-        if s.isReachable {
-            s.sendMessage(payload, replyHandler: nil, errorHandler: nil)
+        guard let s = session, s.activationState == .activated else {
+            plog.error("send skipped — session not activated")
+            return
         }
+        let reach = s.isReachable
+        let paired = s.isPaired
+        let installed = s.isWatchAppInstalled
+        plog.log("send type=\(payload["type"] as? String ?? "?", privacy: .public) reachable=\(reach) paired=\(paired) installed=\(installed)")
+        if reach {
+            s.sendMessage(payload, replyHandler: nil) { err in
+                plog.error("sendMessage failed: \(err.localizedDescription, privacy: .public)")
+            }
+        }
+        // Durable queue — delivers even when the watch app is backgrounded.
+        s.transferUserInfo(payload)
         try? s.updateApplicationContext(payload)
     }
 }
@@ -69,7 +87,9 @@ public class BrewWatchPlugin: CAPPlugin, CAPBridgedPlugin {
  */
 final class WatchSessionForwarder: NSObject, WCSessionDelegate {
     static let shared = WatchSessionForwarder()
-    func session(_ session: WCSession, activationDidCompleteWith state: WCSessionActivationState, error: Error?) {}
+    func session(_ session: WCSession, activationDidCompleteWith state: WCSessionActivationState, error: Error?) {
+        plog.log("phone activationDidComplete state=\(state.rawValue) paired=\(session.isPaired) installed=\(session.isWatchAppInstalled)")
+    }
     func sessionDidBecomeInactive(_ session: WCSession) {}
     func sessionDidDeactivate(_ session: WCSession) { session.activate() }
 }

--- a/native/ios/App/BTTSWatch/BrewWatchModel.swift
+++ b/native/ios/App/BTTSWatch/BrewWatchModel.swift
@@ -1,6 +1,9 @@
 import Foundation
 import WatchConnectivity
 import WatchKit
+import os
+
+private let wlog = Logger(subsystem: "com.roitsch.btts.watchkitapp", category: "brewwatch")
 
 /**
  BTTS watch app — runs the brew timeline locally and buzzes the wrist at each
@@ -16,10 +19,13 @@ import WatchKit
    `notifyUser(hapticType:)` plays a haptic that fires wrist-down / screen-off —
    directly on the watch, with no notification routing and no delay.
 
- The iPhone hands over the whole step schedule (absolute epoch-ms fire times)
- over WatchConnectivity when the brew starts (the user opens this app once at
- brew start, so the session can be started while foreground — required). The
- watch then runs the timeline itself: a phone↔watch hiccup can't drop a buzz.
+ DELIVERY (build 18 hardening): the iPhone re-sends the whole schedule every ~3 s
+ while the brew runs, over BOTH `sendMessage` (when reachable) and
+ `transferUserInfo`/`updateApplicationContext` (durable). The schedule carries a
+ stable `brewId` so a re-send while already running is ignored (no session
+ restart). On launch we also drain any context that arrived before activation.
+ So a single missed reachability window can no longer drop the brew — whenever
+ the watch app next becomes reachable it picks the schedule up and starts.
  */
 final class BrewWatchModel: NSObject, ObservableObject {
     static let shared = BrewWatchModel()
@@ -37,26 +43,43 @@ final class BrewWatchModel: NSObject, ObservableObject {
     @Published var nextLabel: String?
     @Published var nextFireAt: Date?
 
+    // Visible diagnostics (read off the watch face when idle).
+    @Published var wcState = "—"
+    @Published var reachable = false
+    @Published var msgCount = 0
+    @Published var lastFires = 0
+    @Published var lastEvent = "none"
+
     private var fires: [Fire] = []
     private var ticker: Timer?
     private var runtimeSession: WKExtendedRuntimeSession?
+    private var currentBrewId: Double = 0
 
     func activateSession() {
-        guard WCSession.isSupported() else { return }
+        guard WCSession.isSupported() else { wlog.error("WCSession unsupported"); return }
         let s = WCSession.default
         s.delegate = self
         s.activate()
+        wlog.log("activate() called")
     }
 
     // MARK: - Brew lifecycle
 
-    private func startBrew(recipeName: String, fires incoming: [Fire]) {
+    private func startBrew(brewId: Double, recipeName: String, fires incoming: [Fire]) {
+        // Idempotent re-send guard: same brew already running → ignore.
+        if isBrewing && brewId == currentBrewId {
+            wlog.log("duplicate start ignored brewId=\(brewId, privacy: .public)")
+            return
+        }
         let now = Date()
+        currentBrewId = brewId
         let sorted = incoming.sorted { $0.at < $1.at }
         self.fires = sorted.map { var f = $0; if $0.at <= now { f.fired = true }; return f }
         self.recipeName = recipeName
         self.isBrewing = true
         self.currentLabel = "Brewing"
+        self.lastEvent = "start \(self.fires.count)"
+        wlog.log("startBrew name=\(recipeName, privacy: .public) fires=\(self.fires.count) brewId=\(brewId, privacy: .public)")
         startRuntimeSession() // keeps the app alive in the background for the brew
         startTicker()
         refreshLabels(now: now)
@@ -68,10 +91,13 @@ final class BrewWatchModel: NSObject, ObservableObject {
         nextLabel = nil
         nextFireAt = nil
         fires = []
+        currentBrewId = 0
+        lastEvent = "end"
         ticker?.invalidate()
         ticker = nil
         runtimeSession?.invalidate()
         runtimeSession = nil
+        wlog.log("endBrew")
     }
 
     // MARK: - Extended runtime session (physical-therapy → background-running)
@@ -84,6 +110,7 @@ final class BrewWatchModel: NSObject, ObservableObject {
         // opened the watch app at brew start.
         session.start()
         runtimeSession = session
+        wlog.log("runtime session start() requested")
     }
 
     // MARK: - Timeline ticker + haptics
@@ -119,8 +146,12 @@ final class BrewWatchModel: NSObject, ObservableObject {
     /// The wrist cue — the SESSION's haptic, which fires in the background /
     /// wrist-down (unlike WKInterfaceDevice.play()).
     private func buzz() {
-        guard let s = runtimeSession, s.state == .running else { return }
+        guard let s = runtimeSession, s.state == .running else {
+            wlog.error("buzz skipped — session not running")
+            return
+        }
         s.notifyUser(hapticType: .notification, repeatHandler: nil)
+        wlog.log("BUZZ")
     }
 
     private func refreshLabels(now: Date) {
@@ -135,12 +166,16 @@ final class BrewWatchModel: NSObject, ObservableObject {
 
     // MARK: - Payload parsing
 
-    fileprivate func handle(_ payload: [String: Any]) {
+    fileprivate func handle(_ payload: [String: Any], via source: String) {
         DispatchQueue.main.async {
+            self.msgCount += 1
+            self.lastEvent = "rx:\(source)"
             let type = payload["type"] as? String ?? ""
+            wlog.log("rx \(source, privacy: .public) type=\(type, privacy: .public)")
             switch type {
             case "start":
                 let name = payload["recipeName"] as? String ?? "Brew"
+                let brewId = (payload["brewId"] as? Double) ?? (payload["brewId"] as? NSNumber)?.doubleValue ?? 0
                 let raw = payload["fires"] as? [[String: Any]] ?? []
                 let parsed: [Fire] = raw.compactMap { dict in
                     guard let atMs = dict["atMs"] as? Double ?? (dict["atMs"] as? NSNumber)?.doubleValue
@@ -148,8 +183,9 @@ final class BrewWatchModel: NSObject, ObservableObject {
                     let label = dict["label"] as? String ?? "Next step"
                     return Fire(at: Date(timeIntervalSince1970: atMs / 1000.0), label: label)
                 }
-                guard !parsed.isEmpty else { return }
-                self.startBrew(recipeName: name, fires: parsed)
+                self.lastFires = parsed.count
+                guard !parsed.isEmpty else { wlog.error("start with 0 fires"); return }
+                self.startBrew(brewId: brewId, recipeName: name, fires: parsed)
             case "end":
                 self.endBrew()
             default:
@@ -162,9 +198,23 @@ final class BrewWatchModel: NSObject, ObservableObject {
 // MARK: - WCSessionDelegate
 
 extension BrewWatchModel: WCSessionDelegate {
-    func session(_ session: WCSession, activationDidCompleteWith state: WCSessionActivationState, error: Error?) {}
-    func session(_ session: WCSession, didReceiveMessage message: [String: Any]) { handle(message) }
-    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) { handle(applicationContext) }
+    func session(_ session: WCSession, activationDidCompleteWith state: WCSessionActivationState, error: Error?) {
+        DispatchQueue.main.async {
+            self.wcState = state == .activated ? "active" : "inactive(\(state.rawValue))"
+            self.reachable = session.isReachable
+            wlog.log("activationDidComplete state=\(state.rawValue) reachable=\(session.isReachable)")
+            // Drain any application context that arrived before we activated.
+            let ctx = session.receivedApplicationContext
+            if !ctx.isEmpty { self.handle(ctx, via: "ctx@launch") }
+        }
+    }
+    func sessionReachabilityDidChange(_ session: WCSession) {
+        DispatchQueue.main.async { self.reachable = session.isReachable }
+        wlog.log("reachability=\(session.isReachable)")
+    }
+    func session(_ session: WCSession, didReceiveMessage message: [String: Any]) { handle(message, via: "msg") }
+    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) { handle(applicationContext, via: "ctx") }
+    func session(_ session: WCSession, didReceiveUserInfo userInfo: [String: Any]) { handle(userInfo, via: "userInfo") }
 }
 
 // MARK: - WKExtendedRuntimeSessionDelegate
@@ -172,16 +222,20 @@ extension BrewWatchModel: WCSessionDelegate {
 extension BrewWatchModel: WKExtendedRuntimeSessionDelegate {
     func extendedRuntimeSessionDidStart(_ extendedRuntimeSession: WKExtendedRuntimeSession) {
         // A confirmation tap that the wrist took over the brew.
+        wlog.log("runtime session DID START")
         extendedRuntimeSession.notifyUser(hapticType: .start, repeatHandler: nil)
     }
 
-    func extendedRuntimeSessionWillExpire(_ extendedRuntimeSession: WKExtendedRuntimeSession) {}
+    func extendedRuntimeSessionWillExpire(_ extendedRuntimeSession: WKExtendedRuntimeSession) {
+        wlog.log("runtime session WILL EXPIRE")
+    }
 
     func extendedRuntimeSession(
         _ extendedRuntimeSession: WKExtendedRuntimeSession,
         didInvalidateWith reason: WKExtendedRuntimeSessionInvalidationReason,
         error: Error?
     ) {
+        wlog.error("runtime session invalidated reason=\(reason.rawValue) err=\(String(describing: error), privacy: .public)")
         if runtimeSession === extendedRuntimeSession { runtimeSession = nil }
     }
 }

--- a/native/ios/App/BTTSWatch/ContentView.swift
+++ b/native/ios/App/BTTSWatch/ContentView.swift
@@ -36,6 +36,12 @@ struct ContentView: View {
                 Text("Open this at brew start — each step buzzes your wrist, screen off.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
+                // Diagnostic line (build 18) — read this off the watch if a brew
+                // doesn't show up here. Remove once the handoff is confirmed.
+                Text("WC \(model.wcState) · reach \(model.reachable ? "Y" : "N") · rx \(model.msgCount) · fires \(model.lastFires) · \(model.lastEvent)")
+                    .font(.system(size: 11).monospaced())
+                    .foregroundStyle(.tertiary)
+                    .padding(.top, 4)
             }
             Spacer(minLength: 0)
         }

--- a/src/hooks/useBrewStepWatch.ts
+++ b/src/hooks/useBrewStepWatch.ts
@@ -4,13 +4,19 @@ import { type BrewBoundary } from "@/lib/native/brewNotifications";
 import { startBrewOnWatch, endBrewOnWatch, isNativeWatch } from "@/lib/native/brewWatch";
 
 /**
- * Hand the whole step schedule to the paired Apple Watch at brew start, so the
- * watch app runs the timeline itself and buzzes the wrist per step (even with
- * the iPhone screen on). We send ONCE at start (not per step), so a phone↔watch
- * hiccup can't drop a single buzz — the watch holds every fire time.
+ * Hand the whole step schedule to the paired Apple Watch, so the watch app runs
+ * the timeline itself and buzzes the wrist per step (even with the iPhone screen
+ * on). The schedule carries a stable brewId (the wall-clock anchor); the watch
+ * dedupes on it, so we can RE-SEND safely.
  *
- * Resends only if the wall-clock anchor drifts > 1.5 s (a Stop→Resume or
- * visibilitychange snap). Ends the brew on the watch on Reset and on unmount.
+ * We re-send every ~3 s for the whole brew (build 18): the watch app may not be
+ * reachable at the exact instant the brew starts (screen off / wrist down), and
+ * a single send would then be lost. Re-sending means the watch picks the brew up
+ * the moment it next becomes reachable — and the brewId dedupe stops the re-send
+ * from ever restarting an already-running brew.
+ *
+ * A wall-clock anchor drift > 1.5 s (Stop→Resume / visibilitychange snap) starts
+ * a fresh brewId. Ends the brew on the watch on Reset and on unmount.
  * Native-shell-only; a clean no-op in the browser.
  */
 export function useBrewStepWatch(
@@ -27,6 +33,7 @@ export function useBrewStepWatch(
   }, [boundaries, recipeName]);
 
   const sentAnchorRef = useRef<number | null>(null);
+  const lastSendMsRef = useRef(0);
 
   useEffect(() => {
     if (!isNativeWatch()) return;
@@ -35,19 +42,27 @@ export function useBrewStepWatch(
     if (!started || elapsed === 0) {
       if (sentAnchorRef.current !== null) {
         sentAnchorRef.current = null;
+        lastSendMsRef.current = 0;
         endBrewOnWatch();
       }
       return;
     }
     if (elapsed < 1) return;
 
-    const impliedStartMs = Date.now() - elapsed * 1000;
-    if (
+    const now = Date.now();
+    const impliedStartMs = now - elapsed * 1000;
+    const isNewBrew =
       sentAnchorRef.current === null ||
-      Math.abs(impliedStartMs - sentAnchorRef.current) > 1500
-    ) {
+      Math.abs(impliedStartMs - sentAnchorRef.current) > 1500;
+
+    if (isNewBrew) {
       sentAnchorRef.current = impliedStartMs;
-      startBrewOnWatch(boundariesRef.current, impliedStartMs, recipeNameRef.current);
+    }
+    // Send on a new brew, and re-send every ~3 s on the SAME stable anchor so a
+    // missed reachability window recovers (the watch dedupes on the anchor).
+    if (isNewBrew || now - lastSendMsRef.current > 3000) {
+      lastSendMsRef.current = now;
+      startBrewOnWatch(boundariesRef.current, sentAnchorRef.current!, recipeNameRef.current);
     }
   }, [elapsed, started, boundaries]);
 

--- a/src/lib/native/brewWatch.ts
+++ b/src/lib/native/brewWatch.ts
@@ -21,7 +21,7 @@ export interface WatchFire {
 }
 
 interface BrewWatchPluginLike {
-  startBrew(options: { recipeName: string; fires: WatchFire[] }): Promise<void>;
+  startBrew(options: { recipeName: string; brewId: number; fires: WatchFire[] }): Promise<void>;
   endBrew(): Promise<void>;
 }
 
@@ -61,7 +61,9 @@ export function startBrewOnWatch(
   if (!plugin) return;
   const fires = boundariesToFires(boundaries, startedAtMs);
   if (fires.length === 0) return;
-  void plugin.startBrew({ recipeName, fires }).catch(() => {});
+  // startedAtMs doubles as the stable brewId — the watch dedupes on it, so the
+  // periodic re-send from the hook never restarts an already-running brew.
+  void plugin.startBrew({ recipeName, brewId: startedAtMs, fires }).catch(() => {});
 }
 
 /** Tell the watch the brew ended / reset. No-op off the native shell. */


### PR DESCRIPTION
Build 17 never reached the watch (single send lost when the watch wasn't reachable). Build 18: re-send every ~3s + transferUserInfo + brewId dedupe + on-watch status line + os.Logger instrumentation.