### PR TITLE
fix(cold-brew): brew other coffee mid-steep and still log the cold brew

### DIFF
--- a/src/components/flow/ColdBrewSteep.tsx
+++ b/src/components/flow/ColdBrewSteep.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import type { BrewRecipe, BrewPourStep } from "@/lib/types/session";
+import { useFlowStore } from "@/store/flowStore";
 import {
   getActiveColdBrew,
   startColdBrew,
@@ -96,7 +97,11 @@ export default function ColdBrewSteep({
 
   async function handleStart() {
     setBusy(true);
-    const cb = await startColdBrew(coffeeName, steepMinutes);
+    // Park a full snapshot of the flow so this cold brew can be resumed for
+    // logging after it steeps — even if other brews run in between (they
+    // overwrite the single live draft).
+    const { draft, fieldZones } = useFlowStore.getState();
+    const cb = await startColdBrew(coffeeName, steepMinutes, { draft, fieldZones });
     setActive(cb);
     setNow(Date.now());
     setBusy(false);

--- a/src/components/ui/light/NavigationOverlay.tsx
+++ b/src/components/ui/light/NavigationOverlay.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { X } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useFlowStore } from "@/store/flowStore";
+import { getActiveColdBrew, type ColdBrew } from "@/lib/coldBrew/coldBrew";
 
 /**
  * BTTS Navigation Overlay (specs/home.md §7).
@@ -49,7 +52,26 @@ interface NavigationOverlayProps {
 }
 
 export default function NavigationOverlay({ open, onClose }: NavigationOverlayProps) {
+  const router = useRouter();
+  // A parked cold brew (steeping or ready) — surfaced here so it can be
+  // resumed to log, independent of whatever the live flow draft is now.
+  const [coldBrew, setColdBrew] = useState<ColdBrew | null>(null);
+  useEffect(() => {
+    if (!open) return;
+    const cb = getActiveColdBrew();
+    setColdBrew(cb && cb.draft ? cb : null);
+  }, [open]);
+
   if (!open) return null;
+
+  const coldReady = coldBrew ? coldBrew.endMs <= Date.now() : false;
+
+  const resumeCold = () => {
+    if (!coldBrew?.draft) return;
+    useFlowStore.getState().resumeColdBrew(coldBrew.draft, coldBrew.fieldZones ?? null);
+    onClose();
+    router.push("/brew/new");
+  };
 
   return (
     <div
@@ -82,6 +104,18 @@ export default function NavigationOverlay({ open, onClose }: NavigationOverlayPr
       {/* Destination list — Inter 24/500, foreground, gap-6 between items.
           pt-24 + pl-6 per §7.1. No icons (§7.3 anti-pattern). */}
       <nav className="flex flex-col gap-6 pl-6 pt-24">
+        {coldBrew && (
+          <button
+            type="button"
+            onClick={resumeCold}
+            className="text-left font-chivo text-[24px] font-medium text-light-foreground"
+          >
+            Cold brew
+            <span className="ml-2 align-middle text-[13px] font-normal text-light-muted-foreground">
+              {coldReady ? "ready — log it" : "steeping"}
+            </span>
+          </button>
+        )}
         {ITEMS.map((item) =>
           item.href ? (
             <Link

--- a/src/lib/coldBrew/coldBrew.ts
+++ b/src/lib/coldBrew/coldBrew.ts
@@ -13,12 +13,20 @@
  * (the in-app countdown still works); a desktop/PWA simply won't get the push.
  */
 
+import type { DraftSession } from "@/lib/types/session";
+import type { FieldZones } from "@/lib/field/types";
+
 export interface ColdBrew {
   /** Also the notification id (fixed — only one cold brew at a time). */
   id: number;
   coffeeName: string;
   startMs: number;
   endMs: number;
+  /** Snapshot of the brew flow at steep start, so the cold brew can be resumed
+   * to LOG it after steeping — independent of the single live flow draft, which
+   * other brews overwrite in between. Absent for legacy records. */
+  draft?: DraftSession;
+  fieldZones?: FieldZones | null;
 }
 
 const STORE_KEY = "btts.coldbrew.active";
@@ -69,11 +77,24 @@ function notifications(): LocalNotificationsLike | null {
   }
 }
 
-/** Start a cold brew: persist it + schedule the "ready" notification. */
-export async function startColdBrew(coffeeName: string, durationMinutes: number): Promise<ColdBrew> {
+/** Start a cold brew: persist it + schedule the "ready" notification. The
+ * optional snapshot parks the brew-flow draft so the cold brew can be resumed
+ * to log it after steeping, even if other brews run in between. */
+export async function startColdBrew(
+  coffeeName: string,
+  durationMinutes: number,
+  snapshot?: { draft: DraftSession; fieldZones: FieldZones | null },
+): Promise<ColdBrew> {
   const startMs = Date.now();
   const endMs = startMs + durationMinutes * 60_000;
-  const cb: ColdBrew = { id: NOTIF_ID, coffeeName: coffeeName.trim(), startMs, endMs };
+  const cb: ColdBrew = {
+    id: NOTIF_ID,
+    coffeeName: coffeeName.trim(),
+    startMs,
+    endMs,
+    draft: snapshot?.draft,
+    fieldZones: snapshot?.fieldZones ?? null,
+  };
   persist(cb);
 
   const plugin = notifications();

--- a/src/store/flowStore.ts
+++ b/src/store/flowStore.ts
@@ -64,6 +64,11 @@ interface FlowState {
   addClarificationMessage: (msg: ClarificationMessage) => void;
   clearClarifications: () => void;
   reset: () => void;
+  /** Re-hydrate a parked cold-brew session (snapshot stored at steep start) so
+   * the user can return to LOG it after steeping — even if they ran other
+   * brews in between (which overwrite the single live draft). Lands on the
+   * "brew" step, where the cold-steep view shows the ready/steeping state. */
+  resumeColdBrew: (draft: DraftSession, fieldZones: FieldZones | null) => void;
 }
 
 export interface ClarificationMessage {
@@ -116,6 +121,8 @@ export const useFlowStore = create<FlowState>()(
       clearClarifications: () => set({ clarificationMessages: [] }),
       reset: () =>
         set({ step: "scan", draft: initialDraft, fieldZones: null, skipScan: false, pendingScanUrl: null, pendingChatUrl: null, isDripBag: false, isAnalyzing: false, isRecommending: false, recommendError: null, recommendJobId: null, clarificationMessages: [] }),
+      resumeColdBrew: (draft, fieldZones) =>
+        set({ step: "brew", draft, fieldZones, skipScan: true, isDripBag: false, isAnalyzing: false, isRecommending: false, recommendError: null, recommendJobId: null, clarificationMessages: [], pendingScanUrl: null, pendingChatUrl: null }),
     }),
     {
       // localStorage (not sessionStorage) so an in-flight brew survives a


### PR DESCRIPTION
Follow-up to #396, fixing the gap you flagged: *"can I still make other brews between starting a cold brew and the notification?"*

## The gap
The brew flow holds a **single draft**. Starting another brew while a cold brew steeped overwrote it — the iOS "ready" reminder still fired, but there was no way back to rate/log the cold brew. Wrong model for a 12-hour steep, where brewing other coffee in between is the whole point.

## Fix
- At **"Start steep"** the full flow draft is snapshotted into the cold-brew record (localStorage, independent of the live draft).
- A **"Cold brew — steeping / ready — log it"** entry appears in the navigation menu whenever one is parked.
- Tapping it re-hydrates that snapshot (`resumeColdBrew`) onto the brew step → you land on the steep view and can log it whenever it's done.
- Brews you run in between are untouched; the cold brew waits for you.

## Caveat (single-draft limitation, documented)
Resuming a parked cold brew replaces whatever draft is currently in progress, and there's one cold-brew slot at a time. Finish/save an in-progress brew before resuming the cold one.

`tsc` clean, 100/100 tests, rebased cleanly onto current main (resolved against the new `recommendJobId` field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)