### PR TITLE
fix(acaia): independent heartbeat + stall revival so live weight can't freeze

### DIFF
--- a/src/lib/native/acaia/README.md
+++ b/src/lib/native/acaia/README.md
@@ -23,6 +23,14 @@ the 1 s heartbeat, the command encoders — is the reverse-engineered protocol.
   constant defaults (`HEARTBEAT_INTERVAL` 1000, `CONNECTION_MODE` 'V2' = the iOS
   fast path). `lodash.memoize` → a local memoize.
 - **Strict TS.** Nullable `msg`, `ArrayBufferLike` on the decoder, no `any`.
+- **Independent heartbeat + stall revival (`startHeartbeatMonitor`).** Upstream's
+  monitor only re-`ident()`s (a no-op on the iOS V2 path once subscribed) and
+  relies on incoming notifications to drive `heartbeat()` — so the keepalive is
+  self-sustaining ONLY while the scale streams, and a single stall freezes the
+  weight with no recovery. Our monitor instead drives a real heartbeat itself
+  every second (independent of the stream) and re-subscribes when weight has
+  stalled (`NOTIFICATION_STALL_MS`). Uses only the existing ported packets — do
+  NOT "restore upstream parity" here, it reintroduces the freeze.
 
 ## Files
 

--- a/src/lib/native/acaia/acaia.ts
+++ b/src/lib/native/acaia/acaia.ts
@@ -83,6 +83,10 @@ class DecoderWorker {
 }
 
 const HEARTBEAT_INTERVAL = 1000;
+// A notification gap longer than this means the weight stream genuinely stalled
+// (normal pouring streams at ~10 Hz) → re-subscribe to revive it. See
+// startHeartbeatMonitor.
+const NOTIFICATION_STALL_MS = 3000;
 const CONNECTION_MODE: string = "V2";
 
 export class AcaiaScale {
@@ -118,6 +122,7 @@ export class AcaiaScale {
 
   private recievesNotifications = false;
   private encodeNotificationRequestSend = false;
+  private last_notification_ms = 0;
 
   constructor(device_id: string, characteristics: Characteristic[], transport: AcaiaTransport) {
     this.device_id = device_id;
@@ -298,22 +303,45 @@ export class AcaiaScale {
 
   private handleNotification(value: ArrayBuffer): void {
     if (this.connected) {
+      this.last_notification_ms = Date.now();
       this.worker.addBuffer(value);
       this.heartbeat();
     }
   }
 
+  // DELIBERATE DEVIATION FROM BEANCONQUEROR — do NOT "restore upstream parity".
+  // Upstream's monitor only re-calls ident() (a no-op on the iOS V2 path once
+  // subscribed) and relies on incoming notifications to drive heartbeat(). That
+  // makes the keepalive self-sustaining ONLY while the scale streams: a single
+  // stall (BLE congestion / brief out-of-range / auto-dim) breaks the loop and
+  // the weight freezes with no recovery. Here the monitor instead (1) drives a
+  // real heartbeat itself every second — independent of the notification stream —
+  // and (2) re-subscribes when weight has genuinely stalled, so the stream
+  // revives on its own. Both use only the existing ported packets.
   private startHeartbeatMonitor(): void {
-    this.heartbeat_monitor_interval = setInterval(async () => {
-      if (Date.now() > this.last_heartbeat + HEARTBEAT_INTERVAL) {
+    this.heartbeat_monitor_interval = setInterval(() => {
+      if (!this.connected) return;
+      // Independent keepalive: heartbeat() flushes the command queue and sends a
+      // real encodeHeartbeat, self-throttled to ≤1/s via last_heartbeat — so
+      // driving it here too (not only from handleNotification) keeps the scale
+      // awake even when no notifications are arriving.
+      this.heartbeat();
+      // Stream genuinely stalled (no weight for a few seconds) → re-request it.
+      // Gated on recievesNotifications so it never fires before first subscribe,
+      // and on the multi-second gap so normal ~10 Hz pouring never trips it.
+      if (
+        this.recievesNotifications &&
+        Date.now() - this.last_notification_ms > NOTIFICATION_STALL_MS
+      ) {
+        this.encodeNotificationRequestSend = false; // let ident() re-send the request
         if (this.isV1Path()) {
-          await this.initScales();
+          void this.ident();
         } else {
-          this.initScales();
+          this.ident();
         }
-        this.logger.info("Sent heartbeat reviving request.");
+        this.logger.info("Weight stream stalled — re-subscribing.");
       }
-    }, HEARTBEAT_INTERVAL * 2);
+    }, HEARTBEAT_INTERVAL);
   }
 
   private stopHeartbeatMonitor(): void {


### PR DESCRIPTION
## What

The Acaia live weight could **freeze with no recovery**. This adds an independent heartbeat + automatic stream revival so a transient stall self-heals.

## Why

Verified against the upstream **Beanconqueror** source (the MIT port this code came from):
- `heartbeat()` (sends `encodeHeartbeat`, throttled to 1/s) is driven **only by incoming weight notifications**.
- The heartbeat monitor's `ident()` "revival" is a **no-op on the iOS V2 path** (the owner's old-protocol Lunar/Pearl) once `encodeNotificationRequestSend` latches after the first subscribe.

So the keepalive loop is self-sustaining *only while the scale streams*. A single stall — BLE congestion, brief out-of-range, scale auto-dim — breaks the loop and the weight stays frozen until a manual reconnect. This is an upstream design characteristic, not a port bug.

## Fix (`src/lib/native/acaia/acaia.ts`)

The heartbeat monitor now:
1. **Drives a real heartbeat itself every second** — `heartbeat()` is self-throttled via `last_heartbeat`, so calling it from the timer (not only from notifications) keeps the scale awake independent of the stream.
2. **Re-subscribes when weight has genuinely stalled** (`> NOTIFICATION_STALL_MS` = 3 s with no notification): resets the latch and re-`ident()`s to restart the stream. Gated on `recievesNotifications` + the multi-second gap, so it's inert during normal ~10 Hz pouring.

Uses **only the existing ported packets** (`encodeHeartbeat`/`encodeId`/`encodeNotificationRequest`) — no protocol bytes change, only *when* they fire. Native-gated (`acaiaCapable()`) + try/caught, so the PWA and brew timer are untouched. Documented in-code + README as a deliberate deviation from upstream so it isn't "cleaned up" back to parity (which would reintroduce the freeze).

## Tests
- `tsc` clean.
- `tests/dataflow/acaia-protocol.test.mjs` (7) green — packet byte math unchanged (this is timing/control-flow only).

## On-device verify (owner — the only real test; BLE can't run in CI/PWA)
- Connect the Acaia, start a brew → live grams stream as before; **Tare** still works.
- **Stall test:** with weight streaming, set the scale down / let it idle a few seconds (or step briefly out of range), then add water — the weight should **resume on its own** instead of staying frozen.
- Full brew end-to-end → the #407 flow coach still reads live weight throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGTbWUcNjuWfkX99kicyLH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGTbWUcNjuWfkX99kicyLH)_