### PR TITLE
fix(chat): wrap long URLs in message bubbles

### DIFF
--- a/src/components/ui/light/ChatThread.tsx
+++ b/src/components/ui/light/ChatThread.tsx
@@ -146,8 +146,8 @@ export default function ChatThread({ messages, loading }: ChatThreadProps) {
                   </div>
                 )}
                 {m.content && (
-                  <div className="max-w-[80%] rounded-2xl bg-light-card-default px-4 py-3 backdrop-blur-light-card backdrop-saturate-150">
-                    <p className="whitespace-pre-wrap font-chivo text-[15px] font-normal text-light-foreground">
+                  <div className="max-w-[80%] min-w-0 rounded-2xl bg-light-card-default px-4 py-3 backdrop-blur-light-card backdrop-saturate-150">
+                    <p className="whitespace-pre-wrap [overflow-wrap:anywhere] font-chivo text-[15px] font-normal text-light-foreground">
                       {m.content}
                     </p>
                   </div>
@@ -160,7 +160,7 @@ export default function ChatThread({ messages, loading }: ChatThreadProps) {
                     m.content.split(/\n\n+/).map((para, j) => (
                       <p
                         key={j}
-                        className="whitespace-pre-wrap font-chivo text-[15px] font-normal leading-[1.5] text-light-foreground"
+                        className="whitespace-pre-wrap [overflow-wrap:anywhere] font-chivo text-[15px] font-normal leading-[1.5] text-light-foreground"
                       >
                         {renderInlineMarkdown(para)}
                       </p>


### PR DESCRIPTION
A long URL (no spaces) overflowed the chat bubble and ran off-screen — `whitespace-pre-wrap` only breaks at spaces. Added `[overflow-wrap:anywhere]` to the user bubble + agent prose and `min-w-0` so the bubble stays at max-w-[80%] and the URL wraps inside it.

Web-only → instant on both the iOS app and PWA after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)