### PR TITLE
feat: background recipe generation (survives backgrounding the app)

### DIFF
--- a/src/app/api/recommend/route.ts
+++ b/src/app/api/recommend/route.ts
@@ -1,164 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
-import { and, eq, isNull, lte, ne, or, sql } from "drizzle-orm";
-import { generateRecommendation, type RecommendInsight } from "@/lib/claude/recommend";
-import { buildEscherTerrain } from "@/lib/claude/escher";
-import { db } from "@/lib/db/client";
-import { coffees, preferences as preferencesTable, roasters, insights as insightsTable } from "@/lib/db/schema";
 import { requireAuth } from "@/lib/auth/requireAuth";
-import { canonicalRoasterSlug } from "@/lib/roasters/priors";
-import type { UserPreferences } from "@/lib/types/preferences";
-import type { RoasterPrior } from "@/lib/roasters/priors";
+import { runRecommendation } from "@/lib/recommend/run";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 120;
 
 /**
- * Aggregated tasting history for this coffee — what the user actually
- * tastes across logged sessions, plus the AI brew memory. Both are
- * written by the weekly /api/coffees/compact cron and may be undefined
- * for first brews or coffees with <2 sessions.
+ * Synchronous recommendation — generate and return in one request. Kept for
+ * back-compat; the brew flow now uses the background-job path
+ * (`/api/recommend/start` + `/api/recommend/status`) so generation survives the
+ * app being backgrounded. Both share `runRecommendation`.
  */
-interface CoffeeHistory {
-  commonNotes?: string[];
-  writtenSummary?: string;
-}
-
-function mapCoffeeHistory(row: {
-  commonNotes: unknown;
-  writtenSummary: string | null;
-}): CoffeeHistory | undefined {
-  const notes = Array.isArray(row.commonNotes) ? (row.commonNotes as string[]) : undefined;
-  const summary = row.writtenSummary ?? undefined;
-  if ((!notes || notes.length === 0) && !summary) return undefined;
-  return {
-    commonNotes: notes && notes.length > 0 ? notes : undefined,
-    writtenSummary: summary,
-  };
-}
-
-async function loadCoffeeHistory(
-  coffeeId: string | undefined,
-  roaster: string | undefined,
-  name: string | undefined,
-): Promise<CoffeeHistory | undefined> {
-  try {
-    if (coffeeId) {
-      const direct = await db
-        .select({
-          commonNotes: coffees.commonNotes,
-          writtenSummary: coffees.writtenSummary,
-        })
-        .from(coffees)
-        .where(eq(coffees.id, coffeeId))
-        .limit(1);
-      if (direct.length > 0) return mapCoffeeHistory(direct[0]);
-    }
-    if (roaster && name) {
-      const fallback = await db
-        .select({
-          commonNotes: coffees.commonNotes,
-          writtenSummary: coffees.writtenSummary,
-        })
-        .from(coffees)
-        .where(and(eq(coffees.roaster, roaster), eq(coffees.name, name)))
-        .limit(1);
-      if (fallback.length > 0) return mapCoffeeHistory(fallback[0]);
-    }
-  } catch (err) {
-    console.error("loadCoffeeHistory error:", err);
-  }
-  return undefined;
-}
-
 export async function POST(req: NextRequest) {
   const authError = await requireAuth(req);
   if (authError) return authError;
 
   try {
-    const { coffee, context, pastSessions } = await req.json();
-
-    let preferences: UserPreferences | null = null;
-    try {
-      const rows = await db.select().from(preferencesTable).where(eq(preferencesTable.key, "default")).limit(1);
-      if (rows.length > 0) preferences = rows[0].data as UserPreferences;
-    } catch {}
-    const prefs = preferences || {
-      equipment: ["V60", "OreaV4", "Kalita", "Chemex", "Origami (cone)", "Origami (wave)", "CleverDripper", "AeroPress", "Moccamaster"],
-      grinder: "Niche Zero",
-      tasteProfile: { preferredBodyLevel: "medium", preferredAcidityLevel: "medium-high", likedOrigins: ["Ethiopia", "Brazil", "Kenya", "Costa Rica"], likedProcesses: ["Natural", "Washed", "Honey"], avoidProcesses: ["Anaerobic"] },
-      defaultAmount: "small",
-      onboardingComplete: true,
-    };
-
-    const sessions = pastSessions || [];
-
-    // Run DB roaster lookup, Escher terrain, coffee-history lookup, and
-    // multivariate coach insights in parallel — saves 3–5s vs sequential.
-    const [
-      userRoasterPriorResult,
-      terrain,
-      coffeeHistory,
-      coachInsights,
-    ] = await Promise.all([
-      (async (): Promise<RoasterPrior | null> => {
-        if (!coffee?.roaster) return null;
-        try {
-          const slug = canonicalRoasterSlug(coffee.roaster);
-          const direct = await db.select().from(roasters).where(eq(roasters.slug, slug)).limit(1);
-          if (direct.length > 0) return direct[0].data as RoasterPrior;
-          const viaAlias = await db
-            .select()
-            .from(roasters)
-            .where(sql`${roasters.aliases} @> ${JSON.stringify([slug])}::jsonb`)
-            .limit(1);
-          if (viaAlias.length > 0) return viaAlias[0].data as RoasterPrior;
-        } catch {}
-        return null;
-      })(),
-      sessions.length >= 3
-        ? buildEscherTerrain(sessions, coffee).catch(() => "")
-        : Promise.resolve(""),
-      loadCoffeeHistory(coffee?.coffeeId, coffee?.roaster, coffee?.name),
-      // Coach insights — exclude doesnt-apply AND actively-snoozed at
-      // the query layer. new / trying / confirmed / expired-snoozes all
-      // feed the prompt, with confirmed ranked higher by the recommend
-      // prompt block builder.
-      db
-        .select()
-        .from(insightsTable)
-        .where(
-          and(
-            ne(insightsTable.status, "doesnt-apply"),
-            or(
-              ne(insightsTable.status, "snoozed"),
-              isNull(insightsTable.snoozedUntil),
-              lte(insightsTable.snoozedUntil, new Date()),
-            ),
-          ),
-        )
-        .limit(20)
-        .catch(() => []),
-    ]);
-    const userRoasterPrior = userRoasterPriorResult;
-
-    const allInsights: RecommendInsight[] = Array.isArray(coachInsights)
-      ? coachInsights.map((row) => ({
-          observation: row.observation,
-          suggestion: row.suggestion,
-          citationFields: row.citationFields ?? [],
-        }))
-      : [];
-
-    const { recommendation } = await generateRecommendation(
-      coffee,
-      context,
-      prefs,
-      sessions,
-      userRoasterPrior ?? undefined,
-      terrain || undefined,
-      coffeeHistory,
-      allInsights.length > 0 ? allInsights : undefined,
-    );
+    const body = await req.json();
+    const recommendation = await runRecommendation(body);
     return NextResponse.json(recommendation);
   } catch (err) {
     console.error("recommend error:", err);

--- a/src/app/api/recommend/start/route.ts
+++ b/src/app/api/recommend/start/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth/requireAuth";
+import { runRecommendation } from "@/lib/recommend/run";
+import { createJob, markDone, markError } from "@/lib/recommend/jobStore";
+
+export const dynamic = "force-dynamic";
+// The detached task does the ~1-min Opus call; keep the platform from capping
+// it even though THIS handler returns in milliseconds.
+export const maxDuration = 120;
+
+/**
+ * Kick off a recommendation as a server-side background job and return its id
+ * immediately. The generation continues in the long-running Next process after
+ * this response is sent (the same mechanism `liveActivitySchedule` relies on),
+ * so a backgrounded/suspended iOS client no longer kills it. The client polls
+ * `/api/recommend/status` for the result.
+ */
+export async function POST(req: NextRequest) {
+  const authError = await requireAuth(req);
+  if (authError) return authError;
+
+  let body: { coffee: unknown; context: unknown; pastSessions?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const jobId = createJob();
+
+  // Fire-and-forget — do NOT await. The promise keeps running on the event loop
+  // after we respond; the result lands in the job store.
+  void runRecommendation(body)
+    .then((recommendation) => markDone(jobId, recommendation))
+    .catch((err) => {
+      console.error("recommend job error:", err);
+      markError(jobId, "Recommendation failed");
+    });
+
+  return NextResponse.json({ jobId });
+}

--- a/src/app/api/recommend/status/route.ts
+++ b/src/app/api/recommend/status/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth/requireAuth";
+import { getJob } from "@/lib/recommend/jobStore";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Poll the status of a background recommendation job. Returns the recommendation
+ * once `done`. An unknown id (TTL-evicted, or dropped by a server restart
+ * mid-generation) reads as `error` so the client surfaces retry rather than
+ * polling forever.
+ */
+export async function GET(req: NextRequest) {
+  const authError = await requireAuth(req);
+  if (authError) return authError;
+
+  const jobId = req.nextUrl.searchParams.get("jobId");
+  if (!jobId) return NextResponse.json({ error: "Missing jobId" }, { status: 400 });
+
+  const job = getJob(jobId);
+  if (!job) {
+    return NextResponse.json({ status: "error", error: "Recommendation expired" });
+  }
+
+  if (job.status === "done") {
+    return NextResponse.json({ status: "done", recommendation: job.recommendation });
+  }
+  if (job.status === "error") {
+    return NextResponse.json({ status: "error", error: job.error ?? "Recommendation failed" });
+  }
+  return NextResponse.json({ status: "running" });
+}

--- a/src/components/flow/LightStepContext.tsx
+++ b/src/components/flow/LightStepContext.tsx
@@ -167,7 +167,7 @@ interface CoffeeMemory {
 }
 
 export default function LightStepContext() {
-  const { draft, setContext, setStep, setIsRecommending, setRecommendError } = useFlowStore();
+  const { draft, setContext, setStep, setIsRecommending, setRecommendError, setRecommendJobId } = useFlowStore();
   const ctx = (draft.context || {}) as Partial<SessionContext>;
   const [heroQuestion, setHeroQuestion] = useState("");
   useEffect(() => {
@@ -270,24 +270,29 @@ export default function LightStepContext() {
     };
     setIsRecommending(true);
     setRecommendError(null);
+    setRecommendJobId(null);
     setStep("recommend");
+    // Kick the ~1-min Opus call off as a SERVER-side background job and only
+    // hold its id. The generation no longer dies when the iOS PWA is
+    // backgrounded; the always-mounted RecommendJobWatcher polls the job and
+    // fills in the recipe when it lands (or surfaces an error). We await only
+    // the fast `/start` handshake here.
     try {
       let pastSessions: Awaited<ReturnType<typeof getRecentSessions>> = [];
       try {
         pastSessions = await getRecentSessions(100);
       } catch {}
-      const res = await fetch("/api/recommend", {
+      const res = await fetch("/api/recommend/start", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ coffee: draft.coffee, context: finalCtx, pastSessions }),
       });
       if (!res.ok) throw new Error(`Recommendation failed (${res.status})`);
-      const recommendation = await res.json();
-      if (!recommendation.primaryMethod) throw new Error("No recommendation returned");
-      useFlowStore.getState().setRecommendation(recommendation);
+      const { jobId } = await res.json();
+      if (!jobId) throw new Error("Recommendation failed to start");
+      setRecommendJobId(jobId);
     } catch (err) {
       setRecommendError(err instanceof Error ? err.message : "Something went wrong");
-    } finally {
       setIsRecommending(false);
     }
   };

--- a/src/components/flow/LightStepRecommend.tsx
+++ b/src/components/flow/LightStepRecommend.tsx
@@ -191,7 +191,13 @@ export default function LightStepRecommend() {
         <p className="text-[14px] text-light-foreground">{recommendError}</p>
         <button
           type="button"
-          onClick={() => setStep("context")}
+          onClick={() => {
+            // Abandon any lingering job before re-running so a stale result
+            // can't refill after the user steps back.
+            useFlowStore.getState().setRecommendJobId(null);
+            useFlowStore.getState().setRecommendError(null);
+            setStep("context");
+          }}
           className="px-6 py-3 rounded-full bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 text-[14px] text-light-foreground active:scale-95 transition-transform"
         >
           Try again

--- a/src/components/ui/light/LightShell.tsx
+++ b/src/components/ui/light/LightShell.tsx
@@ -6,6 +6,7 @@ import { sweepBrewNotifications } from "@/lib/native/brewNotifications";
 import NativeWidgetBridge from "@/components/native/NativeWidgetBridge";
 import Field from "./Field";
 import ConnectionStatus from "./ConnectionStatus";
+import RecommendJobWatcher from "./RecommendJobWatcher";
 
 // Run the legacy-notification sweep once per app session, not per route mount.
 let didSweepNotifications = false;
@@ -44,6 +45,7 @@ export default function LightShell({ children }: { children: ReactNode }) {
       <div data-light-scope="true" className="font-chivo text-light-foreground min-h-dvh">
         <Field />
         <ConnectionStatus />
+        <RecommendJobWatcher />
         <NativeWidgetBridge />
         {children}
       </div>

--- a/src/components/ui/light/RecommendJobWatcher.tsx
+++ b/src/components/ui/light/RecommendJobWatcher.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { useFlowStore } from "@/store/flowStore";
+
+const POLL_MS = 3000;
+
+/**
+ * Headless, always-mounted (in LightShell) watcher for the server-side
+ * background recommendation job.
+ *
+ * Why this lives here and not in the recipe step: the whole point is that
+ * generation survives the app being backgrounded. The server keeps working
+ * while the iOS PWA is suspended; this watcher resumes polling the moment the
+ * app foregrounds (`visibilitychange`) — the same proven trigger
+ * ConnectionStatus uses to drain the offline queue — so the finished recipe
+ * lands as soon as the user returns. The job id is persisted in the flow store
+ * (localStorage), so a reload mid-generation resumes too.
+ *
+ * Renders nothing; the recipe screen reflects state via isRecommending /
+ * recommendError / draft.recommendation.
+ */
+export default function RecommendJobWatcher() {
+  const jobId = useFlowStore((s) => s.recommendJobId);
+  const pollingRef = useRef(false);
+
+  const poll = useCallback(async () => {
+    const id = useFlowStore.getState().recommendJobId;
+    if (!id || pollingRef.current) return;
+    if (typeof navigator !== "undefined" && !navigator.onLine) return;
+    pollingRef.current = true;
+    try {
+      const res = await fetch(`/api/recommend/status?jobId=${encodeURIComponent(id)}`);
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      const data = await res.json();
+      // The job id may have been cleared (reset / retry) while the request was
+      // in flight — don't clobber a fresh run with a stale result.
+      if (useFlowStore.getState().recommendJobId !== id) return;
+      const store = useFlowStore.getState();
+      if (data.status === "done") {
+        if (data.recommendation?.primaryMethod) {
+          store.setRecommendation(data.recommendation);
+        } else {
+          store.setRecommendError("No recommendation returned");
+        }
+        store.setRecommendJobId(null);
+        store.setIsRecommending(false);
+      } else if (data.status === "error") {
+        store.setRecommendError(data.error || "Something went wrong");
+        store.setRecommendJobId(null);
+        store.setIsRecommending(false);
+      }
+      // "running" → leave the interval to poll again.
+    } catch {
+      // Transient network/poll failure — keep the job alive and retry on the
+      // next tick / foreground. A genuinely dead job surfaces as status:error.
+    } finally {
+      pollingRef.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!jobId) return;
+    // Keep the loading UI honest if a reload rehydrated a job mid-generation.
+    if (!useFlowStore.getState().isRecommending) useFlowStore.getState().setIsRecommending(true);
+    void poll();
+    const interval = setInterval(() => void poll(), POLL_MS);
+    const onVisible = () => {
+      if (document.visibilityState === "visible") void poll();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [jobId, poll]);
+
+  return null;
+}

--- a/src/lib/recommend/jobStore.ts
+++ b/src/lib/recommend/jobStore.ts
@@ -1,0 +1,67 @@
+/**
+ * Recommendation job store (server-side, in-memory).
+ *
+ * `/api/recommend` is a ~1-minute blocking Opus call. Held in the client it
+ * dies the moment the iOS PWA is backgrounded (the WebView suspends and the
+ * in-flight connection is torn down). So instead the SERVER owns the work:
+ * `/api/recommend/start` kicks off generation as a detached task, parks the
+ * result here, and the client polls `/api/recommend/status`. A suspended
+ * client no longer kills the job; when it foregrounds and polls, the finished
+ * recipe is waiting.
+ *
+ * Single-user app → a handful of jobs at most. The standalone Next server is
+ * one long-running process, so this module-level Map persists across requests
+ * (same mechanism `src/lib/native/liveActivitySchedule.ts` relies on). A
+ * process restart mid-generation loses the in-flight job — the client then
+ * reads `error` and offers retry. Acceptable per spec.
+ */
+import type { Recommendation } from "@/lib/types/session";
+
+export type RecommendJobStatus = "running" | "done" | "error";
+
+export interface RecommendJob {
+  status: RecommendJobStatus;
+  recommendation?: Recommendation;
+  error?: string;
+  createdAt: number;
+}
+
+const jobs = new Map<string, RecommendJob>();
+
+// Keep the map from growing unbounded if a client never polls a job to
+// completion. Generation is capped at 120s, so 10 min is comfortable.
+const TTL_MS = 10 * 60 * 1000;
+
+function evictStale(): void {
+  const cutoff = Date.now() - TTL_MS;
+  for (const id of Array.from(jobs.keys())) {
+    const job = jobs.get(id);
+    if (job && job.createdAt < cutoff) jobs.delete(id);
+  }
+}
+
+/** Create a `running` job and return its id. */
+export function createJob(): string {
+  evictStale();
+  const id = crypto.randomUUID();
+  jobs.set(id, { status: "running", createdAt: Date.now() });
+  return id;
+}
+
+export function getJob(id: string): RecommendJob | undefined {
+  return jobs.get(id);
+}
+
+export function markDone(id: string, recommendation: Recommendation): void {
+  const job = jobs.get(id);
+  if (!job) return; // evicted (TTL) or superseded — nothing to update
+  job.status = "done";
+  job.recommendation = recommendation;
+}
+
+export function markError(id: string, error: string): void {
+  const job = jobs.get(id);
+  if (!job) return;
+  job.status = "error";
+  job.error = error;
+}

--- a/src/lib/recommend/run.ts
+++ b/src/lib/recommend/run.ts
@@ -1,0 +1,170 @@
+import { and, eq, isNull, lte, ne, or, sql } from "drizzle-orm";
+import { generateRecommendation, type RecommendInsight } from "@/lib/claude/recommend";
+import { buildEscherTerrain } from "@/lib/claude/escher";
+import { db } from "@/lib/db/client";
+import { coffees, preferences as preferencesTable, roasters, insights as insightsTable } from "@/lib/db/schema";
+import { canonicalRoasterSlug } from "@/lib/roasters/priors";
+import type { UserPreferences } from "@/lib/types/preferences";
+import type { RoasterPrior } from "@/lib/roasters/priors";
+import type { CoffeeIdentity, Recommendation, Session, SessionContext } from "@/lib/types/session";
+
+/**
+ * The full recommendation pipeline minus auth/HTTP: parallel DB lookups
+ * (roaster prior, Escher terrain, coffee history, coach insights) →
+ * generateRecommendation. Shared by the legacy synchronous `/api/recommend`
+ * POST and the background job kicked off in `/api/recommend/start`. Lives in
+ * lib (not a route) so neither route imports another route's module.
+ */
+
+/**
+ * Aggregated tasting history for this coffee — what the user actually tastes
+ * across logged sessions, plus the AI brew memory. Both are written by the
+ * weekly /api/coffees/compact cron and may be undefined for first brews or
+ * coffees with <2 sessions.
+ */
+interface CoffeeHistory {
+  commonNotes?: string[];
+  writtenSummary?: string;
+}
+
+function mapCoffeeHistory(row: {
+  commonNotes: unknown;
+  writtenSummary: string | null;
+}): CoffeeHistory | undefined {
+  const notes = Array.isArray(row.commonNotes) ? (row.commonNotes as string[]) : undefined;
+  const summary = row.writtenSummary ?? undefined;
+  if ((!notes || notes.length === 0) && !summary) return undefined;
+  return {
+    commonNotes: notes && notes.length > 0 ? notes : undefined,
+    writtenSummary: summary,
+  };
+}
+
+async function loadCoffeeHistory(
+  coffeeId: string | undefined,
+  roaster: string | undefined,
+  name: string | undefined,
+): Promise<CoffeeHistory | undefined> {
+  try {
+    if (coffeeId) {
+      const direct = await db
+        .select({
+          commonNotes: coffees.commonNotes,
+          writtenSummary: coffees.writtenSummary,
+        })
+        .from(coffees)
+        .where(eq(coffees.id, coffeeId))
+        .limit(1);
+      if (direct.length > 0) return mapCoffeeHistory(direct[0]);
+    }
+    if (roaster && name) {
+      const fallback = await db
+        .select({
+          commonNotes: coffees.commonNotes,
+          writtenSummary: coffees.writtenSummary,
+        })
+        .from(coffees)
+        .where(and(eq(coffees.roaster, roaster), eq(coffees.name, name)))
+        .limit(1);
+      if (fallback.length > 0) return mapCoffeeHistory(fallback[0]);
+    }
+  } catch (err) {
+    console.error("loadCoffeeHistory error:", err);
+  }
+  return undefined;
+}
+
+export async function runRecommendation(body: {
+  coffee: unknown;
+  context: unknown;
+  pastSessions?: unknown;
+}): Promise<Recommendation> {
+  const { coffee, context, pastSessions } = body as {
+    coffee: CoffeeIdentity;
+    context: SessionContext;
+    pastSessions?: Session[];
+  };
+
+  let preferences: UserPreferences | null = null;
+  try {
+    const rows = await db.select().from(preferencesTable).where(eq(preferencesTable.key, "default")).limit(1);
+    if (rows.length > 0) preferences = rows[0].data as UserPreferences;
+  } catch {}
+  const prefs = preferences || {
+    equipment: ["V60", "OreaV4", "Kalita", "Chemex", "Origami (cone)", "Origami (wave)", "CleverDripper", "AeroPress", "Moccamaster"],
+    grinder: "Niche Zero",
+    tasteProfile: { preferredBodyLevel: "medium", preferredAcidityLevel: "medium-high", likedOrigins: ["Ethiopia", "Brazil", "Kenya", "Costa Rica"], likedProcesses: ["Natural", "Washed", "Honey"], avoidProcesses: ["Anaerobic"] },
+    defaultAmount: "small",
+    onboardingComplete: true,
+  };
+
+  const sessions = pastSessions || [];
+
+  // Run DB roaster lookup, Escher terrain, coffee-history lookup, and
+  // multivariate coach insights in parallel — saves 3–5s vs sequential.
+  const [
+    userRoasterPriorResult,
+    terrain,
+    coffeeHistory,
+    coachInsights,
+  ] = await Promise.all([
+    (async (): Promise<RoasterPrior | null> => {
+      if (!coffee?.roaster) return null;
+      try {
+        const slug = canonicalRoasterSlug(coffee.roaster);
+        const direct = await db.select().from(roasters).where(eq(roasters.slug, slug)).limit(1);
+        if (direct.length > 0) return direct[0].data as RoasterPrior;
+        const viaAlias = await db
+          .select()
+          .from(roasters)
+          .where(sql`${roasters.aliases} @> ${JSON.stringify([slug])}::jsonb`)
+          .limit(1);
+        if (viaAlias.length > 0) return viaAlias[0].data as RoasterPrior;
+      } catch {}
+      return null;
+    })(),
+    sessions.length >= 3
+      ? buildEscherTerrain(sessions, coffee).catch(() => "")
+      : Promise.resolve(""),
+    loadCoffeeHistory(coffee?.coffeeId, coffee?.roaster, coffee?.name),
+    // Coach insights — exclude doesnt-apply AND actively-snoozed at the query
+    // layer. new / trying / confirmed / expired-snoozes all feed the prompt,
+    // with confirmed ranked higher by the recommend prompt block builder.
+    db
+      .select()
+      .from(insightsTable)
+      .where(
+        and(
+          ne(insightsTable.status, "doesnt-apply"),
+          or(
+            ne(insightsTable.status, "snoozed"),
+            isNull(insightsTable.snoozedUntil),
+            lte(insightsTable.snoozedUntil, new Date()),
+          ),
+        ),
+      )
+      .limit(20)
+      .catch(() => []),
+  ]);
+  const userRoasterPrior = userRoasterPriorResult;
+
+  const allInsights: RecommendInsight[] = Array.isArray(coachInsights)
+    ? coachInsights.map((row) => ({
+        observation: row.observation,
+        suggestion: row.suggestion,
+        citationFields: row.citationFields ?? [],
+      }))
+    : [];
+
+  const { recommendation } = await generateRecommendation(
+    coffee,
+    context,
+    prefs,
+    sessions,
+    userRoasterPrior ?? undefined,
+    terrain || undefined,
+    coffeeHistory,
+    allInsights.length > 0 ? allInsights : undefined,
+  );
+  return recommendation;
+}

--- a/src/store/flowStore.ts
+++ b/src/store/flowStore.ts
@@ -30,6 +30,11 @@ interface FlowState {
   isAnalyzing: boolean;
   isRecommending: boolean;
   recommendError: string | null;
+  /** Id of the server-side background recommendation job, set when the recipe
+   * generation is kicked off and cleared when it resolves (or on reset). The
+   * always-mounted RecommendJobWatcher polls it so generation survives the app
+   * being backgrounded — see src/lib/recommend/jobStore.ts. */
+  recommendJobId: string | null;
   clarificationMessages: ClarificationMessage[];
   /** A URL shared into the app via the iOS Share Sheet ("Add to BTTS"), to be
    * auto-analyzed by the scan step on mount, then cleared. */
@@ -55,6 +60,7 @@ interface FlowState {
   setIsAnalyzing: (v: boolean) => void;
   setIsRecommending: (v: boolean) => void;
   setRecommendError: (err: string | null) => void;
+  setRecommendJobId: (id: string | null) => void;
   addClarificationMessage: (msg: ClarificationMessage) => void;
   clearClarifications: () => void;
   reset: () => void;
@@ -84,6 +90,7 @@ export const useFlowStore = create<FlowState>()(
       isAnalyzing: false,
       isRecommending: false,
       recommendError: null,
+      recommendJobId: null,
       clarificationMessages: [],
 
       setStep: (step) => set({ step }),
@@ -103,11 +110,12 @@ export const useFlowStore = create<FlowState>()(
       setIsAnalyzing: (v) => set({ isAnalyzing: v }),
       setIsRecommending: (v) => set({ isRecommending: v }),
       setRecommendError: (err) => set({ recommendError: err }),
+      setRecommendJobId: (id) => set({ recommendJobId: id }),
       addClarificationMessage: (msg) =>
         set((s) => ({ clarificationMessages: [...s.clarificationMessages, msg] })),
       clearClarifications: () => set({ clarificationMessages: [] }),
       reset: () =>
-        set({ step: "scan", draft: initialDraft, fieldZones: null, skipScan: false, pendingScanUrl: null, pendingChatUrl: null, isDripBag: false, isAnalyzing: false, isRecommending: false, recommendError: null, clarificationMessages: [] }),
+        set({ step: "scan", draft: initialDraft, fieldZones: null, skipScan: false, pendingScanUrl: null, pendingChatUrl: null, isDripBag: false, isAnalyzing: false, isRecommending: false, recommendError: null, recommendJobId: null, clarificationMessages: [] }),
     }),
     {
       // localStorage (not sessionStorage) so an in-flight brew survives a

--- a/tests/dataflow/recommend-job-store.test.mjs
+++ b/tests/dataflow/recommend-job-store.test.mjs
@@ -1,0 +1,78 @@
+// Recommendation job store tests. Bundles the REAL jobStore.ts with esbuild so
+// the asserted behaviour is what the server runs.
+//
+//   node --test tests/dataflow/recommend-job-store.test.mjs
+//
+// Locks down: create → running; markDone surfaces the recommendation; markError
+// surfaces the message; unknown id → undefined; markDone on an unknown id is a
+// no-op; and TTL eviction drops a stale job when a new one is created.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const entry = `
+export { createJob, getJob, markDone, markError } from ${JSON.stringify(
+  path.join(ROOT, "src/lib/recommend/jobStore.ts"),
+)};
+`;
+const dir = await mkdtemp(join(tmpdir(), "rec-job-"));
+const out = join(dir, "b.mjs");
+await build({
+  stdin: { contents: entry, resolveDir: ROOT, loader: "ts" },
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  outfile: out,
+  logLevel: "silent",
+});
+const { createJob, getJob, markDone, markError } = await import(pathToFileURL(out).href);
+
+const REC = { primaryMethod: "V60", candidates: [], reasoning: "x" };
+
+test("createJob → running, then markDone → done with the recommendation", () => {
+  const id = createJob();
+  assert.equal(getJob(id).status, "running");
+  markDone(id, REC);
+  const job = getJob(id);
+  assert.equal(job.status, "done");
+  assert.deepEqual(job.recommendation, REC);
+});
+
+test("markError → error with the message", () => {
+  const id = createJob();
+  markError(id, "boom");
+  const job = getJob(id);
+  assert.equal(job.status, "error");
+  assert.equal(job.error, "boom");
+});
+
+test("unknown id → undefined; markDone/markError on it are no-ops", () => {
+  assert.equal(getJob("nope"), undefined);
+  markDone("nope", REC); // must not throw
+  markError("nope", "x"); // must not throw
+  assert.equal(getJob("nope"), undefined);
+});
+
+test("TTL eviction: a stale job is dropped when a new job is created", () => {
+  const realNow = Date.now;
+  try {
+    const base = 1_700_000_000_000;
+    Date.now = () => base;
+    const oldId = createJob();
+    assert.equal(getJob(oldId).status, "running");
+    // Jump >10 min — the next createJob() runs evictStale().
+    Date.now = () => base + 11 * 60 * 1000;
+    const freshId = createJob();
+    assert.equal(getJob(oldId), undefined, "stale job evicted");
+    assert.equal(getJob(freshId).status, "running", "fresh job survives");
+  } finally {
+    Date.now = realNow;
+  }
+});


### PR DESCRIPTION
## Problem

The recipe-crafting step calls `/api/recommend`, a ~1-minute blocking Opus call. Today that whole fetch is held in the client (`LightStepContext.handleNext`). When you background BTTS on iOS — switch to Messages to read a message, lock the phone — the WebView is suspended and the in-flight connection is torn down, so the generation dies and the recipe never lands. "As soon as I leave the screen, the generation fails."

## Fix

Move ownership of the work to the server, which runs as one long-running Node process (the same mechanism `liveActivitySchedule.ts` already relies on). The client just starts the job and polls:

- **`/api/recommend/start`** — kicks off `runRecommendation` as a detached task into an in-memory job store and returns a `jobId` immediately (the generation continues after the response is sent).
- **`/api/recommend/status?jobId=`** — reports `running` / `done` (with the recommendation) / `error`.
- **`RecommendJobWatcher`** — a headless component mounted in `LightShell` (next to `ConnectionStatus`) that polls the job every 3s **and on `visibilitychange`**, the proven iOS-PWA "resume on foreground" trigger. When the user returns, the finished recipe — which the server kept working on the whole time — lands immediately.
- **`flowStore.recommendJobId`** — persisted to localStorage, so the job also survives a reload; cleared on `reset()` ("New Session") and on the recommend-screen retry.

The recommendation pipeline was extracted into `src/lib/recommend/run.ts` (shared by the legacy synchronous `POST /api/recommend`, kept for back-compat, and the new start route). No prompt, model, or output-shape change.

## Decisions (confirmed with owner)

- Primary scenario: **backgrounding the app** (the recipe screen stays mounted, so no cross-route resume affordance is needed).
- Durability: **in-memory** job store, matching `liveActivitySchedule`. Only a server redeploy *during* the ~1-min generation loses the job → `status` returns `error` → the existing "Try again" button.

## Verification

- `npx tsc --noEmit` clean; `node --test` green (136 tests, incl. the new `tests/dataflow/recommend-job-store.test.mjs` covering create/done/error/unknown-id/TTL eviction).
- On-device (after deploy): start a brew → "Get my recipe" → background BTTS for ~60s → return: the recipe shows, not an error. Normal foreground brews still land; "New Session" mid-generation abandons cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PN5acbp95fGpEFRwErrsVP

---
_Generated by [Claude Code](https://claude.ai/code/session_01PN5acbp95fGpEFRwErrsVP)_