### PR TITLE
feat(voice): 'I am listening' earcon when the mic goes hot

### DIFF
--- a/src/hooks/useVoiceCapture.ts
+++ b/src/hooks/useVoiceCapture.ts
@@ -1,5 +1,6 @@
 "use client";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { playListeningCue } from "@/lib/audio/listeningCue";
 
 interface Options {
   onTranscript: (text: string) => void;
@@ -130,6 +131,9 @@ export function useVoiceCapture({ onTranscript, onError }: Options): VoiceCaptur
     recorderRef.current = recorder;
     recorder.start(250);
     setRecording(true);
+    // The mic is now hot — sound the "BTTS is listening" earcon so the user
+    // knows they can speak (bridges the Siri-launch handoff; also confirms a tap).
+    playListeningCue();
   }, [recording, busy, surfaceError, teardownStream]);
 
   const stop = useCallback(async () => {

--- a/src/lib/audio/listeningCue.ts
+++ b/src/lib/audio/listeningCue.ts
@@ -1,0 +1,63 @@
+"use client";
+
+/**
+ * "BTTS is listening now" earcon — two soft ASCENDING sine notes (a rising
+ * fifth, E5 → B5: open / go-ahead). Deliberately distinct from the brew timer's
+ * DESCENDING 880→660 step cue (LightStepBrew) so the two are never confused.
+ *
+ * Played the instant the mic actually starts capturing (useVoiceCapture), so
+ * the user knows they may speak. This is the cue that bridges the Siri-launch
+ * → app-open → mic-hot handoff gap (and equally confirms a plain mic tap).
+ *
+ * Web Audio playback needs an unlocked AudioContext. A user gesture (the mic
+ * tap) unlocks it, so the in-app case is reliable. A gesture-less launch
+ * (future Siri auto-listen) may leave the context suspended on iOS — resume()
+ * is attempted but not guaranteed; the recording itself never depends on it.
+ */
+let ctx: AudioContext | null = null;
+
+function getCtx(): AudioContext | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const Ctor: typeof AudioContext | undefined =
+      window.AudioContext ??
+      (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!Ctor) return null;
+    if (!ctx) ctx = new Ctor();
+    return ctx;
+  } catch {
+    return null;
+  }
+}
+
+export function playListeningCue(): void {
+  const audio = getCtx();
+  if (!audio) return;
+  // A suspended context (no recent gesture) — try to resume; harmless if it fails.
+  if (audio.state === "suspended") audio.resume().catch(() => { /* ignore */ });
+  try {
+    const now = audio.currentTime;
+    // [frequency, startOffset, duration] — a gentle rising fifth.
+    const notes: [number, number, number][] = [
+      [659.25, 0, 0.16],   // E5
+      [987.77, 0.11, 0.2], // B5
+    ];
+    for (const [freq, offset, dur] of notes) {
+      const osc = audio.createOscillator();
+      const gain = audio.createGain();
+      osc.type = "sine";
+      osc.frequency.value = freq;
+      osc.connect(gain);
+      gain.connect(audio.destination);
+      const t0 = now + offset;
+      // Soft ~8ms attack so there's no click, then a gentle exponential decay.
+      gain.gain.setValueAtTime(0.0001, t0);
+      gain.gain.exponentialRampToValueAtTime(0.12, t0 + 0.008);
+      gain.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
+      osc.start(t0);
+      osc.stop(t0 + dur + 0.02);
+    }
+  } catch {
+    /* audio unavailable — must never block recording */
+  }
+}


### PR DESCRIPTION
## What

A soft two-note **ascending** cue (rising fifth, E5→B5) plays the instant the chat mic actually starts capturing, so you know **BTTS is now listening and can speak**.

## Why

Bridges the handoff gap before any Siri work even exists: when the app opens and the mic arms, there's a beat where you'd start talking before BTTS is ready. The earcon marks the exact "go" moment. It also confirms a plain mic tap today.

- Fires at the real truth-moment: right after `recorder.start()` in `useVoiceCapture` (the mic is genuinely hot).
- Deliberately **distinct** from the brew timer's *descending* 880→660 step cue, so the two are never confused.
- Web Audio, gesture-unlocked (the mic tap unlocks it); wrapped so it can never block recording on failure.
- Reusable `playListeningCue()` — the future Siri auto-listen path will call the same helper.

## Note for the Siri path (later)

A gesture-less launch (Siri auto-listen) may leave the AudioContext suspended on iOS; `resume()` is attempted but not guaranteed without a native nudge. The in-app tap case is reliable today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)