### PR TITLE
ci(ios): raise dev-cert trim threshold (fewer revoke emails)

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -151,7 +151,7 @@ jobs:
             const certs = (JSON.parse(r.body).data) || [];
             const dev = certs.filter(c => String(c.attributes.certificateType||'').includes('DEVELOPMENT'));
             console.log(`certs total=${certs.length} development=${dev.length}`);
-            const KEEP = 4, THRESHOLD = 6;
+            const KEEP = 8, THRESHOLD = 10;
             if (dev.length <= THRESHOLD) { console.log('under threshold — no revocation'); return; }
             const oldestFirst = dev.slice().sort((a,b) =>
               new Date(a.attributes.createdDate).getTime() - new Date(b.attributes.createdDate).getTime());


### PR DESCRIPTION
Keep 8 / trim when >10 (was 4/6). Stays quiet through an iteration day; effectively never trims in monthly ops. Peak 11, under the ~12 cap.