### PR TITLE
feat(ios): watch Smart Stack NEXT card (Live Activity .small family)

### DIFF
--- a/native/ios/App/BTTSWidget/BTTSWidget.swift
+++ b/native/ios/App/BTTSWidget/BTTSWidget.swift
@@ -298,7 +298,7 @@ struct BTTSWidgetBundle: WidgetBundle {
     var body: some Widget {
         BTTSWidget()
         ScanWidget()
-        if #available(iOS 16.2, *) {
+        if #available(iOS 18.0, *) {
             BrewLiveActivity()
         }
     }

--- a/native/ios/App/BTTSWidget/BrewLiveActivity.swift
+++ b/native/ios/App/BTTSWidget/BrewLiveActivity.swift
@@ -6,17 +6,17 @@ import SwiftUI
 private let laInk = Color(red: 0.227, green: 0.133, blue: 0.188)   // deep plum
 private let laTint = Color(red: 0.969, green: 0.706, blue: 0.580)  // peach background tint
 
-@available(iOS 16.2, *)
+// Gated to iOS 18: the watch Smart Stack family (supplementalActivityFamilies /
+// @Environment(\.activityFamily)) is iOS 18 / watchOS 11+. Single-user app on the
+// latest OS, so requiring 18 for the Live Activity is fine.
+@available(iOS 18.0, *)
 struct BrewLiveActivity: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: BrewAttributes.self) { context in
-            // LOCK SCREEN — shows the step happening NOW + a countdown to the next.
-            BrewLockScreenView(context: context)
-                .activityBackgroundTint(laTint)
-                .activitySystemActionForegroundColor(laInk)
+            BrewActivityContent(context: context)
         } dynamicIsland: { context in
-            // DYNAMIC ISLAND ("action bar") — shows the NEXT step + countdown.
-            // Rendered on black, so text is light. No coffee-cup glyph.
+            // DYNAMIC ISLAND ("action bar") — the NEXT step + countdown. On black,
+            // so light text. No coffee-cup glyph.
             DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
                     Text("NEXT")
@@ -45,16 +45,65 @@ struct BrewLiveActivity: Widget {
                     .monospacedDigit()
             }
         }
+        .supplementalActivityFamilies([.small]) // watch Smart Stack
     }
 }
 
-@available(iOS 16.2, *)
+/// Picks the layout per family: `.small` = watch Smart Stack (NEXT step),
+/// `.medium` = iOS lock screen (NOW step).
+@available(iOS 18.0, *)
+struct BrewActivityContent: View {
+    @Environment(\.activityFamily) private var family
+    let context: ActivityViewContext<BrewAttributes>
+
+    var body: some View {
+        switch family {
+        case .small:
+            BrewWatchSmartStackView(context: context)
+        default:
+            BrewLockScreenView(context: context)
+                .activityBackgroundTint(laTint)
+                .activitySystemActionForegroundColor(laInk)
+        }
+    }
+}
+
+/// Watch Smart Stack ("activity widget") — the NEXT step + countdown. Rendered on
+/// the system's dark Smart Stack card, so light text; BTTS wordmark on top.
+@available(iOS 18.0, *)
+struct BrewWatchSmartStackView: View {
+    let context: ActivityViewContext<BrewAttributes>
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("BTTS")
+                .font(.system(size: 16, weight: .bold, design: .serif))
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("NEXT")
+                        .font(.system(size: 9, weight: .semibold)).tracking(0.8)
+                        .foregroundStyle(.secondary)
+                    Text(context.state.nextStep)
+                        .font(.system(size: 15, weight: .medium))
+                        .lineLimit(1).minimumScaleFactor(0.7)
+                }
+                Spacer(minLength: 6)
+                Text(timerInterval: context.state.stepStartDate...context.state.nextStepDate, countsDown: true)
+                    .font(.system(size: 18, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+/// iOS lock screen — the step happening NOW + a countdown to the next.
+@available(iOS 18.0, *)
 struct BrewLockScreenView: View {
     let context: ActivityViewContext<BrewAttributes>
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            // Eyebrow — which recipe (context).
             Text(context.attributes.recipeName.uppercased())
                 .font(.system(size: 11, weight: .bold))
                 .tracking(0.8)


### PR DESCRIPTION
Adds the watch Smart Stack layout to the brew Live Activity via supplementalActivityFamilies([.small]) + activityFamily switch (.small = watch NEXT card, .medium = lock-screen NOW). iPhone Live Activity auto-shows in the watch Smart Stack. Gated iOS 18. Native; needs a build.