### PR TITLE
feat(ios): Share-Sheet "Add to BTTS" (share a coffee URL → scan flow)

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -105,6 +105,7 @@ jobs:
           npm run assets || true   # Splash.imageset is absent; the icons (what matters) still generate
           ruby scripts/add_watch_target.rb
           ruby scripts/add_widget_target.rb   # WidgetKit extension — after cap sync + the watch script
+          ruby scripts/add_share_target.rb    # Share Extension ("Add to BTTS")
 
       - name: Write the App Store Connect API key
         run: |

--- a/native/ios/App/BTTSShare/Info.plist
+++ b/native/ios/App/BTTSShare/Info.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Add to BTTS</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>ShareViewController</string>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+				<key>NSExtensionActivationSupportsText</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/native/ios/App/BTTSShare/ShareViewController.swift
+++ b/native/ios/App/BTTSShare/ShareViewController.swift
@@ -1,0 +1,85 @@
+import UIKit
+import UniformTypeIdentifiers
+
+/**
+ Share Extension — "Add to BTTS". Appears in the iOS Share Sheet for URLs and
+ text (e.g. a coffee product page shared from Safari / Instagram). It extracts
+ the URL, opens the host app via the `btts://share?url=…` deep link, and
+ dismisses. The app's deep-link handler (src/lib/native/widgetDeepLinks.ts) then
+ lands in the scan flow and auto-analyzes the URL (/api/analyze-url).
+
+ No App Group needed: the URL is small enough to pass inline in the deep link.
+ Opening the host app from an extension uses the documented responder-chain
+ `openURL:` walk (UIApplication isn't directly reachable from an extension).
+ */
+@objc(ShareViewController)
+class ShareViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .clear
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        extractURL { [weak self] urlString in
+            DispatchQueue.main.async { self?.finish(urlString) }
+        }
+    }
+
+    private func extractURL(_ completion: @escaping (String?) -> Void) {
+        guard let item = extensionContext?.inputItems.first as? NSExtensionItem,
+              let providers = item.attachments else { completion(nil); return }
+
+        let urlType = UTType.url.identifier
+        let textType = UTType.plainText.identifier
+
+        // Prefer an explicit URL attachment.
+        if let p = providers.first(where: { $0.hasItemConformingToTypeIdentifier(urlType) }) {
+            p.loadItem(forTypeIdentifier: urlType, options: nil) { data, _ in
+                completion((data as? URL)?.absoluteString)
+            }
+            return
+        }
+        // Otherwise pull the first URL out of shared plain text.
+        if let p = providers.first(where: { $0.hasItemConformingToTypeIdentifier(textType) }) {
+            p.loadItem(forTypeIdentifier: textType, options: nil) { data, _ in
+                completion(Self.firstURL(in: data as? String))
+            }
+            return
+        }
+        completion(nil)
+    }
+
+    private static func firstURL(in text: String?) -> String? {
+        guard let text = text,
+              let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else { return nil }
+        let range = NSRange(text.startIndex..., in: text)
+        return detector.firstMatch(in: text, range: range)?.url?.absoluteString
+    }
+
+    private func finish(_ urlString: String?) {
+        if let s = urlString,
+           let encoded = s.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+           let deep = URL(string: "btts://share?url=\(encoded)") {
+            openHostApp(deep)
+        }
+        // Give the open a beat, then close the share sheet.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
+            self?.extensionContext?.completeRequest(returningItems: [], completionHandler: nil)
+        }
+    }
+
+    /// Walk the responder chain to find an object that responds to `openURL:`
+    /// (the host UIApplication) and ask it to open our custom-scheme deep link.
+    private func openHostApp(_ url: URL) {
+        let selector = sel_registerName("openURL:")
+        var responder: UIResponder? = self
+        while let r = responder {
+            if r.responds(to: selector), r !== self {
+                _ = r.perform(selector, with: url)
+                return
+            }
+            responder = r.next
+        }
+    }
+}

--- a/native/scripts/add_share_target.rb
+++ b/native/scripts/add_share_target.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+# Adds the BTTSShare Share Extension target ("Add to BTTS") to the Capacitor-
+# generated Xcode project, embedded in the app's PlugIns. Idempotent: drops a
+# prior BTTSShare target/group/embed phase first.
+#
+# Run AFTER `npx cap sync ios` and AFTER add_watch_target.rb / add_widget_target.rb
+# (it only adds its own target + group + embed phase; no overlap with theirs).
+# See docs/ios-shell-roadmap.md.
+#
+# No App Group / extra capability: the shared URL is passed inline in the
+# btts://share?url=… deep link, so automatic signing just needs the bundle id —
+# no portal capability assignment (unlike the widget's App Group).
+require "xcodeproj"
+
+ROOT = File.expand_path("../ios/App", __dir__)
+PROJ = File.join(ROOT, "App.xcodeproj")
+SHARE_BUNDLE_ID = "com.roitsch.btts.BTTSShare"
+
+project = Xcodeproj::Project.open(PROJ)
+app_target = project.targets.find { |t| t.name == "App" } or abort("App target not found")
+
+# --- Clean slate: drop any prior BTTSShare target + group + embed phase -------
+project.targets.select { |t| t.name == "BTTSShare" }.each do |t|
+  app_target.dependencies.dup.each do |d|
+    d.remove_from_project if d.target == t
+  end
+  t.remove_from_project
+end
+app_target.build_phases.select { |p|
+  p.respond_to?(:name) && p.name == "Embed Share Extension"
+}.each(&:remove_from_project)
+if (g = project.main_group["BTTSShare"])
+  g.remove_from_project
+end
+
+# --- Share file references -----------------------------------------------------
+share_group = project.main_group.new_group("BTTSShare", "BTTSShare")
+swift_refs = %w[ShareViewController.swift].map { |f| share_group.new_reference(f) }
+share_group.new_reference("Info.plist") # referenced via INFOPLIST_FILE
+
+# --- The share extension target -----------------------------------------------
+share_target = project.new_target(:app_extension, "BTTSShare", :ios, "15.0", nil, :swift)
+share_target.add_file_references(swift_refs)
+
+settings = {
+  "PRODUCT_BUNDLE_IDENTIFIER" => SHARE_BUNDLE_ID,
+  "PRODUCT_NAME" => "$(TARGET_NAME)",
+  "INFOPLIST_FILE" => "BTTSShare/Info.plist",
+  "GENERATE_INFOPLIST_FILE" => "NO",
+  "CODE_SIGN_STYLE" => "Automatic",
+  "SWIFT_VERSION" => "5.0",
+  "IPHONEOS_DEPLOYMENT_TARGET" => "15.0",
+  "TARGETED_DEVICE_FAMILY" => "1",
+  "SDKROOT" => "iphoneos",
+  "SKIP_INSTALL" => "YES", # embedded-only — ships inside the app, not as a top-level product
+  "MARKETING_VERSION" => "1.0",
+  "CURRENT_PROJECT_VERSION" => "1", # the xcodebuild invocation overrides this build-wide
+  "LD_RUNPATH_SEARCH_PATHS" => "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks",
+}
+share_target.build_configurations.each do |config|
+  settings.each { |k, v| config.build_settings[k] = v }
+end
+
+# --- Embed the extension into the app's PlugIns + build dependency ------------
+app_target.add_dependency(share_target)
+embed = app_target.new_copy_files_build_phase("Embed Share Extension")
+embed.symbol_dst_subfolder_spec = :plug_ins
+bf = embed.add_file_reference(share_target.product_reference, true)
+bf.settings = { "ATTRIBUTES" => ["RemoveHeadersOnCopy"] }
+
+project.save
+puts "OK: added BTTSShare target (#{share_target.uuid}) + embed phase."

--- a/native/scripts/mac-build-upload.sh
+++ b/native/scripts/mac-build-upload.sh
@@ -71,6 +71,7 @@ npx cap sync ios
 npm run assets || true   # Splash.imageset is missing; icons (the part that matters) still generate
 ruby scripts/add_watch_target.rb
 ruby scripts/add_widget_target.rb   # WidgetKit extension — must run AFTER cap sync + after the watch script
+ruby scripts/add_share_target.rb    # Share Extension ("Add to BTTS") — after the others
 
 # ── (1) archive with AUTOMATIC (Xcode-managed) signing ───────────────────────
 # -allowProvisioningUpdates + the ASC key let Xcode register the watch's

--- a/src/components/flow/LightStepScan.tsx
+++ b/src/components/flow/LightStepScan.tsx
@@ -60,7 +60,7 @@ const ROASTER_QA_LOCATION_CHIPS = ["Germany", "Netherlands", "UK", "USA", "Denma
 const ROASTER_QA_STYLE_CHIPS = ["Very light", "Light", "Light-medium", "Medium", "Varies"];
 
 export default function LightStepScan() {
-  const { draft, setCoffee, setMode, setStep, setSkipScan, setFieldZones, isDripBag, setIsDripBag, isAnalyzing, setIsAnalyzing, clarificationMessages, addClarificationMessage, clearClarifications, reset } = useFlowStore();
+  const { draft, setCoffee, setMode, setStep, setSkipScan, setFieldZones, isDripBag, setIsDripBag, isAnalyzing, setIsAnalyzing, clarificationMessages, addClarificationMessage, clearClarifications, reset, pendingScanUrl, setPendingScanUrl } = useFlowStore();
   const router = useRouter();
   const [heroQuestion, setHeroQuestion] = useState("");
   useEffect(() => {
@@ -302,8 +302,20 @@ export default function LightStepScan() {
     } catch {}
   };
 
-  const handleUrlAnalyze = async () => {
-    const url = urlInput.trim();
+  // Auto-analyze a URL shared into the app via the iOS Share Sheet
+  // ("Add to BTTS"): the deep-link handler set pendingScanUrl, so prefill the
+  // URL field and run the analysis once, then clear it.
+  useEffect(() => {
+    if (!pendingScanUrl) return;
+    const shared = pendingScanUrl;
+    setUrlInput(shared);
+    setPendingScanUrl(null);
+    void handleUrlAnalyze(shared);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingScanUrl]);
+
+  const handleUrlAnalyze = async (override?: string) => {
+    const url = (override ?? urlInput).trim();
     if (!url) return;
     setIsAnalyzingUrl(true);
     setUrlError(null);
@@ -858,7 +870,7 @@ export default function LightStepScan() {
                 />
                 <button
                   type="button"
-                  onClick={handleUrlAnalyze}
+                  onClick={() => handleUrlAnalyze()}
                   disabled={!urlInput.trim() || isAnalyzingUrl}
                   aria-label={isAnalyzingUrl ? "Scanning" : "Scan URL"}
                   className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full active:scale-95 transition-all disabled:opacity-40"

--- a/src/lib/native/widgetDeepLinks.ts
+++ b/src/lib/native/widgetDeepLinks.ts
@@ -86,7 +86,8 @@ async function brewCoffeeById(coffeeId: string, nav: Nav): Promise<void> {
 /** Result of parsing a `btts://…` widget URL. `null` = not ours / malformed. */
 export type WidgetAction =
   | { kind: "scan" }
-  | { kind: "brew"; coffeeId: string | null };
+  | { kind: "brew"; coffeeId: string | null }
+  | { kind: "share"; url: string | null };
 
 /**
  * Pure parse of a `btts://…` URL into an action. Side-effect-free + store-free,
@@ -105,6 +106,7 @@ export function parseWidgetUrl(url: string): WidgetAction | null {
   const action = (parsed.host || parsed.pathname.replace(/\//g, "")).toLowerCase();
   if (action === "scan") return { kind: "scan" };
   if (action === "brew") return { kind: "brew", coffeeId: parsed.searchParams.get("coffeeId") };
+  if (action === "share") return { kind: "share", url: parsed.searchParams.get("url") };
   return null;
 }
 
@@ -124,6 +126,16 @@ export async function handleWidgetUrl(url: string, nav: Nav): Promise<void> {
       return;
     }
     await brewCoffeeById(action.coffeeId, nav);
+    return;
+  }
+  if (action.kind === "share") {
+    // Shared from the iOS Share Sheet ("Add to BTTS"): land in the scan flow and
+    // auto-analyze the URL (LightStepScan reads pendingScanUrl on mount).
+    const s = useFlowStore.getState();
+    s.reset();
+    s.setMode("home");
+    if (action.url) s.setPendingScanUrl(action.url);
+    nav("/brew/new");
   }
 }
 

--- a/src/store/flowStore.ts
+++ b/src/store/flowStore.ts
@@ -31,11 +31,15 @@ interface FlowState {
   isRecommending: boolean;
   recommendError: string | null;
   clarificationMessages: ClarificationMessage[];
+  /** A URL shared into the app via the iOS Share Sheet ("Add to BTTS"), to be
+   * auto-analyzed by the scan step on mount, then cleared. */
+  pendingScanUrl: string | null;
 
   // Actions
   setStep: (step: FlowStep) => void;
   setMode: (mode: SessionMode) => void;
   setSkipScan: (v: boolean) => void;
+  setPendingScanUrl: (url: string | null) => void;
   setIsDripBag: (v: boolean) => void;
   setCoffee: (coffee: Partial<CoffeeIdentity>) => void;
   setPlace: (place: ExternalPlace) => void;
@@ -70,6 +74,7 @@ export const useFlowStore = create<FlowState>()(
       draft: initialDraft,
       fieldZones: null,
       skipScan: false,
+      pendingScanUrl: null,
       isDripBag: false,
       isAnalyzing: false,
       isRecommending: false,
@@ -79,6 +84,7 @@ export const useFlowStore = create<FlowState>()(
       setStep: (step) => set({ step }),
       setMode: (mode) => set((s) => ({ draft: { ...s.draft, mode } })),
       setSkipScan: (v) => set({ skipScan: v }),
+      setPendingScanUrl: (pendingScanUrl) => set({ pendingScanUrl }),
       setIsDripBag: (v) => set({ isDripBag: v }),
       setCoffee: (coffee) =>
         set((s) => ({ draft: { ...s.draft, coffee: { ...s.draft.coffee, ...coffee } as CoffeeIdentity } })),
@@ -95,7 +101,7 @@ export const useFlowStore = create<FlowState>()(
         set((s) => ({ clarificationMessages: [...s.clarificationMessages, msg] })),
       clearClarifications: () => set({ clarificationMessages: [] }),
       reset: () =>
-        set({ step: "scan", draft: initialDraft, fieldZones: null, skipScan: false, isDripBag: false, isAnalyzing: false, isRecommending: false, recommendError: null, clarificationMessages: [] }),
+        set({ step: "scan", draft: initialDraft, fieldZones: null, skipScan: false, pendingScanUrl: null, isDripBag: false, isAnalyzing: false, isRecommending: false, recommendError: null, clarificationMessages: [] }),
     }),
     {
       // localStorage (not sessionStorage) so an in-flight brew survives a

--- a/tests/dataflow/widget-deeplinks.test.mjs
+++ b/tests/dataflow/widget-deeplinks.test.mjs
@@ -66,6 +66,16 @@ test("triple-slash host-less form still parses", () => {
   assert.deepEqual(parseWidgetUrl("btts:///scan"), { kind: "scan" });
 });
 
+test("share link extracts the shared url", () => {
+  const r = parseWidgetUrl("btts://share?url=https%3A%2F%2Froaster.com%2Fbag");
+  assert.equal(r.kind, "share");
+  assert.equal(r.url, "https://roaster.com/bag");
+});
+
+test("share link with no url → null url", () => {
+  assert.deepEqual(parseWidgetUrl("btts://share"), { kind: "share", url: null });
+});
+
 test("non-btts schemes return null", () => {
   assert.equal(parseWidgetUrl("https://bettertastethansorry.com/brew?coffeeId=x"), null);
   assert.equal(parseWidgetUrl("http://evil.example/brew"), null);


### PR DESCRIPTION
Share a coffee URL from Safari/Instagram → BTTS opens the scan flow and auto-analyzes it. Native Share Extension (opens host app via btts://share?url=, no App Group) + web wiring (flowStore.pendingScanUrl → LightStepScan auto-analyze). v1 URLs only. tsc + 10 tests green. Needs a TestFlight build.