### PR TITLE
fix(widget): run rotation push independently of deep-link reg

### DIFF
--- a/src/components/native/NativeWidgetBridge.tsx
+++ b/src/components/native/NativeWidgetBridge.tsx
@@ -24,33 +24,37 @@ export default function NativeWidgetBridge() {
   const [diag, setDiag] = useState<string>("");
 
   useEffect(() => {
+    // Deep-link registration — isolated so a failure here can't block the
+    // rotation-data push below (the bug that left the widget empty).
     let cleanup: () => void = () => {};
     try {
       cleanup = registerWidgetDeepLinks((path) => router.push(path));
+    } catch {
+      /* deep links just won't attach */
+    }
 
-      if (!isNativeShell()) {
-        return () => {
-          try { cleanup(); } catch { /* ignore */ }
-        };
-      }
-
-      if (!isWidgetBridgeNative()) {
-        setDiag("widget: plugin NOT found");
-      } else {
-        fetch("/api/coffees", { cache: "no-store" })
-          .then((r) => (r.ok ? (r.json() as Promise<Coffee[]>) : Promise.reject(new Error(`coffees ${r.status}`))))
-          .then((list) => {
-            const rotation = list
-              .filter((c) => c.inRotation)
-              .map((c) => ({ id: c.id, roaster: c.roaster, name: c.name }));
-            pushRotationToWidget(rotation);
-            setDiag(`widget: plugin OK · ${list.length} coffees · ${rotation.length} in rotation pushed`);
-          })
-          .catch((e) => setDiag(`widget: plugin OK · fetch failed: ${e?.message ?? e}`));
+    // Rotation-data push — fully independent of the deep-link registration.
+    try {
+      if (isNativeShell()) {
+        if (!isWidgetBridgeNative()) {
+          setDiag("widget: plugin NOT found");
+        } else {
+          fetch("/api/coffees", { cache: "no-store" })
+            .then((r) => (r.ok ? (r.json() as Promise<Coffee[]>) : Promise.reject(new Error(`coffees ${r.status}`))))
+            .then((list) => {
+              const rotation = list
+                .filter((c) => c.inRotation)
+                .map((c) => ({ id: c.id, roaster: c.roaster, name: c.name }));
+              pushRotationToWidget(rotation);
+              setDiag(`widget: plugin OK · ${list.length} coffees · ${rotation.length} in rotation pushed`);
+            })
+            .catch((e) => setDiag(`widget: plugin OK · fetch failed: ${e?.message ?? e}`));
+        }
       }
     } catch (e) {
-      setDiag(`widget: bridge error: ${(e as Error)?.message ?? e}`);
+      setDiag(`widget: push error: ${(e as Error)?.message ?? e}`);
     }
+
     return () => {
       try { cleanup(); } catch { /* ignore */ }
     };

--- a/src/lib/native/widgetDeepLinks.ts
+++ b/src/lib/native/widgetDeepLinks.ts
@@ -139,27 +139,44 @@ export function registerWidgetDeepLinks(nav: Nav): () => void {
   let handle: AppListenerHandle | null = null;
   let removed = false;
 
-  app
-    .addListener("appUrlOpen", (data) => {
-      void handleWidgetUrl(data.url, nav);
-    })
-    .then((h) => {
-      if (removed) h.remove();
-      else handle = h;
-    })
-    .catch(() => {});
+  // NB: addListener may return either a Promise<handle> OR the handle directly
+  // depending on the Capacitor build, so we never chain `.then` on it raw (that
+  // threw "addListener(...).then is not a function" and aborted the bridge).
+  // Wrap in Promise.resolve and isolate each call so neither can throw out.
+  try {
+    const res = app.addListener("appUrlOpen", (data) => {
+      void handleWidgetUrl(data?.url ?? "", nav);
+    });
+    Promise.resolve(res as unknown)
+      .then((h) => {
+        const handle_ = h as AppListenerHandle | undefined;
+        if (removed) handle_?.remove?.();
+        else handle = handle_ ?? null;
+      })
+      .catch(() => {});
+  } catch {
+    /* ignore — deep links just won't attach */
+  }
 
   // Cold start: the app was launched by the tap, so the event may have fired
   // before this listener attached — getLaunchUrl recovers it.
-  app
-    .getLaunchUrl()
-    .then((r) => {
-      if (r?.url) void handleWidgetUrl(r.url, nav);
-    })
-    .catch(() => {});
+  try {
+    Promise.resolve(app.getLaunchUrl() as unknown)
+      .then((r) => {
+        const url = (r as { url?: string } | null)?.url;
+        if (url) void handleWidgetUrl(url, nav);
+      })
+      .catch(() => {});
+  } catch {
+    /* ignore */
+  }
 
   return () => {
     removed = true;
-    handle?.remove();
+    try {
+      handle?.remove?.();
+    } catch {
+      /* ignore */
+    }
   };
 }


### PR DESCRIPTION
Diagnostic showed registerWidgetDeepLinks threw on `addListener(...).then` (the handle isn't a Promise in this build), aborting before the data push. Now the push runs in its own try block, and the listener plumbing is Promise.resolve-wrapped. Keeps the temporary status line one more round to confirm the push count.