### PR TITLE
fix(ios): brew surfaces match wireframes (step → total, alignment)

### DIFF
--- a/native/ios/App/BTTSWidget/BrewLiveActivity.swift
+++ b/native/ios/App/BTTSWidget/BrewLiveActivity.swift
@@ -8,15 +8,15 @@ private let laTint = Color(red: 0.969, green: 0.706, blue: 0.580)  // peach back
 
 // Gated to iOS 18: the watch Smart Stack family (supplementalActivityFamilies /
 // @Environment(\.activityFamily)) is iOS 18 / watchOS 11+. Single-user app on the
-// latest OS, so requiring 18 for the Live Activity is fine.
+// latest OS. The step strings arrive pre-formatted from the web: the "now"
+// surfaces get "<step> → <total>g", the "next" surfaces get just the step name.
 @available(iOS 18.0, *)
 struct BrewLiveActivity: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: BrewAttributes.self) { context in
             BrewActivityContent(context: context)
         } dynamicIsland: { context in
-            // DYNAMIC ISLAND ("action bar") — the NEXT step + countdown. On black,
-            // so light text. No coffee-cup glyph.
+            // DYNAMIC ISLAND ("action bar") — the NEXT step + countdown, no cup.
             DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
                     Text("NEXT")
@@ -24,10 +24,7 @@ struct BrewLiveActivity: Widget {
                         .foregroundStyle(.secondary)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
-                    Text(timerInterval: context.state.stepStartDate...context.state.nextStepDate, countsDown: true)
-                        .monospacedDigit()
-                        .multilineTextAlignment(.trailing)
-                        .frame(width: 56)
+                    countdown(context).frame(width: 56)
                 }
                 DynamicIslandExpandedRegion(.center) {
                     Text(context.state.nextStep)
@@ -35,17 +32,22 @@ struct BrewLiveActivity: Widget {
                         .lineLimit(1)
                 }
             } compactLeading: {
-                Text("Next").font(.caption2)
+                // Show the step (the owner's fix — it used to say only "Next").
+                Text(context.state.nextStep)
+                    .lineLimit(1)
             } compactTrailing: {
-                Text(timerInterval: context.state.stepStartDate...context.state.nextStepDate, countsDown: true)
-                    .monospacedDigit()
-                    .frame(width: 44)
+                countdown(context).frame(minWidth: 40)
             } minimal: {
-                Text(timerInterval: context.state.stepStartDate...context.state.nextStepDate, countsDown: true)
-                    .monospacedDigit()
+                countdown(context)
             }
         }
         .supplementalActivityFamilies([.small]) // watch Smart Stack
+    }
+
+    // System-rendered countdown to the NEXT step (never total brew time).
+    private func countdown(_ context: ActivityViewContext<BrewAttributes>) -> some View {
+        Text(timerInterval: context.state.stepStartDate...context.state.nextStepDate, countsDown: true)
+            .monospacedDigit()
     }
 }
 
@@ -68,65 +70,63 @@ struct BrewActivityContent: View {
     }
 }
 
-/// Watch Smart Stack ("activity widget") — the NEXT step + countdown. Rendered on
-/// the system's dark Smart Stack card, so light text; BTTS wordmark on top.
+/// Watch Smart Stack ("activity widget") — BTTS + the NEXT step name + countdown,
+/// on one aligned row. Rendered on the system dark card, so light text.
 @available(iOS 18.0, *)
 struct BrewWatchSmartStackView: View {
     let context: ActivityViewContext<BrewAttributes>
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: 6) {
             Text("BTTS")
                 .font(.system(size: 16, weight: .bold, design: .serif))
             HStack(alignment: .firstTextBaseline) {
-                VStack(alignment: .leading, spacing: 1) {
-                    Text("NEXT")
-                        .font(.system(size: 9, weight: .semibold)).tracking(0.8)
-                        .foregroundStyle(.secondary)
-                    Text(context.state.nextStep)
-                        .font(.system(size: 15, weight: .medium))
-                        .lineLimit(1).minimumScaleFactor(0.7)
-                }
+                Text("Next: \(context.state.nextStep)")
+                    .font(.system(size: 15, weight: .medium))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
                 Spacer(minLength: 6)
                 Text(timerInterval: context.state.stepStartDate...context.state.nextStepDate, countsDown: true)
                     .font(.system(size: 18, weight: .bold, design: .rounded))
                     .monospacedDigit()
+                    .layoutPriority(1)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
-/// iOS lock screen — the step happening NOW + a countdown to the next.
+/// iOS lock screen — the step happening NOW (with cumulative total) + a countdown
+/// to the next step on the same row, then a progress bar over the current step.
 @available(iOS 18.0, *)
 struct BrewLockScreenView: View {
     let context: ActivityViewContext<BrewAttributes>
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 6) {
             Text(context.attributes.recipeName.uppercased())
                 .font(.system(size: 11, weight: .bold))
                 .tracking(0.8)
                 .foregroundColor(laInk.opacity(0.6))
                 .lineLimit(1)
 
+            Text("NOW")
+                .font(.system(size: 10, weight: .semibold))
+                .tracking(1.2)
+                .foregroundColor(laInk.opacity(0.5))
+
             HStack(alignment: .firstTextBaseline) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("NOW")
-                        .font(.system(size: 10, weight: .semibold))
-                        .tracking(1.2)
-                        .foregroundColor(laInk.opacity(0.5))
-                    Text(context.state.currentStep)
-                        .font(.system(size: 20, weight: .semibold, design: .serif))
-                        .foregroundColor(laInk)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.6)
-                }
-                Spacer(minLength: 8)
+                Text(context.state.currentStep)
+                    .font(.system(size: 20, weight: .semibold, design: .serif))
+                    .foregroundColor(laInk)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
+                Spacer(minLength: 10)
                 Text(timerInterval: context.state.stepStartDate...context.state.nextStepDate, countsDown: true)
-                    .font(.system(size: 24, weight: .bold, design: .rounded))
+                    .font(.system(size: 26, weight: .bold, design: .rounded))
                     .monospacedDigit()
                     .foregroundColor(laInk)
+                    .layoutPriority(1)
             }
 
             ProgressView(timerInterval: context.state.stepStartDate...context.state.nextStepDate, countsDown: false)

--- a/src/lib/native/brewNotifications.ts
+++ b/src/lib/native/brewNotifications.ts
@@ -48,6 +48,26 @@ export interface BrewBoundary {
   atSec: number;
   title: string;
   body: string;
+  /** Clean step name with no grams — e.g. "Pour 2", "Final pour", "Drawdown",
+   * "Swirl". Used verbatim on the "next" surfaces (Dynamic Island, Smart Stack). */
+  label: string;
+  /** Cumulative target weight to reach by the end of this pour, if it's a pour.
+   * The "now" surfaces show "<label> → <cumulativeGrams>g". Absent for agitation
+   * / drawdown / finishing steps. */
+  cumulativeGrams?: number;
+}
+
+/** Step text for the "now" surfaces (lock screen, watch app): the step plus the
+ * cumulative total to reach, with an arrow — "Pour 2 → 230g". No grams → just
+ * the label ("Swirl", "Drawdown"). */
+export function formatNowStep(b: BrewBoundary): string {
+  return b.cumulativeGrams != null ? `${b.label} → ${b.cumulativeGrams}g` : b.label;
+}
+
+/** Step text for the "next" surfaces (Dynamic Island, watch Smart Stack): just
+ * the step name, no grams. */
+export function formatNextStep(b: BrewBoundary): string {
+  return b.label;
 }
 
 /** The fixed notification id range a pre-removal build scheduled into. The
@@ -84,6 +104,7 @@ export function buildBrewBoundaries(
           atSec: s.startTimeSec,
           title: s.label,
           body: s.notes ?? "after the pour",
+          label: s.label,
         });
         continue;
       }
@@ -93,6 +114,8 @@ export function buildBrewBoundaries(
         atSec: s.startTimeSec,
         title: `${s.label} — +${s.pourGrams}g`,
         body: parts.join(" · "),
+        label: s.label,
+        cumulativeGrams: s.cumulativeGrams,
       });
     }
     if (targetTimeSec != null && targetTimeSec - (out[out.length - 1]?.atSec ?? 0) >= 5) {
@@ -100,6 +123,7 @@ export function buildBrewBoundaries(
         atSec: targetTimeSec,
         title: "Drawdown — brew finishing",
         body: `Target ${formatClock(targetTimeSec)} reached.`,
+        label: "Drawdown",
       });
     }
     return out;
@@ -117,6 +141,8 @@ export function buildBrewBoundaries(
         atSec: s.startTimeSec,
         title: s.label,
         body: parts.join(" · "),
+        label: s.label,
+        cumulativeGrams: s.cumulativeGrams ?? undefined,
       });
     }
     if (targetTimeSec != null && targetTimeSec - (out[out.length - 1]?.atSec ?? 0) >= 5) {
@@ -124,6 +150,7 @@ export function buildBrewBoundaries(
         atSec: targetTimeSec,
         title: "Brew finishing",
         body: `Target ${formatClock(targetTimeSec)} reached.`,
+        label: "Finishing",
       });
     }
     return out;

--- a/src/lib/native/brewWatch.ts
+++ b/src/lib/native/brewWatch.ts
@@ -11,7 +11,7 @@
  * Pure-web module, ZERO `@capacitor/*` imports (ambient types only). Off the
  * native shell every export is a silent no-op.
  */
-import type { BrewBoundary } from "@/lib/native/brewNotifications";
+import { type BrewBoundary, formatNowStep } from "@/lib/native/brewNotifications";
 
 export interface WatchFire {
   /** Epoch milliseconds at which the watch should buzz. */
@@ -48,7 +48,9 @@ export function isNativeWatch(): boolean {
 
 /** Convert the brew's relative-second boundaries into absolute epoch-ms fires. */
 export function boundariesToFires(boundaries: BrewBoundary[], startedAtMs: number): WatchFire[] {
-  return boundaries.map((b) => ({ atMs: startedAtMs + Math.round(b.atSec * 1000), label: b.title }));
+  // The watch app shows the step happening NOW, so the fire label is the
+  // now-format (step → cumulative total), e.g. "Pour 2 → 230g".
+  return boundaries.map((b) => ({ atMs: startedAtMs + Math.round(b.atSec * 1000), label: formatNowStep(b) }));
 }
 
 /** Hand the watch the full schedule at brew start. No-op off the native shell. */

--- a/src/lib/native/liveActivity.ts
+++ b/src/lib/native/liveActivity.ts
@@ -13,7 +13,7 @@
  * Pure-web module, ZERO `@capacitor/*` imports (ambient types). Off the native
  * shell every export is a silent no-op.
  */
-import type { BrewBoundary } from "@/lib/native/brewNotifications";
+import { type BrewBoundary, formatNowStep, formatNextStep } from "@/lib/native/brewNotifications";
 
 export interface BrewActivityState {
   currentStep: string;
@@ -70,11 +70,11 @@ export function brewActivityState(
   for (let i = 0; i < boundaries.length; i++) {
     if (boundaries[i].atSec <= elapsed) curIdx = i;
   }
-  const currentStep = curIdx >= 0 ? boundaries[curIdx].title : "Bloom";
+  const currentStep = curIdx >= 0 ? formatNowStep(boundaries[curIdx]) : "Bloom";
   const stepStartSec = curIdx >= 0 ? boundaries[curIdx].atSec : 0;
   const nextIdx = curIdx + 1;
   const hasNext = nextIdx < boundaries.length;
-  const nextStep = hasNext ? boundaries[nextIdx].title : "Drawdown";
+  const nextStep = hasNext ? formatNextStep(boundaries[nextIdx]) : "Drawdown";
   const nextSec = hasNext ? boundaries[nextIdx].atSec : targetTimeSec;
   return {
     currentStep,


### PR DESCRIPTION
NOW surfaces show '<step> → <cumulative total>g' (arrow); NEXT surfaces show just the step name (no grams). Dynamic Island compact now shows the step. Lock screen + Smart Stack realigned (countdown on the step row, not floating by the eyebrow). Web+native; needs a build.