### PR TITLE
fix(brew): keep a chat V60's drawdown wait as percolation so the flow coach shows

### DIFF
--- a/src/lib/utils/pourSequence.ts
+++ b/src/lib/utils/pourSequence.ts
@@ -366,16 +366,37 @@ export function buildGuideSteps(recipe: BrewRecipe): GuideStep[] | null {
 
 /** True when a recipe's structured steps describe an immersion / AeroPress /
  * staged routine that belongs in the step guide rather than the cumulative-
- * grams pour-over renderer (steep-dominated, or with flip/press/invert/bypass). */
+ * grams pour-over renderer (steep-dominated, or with flip/press/invert/bypass).
+ *
+ * A long `wait` only signals immersion when it's a MID-BREW steep — i.e. some
+ * later step adds water (`waterGramsAtEnd`) or drains/presses/flips/inverts/
+ * bypasses. A long `wait` with nothing of those after it is just a pour-over's
+ * terminal DRAWDOWN, NOT a steep, and must stay percolation (so it keeps the
+ * cumulative-grams renderer + the live flow coach). This came up because the
+ * Home chat's `start_brew` encodes a V60's ~2:00 drawdown as a trailing `wait`,
+ * which used to misroute the whole pour-over to the immersion guide and drop the
+ * flow coach. Order-robust: a trailing "Final swirl" after the drawdown wait
+ * still doesn't qualify (swirl neither adds water nor drains/presses). */
 export function hasImmersionShape(recipe: BrewRecipe): boolean {
   const src = recipe.pourSteps;
   if (!src || src.length === 0) return false;
-  return src.some(
-    (s) =>
-      s.action === "invert" ||
-      s.action === "flip" ||
-      s.action === "press" ||
-      s.action === "bypass" ||
-      (s.action === "wait" && (s.durationSec ?? 0) >= 45),
-  );
+  const isSteepFollowUp = (a: BrewStepAction, hasWater: boolean): boolean =>
+    hasWater ||
+    a === "drain" ||
+    a === "press" ||
+    a === "flip" ||
+    a === "invert" ||
+    a === "bypass";
+  return src.some((s, i) => {
+    if (s.action === "invert" || s.action === "flip" || s.action === "press" || s.action === "bypass") {
+      return true;
+    }
+    if (s.action === "wait" && (s.durationSec ?? 0) >= 45) {
+      // Mid-brew steep only — a later step must add water or drain/press/flip.
+      return src
+        .slice(i + 1)
+        .some((later) => isSteepFollowUp(later.action, later.waterGramsAtEnd != null));
+    }
+    return false;
+  });
 }

--- a/tests/dataflow/brew-timeline.test.mjs
+++ b/tests/dataflow/brew-timeline.test.mjs
@@ -81,6 +81,22 @@ const RECIPES = {
     pourSequence: "50 – 180 – 320 – 500",
     waterGrams: 500,
   },
+  // V60 from the Home chat's start_brew: multiple rising-grams pours, a final
+  // swirl, and the ~2:00 DRAWDOWN encoded as a trailing wait. Must stay
+  // percolation (keeps the cumulative-grams renderer + the live flow coach) —
+  // the trailing wait must NOT misroute it to the immersion guide.
+  "percolation-v60-drawdown": {
+    ...base,
+    targetTimeSec: 270,
+    waterGrams: 450,
+    pourSteps: [
+      { label: "Bloom", action: "bloom", waterGramsAtEnd: 90, durationSec: 8, notes: "swirl gently" },
+      { label: "Pour 1", action: "pour", waterGramsAtEnd: 270, durationSec: 50 },
+      { label: "Pour 2", action: "final", waterGramsAtEnd: 450, durationSec: 50 },
+      { label: "Final swirl", action: "swirl" },
+      { label: "Drawdown", action: "wait", durationSec: 120 },
+    ],
+  },
   "immersion-inverted-aeropress": {
     ...base,
     targetTimeSec: 150,
@@ -160,6 +176,28 @@ for (const [name, recipe] of Object.entries(RECIPES)) {
     assert.equal(activeStepAt(tl, 30, false), -1, "not started → -1");
   });
 }
+
+test("percolation: a trailing drawdown wait stays percolation (keeps the flow coach)", () => {
+  const recipe = RECIPES["percolation-v60-drawdown"];
+  // The trailing wait must NOT trigger the immersion guide.
+  assert.equal(hasImmersionShape(recipe), false, "trailing drawdown wait misrouted to immersion");
+  const tl = buildBrewTimeline(recipe, ROAST, NOW);
+  assert.equal(tl.shape, "percolation");
+  assert.equal(tl.hasGramsCurve, true, "no grams curve → coachFlow returns none → no flow coach");
+  assert.ok(tl.pourSteps && tl.pourSteps.length > 0, "must take the LivePourSequence path");
+  assert.equal(tl.guideSteps, null, "must NOT build immersion guide steps");
+});
+
+test("immersion: a MID-brew steep (wait before drain/press) still routes to the guide", () => {
+  // Guards that the drawdown fix didn't over-reach: Clever (wait → drain) and the
+  // inverted AeroPress (invert/press) must remain immersion.
+  assert.equal(hasImmersionShape(RECIPES["immersion-clever"]), true, "clever steep lost");
+  assert.equal(
+    hasImmersionShape(RECIPES["immersion-inverted-aeropress"]),
+    true,
+    "aeropress steep lost",
+  );
+});
 
 test("percolation: expectedGramsAt is monotonic 0 → final", () => {
   const tl = buildBrewTimeline(RECIPES["percolation-grams-string"], ROAST, NOW);


### PR DESCRIPTION
## What

A brew started from the Home chat (`start_brew`) with the Acaia connected showed live weight but **no live pour-flow analysis** (the `CoachCue` box with the current step + flow cue). The owner is right that the feature is already built — it just wasn't rendering for chat-started brews.

## Root cause

The brew screen has two renderers:
- **`LivePourSequence`** (percolation, V60/Orea/Kalita/Chemex) — renders the `CoachCue` live flow analysis; needs `hasGramsCurve: true`.
- **`StepGuide`** (immersion, AeroPress/Clever/iced) — **no flow coach**; `hasGramsCurve: false`, so `coachFlow()` returns `"none"`.

The reported screenshot ("Step 5 of 7", "→ 450g", "Next: Final swirl") is the **`StepGuide`** layout — so the chat-built Hoffmann V60 was being **misclassified as immersion**.

Why: `hasImmersionShape()` returns true for any `wait` ≥ 45 s. The chat's `start_brew` encodes the V60's ~2:00 **drawdown** as a trailing `wait`, tripping that rule. Recipes from `/recommend` don't carry that trailing wait, so they stayed percolation and kept the coach — hence "it worked before, missing now."

## Fix

A long `wait` now signals immersion **only when it's a mid-brew steep** — a later step adds water (`waterGramsAtEnd`) or `drain`/`press`/`flip`/`invert`/`bypass`. A terminal drawdown wait stays percolation, so the recipe keeps the cumulative-grams renderer + the live flow coach. Order-robust (a trailing "Final swirl" after the drawdown doesn't qualify).

### Safety
- `immersion-clever` (`pour → wait → drain`) and `immersion-inverted-aeropress` (invert/flip/press) stay immersion ✓
- A scan of every `src/lib/knowledge/recipes/*.ts` found **no recipe whose final step is a long `wait`** — nothing else changes.

## Tests
- New `percolation-v60-drawdown` fixture in `tests/dataflow/brew-timeline.test.mjs` mirrors the chat recipe (rising-grams pours + final swirl + trailing 120 s drawdown wait); asserts it classifies as percolation with `hasGramsCurve: true` and takes the `LivePourSequence` path.
- New guard test confirming Clever + inverted AeroPress stay immersion.
- Full `brew-timeline` (24) + `pourSequence` (36) + `acaia-protocol` (7) suites green; `tsc` clean.

## On-device verify (owner)
Start a V60 brew **from the chat**, connect the Acaia → the brew screen should show the `LivePourSequence` pour cards ("Now / +Xg → Yg total") and the flow-analysis box on the active pour card (current step + live grams + cue). Confirm an AeroPress/Clever brew from the chat still renders the immersion guide.

## Out of scope
Noted but not touched: the Acaia keep-alive is sustained only by incoming notifications (no independent heartbeat), a possible "weight freezes" failure mode — unverifiable without the device, separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGTbWUcNjuWfkX99kicyLH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGTbWUcNjuWfkX99kicyLH)_