### PR TITLE
feat(share): share an album photo → auto-adds it to the Home chat

### DIFF
--- a/native/ios/App/App/WidgetBridge.swift
+++ b/native/ios/App/App/WidgetBridge.swift
@@ -23,10 +23,28 @@ public class WidgetBridgePlugin: CAPPlugin, CAPBridgedPlugin {
     public let jsName = "WidgetBridge"
     public let pluginMethods: [CAPPluginMethod] = [
         CAPPluginMethod(name: "setRotation", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "consumeSharedImage", returnType: CAPPluginReturnPromise),
     ]
 
     private let suiteName = "group.com.roitsch.btts"
     private let storeKey = "rotation"
+    private let sharedImageName = "shared-image.jpg"
+
+    /// Read (and delete) a photo the Share Extension wrote into the App Group
+    /// container, returned as a base64 data URL the web can upload + attach to
+    /// the Home chat. Resolves `{ dataUrl: null }` when nothing is waiting.
+    @objc func consumeSharedImage(_ call: CAPPluginCall) {
+        let fm = FileManager.default
+        guard let container = fm.containerURL(forSecurityApplicationGroupIdentifier: suiteName) else {
+            call.resolve(["dataUrl": NSNull()]); return
+        }
+        let fileURL = container.appendingPathComponent(sharedImageName)
+        guard let data = try? Data(contentsOf: fileURL) else {
+            call.resolve(["dataUrl": NSNull()]); return
+        }
+        try? fm.removeItem(at: fileURL) // consume once
+        call.resolve(["dataUrl": "data:image/jpeg;base64,\(data.base64EncodedString())"])
+    }
 
     @objc func setRotation(_ call: CAPPluginCall) {
         let incoming = call.getArray("coffees", JSObject.self) ?? []

--- a/native/ios/App/BTTSShare/BTTSShare.entitlements
+++ b/native/ios/App/BTTSShare/BTTSShare.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.roitsch.btts</string>
+	</array>
+</dict>
+</plist>

--- a/native/ios/App/BTTSShare/Info.plist
+++ b/native/ios/App/BTTSShare/Info.plist
@@ -34,6 +34,8 @@
 				<integer>1</integer>
 				<key>NSExtensionActivationSupportsText</key>
 				<true/>
+					<key>NSExtensionActivationSupportsImageWithMaxCount</key>
+					<integer>1</integer>
 			</dict>
 		</dict>
 	</dict>

--- a/native/ios/App/BTTSShare/ShareViewController.swift
+++ b/native/ios/App/BTTSShare/ShareViewController.swift
@@ -24,8 +24,45 @@ class ShareViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        extractURL { [weak self] urlString in
-            DispatchQueue.main.async { self?.finish(urlString) }
+        // Photo first (a shared album image), then fall back to URL/text.
+        extractImage { [weak self] ok in
+            if ok {
+                DispatchQueue.main.async { self?.finishImage() }
+            } else {
+                self?.extractURL { urlString in
+                    DispatchQueue.main.async { self?.finish(urlString) }
+                }
+            }
+        }
+    }
+
+    private let appGroup = "group.com.roitsch.btts"
+    private let sharedImageName = "shared-image.jpg"
+
+    /// Load a shared image, re-encode to JPEG, and write it into the App Group
+    /// container so the host app's WidgetBridge can read it. The write MUST
+    /// finish inside the async completion handler before we post the
+    /// notification, or a large photo arrives blank (documented race).
+    private func extractImage(_ completion: @escaping (Bool) -> Void) {
+        guard let item = extensionContext?.inputItems.first as? NSExtensionItem,
+              let providers = item.attachments else { completion(false); return }
+        let imageType = UTType.image.identifier
+        guard let p = providers.first(where: { $0.hasItemConformingToTypeIdentifier(imageType) }) else {
+            completion(false); return
+        }
+        p.loadDataRepresentation(forTypeIdentifier: imageType) { [weak self] data, _ in
+            guard let self = self,
+                  let data = data,
+                  let img = UIImage(data: data),
+                  let jpeg = img.jpegData(compressionQuality: 0.85),
+                  let container = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: self.appGroup)
+            else { completion(false); return }
+            do {
+                try jpeg.write(to: container.appendingPathComponent(self.sharedImageName), options: .atomic)
+                completion(true)
+            } catch {
+                completion(false)
+            }
         }
     }
 
@@ -63,18 +100,27 @@ class ShareViewController: UIViewController {
             complete()
             return
         }
-        postNotification(s) { [weak self] in self?.complete() }
+        postNotification(userInfo: ["btts_url": s],
+                         body: "Tap to read this coffee into BTTS.") { [weak self] in self?.complete() }
     }
 
-    /// Post a local notification carrying the shared URL. Tapping it opens BTTS,
-    /// where the LocalNotifications listener reads `btts_url` and runs the scan.
-    private func postNotification(_ urlString: String, then done: @escaping () -> Void) {
+    /// A photo was written to the App Group — bring the app forward to attach it
+    /// to the Home chat. The bytes ride in the App Group, not the notification.
+    private func finishImage() {
+        postNotification(userInfo: ["btts_image": sharedImageName],
+                         body: "Tap to add this photo to the BTTS chat.") { [weak self] in self?.complete() }
+    }
+
+    /// Post a local notification that brings BTTS forward. Tapping it fires
+    /// `localNotificationActionPerformed`, where the web reads `btts_url` /
+    /// `btts_image` from `extra` and routes into the chat.
+    private func postNotification(userInfo: [String: Any], body: String, then done: @escaping () -> Void) {
         let center = UNUserNotificationCenter.current()
         let post = {
             let content = UNMutableNotificationContent()
             content.title = "Add to BTTS"
-            content.body = "Tap to read this coffee into BTTS."
-            content.userInfo = ["btts_url": urlString]
+            content.body = body
+            content.userInfo = userInfo
             content.sound = .default
             let req = UNNotificationRequest(
                 identifier: "btts-share",

--- a/native/scripts/add_share_target.rb
+++ b/native/scripts/add_share_target.rb
@@ -7,9 +7,11 @@
 # (it only adds its own target + group + embed phase; no overlap with theirs).
 # See docs/ios-shell-roadmap.md.
 #
-# No App Group / extra capability: the shared URL is passed inline in the
-# btts://share?url=… deep link, so automatic signing just needs the bundle id —
-# no portal capability assignment (unlike the widget's App Group).
+# App Group: a shared PHOTO can't ride in the deep link, so the extension writes
+# it into the group.com.roitsch.btts container and the host app reads it. Needs the
+# App Group entitlement on this target (BTTSShare.entitlements) AND a one-time portal
+# assignment of the group to the BTTSShare App ID (the ASC API can't script that —
+# same dance as the widget). Shared URLs still ride inline in btts://share?url=…
 require "xcodeproj"
 
 ROOT = File.expand_path("../ios/App", __dir__)
@@ -37,6 +39,7 @@ end
 share_group = project.main_group.new_group("BTTSShare", "BTTSShare")
 swift_refs = %w[ShareViewController.swift].map { |f| share_group.new_reference(f) }
 share_group.new_reference("Info.plist") # referenced via INFOPLIST_FILE
+  share_group.new_reference("BTTSShare.entitlements") # referenced via CODE_SIGN_ENTITLEMENTS
 
 # --- The share extension target -----------------------------------------------
 share_target = project.new_target(:app_extension, "BTTSShare", :ios, "15.0", nil, :swift)
@@ -48,6 +51,7 @@ settings = {
   "INFOPLIST_FILE" => "BTTSShare/Info.plist",
   "GENERATE_INFOPLIST_FILE" => "NO",
   "CODE_SIGN_STYLE" => "Automatic",
+  "CODE_SIGN_ENTITLEMENTS" => "BTTSShare/BTTSShare.entitlements",
   "SWIFT_VERSION" => "5.0",
   "IPHONEOS_DEPLOYMENT_TARGET" => "15.0",
   "TARGETED_DEVICE_FAMILY" => "1",

--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -453,6 +453,37 @@ export default function HomePage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingChatUrl]);
 
+  // A PHOTO shared in via "Add to BTTS" (Share Sheet → album image): the native
+  // bridge read it from the App Group as a data URL. Upload it (so it gets a
+  // real S3 url like any chat photo), attach it, and auto-ask about it — once.
+  const pendingChatImageData = useFlowStore((s) => s.pendingChatImageData);
+  const setPendingChatImageData = useFlowStore((s) => s.setPendingChatImageData);
+  const sharedImageHandledRef = useRef(false);
+  useEffect(() => {
+    if (!pendingChatImageData || sharedImageHandledRef.current) return;
+    sharedImageHandledRef.current = true;
+    const dataUrl = pendingChatImageData;
+    setPendingChatImageData(null);
+    void (async () => {
+      try {
+        const blob = await (await fetch(dataUrl)).blob();
+        const file = new File([blob], `shared-${Date.now()}.jpg`, { type: blob.type || "image/jpeg" });
+        const form = new FormData();
+        form.append("file", file);
+        form.append("path", `uploads/chat-${Date.now()}-shared.jpg`);
+        const res = await fetch("/api/upload", { method: "POST", body: form });
+        if (!res.ok) throw new Error(`upload ${res.status}`);
+        const { url } = await res.json();
+        if (!url) throw new Error("no url");
+        await handleSend({ text: "What do you think of this coffee?", imageUrl: url });
+      } catch {
+        // Upload failed — let the user retry by attaching manually; reset guard.
+        sharedImageHandledRef.current = false;
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pendingChatImageData]);
+
   return (
     <>
       <main className="flex h-dvh flex-col">

--- a/src/lib/native/widgetDeepLinks.ts
+++ b/src/lib/native/widgetDeepLinks.ts
@@ -48,9 +48,16 @@ interface LocalNotificationsLike {
     listener: (event: NotificationTapEvent) => void,
   ): Promise<AppListenerHandle>;
 }
+interface WidgetBridgeLike {
+  consumeSharedImage(): Promise<{ dataUrl?: string | null }>;
+}
 interface CapacitorLike {
   isNativePlatform?: () => boolean;
-  Plugins?: { App?: AppPluginLike; LocalNotifications?: LocalNotificationsLike };
+  Plugins?: {
+    App?: AppPluginLike;
+    LocalNotifications?: LocalNotificationsLike;
+    WidgetBridge?: WidgetBridgeLike;
+  };
 }
 
 function getApp(): AppPluginLike | null {
@@ -155,6 +162,27 @@ export function routeToSharedUrl(url: string, nav: Nav): void {
 }
 
 /**
+ * A photo was shared in ("Add to BTTS" on an album image). The Share Extension
+ * wrote it into the App Group; read it via WidgetBridge as a base64 data URL,
+ * stash it for the Home chat (which uploads + attaches + auto-asks), and go Home.
+ */
+async function consumeSharedImageToChat(nav: Nav): Promise<void> {
+  try {
+    if (typeof window === "undefined") return;
+    const cap = (window as unknown as { Capacitor?: CapacitorLike }).Capacitor;
+    const bridge = cap?.Plugins?.WidgetBridge;
+    if (!bridge) return;
+    const { dataUrl } = await bridge.consumeSharedImage();
+    if (typeof dataUrl === "string" && dataUrl.startsWith("data:")) {
+      useFlowStore.getState().setPendingChatImageData(dataUrl);
+      nav("/");
+    }
+  } catch {
+    /* nothing waiting / bridge missing — ignore */
+  }
+}
+
+/**
  * Register the Share-Extension notification-tap handler. The extension posts a
  * local notification carrying the shared URL (`btts_url`); tapping it opens the
  * app and fires `localNotificationActionPerformed`, where we read the URL and
@@ -179,7 +207,12 @@ export function registerShareNotificationTap(nav: Nav): () => void {
   plugin
     .addListener("localNotificationActionPerformed", (event) => {
       const url = event?.notification?.extra?.btts_url;
-      if (typeof url === "string" && url) routeToSharedUrl(url, nav);
+      if (typeof url === "string" && url) {
+        routeToSharedUrl(url, nav);
+        return;
+      }
+      const img = event?.notification?.extra?.btts_image;
+      if (typeof img === "string" && img) void consumeSharedImageToChat(nav);
     })
     .then((h) => {
       if (removed) h.remove();

--- a/src/store/flowStore.ts
+++ b/src/store/flowStore.ts
@@ -42,6 +42,10 @@ interface FlowState {
   /** A coffee URL shared in via "Add to BTTS" — the Home chat auto-asks
    * "What do you think of this coffee: <url>" on mount, then clears it. */
   pendingChatUrl: string | null;
+  /** A PHOTO shared in via "Add to BTTS" (Share Sheet → album image), as a
+   * base64 data URL read from the App Group. The Home chat uploads it, attaches
+   * it, and auto-asks about it on mount, then clears it. */
+  pendingChatImageData: string | null;
 
   // Actions
   setStep: (step: FlowStep) => void;
@@ -49,6 +53,7 @@ interface FlowState {
   setSkipScan: (v: boolean) => void;
   setPendingScanUrl: (url: string | null) => void;
   setPendingChatUrl: (url: string | null) => void;
+  setPendingChatImageData: (dataUrl: string | null) => void;
   setIsDripBag: (v: boolean) => void;
   setCoffee: (coffee: Partial<CoffeeIdentity>) => void;
   setPlace: (place: ExternalPlace) => void;
@@ -91,6 +96,7 @@ export const useFlowStore = create<FlowState>()(
       skipScan: false,
       pendingScanUrl: null,
       pendingChatUrl: null,
+      pendingChatImageData: null,
       isDripBag: false,
       isAnalyzing: false,
       isRecommending: false,
@@ -103,6 +109,7 @@ export const useFlowStore = create<FlowState>()(
       setSkipScan: (v) => set({ skipScan: v }),
       setPendingScanUrl: (pendingScanUrl) => set({ pendingScanUrl }),
       setPendingChatUrl: (pendingChatUrl) => set({ pendingChatUrl }),
+      setPendingChatImageData: (pendingChatImageData) => set({ pendingChatImageData }),
       setIsDripBag: (v) => set({ isDripBag: v }),
       setCoffee: (coffee) =>
         set((s) => ({ draft: { ...s.draft, coffee: { ...s.draft.coffee, ...coffee } as CoffeeIdentity } })),
@@ -120,9 +127,9 @@ export const useFlowStore = create<FlowState>()(
         set((s) => ({ clarificationMessages: [...s.clarificationMessages, msg] })),
       clearClarifications: () => set({ clarificationMessages: [] }),
       reset: () =>
-        set({ step: "scan", draft: initialDraft, fieldZones: null, skipScan: false, pendingScanUrl: null, pendingChatUrl: null, isDripBag: false, isAnalyzing: false, isRecommending: false, recommendError: null, recommendJobId: null, clarificationMessages: [] }),
+        set({ step: "scan", draft: initialDraft, fieldZones: null, skipScan: false, pendingScanUrl: null, pendingChatUrl: null, pendingChatImageData: null, isDripBag: false, isAnalyzing: false, isRecommending: false, recommendError: null, recommendJobId: null, clarificationMessages: [] }),
       resumeColdBrew: (draft, fieldZones) =>
-        set({ step: "brew", draft, fieldZones, skipScan: true, isDripBag: false, isAnalyzing: false, isRecommending: false, recommendError: null, recommendJobId: null, clarificationMessages: [], pendingScanUrl: null, pendingChatUrl: null }),
+        set({ step: "brew", draft, fieldZones, skipScan: true, isDripBag: false, isAnalyzing: false, isRecommending: false, recommendError: null, recommendJobId: null, clarificationMessages: [], pendingScanUrl: null, pendingChatUrl: null, pendingChatImageData: null }),
     }),
     {
       // localStorage (not sessionStorage) so an in-flight brew survives a


### PR DESCRIPTION
Extends the "Add to BTTS" Share Sheet (currently URLs/text) to accept a **photo from the album** and drop it straight into the Home AI chat.

A photo is too big to ride in the deep-link/notification, so:
- **Share Extension**: re-encodes the shared image to JPEG, writes it into the App Group container, posts the existing notification with `btts_image`. (Adds the image activation rule + `BTTSShare.entitlements` App Group, wired in `add_share_target.rb`.)
- **WidgetBridge.consumeSharedImage()**: reads + deletes the App Group image, returns a base64 data URL.
- **Web**: the share-notification handler reads `btts_image` → `consumeSharedImage()` → `pendingChatImageData` → Home, which uploads it via `/api/upload` (real S3 url), attaches it, and auto-asks "What do you think of this coffee?" once.

Native-gated; PWA + the URL/text path untouched. tsc + build clean.

**Needs (owner, one-time, before the build can sign):** Developer portal → Identifiers → `com.roitsch.btts.BTTSShare` → enable **App Groups** → tick `group.com.roitsch.btts` → Save. (The ASC API can't script App-Groups assignment — same step the widget needed.) Then I trigger the TestFlight build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)