### PR TITLE
fix(chat): brew-from-chat shows the pour guide (AeroPress + immersion)

### DIFF
--- a/src/app/api/explore-agent/route.ts
+++ b/src/app/api/explore-agent/route.ts
@@ -16,6 +16,8 @@ import { ALL_RECIPES, formatRecipeForPrompt } from "@/lib/knowledge/recipes";
 import { db } from "@/lib/db/client";
 import { places } from "@/lib/db/schema";
 import { assertSafeHttpsUrl } from "@/lib/utils/safeFetch";
+import { sanitizePourSteps, pourSequenceFromSteps } from "@/lib/utils/pourSteps";
+import { reconcileWaterToPourPlan } from "@/lib/claude/recipeFidelity";
 import type { Session, BrewRecipe } from "@/lib/types/session";
 
 export const dynamic = "force-dynamic";
@@ -397,6 +399,28 @@ const TOOLS: Anthropic.Tool[] = [
   },
 ];
 
+/**
+ * Clean a chat-authored `start_brew` recipe so the brew timer can render it the
+ * same way a /recommend recipe renders. The model's tool input is raw: its step
+ * `action` wording drifts ("Plunge", "Steep", "Press") and it carries no
+ * `pourSequence` fallback string. Without this the AeroPress / immersion guide
+ * mis-routes (the renderer matches exact action words) and shows no steps. We:
+ *   1. action-normalize + validate the structured steps (shared with /recommend),
+ *   2. derive the legacy `pourSequence` backstop from those steps, and
+ *   3. snap the headline water to the actual pour plan (the "too much water"
+ *      header-vs-plan mismatch /recommend already corrects).
+ */
+function cleanChatRecipe(recipe: BrewRecipe | undefined): BrewRecipe | undefined {
+  if (!recipe) return undefined;
+  const pourSteps = sanitizePourSteps(recipe.pourSteps);
+  const out: BrewRecipe = {
+    ...recipe,
+    ...(pourSteps ? { pourSteps } : {}),
+    pourSequence: recipe.pourSequence ?? pourSequenceFromSteps(pourSteps),
+  };
+  return reconcileWaterToPourPlan(out);
+}
+
 // suggest_navigation and start_brew are terminal "action" tools — collected
 // into the response's actions, not round-tripped. The destination comes from
 // the TOOL NAME for start_brew (its input has no destination field), and from
@@ -411,7 +435,7 @@ function toNavAction(toolName: string, input: NavAction): NavAction {
       method: input.method,
       title: input.title,
       basedOn: input.basedOn,
-      recipe: input.recipe,
+      recipe: cleanChatRecipe(input.recipe),
     };
   }
   if (toolName === "remember_advice") {

--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -7,8 +7,6 @@ import type {
   CandidateRole,
   CandidateConfidence,
   BrewRecipe,
-  BrewPourStep,
-  BrewStepAction,
 } from "../types/session";
 import type { Session } from "../types/session";
 import type { UserPreferences } from "../types/preferences";
@@ -30,6 +28,7 @@ import {
 } from "../knowledge/varieties";
 import { TECHNIQUES } from "../knowledge/techniques";
 import { reconcileToReference, reconcileWaterToPourPlan } from "./recipeFidelity";
+import { sanitizePourSteps } from "../utils/pourSteps";
 import { parseClaudeJson, z } from "./parseJson";
 
 const CandidateSchema = z.object({
@@ -56,40 +55,6 @@ const RecommendationResponseSchema = z.object({
   coffeeAssessment: z.string().optional(),
 });
 
-const STEP_ACTIONS: readonly BrewStepAction[] = [
-  "bloom", "pour", "final", "stir", "swirl", "wait",
-  "press", "invert", "flip", "drain", "bypass", "melodrip", "agitate-bed",
-];
-
-/** Map free-text / synonym actions onto the structured vocabulary so a minor
- * wording drift ("rest", "plunge") doesn't drop the whole step array. */
-function normalizeStepAction(a: string): BrewStepAction {
-  const t = a.toLowerCase().trim();
-  if ((STEP_ACTIONS as string[]).includes(t)) return t as BrewStepAction;
-  if (/plunge|press/.test(t)) return "press";
-  if (/flip/.test(t)) return "flip";
-  if (/invert/.test(t)) return "invert";
-  if (/bypass|dilute/.test(t)) return "bypass";
-  if (/drain|draw|release/.test(t)) return "drain";
-  if (/steep|wait|rest|brew/.test(t)) return "wait";
-  if (/melodrip/.test(t)) return "melodrip";
-  if (/agitate/.test(t)) return "agitate-bed";
-  if (/stir|mix/.test(t)) return "stir";
-  if (/swirl|shake/.test(t)) return "swirl";
-  if (/bloom/.test(t)) return "bloom";
-  if (/final|last/.test(t)) return "final";
-  return "pour";
-}
-
-const PourStepInputSchema = z.object({
-  label: z.string(),
-  action: z.string().transform(normalizeStepAction),
-  waterGramsAtEnd: z.number().optional(),
-  durationSec: z.number().optional(),
-  temperatureC: z.number().optional(),
-  notes: z.string().optional(),
-});
-
 /**
  * Validate + coerce the model's `pourSteps`. Lenient by design: a well-formed
  * array is kept (actions normalised); anything malformed is dropped so the
@@ -98,9 +63,9 @@ const PourStepInputSchema = z.object({
  */
 function sanitizeRecipe(recipe: Record<string, unknown>): BrewRecipe {
   const out = { ...recipe } as Record<string, unknown>;
-  const parsed = z.array(PourStepInputSchema).safeParse(out.pourSteps);
-  if (parsed.success && parsed.data.length >= 2) {
-    out.pourSteps = parsed.data as BrewPourStep[];
+  const clean = sanitizePourSteps(out.pourSteps);
+  if (clean) {
+    out.pourSteps = clean;
   } else {
     delete out.pourSteps;
   }

--- a/src/lib/utils/pourSteps.ts
+++ b/src/lib/utils/pourSteps.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared pour-step sanitation — the SINGLE place that turns a model-authored
+ * `pourSteps` array (from /recommend OR the home-chat `start_brew` tool) into the
+ * strict, renderer-ready shape the brew timer consumes.
+ *
+ * Why this exists: the brew renderers (`pourStepsFromStructured`,
+ * `hasImmersionShape`, `buildGuideSteps`) compare `step.action` against the exact
+ * `BrewStepAction` vocabulary. A model that emits "Pour" / "rest" / "plunge"
+ * never matches, so an immersion recipe mis-routes to the pour-over renderer and
+ * agitation steps go undetected → the guide renders nothing. `/recommend` already
+ * guarded this via `sanitizeRecipe`; the chat's `start_brew` path passed the raw
+ * tool input straight through and so showed no pour guidance. This module is that
+ * guard, extracted so both paths share one source of truth.
+ */
+import { z } from "zod";
+import type { BrewPourStep, BrewStepAction } from "@/lib/types/session";
+
+export const STEP_ACTIONS: readonly BrewStepAction[] = [
+  "bloom", "pour", "final", "stir", "swirl", "wait",
+  "press", "invert", "flip", "drain", "bypass", "melodrip", "agitate-bed",
+];
+
+/** Map free-text / synonym actions onto the structured vocabulary so a minor
+ * wording drift ("rest", "plunge") doesn't drop the whole step array. */
+export function normalizeStepAction(a: string): BrewStepAction {
+  const t = a.toLowerCase().trim();
+  if ((STEP_ACTIONS as string[]).includes(t)) return t as BrewStepAction;
+  if (/plunge|press/.test(t)) return "press";
+  if (/flip/.test(t)) return "flip";
+  if (/invert/.test(t)) return "invert";
+  if (/bypass|dilute/.test(t)) return "bypass";
+  if (/drain|draw|release/.test(t)) return "drain";
+  if (/steep|wait|rest|brew/.test(t)) return "wait";
+  if (/melodrip/.test(t)) return "melodrip";
+  if (/agitate/.test(t)) return "agitate-bed";
+  if (/stir|mix/.test(t)) return "stir";
+  if (/swirl|shake/.test(t)) return "swirl";
+  if (/bloom/.test(t)) return "bloom";
+  if (/final|last/.test(t)) return "final";
+  return "pour";
+}
+
+export const PourStepInputSchema = z.object({
+  label: z.string(),
+  action: z.string().transform(normalizeStepAction),
+  waterGramsAtEnd: z.number().optional(),
+  durationSec: z.number().optional(),
+  temperatureC: z.number().optional(),
+  notes: z.string().optional(),
+});
+
+/**
+ * Validate + action-normalize a raw `pourSteps` array (e.g. straight from an LLM
+ * tool call). Returns a clean `BrewPourStep[]` when there are ≥2 well-formed
+ * steps, else `undefined` so the caller can fall back. NEVER throws — a bad step
+ * array must not fail the whole recipe. Mirrors the guard `/recommend` applies
+ * inside `sanitizeRecipe`.
+ */
+export function sanitizePourSteps(raw: unknown): BrewPourStep[] | undefined {
+  const parsed = z.array(PourStepInputSchema).safeParse(raw);
+  if (parsed.success && parsed.data.length >= 2) return parsed.data as BrewPourStep[];
+  return undefined;
+}
+
+/** Water-adding actions that contribute to the cumulative pour sequence. */
+const WATER_ADDING: ReadonlySet<BrewStepAction> = new Set<BrewStepAction>([
+  "bloom", "pour", "final", "melodrip",
+]);
+
+/**
+ * Derive a legacy " – "-joined cumulative-grams `pourSequence` string from
+ * structured steps (e.g. "50 – 180 – 320 – 500"), so a recipe authored only as
+ * structured `pourSteps` still has the string backstop the brew timer falls back
+ * to. Returns `undefined` when fewer than two water-adding milestones carry a
+ * cumulative-grams value.
+ */
+export function pourSequenceFromSteps(steps: BrewPourStep[] | undefined): string | undefined {
+  if (!steps || steps.length === 0) return undefined;
+  const grams = steps
+    .filter((s) => WATER_ADDING.has(s.action) && typeof s.waterGramsAtEnd === "number")
+    .map((s) => s.waterGramsAtEnd as number);
+  if (grams.length < 2) return undefined;
+  return grams.join(" – ");
+}

--- a/tests/dataflow/chat-recipe-sanitize.test.mjs
+++ b/tests/dataflow/chat-recipe-sanitize.test.mjs
@@ -1,0 +1,99 @@
+// The home-chat `start_brew` path must hand the brew timer a recipe the renderer
+// can actually lay out — same treatment /recommend gives its recipes.
+//
+//   node --test tests/dataflow/chat-recipe-sanitize.test.mjs
+//
+// THE BUG THIS LOCKS: a chat-authored AeroPress recipe arrived with drifted step
+// actions ("Steep", "Plunge") and NO pourSequence string. The brew renderers
+// match `step.action` against the exact BrewStepAction vocabulary, so the
+// immersion guide (which fires on press/invert/flip/long-wait) never recognised
+// it, fell back to the pour-over renderer, found no cumulative-grams milestones,
+// and showed an EMPTY pour guide. sanitizePourSteps normalizes the actions so
+// hasImmersionShape routes it to the step guide; pourSequenceFromSteps adds the
+// legacy backstop string.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const entry = `
+export { sanitizePourSteps, pourSequenceFromSteps, normalizeStepAction } from ${JSON.stringify(
+  path.join(ROOT, "src/lib/utils/pourSteps.ts"),
+)};
+export { buildBrewTimeline } from ${JSON.stringify(path.join(ROOT, "src/lib/brew/timeline.ts"))};
+`;
+const dir = await mkdtemp(join(tmpdir(), "chatrec-"));
+const out = join(dir, "m.mjs");
+await build({
+  stdin: { contents: entry, resolveDir: ROOT, loader: "ts" },
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  outfile: out,
+  logLevel: "silent",
+});
+const { sanitizePourSteps, pourSequenceFromSteps, normalizeStepAction, buildBrewTimeline } =
+  await import(pathToFileURL(out).href);
+
+test("normalizeStepAction maps drifted AeroPress wording onto the vocabulary", () => {
+  assert.equal(normalizeStepAction("Plunge"), "press");
+  assert.equal(normalizeStepAction("Steep"), "wait");
+  assert.equal(normalizeStepAction("Invert"), "invert");
+  assert.equal(normalizeStepAction("Pour"), "pour");
+  assert.equal(normalizeStepAction("Bloom"), "bloom");
+});
+
+// The exact failure the owner hit: an AeroPress recipe from the chat with
+// capitalised / synonym actions and no pourSequence string.
+const rawAeroPress = {
+  doseGrams: 15,
+  waterGrams: 220,
+  waterTempC: 90,
+  grindSize: "medium-fine",
+  targetTimeSec: 150,
+  pourSteps: [
+    { label: "Add coffee, pour 220g", action: "Pour", waterGramsAtEnd: 220 },
+    { label: "Steep", action: "Steep", durationSec: 90 },
+    { label: "Plunge slowly", action: "Plunge", durationSec: 30 },
+  ],
+};
+
+test("sanitizePourSteps normalizes actions and keeps ≥2 steps", () => {
+  const clean = sanitizePourSteps(rawAeroPress.pourSteps);
+  assert.ok(clean, "expected a sanitized array");
+  assert.deepEqual(
+    clean.map((s) => s.action),
+    ["pour", "wait", "press"],
+  );
+});
+
+test("BEFORE: raw AeroPress steps render NO immersion guide (the bug)", () => {
+  // Drifted actions → hasImmersionShape can't see press/wait → mis-routes.
+  const t = buildBrewTimeline(rawAeroPress, "2026-06-01", new Date("2026-06-16T08:00:00Z").getTime());
+  assert.notEqual(t.shape, "immersion");
+});
+
+test("AFTER: sanitized AeroPress routes to the immersion step guide", () => {
+  const clean = sanitizePourSteps(rawAeroPress.pourSteps);
+  const recipe = { ...rawAeroPress, pourSteps: clean };
+  const t = buildBrewTimeline(recipe, "2026-06-01", new Date("2026-06-16T08:00:00Z").getTime());
+  assert.equal(t.shape, "immersion");
+  assert.ok(t.guideSteps && t.guideSteps.length >= 2, "expected populated guide steps");
+});
+
+test("pourSequenceFromSteps derives the legacy grams backstop for pour-overs", () => {
+  const pourOver = sanitizePourSteps([
+    { label: "Bloom", action: "Bloom", waterGramsAtEnd: 50 },
+    { label: "Pour to 180", action: "Pour", waterGramsAtEnd: 180 },
+    { label: "Final pour", action: "Final", waterGramsAtEnd: 320 },
+  ]);
+  assert.equal(pourSequenceFromSteps(pourOver), "50 – 180 – 320");
+  // AeroPress (only one water-adding milestone) → no useful string backstop.
+  assert.equal(pourSequenceFromSteps(sanitizePourSteps(rawAeroPress.pourSteps)), undefined);
+});


### PR DESCRIPTION
## What was broken
Starting a brew from the home AI chat (the **Brew X** button → `start_brew`) dropped you into the timer with **no pour guidance** — confirmed by the owner on an **AeroPress** recipe.

## Root cause
The chat handed the brew screen the model's **raw** recipe. `/recommend` first runs every recipe through `sanitizeRecipe`; the chat path skipped it. Two gaps:

1. **Step actions weren't normalized.** The brew renderers match `step.action` against the exact `BrewStepAction` vocabulary. A chat AeroPress with drifted wording (`"Steep"`, `"Plunge"`, `"Press"`) was never recognised as an immersion shape → fell back to the pour-over renderer → no cumulative-grams milestones → **empty guide**.
2. **No `pourSequence` fallback string** on chat recipes, so nothing rendered once structured parsing produced nothing.

(The "scale" the owner also missed is the Acaia BLE panel — native-iOS-only, invisible on the PWA regardless of how a brew starts; not affected by this path. The "too much water" was the unreconciled headline water, also fixed here.)

## Fix
- Extract the pour-step sanitation into a shared `src/lib/utils/pourSteps.ts` (`normalizeStepAction` + `sanitizePourSteps`) — now the single source `/recommend` also uses (DRY, behaviour-identical).
- Clean the chat recipe **server-side** in explore-agent's `toNavAction`: normalize+validate steps, derive the legacy `pourSequence` backstop, and snap the headline water to the real pour plan (`reconcileWaterToPourPlan`).

## Verification
- `tsc` clean; full suite 141 pass.
- New `tests/dataflow/chat-recipe-sanitize.test.mjs` proves the **raw** AeroPress mis-routes and the **sanitized** one routes to the immersion step guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)