### PR TITLE
feat(ios): G3 — brew Live Activity (lock screen + Dynamic Island)

### DIFF
--- a/native/ios/App/App/BrewActivityAttributes.swift
+++ b/native/ios/App/App/BrewActivityAttributes.swift
@@ -1,0 +1,24 @@
+import Foundation
+import ActivityKit
+
+/// Shared between the App target (starts/updates/ends the activity) and the
+/// BTTSWidget target (renders it). ActivityKit is iOS 16.1+, so the type is
+/// availability-gated; the App target (min iOS 15) only touches it behind the
+/// same `#available` guards in LiveActivityPlugin.
+@available(iOS 16.1, *)
+struct BrewAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        /// What to do right now — "Pour to 180g", "Steep", "Drawdown", …
+        var stepLabel: String
+        var stepIndex: Int
+        var stepCount: Int
+        /// Target finish — drives the system-rendered countdown + progress bar.
+        var endDate: Date
+        var paused: Bool
+    }
+
+    var recipeName: String
+    var coffeeName: String
+    /// Brew start — the lower bound of the timer/progress interval.
+    var startDate: Date
+}

--- a/native/ios/App/App/Info.plist
+++ b/native/ios/App/App/Info.plist
@@ -35,6 +35,8 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSBluetoothAlwaysUsageDescription</key>

--- a/native/ios/App/App/LiveActivityPlugin.swift
+++ b/native/ios/App/App/LiveActivityPlugin.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Capacitor
+import ActivityKit
+
+/**
+ LiveActivity — phone-side bridge from the WKWebView (JS) to a brew Live Activity
+ (lock screen + Dynamic Island). The web layer (src/lib/native/liveActivity.ts)
+ calls start at brew start, update when the step changes, end on reset/finish.
+
+ App-local plugin → registered manually in MainViewController.capacitorDidLoad
+ (same mechanism as BrewWatch / WidgetBridge). All ActivityKit calls are gated
+ to iOS 16.2+ so the iOS-15-min App target still builds; on older iOS every
+ method is a graceful no-op.
+ */
+@objc(LiveActivityPlugin)
+public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "LiveActivityPlugin"
+    public let jsName = "LiveActivity"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "start", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "update", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "end", returnType: CAPPluginReturnPromise),
+    ]
+
+    @objc func start(_ call: CAPPluginCall) {
+        guard #available(iOS 16.2, *) else { call.resolve(["started": false]); return }
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+            call.resolve(["started": false, "reason": "disabled"]); return
+        }
+        // Never stack — end any leftovers first.
+        for activity in Activity<BrewAttributes>.activities {
+            Task { await activity.end(nil, dismissalPolicy: .immediate) }
+        }
+        let attributes = BrewAttributes(
+            recipeName: call.getString("recipeName") ?? "Brew",
+            coffeeName: call.getString("coffeeName") ?? "",
+            startDate: date(call, "startMs") ?? Date()
+        )
+        do {
+            _ = try Activity.request(
+                attributes: attributes,
+                content: .init(state: contentState(call), staleDate: nil)
+            )
+            call.resolve(["started": true])
+        } catch {
+            call.resolve(["started": false, "error": error.localizedDescription])
+        }
+    }
+
+    @objc func update(_ call: CAPPluginCall) {
+        guard #available(iOS 16.2, *) else { call.resolve(); return }
+        let state = contentState(call)
+        Task {
+            for activity in Activity<BrewAttributes>.activities {
+                await activity.update(.init(state: state, staleDate: nil))
+            }
+            call.resolve()
+        }
+    }
+
+    @objc func end(_ call: CAPPluginCall) {
+        guard #available(iOS 16.2, *) else { call.resolve(); return }
+        Task {
+            for activity in Activity<BrewAttributes>.activities {
+                await activity.end(nil, dismissalPolicy: .immediate)
+            }
+            call.resolve()
+        }
+    }
+
+    @available(iOS 16.1, *)
+    private func contentState(_ call: CAPPluginCall) -> BrewAttributes.ContentState {
+        BrewAttributes.ContentState(
+            stepLabel: call.getString("stepLabel") ?? "Brewing",
+            stepIndex: call.getInt("stepIndex") ?? 0,
+            stepCount: call.getInt("stepCount") ?? 0,
+            endDate: date(call, "endMs") ?? Date().addingTimeInterval(180),
+            paused: call.getBool("paused") ?? false
+        )
+    }
+
+    private func date(_ call: CAPPluginCall, _ key: String) -> Date? {
+        guard let ms = call.getDouble(key) else { return nil }
+        return Date(timeIntervalSince1970: ms / 1000)
+    }
+}

--- a/native/ios/App/App/MainViewController.swift
+++ b/native/ios/App/App/MainViewController.swift
@@ -21,5 +21,6 @@ class MainViewController: CAPBridgeViewController {
     override open func capacitorDidLoad() {
         bridge?.registerPluginInstance(BrewWatchPlugin())
         bridge?.registerPluginInstance(WidgetBridgePlugin())
+        bridge?.registerPluginInstance(LiveActivityPlugin())
     }
 }

--- a/native/ios/App/BTTSWidget/BTTSWidget.swift
+++ b/native/ios/App/BTTSWidget/BTTSWidget.swift
@@ -298,5 +298,8 @@ struct BTTSWidgetBundle: WidgetBundle {
     var body: some Widget {
         BTTSWidget()
         ScanWidget()
+        if #available(iOS 16.2, *) {
+            BrewLiveActivity()
+        }
     }
 }

--- a/native/ios/App/BTTSWidget/BrewLiveActivity.swift
+++ b/native/ios/App/BTTSWidget/BrewLiveActivity.swift
@@ -1,0 +1,92 @@
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+// Fruity Live Activity palette (matches the widgets — no beige).
+private let laInk = Color(red: 0.227, green: 0.133, blue: 0.188)   // deep plum
+private let laTint = Color(red: 0.969, green: 0.706, blue: 0.580)  // peach background tint
+
+@available(iOS 16.2, *)
+struct BrewLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: BrewAttributes.self) { context in
+            // Lock screen / banner
+            BrewLockScreenView(context: context)
+                .activityBackgroundTint(laTint)
+                .activitySystemActionForegroundColor(laInk)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Image(systemName: "cup.and.saucer.fill").foregroundColor(laInk)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text(timerInterval: context.attributes.startDate...context.state.endDate, countsDown: true)
+                        .monospacedDigit()
+                        .multilineTextAlignment(.trailing)
+                        .frame(width: 56)
+                        .foregroundColor(laInk)
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    Text(context.state.stepLabel)
+                        .font(.headline)
+                        .lineLimit(1)
+                        .foregroundColor(laInk)
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    ProgressView(timerInterval: context.attributes.startDate...context.state.endDate, countsDown: false)
+                        .tint(laInk)
+                        .labelsHidden()
+                }
+            } compactLeading: {
+                Image(systemName: "cup.and.saucer.fill")
+            } compactTrailing: {
+                Text(timerInterval: context.attributes.startDate...context.state.endDate, countsDown: true)
+                    .monospacedDigit()
+                    .frame(width: 44)
+            } minimal: {
+                Image(systemName: "cup.and.saucer.fill")
+            }
+        }
+    }
+}
+
+@available(iOS 16.2, *)
+struct BrewLockScreenView: View {
+    let context: ActivityViewContext<BrewAttributes>
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(context.attributes.recipeName.uppercased())
+                        .font(.system(size: 10, weight: .bold))
+                        .tracking(0.8)
+                        .foregroundColor(laInk.opacity(0.6))
+                        .lineLimit(1)
+                    if !context.attributes.coffeeName.isEmpty {
+                        Text(context.attributes.coffeeName)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(laInk.opacity(0.8))
+                            .lineLimit(1)
+                    }
+                }
+                Spacer()
+                Text(timerInterval: context.attributes.startDate...context.state.endDate, countsDown: true)
+                    .font(.system(size: 24, weight: .semibold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundColor(laInk)
+            }
+
+            Text(context.state.stepLabel)
+                .font(.system(size: 20, weight: .semibold, design: .serif))
+                .foregroundColor(laInk)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+
+            ProgressView(timerInterval: context.attributes.startDate...context.state.endDate, countsDown: false)
+                .tint(laInk)
+                .labelsHidden()
+        }
+        .padding(16)
+    }
+}

--- a/native/scripts/add_widget_target.rb
+++ b/native/scripts/add_widget_target.rb
@@ -35,21 +35,28 @@ app_target.build_phases.select { |p|
 if (g = project.main_group["BTTSWidget"])
   g.remove_from_project
 end
-# Drop a prior WidgetBridge.swift ref so we don't double-add it to the App target.
+# Drop prior refs to our App-target files so we don't double-add them.
 app_group = project.main_group["App"] or abort("App group not found")
-if (old = app_group.files.find { |f| f.display_name == "WidgetBridge.swift" })
-  old.remove_from_project
+%w[WidgetBridge.swift LiveActivityPlugin.swift BrewActivityAttributes.swift].each do |name|
+  if (old = app_group.files.find { |f| f.display_name == name })
+    old.remove_from_project
+  end
 end
 
 # --- Widget file references ----------------------------------------------------
 widget_group = project.main_group.new_group("BTTSWidget", "BTTSWidget")
-swift_refs = %w[BTTSWidget.swift].map { |f| widget_group.new_reference(f) }
+swift_refs = %w[BTTSWidget.swift BrewLiveActivity.swift].map { |f| widget_group.new_reference(f) }
 widget_group.new_reference("Info.plist") # referenced via INFOPLIST_FILE, not a build phase
 widget_group.new_reference("BTTSWidget.entitlements") # referenced via CODE_SIGN_ENTITLEMENTS
 
+# Shared ActivityAttributes — ONE file compiled into BOTH the widget and the App
+# target (the Live Activity type the app starts/updates and the widget renders).
+# Lives in App/, referenced from the App group; added to both targets below.
+attrs_ref = app_group.new_reference("BrewActivityAttributes.swift")
+
 # --- The widget extension target ----------------------------------------------
 widget_target = project.new_target(:app_extension, "BTTSWidget", :ios, "17.0", nil, :swift)
-widget_target.add_file_references(swift_refs)
+widget_target.add_file_references(swift_refs + [attrs_ref])
 
 wsettings = {
   "PRODUCT_BUNDLE_IDENTIFIER" => WIDGET_BUNDLE_ID,
@@ -83,7 +90,11 @@ end
 # add_watch_target.rb's APP_SWIFT_FILES); the class must compile, so the source
 # must be in the App target. (App.entitlements is referenced via the build
 # setting, not as a compiled source, so it is NOT added here.)
-app_target.add_file_references([app_group.new_reference("WidgetBridge.swift")])
+app_target.add_file_references([
+  app_group.new_reference("WidgetBridge.swift"),
+  app_group.new_reference("LiveActivityPlugin.swift"),
+  attrs_ref,
+])
 
 # --- Embed the widget into the app's PlugIns + build dependency ---------------
 app_target.add_dependency(widget_target)

--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -16,6 +16,7 @@ import type { BrewStepAction } from "@/lib/types/session";
 import { basedOnReference } from "@/lib/utils/resolveRecipe";
 import { useBrewStepHaptics } from "@/hooks/useBrewStepHaptics";
 import { useBrewStepWatch } from "@/hooks/useBrewStepWatch";
+import { useBrewLiveActivity } from "@/hooks/useBrewLiveActivity";
 import { boundariesFromTimeline } from "@/lib/native/brewNotifications";
 import { ScalePanel } from "@/components/flow/ScalePanel";
 import { useAcaiaScale } from "@/hooks/useAcaiaScale";
@@ -199,6 +200,18 @@ export default function LightStepBrew() {
   // physical-therapy extended-runtime session (fires screen-off / wrist-down,
   // directly on the watch — no notification delay). Native-only no-op.
   useBrewStepWatch(boundaries, elapsed, started, recipeName ?? "Brew");
+
+  // Live Activity — live brew timer on the lock screen / Dynamic Island. The
+  // timer + progress tick natively; the step label updates on step change.
+  // Native-only no-op.
+  useBrewLiveActivity(
+    boundaries,
+    elapsed,
+    started,
+    recipeName ?? "Brew",
+    draft.coffee?.name ?? "",
+    recipe?.targetTimeSec ?? 0,
+  );
 
   return (
     <LightFlowShell

--- a/src/hooks/useBrewLiveActivity.ts
+++ b/src/hooks/useBrewLiveActivity.ts
@@ -1,0 +1,80 @@
+"use client";
+import { useEffect, useRef } from "react";
+import { type BrewBoundary } from "@/lib/native/brewNotifications";
+import {
+  currentBrewStep,
+  startBrewActivity,
+  updateBrewActivity,
+  endBrewActivity,
+  isNativeLiveActivity,
+} from "@/lib/native/liveActivity";
+
+/**
+ * Runs a Live Activity for the active brew: starts it at brew start, updates the
+ * step label when the step changes, ends it on reset / unmount. The timer and
+ * progress bar tick natively (system-rendered), so we don't update per second —
+ * only on a step change. Native-shell-only; a clean no-op in the browser.
+ */
+export function useBrewLiveActivity(
+  boundaries: BrewBoundary[],
+  elapsed: number,
+  started: boolean,
+  recipeName: string,
+  coffeeName: string,
+  targetTimeSec: number,
+): void {
+  const ctx = useRef({ boundaries, recipeName, coffeeName, targetTimeSec });
+  useEffect(() => {
+    ctx.current = { boundaries, recipeName, coffeeName, targetTimeSec };
+  }, [boundaries, recipeName, coffeeName, targetTimeSec]);
+
+  const anchorRef = useRef<number | null>(null);
+  const lastStepRef = useRef<string>("");
+
+  useEffect(() => {
+    if (!isNativeLiveActivity()) return;
+
+    // Reset → end the activity.
+    if (!started || elapsed === 0) {
+      if (anchorRef.current !== null) {
+        anchorRef.current = null;
+        lastStepRef.current = "";
+        endBrewActivity();
+      }
+      return;
+    }
+    if (elapsed < 1 || targetTimeSec <= 0) return;
+
+    const now = Date.now();
+    const impliedStartMs = now - elapsed * 1000;
+    const { boundaries, recipeName, coffeeName, targetTimeSec: target } = ctx.current;
+    const endMs = impliedStartMs + target * 1000;
+    const step = currentBrewStep(boundaries, elapsed);
+
+    const isNew =
+      anchorRef.current === null || Math.abs(impliedStartMs - anchorRef.current) > 1500;
+
+    if (isNew) {
+      anchorRef.current = impliedStartMs;
+      lastStepRef.current = step.stepLabel;
+      startBrewActivity({
+        recipeName,
+        coffeeName,
+        startMs: impliedStartMs,
+        endMs,
+        ...step,
+        paused: false,
+      });
+    } else if (step.stepLabel !== lastStepRef.current) {
+      lastStepRef.current = step.stepLabel;
+      updateBrewActivity({ endMs, ...step, paused: false });
+    }
+  }, [elapsed, started, targetTimeSec]);
+
+  // End the activity if the screen unmounts mid-brew.
+  useEffect(() => {
+    return () => {
+      if (isNativeLiveActivity()) endBrewActivity();
+    };
+  }, []);
+}

--- a/src/lib/native/liveActivity.ts
+++ b/src/lib/native/liveActivity.ts
@@ -1,0 +1,79 @@
+/**
+ * Brew Live Activity bridge — drives an iOS 16.2+ Live Activity (lock screen +
+ * Dynamic Island) showing the live brew timer and current step.
+ *
+ * The timer + progress bar are SYSTEM-rendered (`Text(timerInterval:)` /
+ * `ProgressView(timerInterval:)`), so they keep ticking on the lock screen even
+ * when the WKWebView JS is frozen. Only the step LABEL needs an explicit
+ * `update` call, which the hook fires when the step changes while the app is
+ * foreground (during a brew the screen is wake-locked, so JS is alive at each
+ * step boundary). Locked-phone step-label progression would need APNs ActivityKit
+ * pushes — out of scope for v1; the ticking timer covers the locked case.
+ *
+ * Pure-web module, ZERO `@capacitor/*` imports (ambient types). Off the native
+ * shell every export is a silent no-op.
+ */
+import type { BrewBoundary } from "@/lib/native/brewNotifications";
+
+export interface BrewActivityState {
+  stepLabel: string;
+  stepIndex: number;
+  stepCount: number;
+  /** Epoch ms of the brew's target finish — drives the system timer/progress. */
+  endMs: number;
+  paused: boolean;
+}
+
+interface LiveActivityPluginLike {
+  start(o: { recipeName: string; coffeeName: string; startMs: number } & BrewActivityState): Promise<{ started?: boolean }>;
+  update(o: BrewActivityState): Promise<void>;
+  end(): Promise<void>;
+}
+
+interface CapacitorLike {
+  isNativePlatform?: () => boolean;
+  Plugins?: { LiveActivity?: LiveActivityPluginLike };
+}
+
+function getPlugin(): LiveActivityPluginLike | null {
+  try {
+    if (typeof window === "undefined") return null;
+    const cap = (window as unknown as { Capacitor?: CapacitorLike }).Capacitor;
+    if (!cap?.isNativePlatform?.()) return null;
+    return cap.Plugins?.LiveActivity ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** True only inside the Capacitor shell with the LiveActivity plugin present. */
+export function isNativeLiveActivity(): boolean {
+  return getPlugin() !== null;
+}
+
+/** The current brew step from the boundary schedule (the last boundary passed). */
+export function currentBrewStep(
+  boundaries: BrewBoundary[],
+  elapsed: number,
+): { stepLabel: string; stepIndex: number; stepCount: number } {
+  let idx = -1;
+  for (let i = 0; i < boundaries.length; i++) {
+    if (boundaries[i].atSec <= elapsed) idx = i;
+  }
+  const stepLabel = idx >= 0 ? boundaries[idx].title : "Bloom";
+  return { stepLabel, stepIndex: idx + 1, stepCount: boundaries.length };
+}
+
+export function startBrewActivity(
+  opts: { recipeName: string; coffeeName: string; startMs: number } & BrewActivityState,
+): void {
+  getPlugin()?.start(opts).catch(() => {});
+}
+
+export function updateBrewActivity(state: BrewActivityState): void {
+  getPlugin()?.update(state).catch(() => {});
+}
+
+export function endBrewActivity(): void {
+  getPlugin()?.end().catch(() => {});
+}


### PR DESCRIPTION
Live brew timer on the lock screen / Dynamic Island. System-rendered timer+progress (tick while locked); step label updates on step change (foreground). Web bridge+hook (native-only no-op, tsc clean) + ActivityKit plugin + Live Activity UI (fruity peach). Needs a TestFlight build.