### PR TITLE
fix(map): locate-me works in the iOS app (native geolocation plugin)

### DIFF
--- a/native/ios/App/App/Info.plist
+++ b/native/ios/App/App/Info.plist
@@ -43,6 +43,10 @@
 	<string>BTTS connects to your Acaia scale over Bluetooth to read live weight and flow during a brew.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>BTTS uses the camera to scan coffee bags and read their details.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>BTTS uses your location to show coffee places near you on the map.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>BTTS uses your location to show coffee places near you on the map.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>BTTS uses the microphone for voice chat — talk to your coffee assistant instead of typing.</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/native/package-lock.json
+++ b/native/package-lock.json
@@ -11,6 +11,7 @@
         "@capacitor-community/bluetooth-le": "^8.2.0",
         "@capacitor/app": "^8.1.0",
         "@capacitor/core": "^8.4.0",
+        "@capacitor/geolocation": "^8.2.0",
         "@capacitor/haptics": "^8.0.2",
         "@capacitor/ios": "^8.4.0",
         "@capacitor/local-notifications": "^8.2.0"
@@ -507,6 +508,18 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@capacitor/geolocation": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/geolocation/-/geolocation-8.2.0.tgz",
+      "integrity": "sha512-N29QcoIPmme0xSxRkm7+3hjoHp6mBAOarxecvtCCZKyOBeKiJsFUq981cezg2XWBa6fhCXJMCCjQPngKK/dIag==",
+      "license": "MIT",
+      "dependencies": {
+        "@capacitor/synapse": "^1.0.4"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
     "node_modules/@capacitor/haptics": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@capacitor/haptics/-/haptics-8.0.2.tgz",
@@ -533,6 +546,12 @@
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
       }
+    },
+    "node_modules/@capacitor/synapse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.4.tgz",
+      "integrity": "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==",
+      "license": "ISC"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",

--- a/native/package.json
+++ b/native/package.json
@@ -11,6 +11,7 @@
     "@capacitor-community/bluetooth-le": "^8.2.0",
     "@capacitor/app": "^8.1.0",
     "@capacitor/core": "^8.4.0",
+    "@capacitor/geolocation": "^8.2.0",
     "@capacitor/haptics": "^8.0.2",
     "@capacitor/ios": "^8.4.0",
     "@capacitor/local-notifications": "^8.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@aws-sdk/client-s3": "^3.700.0",
         "@capacitor-community/bluetooth-le": "^8.2.0",
         "@capacitor/core": "^8.4.0",
+        "@capacitor/geolocation": "^8.2.0",
         "@ducanh2912/next-pwa": "^10.2.9",
         "@hookform/resolvers": "^5.2.2",
         "@simplewebauthn/browser": "^13.3.0",
@@ -2460,6 +2461,24 @@
       "dependencies": {
         "tslib": "^2.1.0"
       }
+    },
+    "node_modules/@capacitor/geolocation": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/geolocation/-/geolocation-8.2.0.tgz",
+      "integrity": "sha512-N29QcoIPmme0xSxRkm7+3hjoHp6mBAOarxecvtCCZKyOBeKiJsFUq981cezg2XWBa6fhCXJMCCjQPngKK/dIag==",
+      "license": "MIT",
+      "dependencies": {
+        "@capacitor/synapse": "^1.0.4"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/synapse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.4.tgz",
+      "integrity": "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==",
+      "license": "ISC"
     },
     "node_modules/@drizzle-team/brocli": {
       "version": "0.10.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@aws-sdk/client-s3": "^3.700.0",
     "@capacitor-community/bluetooth-le": "^8.2.0",
     "@capacitor/core": "^8.4.0",
+    "@capacitor/geolocation": "^8.2.0",
     "@ducanh2912/next-pwa": "^10.2.9",
     "@hookform/resolvers": "^5.2.2",
     "@simplewebauthn/browser": "^13.3.0",

--- a/src/components/cafes/CafeMap.tsx
+++ b/src/components/cafes/CafeMap.tsx
@@ -5,6 +5,7 @@ import type { Map as LMap, Marker as LMarker } from "leaflet";
 import { ThumbsUp, ThumbsDown } from "lucide-react";
 import type { CafeSummary, Place, CafeVisit, CafeVisitRating } from "@/lib/types/cafes";
 import StarRating from "@/components/ui/light/StarRating";
+import { getPosition, getPositionIfGranted } from "@/lib/native/geo";
 
 function haversineKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
   const R = 6371;
@@ -207,18 +208,12 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
       const youAreHereIcon = L.divIcon({ html: YOU_ARE_HERE_HTML, className: "", iconSize: [12, 12], iconAnchor: [6, 6] });
       pinIconRef.current = pinIcon;
 
-      locateMeFnRef.current = () => {
-        if (typeof navigator === "undefined" || !navigator.geolocation) {
-          setLocateError("Location isn't available on this device");
-          setTimeout(() => setLocateError(null), 3000);
-          return;
-        }
+      locateMeFnRef.current = async () => {
         setLocatingUser(true);
 
-        // Watchdog: iOS WKWebView / PWA can drop BOTH geolocation callbacks
-        // when the permission prompt is dismissed or the app is backgrounded,
-        // which would leave the button stuck disabled forever. This guarantees
-        // a reset so the button is always tappable again.
+        // Watchdog: even via the native plugin a permission prompt that's
+        // dismissed / an app backgrounded can leave the request hanging — this
+        // guarantees the button never gets stuck spinning.
         let settled = false;
         const watchdog = setTimeout(() => {
           if (settled) return;
@@ -226,78 +221,78 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
           setLocateError("Couldn't get your location. Try again.");
           setTimeout(() => setLocateError(null), 3000);
           setLocatingUser(false);
-        }, 16000);
+        }, 18000);
 
-        navigator.geolocation.getCurrentPosition(
-          async (pos) => {
-            if (settled) return;
-            settled = true;
-            clearTimeout(watchdog);
-            const { latitude: lat, longitude: lng } = pos.coords;
+        try {
+          // getPosition() uses the native @capacitor/geolocation plugin inside
+          // the iOS app (the web API doesn't resolve over a remote WKWebView)
+          // and the browser API in the PWA. Coarse + cached → fast.
+          const { lat, lng } = await getPosition();
+          if (settled) return;
+          settled = true;
+          clearTimeout(watchdog);
 
-            userMarkerRef.current?.remove();
-            userMarkerRef.current = L.marker([lat, lng], { icon: youAreHereIcon, zIndexOffset: 1000 }).addTo(map);
+          userMarkerRef.current?.remove();
+          userMarkerRef.current = L.marker([lat, lng], { icon: youAreHereIcon, zIndexOffset: 1000 }).addTo(map);
 
-            // Ask the server for the nearest resolved places — no full-table
-            // download, the distance ranking happens in SQL.
-            let nearby: Place[] = [];
-            try {
-              const res = await fetch(`/api/places?near=${lat},${lng}`);
-              nearby = await res.json();
-            } catch { /* network error — treated as no results below */ }
+          // Ask the server for the nearest resolved places — no full-table
+          // download, the distance ranking happens in SQL.
+          let nearby: Place[] = [];
+          try {
+            const res = await fetch(`/api/places?near=${lat},${lng}`);
+            nearby = await res.json();
+          } catch { /* network error — treated as no results below */ }
 
-            const resolved = nearby.filter(p => p.lat != null && p.lng != null);
+          const resolved = nearby.filter(p => p.lat != null && p.lng != null);
 
-            if (resolved.length === 0) {
-              map.flyTo([lat, lng], 15);
-              setLocateError("No cafés in database for this area yet");
-              setTimeout(() => setLocateError(null), 3000);
-              setLocatingUser(false);
-              return;
-            }
-
-            // Small city mode: nearest place <50 km away and whole city fits in 25 → show all
-            const sorted = resolved
-              .map(p => ({ p, dist: haversineKm(lat, lng, p.lat!, p.lng!) }))
-              .sort((a, b) => a.dist - b.dist);
-            const nearestCity = sorted[0].p.city;
-            const cityPlaces = resolved.filter(
-              p => p.city.toLowerCase() === nearestCity.toLowerCase()
-            );
-            const toShow =
-              sorted[0].dist < 50 && cityPlaces.length <= 25
-                ? cityPlaces
-                : sorted.slice(0, 25).map(x => x.p);
-
-            setPlaces(resolved);
-            setNearbyIds(new Set(toShow.map(p => p.id)));
-
-            // Fit map to user location + all nearby spots
-            const bounds = L.latLngBounds([
-              [lat, lng],
-              ...toShow.map(p => [p.lat!, p.lng!] as [number, number]),
-            ]);
-            map.fitBounds(bounds.pad(0.2));
-
-            setLocatingUser(false);
-          },
-          (err) => {
-            if (settled) return;
-            settled = true;
-            clearTimeout(watchdog);
-            setLocateError(
-              err.code === err.PERMISSION_DENIED
-                ? "Location access is off — enable it in Settings"
-                : "Couldn't get your location. Try again."
-            );
+          if (resolved.length === 0) {
+            map.flyTo([lat, lng], 15);
+            setLocateError("No coffee places in the database near you yet");
             setTimeout(() => setLocateError(null), 3000);
             setLocatingUser(false);
-          },
-          // Coarse + recent-cache fix: fast and reliable on a phone. High
-          // accuracy GPS routinely times out indoors — overkill for ranking
-          // nearby cafés, where city-block precision is plenty.
-          { enableHighAccuracy: false, timeout: 15000, maximumAge: 60000 }
-        );
+            return;
+          }
+
+          // Small city mode: nearest place <50 km away and whole city fits in 25 → show all
+          const sorted = resolved
+            .map(p => ({ p, dist: haversineKm(lat, lng, p.lat!, p.lng!) }))
+            .sort((a, b) => a.dist - b.dist);
+          const nearestCity = sorted[0].p.city;
+          const cityPlaces = resolved.filter(
+            p => p.city.toLowerCase() === nearestCity.toLowerCase()
+          );
+          const toShow =
+            sorted[0].dist < 50 && cityPlaces.length <= 25
+              ? cityPlaces
+              : sorted.slice(0, 25).map(x => x.p);
+
+          setPlaces(resolved);
+          setNearbyIds(new Set(toShow.map(p => p.id)));
+
+          // Fit map to user location + all nearby spots
+          const bounds = L.latLngBounds([
+            [lat, lng],
+            ...toShow.map(p => [p.lat!, p.lng!] as [number, number]),
+          ]);
+          map.fitBounds(bounds.pad(0.2));
+
+          setLocatingUser(false);
+        } catch (err) {
+          if (settled) return;
+          settled = true;
+          clearTimeout(watchdog);
+          // Permission denied → point the user at Settings; everything else is
+          // a transient "try again" (web code 1 = denied; plugin message-matches).
+          const e = err as { code?: number; message?: string };
+          const denied = e?.code === 1 || /denied|permission/i.test(e?.message ?? "");
+          setLocateError(
+            denied
+              ? "Location access is off — enable it in Settings"
+              : "Couldn't get your location. Try again."
+          );
+          setTimeout(() => setLocateError(null), 3000);
+          setLocatingUser(false);
+        }
       };
 
       // Show the map immediately at a sensible default view. The map is
@@ -317,14 +312,12 @@ export default function CafeMap({ cafes, onSelect, initialSearch }: {
       // denied (or the 5s soft-timeout fires), the pin-loop fallback
       // below takes over.
       (async () => {
-        const userPos = await new Promise<{ lat: number; lng: number } | null>(resolve => {
-          const timer = setTimeout(() => resolve(null), 5000);
-          navigator.geolocation?.getCurrentPosition(
-            pos => { clearTimeout(timer); resolve({ lat: pos.coords.latitude, lng: pos.coords.longitude }); },
-            () => { clearTimeout(timer); resolve(null); },
-            { enableHighAccuracy: false, timeout: 5000, maximumAge: 60000 }
-          );
-        });
+        const userPos = await Promise.race<{ lat: number; lng: number } | null>([
+          // Silent — never prompts on mount; only returns if permission is
+          // already granted (native) or the browser resolves it.
+          getPositionIfGranted({ timeoutMs: 5000 }),
+          new Promise<null>(resolve => setTimeout(() => resolve(null), 5000)),
+        ]);
         if (cancelled || !userPos || !mapRef.current) return;
         userLocated = true;
         mapRef.current.setView([userPos.lat, userPos.lng], 14);

--- a/src/lib/native/geo.ts
+++ b/src/lib/native/geo.ts
@@ -1,0 +1,83 @@
+import { Capacitor } from "@capacitor/core";
+
+/**
+ * One place to get the user's location that works in BOTH the Safari PWA and
+ * the iOS app.
+ *
+ * The catch (researched June 2026): the W3C `navigator.geolocation` API does
+ * NOT resolve inside the iOS Capacitor WKWebView when the app loads a REMOTE
+ * `server.url` — its secure-context geolocation path is only granted for the
+ * `localhost` origin Capacitor uses when serving bundled assets, which we don't.
+ * So on the installed app the web API's callbacks silently never fire and the
+ * "locate me" button spins forever. The fix is the native `@capacitor/geolocation`
+ * plugin, which talks to CoreLocation directly and works over a remote origin.
+ *
+ * This wrapper routes to the plugin on native (dynamic import → it never enters
+ * the PWA's main chunk) and to the untouched web API in a real browser, where it
+ * works fine. Both return the same `{ lat, lng }`.
+ */
+
+export interface GeoPoint {
+  lat: number;
+  lng: number;
+}
+
+export async function getPosition(opts?: {
+  highAccuracy?: boolean;
+  timeoutMs?: number;
+  maxAgeMs?: number;
+}): Promise<GeoPoint> {
+  const enableHighAccuracy = opts?.highAccuracy ?? false; // coarse = fast + reliable on a phone
+  const timeout = opts?.timeoutMs ?? 15000;
+  const maximumAge = opts?.maxAgeMs ?? 60000; // accept a recent cached fix → near-instant
+
+  if (Capacitor.isNativePlatform()) {
+    const { Geolocation } = await import("@capacitor/geolocation");
+    try {
+      const perm = await Geolocation.checkPermissions();
+      if (perm.location !== "granted" && perm.coarseLocation !== "granted") {
+        await Geolocation.requestPermissions();
+      }
+    } catch {
+      /* requestPermissions can throw if already decided — getCurrentPosition reports the real state */
+    }
+    const pos = await Geolocation.getCurrentPosition({ enableHighAccuracy, timeout, maximumAge });
+    return { lat: pos.coords.latitude, lng: pos.coords.longitude };
+  }
+
+  return new Promise<GeoPoint>((resolve, reject) => {
+    if (typeof navigator === "undefined" || !navigator.geolocation) {
+      reject(new Error("Geolocation unavailable"));
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (p) => resolve({ lat: p.coords.latitude, lng: p.coords.longitude }),
+      (err) => reject(err),
+      { enableHighAccuracy, timeout, maximumAge },
+    );
+  });
+}
+
+/**
+ * Silent best-effort position for the on-mount auto-locate: on the iOS app it
+ * returns null WITHOUT prompting unless permission is already granted (so just
+ * opening Nearby never throws a permission dialog — that's reserved for the
+ * explicit "locate me" tap). In the browser it behaves as before. Never throws.
+ */
+export async function getPositionIfGranted(opts?: {
+  highAccuracy?: boolean;
+  timeoutMs?: number;
+  maxAgeMs?: number;
+}): Promise<GeoPoint | null> {
+  if (Capacitor.isNativePlatform()) {
+    try {
+      const { Geolocation } = await import("@capacitor/geolocation");
+      const perm = await Geolocation.checkPermissions();
+      if (perm.location !== "granted" && perm.coarseLocation !== "granted") return null;
+      return await getPosition(opts);
+    } catch {
+      return null;
+    }
+  }
+  return getPosition(opts).catch(() => null);
+}


### PR DESCRIPTION
**The locate-me button spins forever in the iOS app** because the web `navigator.geolocation` API doesn't resolve inside a Capacitor WKWebView loading a remote `server.url` (its secure-context geolocation is only granted for the localhost origin Capacitor uses for bundled assets — confirmed against Capacitor + WebKit + Apple docs). The callbacks never fire, so my earlier coarse+watchdog web fix couldn't help.

**Fix:**
- Shell: `@capacitor/geolocation@^8.2.0` + Info.plist `NSLocationWhenInUseUsageDescription` / `NSLocationAlwaysAndWhenInUseUsageDescription`.
- Web: `src/lib/native/geo.ts` — `getPosition()` uses the native plugin (CoreLocation, works over a remote origin) on native, the browser API in the PWA (unchanged). CafeMap's button + the silent on-mount auto-locate (`getPositionIfGranted`, never prompts on open) both use it; watchdog kept.

**Needs the TestFlight build to take effect** (native plugin). On the current build it now fails cleanly after the watchdog instead of spinning forever. Photo-share is the next (bigger) native piece — separate build.

tsc + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)