### PR TITLE
fix(brew): stop fresh-scan recipe screen crashing to a black screen

### DIFF
--- a/src/app/(light)/error.tsx
+++ b/src/app/(light)/error.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+
+/**
+ * Route-group error boundary for the whole (light) tree.
+ *
+ * Before this, any render throw in a step (e.g. a fresh-scan field crashing
+ * buildCraftingPhases on the recipe-loading screen) bubbled to Next's root
+ * handler and showed the bare black "Application error: a client-side
+ * exception" page — a dead end, no way back to brewing. This catches the throw
+ * and offers recovery (retry the segment, or head Home) without leaving the
+ * app. The stale-chunk self-heal in the root layout still handles ChunkLoadError
+ * separately (it reloads with a fresh shell); this is for genuine render throws.
+ */
+export default function LightError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    // Surface it in the console for diagnosis; never shown to the user.
+    console.error("[light] render error:", error);
+  }, [error]);
+
+  return (
+    <div className="min-h-dvh flex flex-col items-center justify-center gap-6 px-8 text-center">
+      <div className="space-y-2">
+        <h1 className="font-fraunces text-[28px] leading-tight tracking-[-0.01em] text-light-foreground">
+          This screen hit a snag.
+        </h1>
+        <p className="text-[14px] leading-relaxed text-light-foreground/70 max-w-[28ch] mx-auto">
+          Try again — your coffee and context are still here. If it sticks, head
+          Home and start fresh.
+        </p>
+      </div>
+      <div className="flex flex-col items-stretch gap-3 w-full max-w-[16rem]">
+        <button
+          type="button"
+          onClick={() => reset()}
+          className="w-full h-14 rounded-full bg-light-foreground text-light-text-on-dark font-semibold active:scale-[0.98] transition-transform"
+        >
+          Try Again
+        </button>
+        <Link
+          href="/"
+          className="w-full h-12 rounded-full flex items-center justify-center bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 text-[14px] text-light-foreground active:scale-[0.98] transition-transform"
+        >
+          Go Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -64,16 +64,21 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         {/* Stale-chunk self-heal. After a deploy, an installed PWA / WKWebView
             can hold a cached HTML shell that references JS chunk filenames the
             new build no longer has → "Application error: a client-side
-            exception" (a ChunkLoadError). This pre-hydration script catches that
-            and reloads ONCE per session so the client silently picks up the new
-            build instead of white-screening. One-shot via sessionStorage → no
-            reload loop (a persistently-broken chunk shows the error rather than
-            looping; a fresh app launch resets the flag). Caused by the June-2026
-            widget-deploy incident — see docs/ios-shell-roadmap. */}
+            exception" (a ChunkLoadError). The brew flow loads its step chunks
+            lazily, so the crash lands exactly when you cross into the recipe /
+            brew step. A plain location.reload() reuses the service-worker cache
+            and re-fetches the SAME stale shell → the old one-shot reload couldn't
+            recover and left a black screen. So on a chunk error we first PURGE
+            the Cache Storage + unregister the service worker, THEN reload, so the
+            fresh shell + new chunks actually load. One-shot per session via
+            sessionStorage → no reload loop (a persistently-broken chunk shows the
+            error rather than looping; a fresh app launch resets the flag). A
+            1.5s watchdog reloads even if the cache purge hangs. Caused by the
+            June-2026 widget-deploy incident — see docs/ios-shell-roadmap. */}
         <script
           dangerouslySetInnerHTML={{
             __html:
-              "(function(){try{var K='btts_chunk_reloaded';function c(m){return /ChunkLoadError|Loading chunk [\\w-]+ failed|Importing a module script failed|Failed to fetch dynamically imported module|error loading dynamically imported module/i.test(m||'')}function h(m){if(!c(m))return;try{if(sessionStorage.getItem(K))return;sessionStorage.setItem(K,'1')}catch(e){}location.reload()}window.addEventListener('error',function(e){h((e&&e.message)||(e&&e.error&&e.error.message)||'')},true);window.addEventListener('unhandledrejection',function(e){var r=e&&e.reason;h((r&&r.message)||String(r||''))})}catch(e){}})();",
+              "(function(){try{var K='btts_chunk_reloaded';function c(m){return /ChunkLoadError|Loading chunk [\\w-]+ failed|Importing a module script failed|Failed to fetch dynamically imported module|error loading dynamically imported module/i.test(m||'')}function h(m){if(!c(m))return;try{if(sessionStorage.getItem(K))return;sessionStorage.setItem(K,'1')}catch(e){}var done=false;function go(){if(done)return;done=true;location.reload()}try{var t=[];if(window.caches&&caches.keys){t.push(caches.keys().then(function(ks){return Promise.all(ks.map(function(k){return caches.delete(k)}))}))}if(navigator.serviceWorker&&navigator.serviceWorker.getRegistrations){t.push(navigator.serviceWorker.getRegistrations().then(function(rs){return Promise.all(rs.map(function(r){return r.unregister()}))}))}Promise.all(t).then(go).catch(go);setTimeout(go,1500)}catch(e){go()}}window.addEventListener('error',function(e){h((e&&e.message)||(e&&e.error&&e.error.message)||'')},true);window.addEventListener('unhandledrejection',function(e){var r=e&&e.reason;h((r&&r.message)||String(r||''))})}catch(e){}})();",
           }}
         />
         <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />

--- a/src/lib/craftingPhases.ts
+++ b/src/lib/craftingPhases.ts
@@ -15,9 +15,15 @@ import type { CoffeeIdentity, SessionContext } from "@/lib/types/session";
  * `CraftingStatus` cycles this list and holds on the final entry.
  */
 
-/** A stored string we can actually show (not empty / placeholder). */
-function real(v?: string | null): v is string {
-  if (!v) return false;
+/** A stored string we can actually show (not empty / placeholder).
+ *
+ * `draft.coffee` is a Partial populated by AI bag extraction, so a field can
+ * arrive as a non-string at runtime even though the type says string. This used
+ * to call `.trim()` unconditionally — a non-string value threw DURING RENDER
+ * (buildCraftingPhases runs in a useMemo), which crashed the whole recipe step
+ * to a black "client-side exception" on a fresh scan. Guard the type at runtime. */
+function real(v?: unknown): v is string {
+  if (typeof v !== "string") return false;
   const s = v.trim().toLowerCase();
   return s !== "" && s !== "unknown" && s !== "other" && s !== "n/a" && s !== "none";
 }


### PR DESCRIPTION
A new bag scan → context → "Get my recipe" hard-crashed to the bare "Application error: a client-side exception" page right before recipe creation.

Root cause: `craftingPhases.real()` (run during the recipe-loading screen's render, in a `useMemo`) called `.trim()` assuming every coffee field is a string. `draft.coffee` is a `Partial` populated by AI bag extraction, so a non-string field threw during render and crashed the whole step — and the `(light)` tree had no error boundary, so it fell through to Next's black root error page. The cold-brew path uses canonical values, which is why only a fresh scan tripped it.

Three complementary, safe fixes:
- **`craftingPhases.real()`** now guards the type at runtime (`typeof v === "string"`) — the actual crash fix.
- **`(light)/error.tsx`** route-group error boundary — any render throw now shows a recoverable "Try Again / Go Home" screen instead of the dead black page.
- **Stale-chunk self-heal** (root layout) now purges the service-worker caches before reloading — a plain reload reused the cached shell and re-hit the same ChunkLoadError, so the prior one-shot reload couldn't recover.

`tsc` clean; crafting-phases tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKxzFDPzLfL8tgYrtajAsG)_