### PR TITLE
feat(ios): brew surfaces — countdown to next step, now/next per surface

### DIFF
--- a/native/ios/App/App/BrewActivityAttributes.swift
+++ b/native/ios/App/App/BrewActivityAttributes.swift
@@ -5,20 +5,24 @@ import ActivityKit
 /// BTTSWidget target (renders it). ActivityKit is iOS 16.1+, so the type is
 /// availability-gated; the App target (min iOS 15) only touches it behind the
 /// same `#available` guards in LiveActivityPlugin.
+///
+/// The countdown is always to the NEXT step (`nextStepDate`), never the total
+/// brew. The "now" surfaces (lock screen, watch app) show `currentStep`; the
+/// "next" surfaces (Dynamic Island, watch Smart Stack) show `nextStep`. The
+/// progress bar fills over the current step (`stepStartDate`…`nextStepDate`).
 @available(iOS 16.1, *)
 struct BrewAttributes: ActivityAttributes {
     public struct ContentState: Codable, Hashable {
-        /// What to do right now — "Pour to 180g", "Steep", "Drawdown", …
-        var stepLabel: String
+        var currentStep: String
+        var nextStep: String
+        /// When the next step fires — the countdown target.
+        var nextStepDate: Date
+        /// When the current step started — lower bound of the progress bar.
+        var stepStartDate: Date
         var stepIndex: Int
         var stepCount: Int
-        /// Target finish — drives the system-rendered countdown + progress bar.
-        var endDate: Date
-        var paused: Bool
     }
 
     var recipeName: String
     var coffeeName: String
-    /// Brew start — the lower bound of the timer/progress interval.
-    var startDate: Date
 }

--- a/native/ios/App/App/LiveActivityPlugin.swift
+++ b/native/ios/App/App/LiveActivityPlugin.swift
@@ -33,8 +33,7 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
         }
         let attributes = BrewAttributes(
             recipeName: call.getString("recipeName") ?? "Brew",
-            coffeeName: call.getString("coffeeName") ?? "",
-            startDate: date(call, "startMs") ?? Date()
+            coffeeName: call.getString("coffeeName") ?? ""
         )
         do {
             _ = try Activity.request(
@@ -71,11 +70,12 @@ public class LiveActivityPlugin: CAPPlugin, CAPBridgedPlugin {
     @available(iOS 16.1, *)
     private func contentState(_ call: CAPPluginCall) -> BrewAttributes.ContentState {
         BrewAttributes.ContentState(
-            stepLabel: call.getString("stepLabel") ?? "Brewing",
+            currentStep: call.getString("currentStep") ?? "Brewing",
+            nextStep: call.getString("nextStep") ?? "",
+            nextStepDate: date(call, "nextStepMs") ?? Date().addingTimeInterval(60),
+            stepStartDate: date(call, "stepStartMs") ?? Date(),
             stepIndex: call.getInt("stepIndex") ?? 0,
-            stepCount: call.getInt("stepCount") ?? 0,
-            endDate: date(call, "endMs") ?? Date().addingTimeInterval(180),
-            paused: call.getBool("paused") ?? false
+            stepCount: call.getInt("stepCount") ?? 0
         )
     }
 

--- a/native/ios/App/BTTSWatch/ContentView.swift
+++ b/native/ios/App/BTTSWatch/ContentView.swift
@@ -34,8 +34,8 @@ struct ContentView: View {
     @ViewBuilder
     private var content: some View {
         if model.isBrewing {
+            // Brewstep screen — the step happening NOW + a countdown to the next.
             VStack(alignment: .leading, spacing: 4) {
-                // Eyebrow — which recipe (context, not the focus).
                 Text(model.recipeName.uppercased())
                     .font(.system(size: 11, weight: .bold))
                     .tracking(0.8)
@@ -44,26 +44,20 @@ struct ContentView: View {
 
                 Spacer(minLength: 0)
 
-                if let next = model.nextLabel, let at = model.nextFireAt {
-                    Text("NEXT")
-                        .font(.system(size: 10, weight: .semibold))
-                        .tracking(1.2)
-                        .foregroundStyle(ink.opacity(0.5))
-                    Text(next)
-                        .font(.system(size: 17, weight: .semibold, design: .serif))
-                        .foregroundStyle(ink)
-                        .lineLimit(2)
-                        .minimumScaleFactor(0.8)
-                    // The hero: how long until the next step.
+                Text("NOW")
+                    .font(.system(size: 10, weight: .semibold))
+                    .tracking(1.2)
+                    .foregroundStyle(ink.opacity(0.5))
+                Text(model.currentLabel.isEmpty ? "Brewing" : model.currentLabel)
+                    .font(.system(size: 17, weight: .semibold, design: .serif))
+                    .foregroundStyle(ink)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.8)
+                // The hero: how long until the next step.
+                if let at = model.nextFireAt {
                     Text(at, style: .timer)
                         .font(.system(size: 30, weight: .bold, design: .rounded).monospacedDigit())
                         .foregroundStyle(ink)
-                } else {
-                    Text(model.currentLabel.isEmpty ? "Brewing" : model.currentLabel)
-                        .font(.system(size: 20, weight: .semibold, design: .serif))
-                        .foregroundStyle(ink)
-                        .lineLimit(2)
-                        .minimumScaleFactor(0.8)
                 }
 
                 Spacer(minLength: 0)

--- a/native/ios/App/BTTSWidget/BrewLiveActivity.swift
+++ b/native/ios/App/BTTSWidget/BrewLiveActivity.swift
@@ -10,41 +10,39 @@ private let laTint = Color(red: 0.969, green: 0.706, blue: 0.580)  // peach back
 struct BrewLiveActivity: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: BrewAttributes.self) { context in
-            // Lock screen / banner
+            // LOCK SCREEN — shows the step happening NOW + a countdown to the next.
             BrewLockScreenView(context: context)
                 .activityBackgroundTint(laTint)
                 .activitySystemActionForegroundColor(laInk)
         } dynamicIsland: { context in
+            // DYNAMIC ISLAND ("action bar") — shows the NEXT step + countdown.
+            // Rendered on black, so text is light. No coffee-cup glyph.
             DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
-                    Image(systemName: "cup.and.saucer.fill").foregroundColor(laInk)
+                    Text("NEXT")
+                        .font(.system(size: 11, weight: .bold)).tracking(1)
+                        .foregroundStyle(.secondary)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
-                    Text(timerInterval: context.attributes.startDate...context.state.endDate, countsDown: true)
+                    Text(timerInterval: context.state.stepStartDate...context.state.nextStepDate, countsDown: true)
                         .monospacedDigit()
                         .multilineTextAlignment(.trailing)
                         .frame(width: 56)
-                        .foregroundColor(laInk)
                 }
                 DynamicIslandExpandedRegion(.center) {
-                    Text(context.state.stepLabel)
+                    Text(context.state.nextStep)
                         .font(.headline)
                         .lineLimit(1)
-                        .foregroundColor(laInk)
-                }
-                DynamicIslandExpandedRegion(.bottom) {
-                    ProgressView(timerInterval: context.attributes.startDate...context.state.endDate, countsDown: false)
-                        .tint(laInk)
-                        .labelsHidden()
                 }
             } compactLeading: {
-                Image(systemName: "cup.and.saucer.fill")
+                Text("Next").font(.caption2)
             } compactTrailing: {
-                Text(timerInterval: context.attributes.startDate...context.state.endDate, countsDown: true)
+                Text(timerInterval: context.state.stepStartDate...context.state.nextStepDate, countsDown: true)
                     .monospacedDigit()
                     .frame(width: 44)
             } minimal: {
-                Image(systemName: "cup.and.saucer.fill")
+                Text(timerInterval: context.state.stepStartDate...context.state.nextStepDate, countsDown: true)
+                    .monospacedDigit()
             }
         }
     }
@@ -56,34 +54,33 @@ struct BrewLockScreenView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            HStack(alignment: .top) {
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(context.attributes.recipeName.uppercased())
-                        .font(.system(size: 10, weight: .bold))
-                        .tracking(0.8)
-                        .foregroundColor(laInk.opacity(0.6))
+            // Eyebrow — which recipe (context).
+            Text(context.attributes.recipeName.uppercased())
+                .font(.system(size: 11, weight: .bold))
+                .tracking(0.8)
+                .foregroundColor(laInk.opacity(0.6))
+                .lineLimit(1)
+
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("NOW")
+                        .font(.system(size: 10, weight: .semibold))
+                        .tracking(1.2)
+                        .foregroundColor(laInk.opacity(0.5))
+                    Text(context.state.currentStep)
+                        .font(.system(size: 20, weight: .semibold, design: .serif))
+                        .foregroundColor(laInk)
                         .lineLimit(1)
-                    if !context.attributes.coffeeName.isEmpty {
-                        Text(context.attributes.coffeeName)
-                            .font(.system(size: 13, weight: .medium))
-                            .foregroundColor(laInk.opacity(0.8))
-                            .lineLimit(1)
-                    }
+                        .minimumScaleFactor(0.6)
                 }
-                Spacer()
-                Text(timerInterval: context.attributes.startDate...context.state.endDate, countsDown: true)
-                    .font(.system(size: 24, weight: .semibold, design: .rounded))
+                Spacer(minLength: 8)
+                Text(timerInterval: context.state.stepStartDate...context.state.nextStepDate, countsDown: true)
+                    .font(.system(size: 24, weight: .bold, design: .rounded))
                     .monospacedDigit()
                     .foregroundColor(laInk)
             }
 
-            Text(context.state.stepLabel)
-                .font(.system(size: 20, weight: .semibold, design: .serif))
-                .foregroundColor(laInk)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
-
-            ProgressView(timerInterval: context.attributes.startDate...context.state.endDate, countsDown: false)
+            ProgressView(timerInterval: context.state.stepStartDate...context.state.nextStepDate, countsDown: false)
                 .tint(laInk)
                 .labelsHidden()
         }

--- a/src/hooks/useBrewLiveActivity.ts
+++ b/src/hooks/useBrewLiveActivity.ts
@@ -2,7 +2,7 @@
 import { useEffect, useRef } from "react";
 import { type BrewBoundary } from "@/lib/native/brewNotifications";
 import {
-  currentBrewStep,
+  brewActivityState,
   startBrewActivity,
   updateBrewActivity,
   endBrewActivity,
@@ -48,26 +48,18 @@ export function useBrewLiveActivity(
     const now = Date.now();
     const impliedStartMs = now - elapsed * 1000;
     const { boundaries, recipeName, coffeeName, targetTimeSec: target } = ctx.current;
-    const endMs = impliedStartMs + target * 1000;
-    const step = currentBrewStep(boundaries, elapsed);
+    const state = brewActivityState(boundaries, elapsed, impliedStartMs, target);
 
     const isNew =
       anchorRef.current === null || Math.abs(impliedStartMs - anchorRef.current) > 1500;
 
     if (isNew) {
       anchorRef.current = impliedStartMs;
-      lastStepRef.current = step.stepLabel;
-      startBrewActivity({
-        recipeName,
-        coffeeName,
-        startMs: impliedStartMs,
-        endMs,
-        ...step,
-        paused: false,
-      });
-    } else if (step.stepLabel !== lastStepRef.current) {
-      lastStepRef.current = step.stepLabel;
-      updateBrewActivity({ endMs, ...step, paused: false });
+      lastStepRef.current = state.currentStep;
+      startBrewActivity({ recipeName, coffeeName, ...state });
+    } else if (state.currentStep !== lastStepRef.current) {
+      lastStepRef.current = state.currentStep;
+      updateBrewActivity(state);
     }
   }, [elapsed, started, targetTimeSec]);
 

--- a/src/lib/native/liveActivity.ts
+++ b/src/lib/native/liveActivity.ts
@@ -16,16 +16,18 @@
 import type { BrewBoundary } from "@/lib/native/brewNotifications";
 
 export interface BrewActivityState {
-  stepLabel: string;
+  currentStep: string;
+  nextStep: string;
+  /** Epoch ms when the NEXT step fires — the countdown target. */
+  nextStepMs: number;
+  /** Epoch ms when the current step started — progress-bar lower bound. */
+  stepStartMs: number;
   stepIndex: number;
   stepCount: number;
-  /** Epoch ms of the brew's target finish — drives the system timer/progress. */
-  endMs: number;
-  paused: boolean;
 }
 
 interface LiveActivityPluginLike {
-  start(o: { recipeName: string; coffeeName: string; startMs: number } & BrewActivityState): Promise<{ started?: boolean }>;
+  start(o: { recipeName: string; coffeeName: string } & BrewActivityState): Promise<{ started?: boolean }>;
   update(o: BrewActivityState): Promise<void>;
   end(): Promise<void>;
 }
@@ -51,21 +53,41 @@ export function isNativeLiveActivity(): boolean {
   return getPlugin() !== null;
 }
 
-/** The current brew step from the boundary schedule (the last boundary passed). */
-export function currentBrewStep(
+/**
+ * Build the activity state from the boundary schedule: the current step (last
+ * boundary passed), the next step + when it fires (the countdown target), and
+ * when the current step started (progress-bar lower bound). Before the first
+ * boundary the current step is "Bloom"; after the last, the "next" is Drawdown
+ * at the target finish.
+ */
+export function brewActivityState(
   boundaries: BrewBoundary[],
   elapsed: number,
-): { stepLabel: string; stepIndex: number; stepCount: number } {
-  let idx = -1;
+  brewStartMs: number,
+  targetTimeSec: number,
+): BrewActivityState {
+  let curIdx = -1;
   for (let i = 0; i < boundaries.length; i++) {
-    if (boundaries[i].atSec <= elapsed) idx = i;
+    if (boundaries[i].atSec <= elapsed) curIdx = i;
   }
-  const stepLabel = idx >= 0 ? boundaries[idx].title : "Bloom";
-  return { stepLabel, stepIndex: idx + 1, stepCount: boundaries.length };
+  const currentStep = curIdx >= 0 ? boundaries[curIdx].title : "Bloom";
+  const stepStartSec = curIdx >= 0 ? boundaries[curIdx].atSec : 0;
+  const nextIdx = curIdx + 1;
+  const hasNext = nextIdx < boundaries.length;
+  const nextStep = hasNext ? boundaries[nextIdx].title : "Drawdown";
+  const nextSec = hasNext ? boundaries[nextIdx].atSec : targetTimeSec;
+  return {
+    currentStep,
+    nextStep,
+    nextStepMs: brewStartMs + nextSec * 1000,
+    stepStartMs: brewStartMs + stepStartSec * 1000,
+    stepIndex: curIdx + 1,
+    stepCount: boundaries.length,
+  };
 }
 
 export function startBrewActivity(
-  opts: { recipeName: string; coffeeName: string; startMs: number } & BrewActivityState,
+  opts: { recipeName: string; coffeeName: string } & BrewActivityState,
 ): void {
   getPlugin()?.start(opts).catch(() => {});
 }


### PR DESCRIPTION
Per wireframes: countdown always to the NEXT step. Live Activity lock screen = NOW (peach, progress, no cup); Dynamic Island = NEXT (no cup); watch brewstep = NOW. Data model reworked (current/next/nextStepDate/stepStartDate). Watch Smart Stack card next build. Native+web; needs a build.