### PR TITLE
feat(voice): btts://voice deep link → open Home chat + start listening

### DIFF
--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -484,6 +484,19 @@ export default function HomePage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pendingChatImageData]);
 
+  // Siri "BTTS Voice" / Action Button (btts://voice): the native bridge set
+  // pendingVoiceChat and routed here. Bump a nonce that ChatInput watches to
+  // arm the mic (→ listening earcon), then clear the flag so a normal open
+  // never auto-listens.
+  const pendingVoiceChat = useFlowStore((s) => s.pendingVoiceChat);
+  const setPendingVoiceChat = useFlowStore((s) => s.setPendingVoiceChat);
+  const [autoListenNonce, setAutoListenNonce] = useState(0);
+  useEffect(() => {
+    if (!pendingVoiceChat) return;
+    setPendingVoiceChat(false);
+    setAutoListenNonce((n) => n + 1);
+  }, [pendingVoiceChat, setPendingVoiceChat]);
+
   return (
     <>
       <main className="flex h-dvh flex-col">
@@ -520,6 +533,7 @@ export default function HomePage() {
           assistantSpeaking={voice.speaking}
           onCancelSpeak={voice.cancel}
           onUnlockAudio={voice.unlock}
+          autoListenSignal={autoListenNonce}
         />
       </main>
 

--- a/src/components/ui/light/ChatInput.tsx
+++ b/src/components/ui/light/ChatInput.tsx
@@ -59,6 +59,14 @@ interface ChatInputProps {
    * required before any later programmatic playback succeeds.
    */
   onUnlockAudio?: () => void;
+  /**
+   * Auto-start the mic when this nonce changes to a new non-zero value —
+   * driven by the Siri "BTTS Voice" / Action-Button deep link (`btts://voice`)
+   * so the user lands in a listening chat. Starting the mic sounds the
+   * listening earcon. A gesture-less launch may have iOS withhold getUserMedia;
+   * the hook surfaces its own error in that case and the user taps the mic.
+   */
+  autoListenSignal?: number;
 }
 
 async function uploadPhoto(file: File): Promise<string> {
@@ -84,6 +92,7 @@ export default function ChatInput({
   assistantSpeaking = false,
   onCancelSpeak,
   onUnlockAudio,
+  autoListenSignal,
 }: ChatInputProps) {
   const [text, setText] = useState("");
   const [voiceError, setVoiceError] = useState<string | null>(null);
@@ -201,6 +210,18 @@ export default function ChatInput({
   useEffect(() => {
     onComposingChange?.(isCompositionActive);
   }, [isCompositionActive, onComposingChange]);
+
+  // Siri "BTTS Voice" / Action Button → arm the mic on arrival. Fires when the
+  // nonce changes to a new non-zero value (works for both a warm Home page and
+  // a cold launch where the initial signal is already set). Guarded so it can't
+  // double-fire mid-recording.
+  const autoListenSeenRef = useRef<number | undefined>(undefined);
+  useEffect(() => {
+    if (!autoListenSignal) return;
+    if (autoListenSeenRef.current === autoListenSignal) return;
+    autoListenSeenRef.current = autoListenSignal;
+    if (!voice.recording && !voice.busy) void voice.start();
+  }, [autoListenSignal, voice]);
 
   const handleInput = (e: React.FormEvent<HTMLDivElement>) => {
     setText(e.currentTarget.textContent ?? "");

--- a/src/lib/native/widgetDeepLinks.ts
+++ b/src/lib/native/widgetDeepLinks.ts
@@ -7,6 +7,8 @@
  *     "Brew" button).
  *   - `btts://scan`               → a fresh scan: reset the flow and open
  *     `/brew/new` at Step "scan".
+ *   - `btts://voice`              → open the Home voice chat and start listening
+ *     (Siri "BTTS Voice" / Action Button). Sets a flag the Home page consumes.
  *
  * The scheme is registered in the shell's Info.plist (CFBundleURLTypes) and the
  * open event is delivered by `@capacitor/app`'s `appUrlOpen`, which we read
@@ -103,7 +105,8 @@ async function brewCoffeeById(coffeeId: string, nav: Nav): Promise<void> {
 export type WidgetAction =
   | { kind: "scan" }
   | { kind: "brew"; coffeeId: string | null }
-  | { kind: "share"; url: string | null };
+  | { kind: "share"; url: string | null }
+  | { kind: "voice" };
 
 /**
  * Pure parse of a `btts://…` URL into an action. Side-effect-free + store-free,
@@ -123,6 +126,7 @@ export function parseWidgetUrl(url: string): WidgetAction | null {
   if (action === "scan") return { kind: "scan" };
   if (action === "brew") return { kind: "brew", coffeeId: parsed.searchParams.get("coffeeId") };
   if (action === "share") return { kind: "share", url: parsed.searchParams.get("url") };
+  if (action === "voice") return { kind: "voice" };
   return null;
 }
 
@@ -147,6 +151,13 @@ export async function handleWidgetUrl(url: string, nav: Nav): Promise<void> {
   if (action.kind === "share") {
     if (action.url) routeToSharedUrl(action.url, nav);
     else nav("/brew/new");
+    return;
+  }
+  if (action.kind === "voice") {
+    // Siri ("BTTS Voice") / Action Button → open the Home voice chat and start
+    // listening. The Home page consumes the flag, arms the mic + earcon.
+    useFlowStore.getState().setPendingVoiceChat(true);
+    nav("/");
   }
 }
 

--- a/src/store/flowStore.ts
+++ b/src/store/flowStore.ts
@@ -46,6 +46,11 @@ interface FlowState {
    * base64 data URL read from the App Group. The Home chat uploads it, attaches
    * it, and auto-asks about it on mount, then clears it. */
   pendingChatImageData: string | null;
+  /** A Siri / Action-Button trigger (`btts://voice`) asked to open the Home
+   * voice chat and start listening. The Home page consumes this on mount,
+   * arms the mic (which sounds the listening earcon), then clears it. Cleared
+   * back to false in steady state so a normal app open never auto-listens. */
+  pendingVoiceChat: boolean;
 
   // Actions
   setStep: (step: FlowStep) => void;
@@ -54,6 +59,7 @@ interface FlowState {
   setPendingScanUrl: (url: string | null) => void;
   setPendingChatUrl: (url: string | null) => void;
   setPendingChatImageData: (dataUrl: string | null) => void;
+  setPendingVoiceChat: (v: boolean) => void;
   setIsDripBag: (v: boolean) => void;
   setCoffee: (coffee: Partial<CoffeeIdentity>) => void;
   setPlace: (place: ExternalPlace) => void;
@@ -97,6 +103,7 @@ export const useFlowStore = create<FlowState>()(
       pendingScanUrl: null,
       pendingChatUrl: null,
       pendingChatImageData: null,
+      pendingVoiceChat: false,
       isDripBag: false,
       isAnalyzing: false,
       isRecommending: false,
@@ -110,6 +117,7 @@ export const useFlowStore = create<FlowState>()(
       setPendingScanUrl: (pendingScanUrl) => set({ pendingScanUrl }),
       setPendingChatUrl: (pendingChatUrl) => set({ pendingChatUrl }),
       setPendingChatImageData: (pendingChatImageData) => set({ pendingChatImageData }),
+      setPendingVoiceChat: (pendingVoiceChat) => set({ pendingVoiceChat }),
       setIsDripBag: (v) => set({ isDripBag: v }),
       setCoffee: (coffee) =>
         set((s) => ({ draft: { ...s.draft, coffee: { ...s.draft.coffee, ...coffee } as CoffeeIdentity } })),
@@ -127,9 +135,9 @@ export const useFlowStore = create<FlowState>()(
         set((s) => ({ clarificationMessages: [...s.clarificationMessages, msg] })),
       clearClarifications: () => set({ clarificationMessages: [] }),
       reset: () =>
-        set({ step: "scan", draft: initialDraft, fieldZones: null, skipScan: false, pendingScanUrl: null, pendingChatUrl: null, pendingChatImageData: null, isDripBag: false, isAnalyzing: false, isRecommending: false, recommendError: null, recommendJobId: null, clarificationMessages: [] }),
+        set({ step: "scan", draft: initialDraft, fieldZones: null, skipScan: false, pendingScanUrl: null, pendingChatUrl: null, pendingChatImageData: null, pendingVoiceChat: false, isDripBag: false, isAnalyzing: false, isRecommending: false, recommendError: null, recommendJobId: null, clarificationMessages: [] }),
       resumeColdBrew: (draft, fieldZones) =>
-        set({ step: "brew", draft, fieldZones, skipScan: true, isDripBag: false, isAnalyzing: false, isRecommending: false, recommendError: null, recommendJobId: null, clarificationMessages: [], pendingScanUrl: null, pendingChatUrl: null, pendingChatImageData: null }),
+        set({ step: "brew", draft, fieldZones, skipScan: true, isDripBag: false, isAnalyzing: false, isRecommending: false, recommendError: null, recommendJobId: null, clarificationMessages: [], pendingScanUrl: null, pendingChatUrl: null, pendingChatImageData: null, pendingVoiceChat: false }),
     }),
     {
       // localStorage (not sessionStorage) so an in-flight brew survives a

--- a/tests/dataflow/widget-deeplinks.test.mjs
+++ b/tests/dataflow/widget-deeplinks.test.mjs
@@ -76,6 +76,11 @@ test("share link with no url → null url", () => {
   assert.deepEqual(parseWidgetUrl("btts://share"), { kind: "share", url: null });
 });
 
+test("voice link → voice action (Siri / Action Button)", () => {
+  assert.deepEqual(parseWidgetUrl("btts://voice"), { kind: "voice" });
+  assert.deepEqual(parseWidgetUrl("btts://VOICE"), { kind: "voice" });
+});
+
 test("non-btts schemes return null", () => {
   assert.equal(parseWidgetUrl("https://bettertastethansorry.com/brew?coffeeId=x"), null);
   assert.equal(parseWidgetUrl("http://evil.example/brew"), null);


### PR DESCRIPTION
The **web half** of the Siri "BTTS Voice" + Action-Button trigger. Ships now, harmless off the native shell; the native App Intent that fires `btts://voice` comes in a shell build.

## Flow

`btts://voice` (Siri / Action Button) → existing deep-link rail (`appUrlOpen` → `handleWidgetUrl`) → sets transient `pendingVoiceChat` → routes Home → Home bumps a nonce → `ChatInput` arms the mic → **listening earcon** sounds → user speaks → Claude (explore-agent) builds the recipe.

## Pieces

- `parseWidgetUrl`/`handleWidgetUrl`: new `{ kind: "voice" }` action (+ test).
- `flowStore`: transient `pendingVoiceChat` flag, cleared after handling so a **normal app open never auto-listens** (mirrors the `pendingChatUrl` pattern; not persisted-replay-prone in steady state).
- `ChatInput`: `autoListenSignal` nonce → `voice.start()` on change (guarded against double-fire; works warm and cold-launch).
- Home page: consumes the flag, drives the nonce.

## Caveat (on-device)

A gesture-less launch (Siri/Action Button) may have iOS withhold `getUserMedia` in the WKWebView. Mic permission is already granted, which helps; if it balks, the hook surfaces its error and the user taps the mic once. To be validated on-device once the native intent ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)