### PR TITLE
feat(brew): live scale pour-coaching on AeroPress / immersion brews

### DIFF
--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -295,7 +295,9 @@ export default function LightStepBrew() {
           />
         )}
 
-        {guideSteps && <StepGuide steps={guideSteps} elapsed={elapsed} started={started} />}
+        {guideSteps && (
+          <StepGuide steps={guideSteps} elapsed={elapsed} started={started} coach={coach} />
+        )}
 
         {proseSequence && <StepGuide sequence={proseSequence} elapsed={elapsed} started={started} />}
       </div>
@@ -745,11 +747,15 @@ function StepGuide({
   sequence,
   elapsed,
   started,
+  coach,
 }: {
   steps?: GuideStep[];
   sequence?: string;
   elapsed: number;
   started: boolean;
+  /** Live scale flow comparison — shown on this view's water-pour steps when the
+   * Acaia is connected (same cue the pour-over renderer uses). Null/"none" → nothing. */
+  coach?: FlowComparison | null;
 }) {
   const audioCtxRef = useRef<AudioContext | null>(null);
   const prevAutoIdxRef = useRef(-1);
@@ -880,6 +886,8 @@ function StepGuide({
             />
           )}
         </div>
+
+        {showsCoach(coach) && <CoachCue coach={coach} />}
 
         {nextStep && nextCountdown !== null && nextCountdown <= 15 && nextCountdown > 0 && (
           <div className="mt-3 pt-3 border-t border-light-foreground/15 flex items-center justify-between">

--- a/src/lib/brew/flowCoach.ts
+++ b/src/lib/brew/flowCoach.ts
@@ -114,8 +114,11 @@ function fmtDetail(remaining: number, rate: number | null): string {
 
 /**
  * Compare the live pour to the intended flow at this instant. Returns a single
- * cue + the numbers behind it. Degrades to "no-data" off the grams curve
- * (immersion) or before there's a weight reading.
+ * cue + the numbers behind it. Coaches the water-pour steps of BOTH percolation
+ * AND immersion/AeroPress brews — any step that carries a cumulative-grams
+ * target. Steps with no grams target (a steep/press/drain on an immersion brew)
+ * fall through to "no-data" below, so those stay purely time-driven. Degrades to
+ * "no-data" before there's a weight reading or the brew has started.
  */
 export function coachFlow(
   timeline: BrewTimeline | null,
@@ -124,7 +127,7 @@ export function coachFlow(
   liveGrams: number | null,
   samples: WeightSample[],
 ): FlowComparison {
-  if (!timeline || !started || liveGrams == null || !timeline.hasGramsCurve) {
+  if (!timeline || !started || liveGrams == null) {
     return { ...NO_DATA, liveGrams };
   }
 

--- a/tests/dataflow/brew-flowcoach.test.mjs
+++ b/tests/dataflow/brew-flowcoach.test.mjs
@@ -120,9 +120,23 @@ test("detail shows grams-to-go and rate", () => {
   assert.match(c.detail, /90g to go · 4\.0 g\/s/);
 });
 
-test("immersion / no scale → no-data, no cue", () => {
+test("immersion: steep step (no grams target) → no-data, no cue", () => {
+  // At t=30 the active step is the 90s steep (no cumulative grams) → time-only.
   assert.equal(coachFlow(IMMERSION, 30, true, 100, ramp(4)).cue, "none");
   assert.equal(coachFlow(IMMERSION, 30, true, 100, ramp(4)).state, "no-data");
   assert.equal(coachFlow(PERC, 60, true, null, []).cue, "none"); // no weight yet
   assert.equal(coachFlow(PERC, 60, false, 90, ramp(4)).cue, "none"); // not started
+});
+
+test("immersion: the water-POUR step gets scale coaching (AeroPress fix)", () => {
+  // At t=8 the active step is "Add water → 200g" (start 0, 15s). The scale must
+  // coach the pour just like a pour-over, not stay silent.
+  const c = coachFlow(IMMERSION, 8, true, 100, ramp(4));
+  assert.notEqual(c.cue, "none");
+  assert.equal(c.liveGrams, 100);
+  assert.equal(c.currentStepTargetG, 200);
+  // Past the target on that pour → the "Overshot +Xg" cue from the screenshot.
+  const over = coachFlow(IMMERSION, 8, true, 215, ramp(4));
+  assert.equal(over.cue, "overshot");
+  assert.equal(over.detail, "+15g");
 });


### PR DESCRIPTION
## What you asked for
> "There is the pour flow guidance with the scale value!! I want this **always**" — incl. AeroPress, "only when I connect the scale."

## Why it was missing
The live Acaia flow coach (`Steady` / `Ease off` / `Overshot +15g` with the running grams) was **hard-gated to pour-over brews** — `coachFlow` bailed immediately on any immersion/AeroPress recipe (`!timeline.hasGramsCurve`). So a V60 got the scale-aware guidance, an AeroPress never could.

## Fix
- `coachFlow` now runs on **any step with a cumulative-grams target** — the water-**pour** steps of an immersion brew included. Steep / press / drain steps (no gram target) still return "no-data" and stay time-only — correct, since there's nothing to pour there.
- `StepGuide` (the immersion/AeroPress renderer) now receives `coach` and renders the same `CoachCue` the pour-over view uses, gated by `showsCoach` → it shows **only while the Acaia is connected** and **only on pour steps**.

Net: the V60-style pour-flow guidance with the live scale reading now appears on **every brew that pours to a target**, AeroPress included.

## Verification
- `tsc` clean; full suite **147 pass**.
- `brew-flowcoach.test.mjs` now locks: the immersion water-pour step coaches (incl. the `Overshot +15g` case from your screenshot), and the steep step stays silent.

Note: this builds on #410 (which restored the AeroPress step guide in the first place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)