### PR TITLE
feat(widget): native half — WidgetKit medium widget + WidgetBridge + btts:// scheme (G2)

### DIFF
--- a/docs/ios-shell-roadmap.md
+++ b/docs/ios-shell-roadmap.md
@@ -124,11 +124,21 @@ Each milestone is independently shippable on the v1 shell. Two infrastructure tr
 - **What it buys in the brew flow:** live grams + flow rate on the timer screen, tare from the app, auto-log final dose/water into the session, optional pour auto-advance from rate-of-change (manual tap stays).
 - **Residual risk:** iOS connection-timing quirks (Beanconqueror has two iOS connection modes + magic 150 ms sleeps for a reason) and scale auto-sleep. First step is a one-evening on-device spike: shell + plugin + verbatim decoder, confirm weight events stream from the Lunar.
 
-### G2 — Home-screen widget (2–3 days; validates the extension pipeline)
+### G2 — Home-screen widget (🟡 CODE COMPLETE 2026-06-17, awaiting one Apple-side prereq + a Mac build)
 
-- The deliberately-easy first extension milestone: a small SwiftUI timeline widget showing rotation bags / last brew, fetching a tiny authenticated JSON endpoint directly via URLSession from the widget process (Apple-documented pattern — no bridge plugin needed). Needs a long-lived token endpoint since the session cookie lives in WKWebView.
-- Refresh budget ~40–70/day — generous for data that changes a few times a day.
-- **One-time shared cost it pays down:** adding a widget-extension target to the committed Xcode project without a Mac — **primary path: one-time generation on a runner or XcodeGen; a scripted pbxproj edit is the fragile option, last resort only** (decide for real in the G2 session) — own bundle id (`com.roitsch.btts.widgets`), and cloud signing for multi-target archives (`-allowProvisioningUpdates` handles extensions automatically — verified, with known-but-solvable CI config friction). Everything G3 needs, de-risked on the simplest possible extension.
+**Scope (owner-decided, deliberately tight):** ONE **medium** home-screen widget, two functions only — **rotation bags → tap-to-brew** and **scan a bag**. Explicitly NOT: last-brew (owner: "sucks"), freshness, coach, greeting, lock-screen, small/other sizes. Text-only tiles in v1 (photos deferred).
+
+**Data path (decided — App Group, NOT a URLSession-fetch widget):** the original plan was a widget that fetches an authenticated JSON endpoint (needs a long-lived token). Dropped in favour of an **App Group shared store**: the app, on open, pushes the in-rotation coffees to a custom `WidgetBridge` Capacitor plugin → `UserDefaults(suiteName: "group.com.roitsch.btts")` + `WidgetCenter.reloadAllTimelines()`. No token, no auth surface, no network in the widget. Rotation changes rarely and the user opens the app to brew anyway, so app-run-gated freshness is fine.
+
+**Extension-target-without-a-Mac-GUI:** the roadmap fretted over this ("runner generation / XcodeGen / fragile pbxproj edit"). It was already solved by the watch — `native/scripts/add_widget_target.rb` is a direct sibling of `add_watch_target.rb` (the `xcodeproj` gem), idempotent, run after `cap sync` + the watch script. Bundle id `com.roitsch.btts.BTTSWidget`.
+
+**What's built:**
+- *Web (PR #365, merged/feature-detected, inert off the shell):* `widgetDeepLinks.ts` (handles `btts://brew?coffeeId=X` → `startBrewAgain` → Context; `btts://scan` → reset → `/brew/new`; pure `parseWidgetUrl` unit-tested), `widgetBridge.ts` (push rotation to the App Group via the `WidgetBridge` plugin), `NativeWidgetBridge` mounted in `LightShell` (deep-link listener + tile refresh on open). Test: `tests/dataflow/widget-deeplinks.test.mjs`.
+- *Native (this PR):* `@capacitor/app` added to the shell (delivers `appUrlOpen`; AppDelegate already forwards `open url` to the Capacitor proxy), `btts` scheme in `Info.plist` (CFBundleURLTypes), `WidgetBridge.swift` + registration in `MainViewController`, the WidgetKit extension (`BTTSWidget/BTTSWidget.swift` medium widget + `Info.plist` + `BTTSWidget.entitlements`), App Group entitlement on the App (`App/App.entitlements`), `add_widget_target.rb`, and the `mac-build-upload.sh` step.
+
+**THE ONE APPLE-SIDE PREREQ before the build (App Groups can't be cloud-auto-created reliably):** in the Apple Developer portal (browser, iPhone-OK) → Certificates, IDs & Profiles → **Identifiers → App Groups → register `group.com.roitsch.btts`**; then edit App ID **`com.roitsch.btts` → App Groups capability → tick that group**. The widget App ID `com.roitsch.btts.BTTSWidget` is auto-created by `-allowProvisioningUpdates` during the build and automatic signing assigns the existing group to it. If the build fails on the widget's app-group entitlement, enable App Groups on that auto-created widget App ID too and re-run. (Same capability-enablement pattern as push/HealthKit, which the ASC Admin key can also script if preferred.)
+
+**Then:** `native/scripts/mac-build-upload.sh <N>` (now runs both target scripts) → install → add the BTTS medium widget to the home screen → tap a rotation tile (lands in Context) / tap Scan (opens the scanner). Expect a possible build-iteration on first run (extension signing / app-group, like the watch).
 
 ### G3 — Live Activity brew timer (3–5 days on top of G2)
 
@@ -482,3 +492,14 @@ The p12 was built from the on-disk `/tmp/dist.key` + `/tmp/dist.cer` (cert valid
 - **Traps found:** App-Manager-vs-Admin key on cloud-sign export; `macos-15` Xcode-16 vs Apple's iOS-26-SDK mandate (both in Stolperstein log).
 - **Next entry-point:** G1 Acaia on-device BLE spike. The monthly rebuild is hands-off now.
 - **PRs / commits this session:** #360 (lovable + park iOS CI), #361 (orphaned APNs test), #362 (CI automation), #363 (macos-26).
+
+### 2026-06-17 — G1 marked done; G2 widget built (web + native, code complete)
+- **Done (housekeeping):** owner confirmed **G1 Acaia works on-device** ("works brilliantly") — marked DONE & verified across the Status section + memory; it is NOT pending, stop re-proposing the spike.
+- **Done (G2 widget — owner picked it as the next track, scope locked to a MEDIUM widget with exactly two functions: rotation→brew + scan; explicitly no last-brew/freshness/coach/greeting/lock-screen).**
+  - **Web (PR #365):** `src/lib/native/widgetDeepLinks.ts` (`btts://brew?coffeeId=X` → `startBrewAgain` → Context; `btts://scan` → reset → `/brew/new`; pure `parseWidgetUrl`), `src/lib/native/widgetBridge.ts` (push rotation to the App Group via the app-local `WidgetBridge` plugin), `NativeWidgetBridge` in `LightShell`. `tests/dataflow/widget-deeplinks.test.mjs` (8 cases). tsc + test green. Feature-detected → inert on the Safari PWA.
+  - **Native (this PR):** `@capacitor/app` in the shell; `btts` URL scheme in `Info.plist`; `WidgetBridge.swift` + registration in `MainViewController`; the WidgetKit extension `BTTSWidget/` (medium SwiftUI widget reading the App Group, tap-to-brew tiles + Scan, Light cream/anthracite palette); App Group entitlement on the app (`App/App.entitlements`) + widget; `add_widget_target.rb` (sibling of the watch script, idempotent); `mac-build-upload.sh` runs it. Ruby syntax + all plists validated locally; Swift/widget NOT compile-tested (no Mac).
+  - **Decisions:** App Group shared store (not a token-authed URLSession-fetch widget) — no auth surface; the watch's `xcodeproj`-gem approach already solved "add an extension target without a Mac GUI."
+- **Open / blocked:** ONE Apple-side prereq before the build — register App Group `group.com.roitsch.btts` + enable App Groups on App ID `com.roitsch.btts` (portal, browser). Then `mac-build-upload.sh <N>` → install → add the medium widget. Expect a possible first-build signing/app-group iteration (extension, like the watch).
+- **Traps found:** — (the extension-target-without-GUI fear was already retired by the watch script; noted in the G2 section).
+- **Next entry-point:** owner does the App Group portal step → runs the Mac build → adds the widget + verifies tap-to-brew / scan. Then G2 is done; reassess G3 (Live Activity).
+- **PRs / commits this session:** #365 (web half), + this branch `feat/widget-native` (native half).

--- a/native/ios/App/App/App.entitlements
+++ b/native/ios/App/App/App.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.roitsch.btts</string>
+	</array>
+</dict>
+</plist>

--- a/native/ios/App/App/Info.plist
+++ b/native/ios/App/App/Info.plist
@@ -22,6 +22,17 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.roitsch.btts.widget</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>btts</string>
+			</array>
+		</dict>
+	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/native/ios/App/App/MainViewController.swift
+++ b/native/ios/App/App/MainViewController.swift
@@ -20,5 +20,6 @@ import Capacitor
 class MainViewController: CAPBridgeViewController {
     override open func capacitorDidLoad() {
         bridge?.registerPluginInstance(BrewWatchPlugin())
+        bridge?.registerPluginInstance(WidgetBridgePlugin())
     }
 }

--- a/native/ios/App/App/WidgetBridge.swift
+++ b/native/ios/App/App/WidgetBridge.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Capacitor
+import WidgetKit
+
+/**
+ WidgetBridge — phone-side bridge from the WKWebView (JS) to the home-screen
+ widget (a separate process).
+
+ The web layer (`src/lib/native/widgetBridge.ts`) calls `setRotation` on app
+ open with the user's in-rotation coffees. We write that list as JSON into the
+ shared App Group container (`group.com.roitsch.btts`) and ask WidgetKit to
+ reload, so the BTTSWidget extension reads the tiles with no network and no
+ auth/token surface. The widget renders each as a `btts://brew?coffeeId=…`
+ deep-link tile (+ a `btts://scan` tile), handled back in
+ `src/lib/native/widgetDeepLinks.ts`.
+
+ App-local plugin (NOT an npm package), so it is registered manually in
+ MainViewController.capacitorDidLoad — same mechanism as BrewWatchPlugin.
+ */
+@objc(WidgetBridgePlugin)
+public class WidgetBridgePlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "WidgetBridgePlugin"
+    public let jsName = "WidgetBridge"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "setRotation", returnType: CAPPluginReturnPromise),
+    ]
+
+    private let suiteName = "group.com.roitsch.btts"
+    private let storeKey = "rotation"
+
+    @objc func setRotation(_ call: CAPPluginCall) {
+        let incoming = call.getArray("coffees", JSObject.self) ?? []
+        // Project to the exact shape the widget decodes ([{id,roaster,name}]).
+        var out: [[String: String]] = []
+        for c in incoming {
+            guard let id = c["id"] as? String,
+                  let name = c["name"] as? String else { continue }
+            let roaster = c["roaster"] as? String ?? ""
+            out.append(["id": id, "roaster": roaster, "name": name])
+        }
+
+        if let defaults = UserDefaults(suiteName: suiteName),
+           let data = try? JSONSerialization.data(withJSONObject: out, options: []),
+           let json = String(data: data, encoding: .utf8) {
+            defaults.set(json, forKey: storeKey)
+        }
+
+        if #available(iOS 14.0, *) {
+            WidgetCenter.shared.reloadAllTimelines()
+        }
+        call.resolve()
+    }
+}

--- a/native/ios/App/BTTSWidget/BTTSWidget.entitlements
+++ b/native/ios/App/BTTSWidget/BTTSWidget.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.roitsch.btts</string>
+	</array>
+</dict>
+</plist>

--- a/native/ios/App/BTTSWidget/BTTSWidget.swift
+++ b/native/ios/App/BTTSWidget/BTTSWidget.swift
@@ -1,0 +1,149 @@
+import WidgetKit
+import SwiftUI
+
+// MARK: - Data
+
+/// One rotation tile. Matches the JSON written by WidgetBridgePlugin.setRotation
+/// (an array of {id, roaster, name}) and the web side
+/// (src/lib/native/widgetBridge.ts WidgetRotationCoffee).
+struct RotationCoffee: Decodable, Identifiable {
+    let id: String
+    let roaster: String
+    let name: String
+}
+
+private let appGroup = "group.com.roitsch.btts"
+private let storeKey = "rotation"
+
+private func loadRotation() -> [RotationCoffee] {
+    guard let defaults = UserDefaults(suiteName: appGroup),
+          let raw = defaults.string(forKey: storeKey),
+          let data = raw.data(using: .utf8),
+          let list = try? JSONDecoder().decode([RotationCoffee].self, from: data)
+    else { return [] }
+    return list
+}
+
+// MARK: - Palette (BTTS Light tokens)
+
+private let cream = Color(red: 0.953, green: 0.898, blue: 0.863)        // #F3E5DC
+private let anthracite = Color(red: 0.165, green: 0.141, blue: 0.110)   // #2A241C
+
+// MARK: - Timeline
+
+struct BTTSEntry: TimelineEntry {
+    let date: Date
+    let coffees: [RotationCoffee]
+}
+
+struct Provider: TimelineProvider {
+    func placeholder(in context: Context) -> BTTSEntry {
+        BTTSEntry(date: Date(), coffees: [])
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (BTTSEntry) -> Void) {
+        completion(BTTSEntry(date: Date(), coffees: loadRotation()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<BTTSEntry>) -> Void) {
+        // The app pushes fresh data + calls reloadAllTimelines() on open, so we
+        // don't need a refresh cadence — `.never` until the next explicit reload.
+        let entry = BTTSEntry(date: Date(), coffees: loadRotation())
+        completion(Timeline(entries: [entry], policy: .never))
+    }
+}
+
+// MARK: - View
+
+struct BTTSWidgetEntryView: View {
+    var entry: Provider.Entry
+
+    private var tiles: [RotationCoffee] { Array(entry.coffees.prefix(3)) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .center) {
+                Text("In rotation")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(anthracite.opacity(0.55))
+                Spacer()
+                Link(destination: URL(string: "btts://scan")!) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "camera").font(.system(size: 11, weight: .semibold))
+                        Text("Scan").font(.system(size: 12, weight: .semibold))
+                    }
+                    .foregroundColor(cream)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(Capsule().fill(anthracite))
+                }
+            }
+
+            if tiles.isEmpty {
+                Spacer(minLength: 0)
+                Text("Open BTTS to pick today's bag.")
+                    .font(.system(size: 13))
+                    .foregroundColor(anthracite.opacity(0.6))
+                Spacer(minLength: 0)
+            } else {
+                ForEach(tiles) { coffee in
+                    Link(destination: URL(string: "btts://brew?coffeeId=\(coffee.id)")!) {
+                        HStack(spacing: 8) {
+                            VStack(alignment: .leading, spacing: 1) {
+                                if !coffee.roaster.isEmpty {
+                                    Text(coffee.roaster)
+                                        .font(.system(size: 10))
+                                        .foregroundColor(anthracite.opacity(0.5))
+                                        .lineLimit(1)
+                                }
+                                Text(coffee.name)
+                                    .font(.system(size: 14, weight: .medium))
+                                    .foregroundColor(anthracite)
+                                    .lineLimit(1)
+                            }
+                            Spacer(minLength: 4)
+                            Text("Brew")
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundColor(cream)
+                                .padding(.horizontal, 10)
+                                .padding(.vertical, 4)
+                                .background(Capsule().fill(anthracite))
+                        }
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 7)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(
+                            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                .fill(Color.white.opacity(0.35))
+                        )
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .containerBackground(cream, for: .widget)
+    }
+}
+
+// MARK: - Widget
+
+struct BTTSWidget: Widget {
+    let kind = "BTTSWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+            BTTSWidgetEntryView(entry: entry)
+        }
+        .configurationDisplayName("BTTS Rotation")
+        .description("Brew a bag in rotation, or scan a new one.")
+        .supportedFamilies([.systemMedium])
+    }
+}
+
+@main
+struct BTTSWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        BTTSWidget()
+    }
+}

--- a/native/ios/App/BTTSWidget/Info.plist
+++ b/native/ios/App/BTTSWidget/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>BTTS</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/native/package-lock.json
+++ b/native/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@capacitor-community/bluetooth-le": "^8.2.0",
+        "@capacitor/app": "^8.1.0",
         "@capacitor/core": "^8.4.0",
         "@capacitor/haptics": "^8.0.2",
         "@capacitor/ios": "^8.4.0",
@@ -52,6 +53,15 @@
       "dependencies": {
         "@types/web-bluetooth": "^0.0.20"
       },
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/app": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-8.1.0.tgz",
+      "integrity": "sha512-MlmttTOWHDedr/G4SrhNRxsXMqY+R75S4MM4eIgzsgCzOYhb/MpCkA5Q3nuOCfL1oHm26xjUzqZ5aupbOwdfYg==",
+      "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
       }

--- a/native/package.json
+++ b/native/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@capacitor-community/bluetooth-le": "^8.2.0",
+    "@capacitor/app": "^8.1.0",
     "@capacitor/core": "^8.4.0",
     "@capacitor/haptics": "^8.0.2",
     "@capacitor/ios": "^8.4.0",

--- a/native/scripts/add_widget_target.rb
+++ b/native/scripts/add_widget_target.rb
@@ -1,0 +1,96 @@
+#!/usr/bin/env ruby
+# Adds the BTTSWidget WidgetKit app-extension target to the Capacitor-generated
+# Xcode project, plus the phone-side WidgetBridge.swift, the App Group
+# entitlement on BOTH the App and the widget, an Embed App Extensions phase, and
+# the target dependency. Idempotent: re-running removes a prior BTTSWidget target
+# first so the project never accumulates duplicates.
+#
+# Run AFTER `npx cap sync ios` and AFTER add_watch_target.rb (both touch the App
+# target; this only adds WidgetBridge.swift + the App-group entitlement wiring,
+# so it doesn't collide with the watch script). See docs/ios-shell-roadmap.md (G2).
+#
+# Prereq baked OUTSIDE this script (Apple side, once): App Groups capability
+# enabled on App IDs com.roitsch.btts + com.roitsch.btts.BTTSWidget, and the
+# group `group.com.roitsch.btts` registered — else automatic signing can't bake
+# the application-groups entitlement. See the roadmap G2 checklist.
+require "xcodeproj"
+
+ROOT = File.expand_path("../ios/App", __dir__)
+PROJ = File.join(ROOT, "App.xcodeproj")
+WIDGET_BUNDLE_ID = "com.roitsch.btts.BTTSWidget"
+
+project = Xcodeproj::Project.open(PROJ)
+app_target = project.targets.find { |t| t.name == "App" } or abort("App target not found")
+
+# --- Clean slate: drop any prior BTTSWidget target + group + embed phase ------
+project.targets.select { |t| t.name == "BTTSWidget" }.each do |t|
+  app_target.dependencies.dup.each do |d|
+    d.remove_from_project if d.target == t
+  end
+  t.remove_from_project
+end
+app_target.build_phases.select { |p|
+  p.respond_to?(:name) && p.name == "Embed Foundation Extensions"
+}.each(&:remove_from_project)
+if (g = project.main_group["BTTSWidget"])
+  g.remove_from_project
+end
+# Drop a prior WidgetBridge.swift ref so we don't double-add it to the App target.
+app_group = project.main_group["App"] or abort("App group not found")
+if (old = app_group.files.find { |f| f.display_name == "WidgetBridge.swift" })
+  old.remove_from_project
+end
+
+# --- Widget file references ----------------------------------------------------
+widget_group = project.main_group.new_group("BTTSWidget", "BTTSWidget")
+swift_refs = %w[BTTSWidget.swift].map { |f| widget_group.new_reference(f) }
+widget_group.new_reference("Info.plist") # referenced via INFOPLIST_FILE, not a build phase
+widget_group.new_reference("BTTSWidget.entitlements") # referenced via CODE_SIGN_ENTITLEMENTS
+
+# --- The widget extension target ----------------------------------------------
+widget_target = project.new_target(:app_extension, "BTTSWidget", :ios, "17.0", nil, :swift)
+widget_target.add_file_references(swift_refs)
+
+wsettings = {
+  "PRODUCT_BUNDLE_IDENTIFIER" => WIDGET_BUNDLE_ID,
+  "PRODUCT_NAME" => "$(TARGET_NAME)",
+  "INFOPLIST_FILE" => "BTTSWidget/Info.plist",
+  "CODE_SIGN_ENTITLEMENTS" => "BTTSWidget/BTTSWidget.entitlements", # App Group
+  "GENERATE_INFOPLIST_FILE" => "NO",
+  "CODE_SIGN_STYLE" => "Automatic",
+  "SWIFT_VERSION" => "5.0",
+  "IPHONEOS_DEPLOYMENT_TARGET" => "17.0",
+  "TARGETED_DEVICE_FAMILY" => "1",
+  "SDKROOT" => "iphoneos",
+  "SKIP_INSTALL" => "YES", # embedded-only: the extension ships inside the app, not as a top-level product
+  "MARKETING_VERSION" => "1.0",
+  "CURRENT_PROJECT_VERSION" => "1", # the xcodebuild invocation overrides this for the whole build
+  "LD_RUNPATH_SEARCH_PATHS" => "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks",
+}
+widget_target.build_configurations.each do |config|
+  wsettings.each { |k, v| config.build_settings[k] = v }
+end
+
+# --- App Group entitlement on the App target (first app-level capability) ------
+# The App target had no entitlements file before the widget; point it at the new
+# App.entitlements every run so cap sync can't drop it.
+app_target.build_configurations.each do |config|
+  config.build_settings["CODE_SIGN_ENTITLEMENTS"] = "App/App.entitlements"
+end
+
+# --- Phone-side WidgetBridge.swift into the App target ------------------------
+# MainViewController.capacitorDidLoad registers WidgetBridgePlugin (added by
+# add_watch_target.rb's APP_SWIFT_FILES); the class must compile, so the source
+# must be in the App target. (App.entitlements is referenced via the build
+# setting, not as a compiled source, so it is NOT added here.)
+app_target.add_file_references([app_group.new_reference("WidgetBridge.swift")])
+
+# --- Embed the widget into the app's PlugIns + build dependency ---------------
+app_target.add_dependency(widget_target)
+embed = app_target.new_copy_files_build_phase("Embed Foundation Extensions")
+embed.symbol_dst_subfolder_spec = :plug_ins
+bf = embed.add_file_reference(widget_target.product_reference, true)
+bf.settings = { "ATTRIBUTES" => ["RemoveHeadersOnCopy"] }
+
+project.save
+puts "OK: added BTTSWidget target (#{widget_target.uuid}) + embed phase + WidgetBridge ref + App Group entitlements."

--- a/native/scripts/mac-build-upload.sh
+++ b/native/scripts/mac-build-upload.sh
@@ -63,13 +63,14 @@ security find-identity -v -p codesigning | grep -q "$IDENTITY" \
 gem list -i xcodeproj >/dev/null 2>&1 \
   || { echo "ERROR: ruby gem 'xcodeproj' missing. Run: gem install xcodeproj --user-install --no-document" >&2; exit 1; }
 
-# ── (0) sync project + watch target ──────────────────────────────────────────
-say "Sync Capacitor project + watch target"
+# ── (0) sync project + watch + widget targets ────────────────────────────────
+say "Sync Capacitor project + watch + widget targets"
 cd "$NATIVE"
 npm install
 npx cap sync ios
 npm run assets || true   # Splash.imageset is missing; icons (the part that matters) still generate
 ruby scripts/add_watch_target.rb
+ruby scripts/add_widget_target.rb   # WidgetKit extension — must run AFTER cap sync + after the watch script
 
 # ── (1) archive with AUTOMATIC (Xcode-managed) signing ───────────────────────
 # -allowProvisioningUpdates + the ASC key let Xcode register the watch's


### PR DESCRIPTION
Native half of the **G2 home-screen widget** (medium widget, two functions: rotation-bag → tap-to-brew + scan). Pairs with the web half in #365. **Needs a Mac build** (`native/scripts/mac-build-upload.sh <N>` — now runs both target scripts).

## What's in this PR
- **`@capacitor/app`** added to the shell — delivers `appUrlOpen` for the `btts://` deep links. (AppDelegate already forwards `application(_:open:)` to Capacitor's proxy, so no AppDelegate change needed.)
- **`btts` URL scheme** in `App/Info.plist` (`CFBundleURLTypes`).
- **`WidgetBridge.swift`** — app-local Capacitor plugin: writes the rotation list to the App Group (`group.com.roitsch.btts`) + `WidgetCenter.reloadAllTimelines()`. Registered in `MainViewController` next to `BrewWatch`.
- **`BTTSWidget/`** — the WidgetKit extension: a **medium** SwiftUI widget that reads the App Group and renders rotation bags as `btts://brew?coffeeId=…` tiles + a `btts://scan` button, in the Light cream/anthracite palette. `Info.plist` + `BTTSWidget.entitlements` (App Group).
- **`App/App.entitlements`** — App Group on the host app (its first app-level capability).
- **`add_widget_target.rb`** — sibling of `add_watch_target.rb` (the `xcodeproj` gem, idempotent: drops any prior `BTTSWidget` target first). Wired into `mac-build-upload.sh` after the watch step.

## ⚠️ One Apple-side prerequisite before building
App Groups can't be reliably auto-created by cloud signing, so once (portal, browser/iPhone-OK):
1. Certificates, IDs & Profiles → **Identifiers → App Groups → register `group.com.roitsch.btts`**.
2. Edit App ID **`com.roitsch.btts` → App Groups → tick that group**.

The widget App ID `com.roitsch.btts.BTTSWidget` is auto-created during the build by `-allowProvisioningUpdates`; automatic signing assigns the existing group to it. If the build fails on the widget's app-group entitlement, enable App Groups on that auto-created widget App ID too and re-run.

## Then
`mac-build-upload.sh <N>` → install → add the BTTS **medium** widget to the home screen → tap a rotation tile (lands in Context) / tap **Scan** (opens the scanner). As with the watch, the first build may need a signing/app-group iteration.

## Verification done here (no Mac)
- `ruby -c add_widget_target.rb` — Syntax OK.
- `plutil -lint` — all four plists OK.
- Swift / WidgetKit **not** compile-tested (no Mac in this environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)