### PR TITLE
feat: shared coffee URL auto-asks the Home chat

### DIFF
--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -7,6 +7,7 @@ import ChatInput, { type SendPayload } from "@/components/ui/light/ChatInput";
 import ChatThread, { type Message } from "@/components/ui/light/ChatThread";
 import HaikuStarter from "@/components/ui/light/HaikuStarter";
 import { useVoicePlayback } from "@/hooks/useVoicePlayback";
+import { useFlowStore } from "@/store/flowStore";
 import type { Session } from "@/lib/types/session";
 import type { NavAction } from "@/app/api/explore-agent/route";
 
@@ -436,6 +437,21 @@ export default function HomePage() {
     abortRef.current?.abort();
     voice.cancel();
   };
+
+  // A coffee URL shared in via "Add to BTTS" (Share Sheet → its notification):
+  // auto-ask the chat about it, once. The native bridge set pendingChatUrl and
+  // routed here; clear it immediately and guard against a re-fire.
+  const pendingChatUrl = useFlowStore((s) => s.pendingChatUrl);
+  const setPendingChatUrl = useFlowStore((s) => s.setPendingChatUrl);
+  const sharedHandledRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!pendingChatUrl || sharedHandledRef.current === pendingChatUrl) return;
+    sharedHandledRef.current = pendingChatUrl;
+    const url = pendingChatUrl;
+    setPendingChatUrl(null);
+    void handleSend({ text: `What do you think of this coffee: ${url}` });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingChatUrl]);
 
   return (
     <>

--- a/src/lib/native/widgetDeepLinks.ts
+++ b/src/lib/native/widgetDeepLinks.ts
@@ -144,16 +144,14 @@ export async function handleWidgetUrl(url: string, nav: Nav): Promise<void> {
 }
 
 /**
- * Seed the scan flow with a URL shared into the app and navigate there;
- * LightStepScan auto-analyzes `pendingScanUrl` on mount. Shared by the
- * `btts://share` deep link and the Share-Extension notification tap.
+ * Hand a URL shared into the app to the HOME AI chat: the Home page auto-asks
+ * "What do you think of this coffee: <url>" and sends it. Shared by the
+ * `btts://share` deep link and the Share-Extension notification tap. (Bag-URL
+ * analysis lives in the chat now, not the scan step.)
  */
 export function routeToSharedUrl(url: string, nav: Nav): void {
-  const s = useFlowStore.getState();
-  s.reset();
-  s.setMode("home");
-  s.setPendingScanUrl(url);
-  nav("/brew/new");
+  useFlowStore.getState().setPendingChatUrl(url);
+  nav("/");
 }
 
 /**

--- a/src/store/flowStore.ts
+++ b/src/store/flowStore.ts
@@ -34,12 +34,16 @@ interface FlowState {
   /** A URL shared into the app via the iOS Share Sheet ("Add to BTTS"), to be
    * auto-analyzed by the scan step on mount, then cleared. */
   pendingScanUrl: string | null;
+  /** A coffee URL shared in via "Add to BTTS" — the Home chat auto-asks
+   * "What do you think of this coffee: <url>" on mount, then clears it. */
+  pendingChatUrl: string | null;
 
   // Actions
   setStep: (step: FlowStep) => void;
   setMode: (mode: SessionMode) => void;
   setSkipScan: (v: boolean) => void;
   setPendingScanUrl: (url: string | null) => void;
+  setPendingChatUrl: (url: string | null) => void;
   setIsDripBag: (v: boolean) => void;
   setCoffee: (coffee: Partial<CoffeeIdentity>) => void;
   setPlace: (place: ExternalPlace) => void;
@@ -75,6 +79,7 @@ export const useFlowStore = create<FlowState>()(
       fieldZones: null,
       skipScan: false,
       pendingScanUrl: null,
+      pendingChatUrl: null,
       isDripBag: false,
       isAnalyzing: false,
       isRecommending: false,
@@ -85,6 +90,7 @@ export const useFlowStore = create<FlowState>()(
       setMode: (mode) => set((s) => ({ draft: { ...s.draft, mode } })),
       setSkipScan: (v) => set({ skipScan: v }),
       setPendingScanUrl: (pendingScanUrl) => set({ pendingScanUrl }),
+      setPendingChatUrl: (pendingChatUrl) => set({ pendingChatUrl }),
       setIsDripBag: (v) => set({ isDripBag: v }),
       setCoffee: (coffee) =>
         set((s) => ({ draft: { ...s.draft, coffee: { ...s.draft.coffee, ...coffee } as CoffeeIdentity } })),
@@ -101,7 +107,7 @@ export const useFlowStore = create<FlowState>()(
         set((s) => ({ clarificationMessages: [...s.clarificationMessages, msg] })),
       clearClarifications: () => set({ clarificationMessages: [] }),
       reset: () =>
-        set({ step: "scan", draft: initialDraft, fieldZones: null, skipScan: false, pendingScanUrl: null, isDripBag: false, isAnalyzing: false, isRecommending: false, recommendError: null, clarificationMessages: [] }),
+        set({ step: "scan", draft: initialDraft, fieldZones: null, skipScan: false, pendingScanUrl: null, pendingChatUrl: null, isDripBag: false, isAnalyzing: false, isRecommending: false, recommendError: null, clarificationMessages: [] }),
     }),
     {
       // localStorage (not sessionStorage) so an in-flight brew survives a


### PR DESCRIPTION
A URL shared via 'Add to BTTS' now auto-sends 'What do you think of this coffee: <url>' to the Home AI chat (where bag-URL analysis now lives), instead of the scan step. Web-only — the native notification already carries the URL; this redirects the tap. No build needed.