### PR TITLE
fix(ios): Share Sheet opens the app + remove watch Test Buzz

### DIFF
--- a/native/ios/App/BTTSShare/ShareViewController.swift
+++ b/native/ios/App/BTTSShare/ShareViewController.swift
@@ -57,26 +57,37 @@ class ShareViewController: UIViewController {
         return detector.firstMatch(in: text, range: range)?.url?.absoluteString
     }
 
+    // Selector stub so `#selector(openURL(_:))` resolves; the host app's
+    // responder provides the real implementation. We walk from `self.next` so
+    // this stub is skipped.
+    @objc func openURL(_ url: URL) {}
+
     private func finish(_ urlString: String?) {
-        if let s = urlString,
-           let encoded = s.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-           let deep = URL(string: "btts://share?url=\(encoded)") {
-            openHostApp(deep)
+        guard let s = urlString,
+              let encoded = s.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+              let deep = URL(string: "btts://share?url=\(encoded)") else {
+            extensionContext?.completeRequest(returningItems: [], completionHandler: nil)
+            return
         }
-        // Give the open a beat, then close the share sheet.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
+        openHostApp(deep)
+        // Tear the extension down AFTER the host-app launch has a beat to take —
+        // completing too early (0.15 s) cancels the pending open, which is why
+        // nothing happened. 0.8 s is comfortably enough.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
             self?.extensionContext?.completeRequest(returningItems: [], completionHandler: nil)
         }
     }
 
-    /// Walk the responder chain to find an object that responds to `openURL:`
-    /// (the host UIApplication) and ask it to open our custom-scheme deep link.
+    /// Open the host app with our custom-scheme deep link. NSExtensionContext.open
+    /// is tried first (harmless if unsupported), then the documented responder-
+    /// chain `openURL:` walk — the standard way a share extension opens its host.
     private func openHostApp(_ url: URL) {
-        let selector = sel_registerName("openURL:")
-        var responder: UIResponder? = self
+        extensionContext?.open(url, completionHandler: nil)
+        let selector = #selector(openURL(_:))
+        var responder: UIResponder? = self.next
         while let r = responder {
-            if r.responds(to: selector), r !== self {
-                _ = r.perform(selector, with: url)
+            if r.responds(to: selector) {
+                r.perform(selector, with: url)
                 return
             }
             responder = r.next

--- a/native/ios/App/BTTSWatch/ContentView.swift
+++ b/native/ios/App/BTTSWatch/ContentView.swift
@@ -36,16 +36,6 @@ struct ContentView: View {
                 Text("Open this at brew start — each step buzzes your wrist, screen off.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
-                // Diagnostic line (build 19) — read this off the watch if a brew
-                // doesn't show up here. Remove once the haptic is confirmed.
-                Text("WC \(model.wcState) · reach \(model.reachable ? "Y" : "N") · rx \(model.msgCount) · fires \(model.lastFires)\nworkout \(model.workout) · \(model.lastEvent)")
-                    .font(.system(size: 11).monospaced())
-                    .foregroundStyle(.tertiary)
-                    .padding(.top, 4)
-                // Isolation test: does a plain device haptic buzz at all?
-                Button("Test buzz") { model.testBuzz() }
-                    .font(.footnote)
-                    .padding(.top, 2)
             }
             Spacer(minLength: 0)
         }


### PR DESCRIPTION
Share Sheet opened a blank card then closed without opening BTTS — completeRequest fired too early (0.15s) and cancelled the open. Now: openURL selector stub + responder walk from self.next + NSExtensionContext.open + 0.8s delay. Also removes the watch Test Buzz button + diagnostic line. Native; needs a build.