### PR TITLE
fix(widget): re-land widget bridge (hardened) + stale-chunk self-heal

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -61,6 +61,21 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable} ${jetbrainsMono.variable} ${instrumentSerif.variable} ${fraunces.variable} ${chivo.variable}`}>
       <head>
+        {/* Stale-chunk self-heal. After a deploy, an installed PWA / WKWebView
+            can hold a cached HTML shell that references JS chunk filenames the
+            new build no longer has → "Application error: a client-side
+            exception" (a ChunkLoadError). This pre-hydration script catches that
+            and reloads ONCE per session so the client silently picks up the new
+            build instead of white-screening. One-shot via sessionStorage → no
+            reload loop (a persistently-broken chunk shows the error rather than
+            looping; a fresh app launch resets the flag). Caused by the June-2026
+            widget-deploy incident — see docs/ios-shell-roadmap. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html:
+              "(function(){try{var K='btts_chunk_reloaded';function c(m){return /ChunkLoadError|Loading chunk [\\w-]+ failed|Importing a module script failed|Failed to fetch dynamically imported module|error loading dynamically imported module/i.test(m||'')}function h(m){if(!c(m))return;try{if(sessionStorage.getItem(K))return;sessionStorage.setItem(K,'1')}catch(e){}location.reload()}window.addEventListener('error',function(e){h((e&&e.message)||(e&&e.error&&e.error.message)||'')},true);window.addEventListener('unhandledrejection',function(e){var r=e&&e.reason;h((r&&r.message)||String(r||''))})}catch(e){}})();",
+          }}
+        />
         <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
         <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />
         <link rel="apple-touch-icon" sizes="167x167" href="/icons/icon-167.png" />

--- a/src/components/native/NativeWidgetBridge.tsx
+++ b/src/components/native/NativeWidgetBridge.tsx
@@ -23,24 +23,36 @@ export default function NativeWidgetBridge() {
   const router = useRouter();
 
   useEffect(() => {
-    const cleanup = registerWidgetDeepLinks((path) => router.push(path));
+    // Belt-and-braces: this bridge mounts in the global shell, so a throw here
+    // would crash the whole app. Everything is wrapped so it can NEVER do that.
+    let cleanup: () => void = () => {};
+    try {
+      cleanup = registerWidgetDeepLinks((path) => router.push(path));
 
-    // Refresh the widget's rotation tiles on app open. Filtered client-side from
-    // the same /api/coffees the library uses; failure is silent (the widget just
-    // keeps its last tiles).
-    if (isWidgetBridgeNative()) {
-      fetch("/api/coffees", { cache: "no-store" })
-        .then((r) => (r.ok ? (r.json() as Promise<Coffee[]>) : []))
-        .then((list) => {
-          const rotation = list
-            .filter((c) => c.inRotation)
-            .map((c) => ({ id: c.id, roaster: c.roaster, name: c.name }));
-          pushRotationToWidget(rotation);
-        })
-        .catch(() => {});
+      // Refresh the widget's rotation tiles on app open. Filtered client-side
+      // from the same /api/coffees the library uses; failure is silent (the
+      // widget just keeps its last tiles). Native-shell-only; no-op on the PWA.
+      if (isWidgetBridgeNative()) {
+        fetch("/api/coffees", { cache: "no-store" })
+          .then((r) => (r.ok ? (r.json() as Promise<Coffee[]>) : []))
+          .then((list) => {
+            const rotation = list
+              .filter((c) => c.inRotation)
+              .map((c) => ({ id: c.id, roaster: c.roaster, name: c.name }));
+            pushRotationToWidget(rotation);
+          })
+          .catch(() => {});
+      }
+    } catch {
+      // swallow — a widget bridge must never take the app down
     }
-
-    return cleanup;
+    return () => {
+      try {
+        cleanup();
+      } catch {
+        /* ignore */
+      }
+    };
   }, [router]);
 
   return null;

--- a/src/components/ui/light/LightShell.tsx
+++ b/src/components/ui/light/LightShell.tsx
@@ -3,6 +3,7 @@
 import { type ReactNode, useEffect } from "react";
 import { FieldProvider } from "@/lib/field/FieldContext";
 import { sweepBrewNotifications } from "@/lib/native/brewNotifications";
+import NativeWidgetBridge from "@/components/native/NativeWidgetBridge";
 import Field from "./Field";
 import ConnectionStatus from "./ConnectionStatus";
 
@@ -43,6 +44,7 @@ export default function LightShell({ children }: { children: ReactNode }) {
       <div data-light-scope="true" className="font-chivo text-light-foreground min-h-dvh">
         <Field />
         <ConnectionStatus />
+        <NativeWidgetBridge />
         {children}
       </div>
     </FieldProvider>


### PR DESCRIPTION
Restores the widget data-push + `btts://` deep-link handler that the emergency revert removed, so rotation tiles fill and taps route into brew/scan. Hardened: the bridge effect is fully try/caught (can't crash the shell), and a pre-hydration script in the root layout auto-reloads once on a ChunkLoadError so a stale-cache shell after a deploy self-heals instead of white-screening (the root cause of today's outage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)