### PR TITLE
feat(ios): Siri + Action Button App Intent → BTTS Voice chat

### DIFF
--- a/native/ios/App/App/VoiceChatIntent.swift
+++ b/native/ios/App/App/VoiceChatIntent.swift
@@ -1,0 +1,52 @@
+import AppIntents
+import UIKit
+
+/// Opens the BTTS Home voice chat and starts listening.
+///
+/// Fired by Siri ("Hey Siri, BTTS Voice") AND by the iPhone Action Button (the
+/// owner assigns this shortcut once in Settings → Action Button → Shortcut).
+/// It foregrounds the app and routes through the existing `btts://voice` custom
+/// URL scheme, which the web layer (`src/lib/native/widgetDeepLinks.ts`) turns
+/// into "open the Home chat + arm the mic" — the mic start sounds the listening
+/// earcon so the user knows to speak.
+///
+/// A custom URL scheme is opened via `UIApplication.shared.open` (the documented
+/// path for non-universal links — `OpenURLIntent` only accepts universal links).
+/// AppIntents requires iOS 16, so the whole surface is availability-gated; the
+/// app's deployment target is 15 and the owner's device is far newer.
+@available(iOS 16.0, *)
+struct OpenVoiceChatIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open BTTS Voice Chat"
+    static var description = IntentDescription("Open the BTTS voice chat and start listening.")
+
+    // Bring the app to the foreground when the intent runs.
+    static var openAppWhenRun: Bool = true
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        if let url = URL(string: "btts://voice") {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+        return .result()
+    }
+}
+
+/// Registers the App Shortcut so Siri recognises the spoken phrase and the
+/// shortcut appears in the Shortcuts app (which is how it's bound to the Action
+/// Button). Apple requires the app name in every phrase — `\(.applicationName)`
+/// resolves to "BTTS", so the primary phrase is "BTTS Voice".
+@available(iOS 16.0, *)
+struct BTTSAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: OpenVoiceChatIntent(),
+            phrases: [
+                "\(.applicationName) Voice",
+                "Open \(.applicationName) Voice",
+                "Talk to \(.applicationName)",
+            ],
+            shortTitle: "Voice Chat",
+            systemImageName: "mic.fill"
+        )
+    }
+}

--- a/native/scripts/add_widget_target.rb
+++ b/native/scripts/add_widget_target.rb
@@ -93,6 +93,10 @@ end
 app_target.add_file_references([
   app_group.new_reference("WidgetBridge.swift"),
   app_group.new_reference("LiveActivityPlugin.swift"),
+  # Siri / Action-Button App Intent + AppShortcutsProvider ("BTTS Voice") —
+  # opens btts://voice → the Home voice chat. App-target source, so it compiles
+  # into the app (not the widget extension).
+  app_group.new_reference("VoiceChatIntent.swift"),
   attrs_ref,
 ])
 


### PR DESCRIPTION
The **native half** — the App Intent that Siri and the Action Button fire to open the listening voice chat. Pairs with #417 (the web `btts://voice` handler).

## What
- `OpenVoiceChatIntent` (`openAppWhenRun`) → `UIApplication.shared.open("btts://voice")` → AppDelegate `open url` → Capacitor `appUrlOpen` → the web handler opens the Home chat + arms the mic (listening earcon).
- `BTTSAppShortcuts` (AppShortcutsProvider) registers the phrase **"BTTS Voice"** (`\(.applicationName) Voice`) for Siri; the same shortcut appears in the Shortcuts app, so it can be bound to the **Action Button**.
- Availability-gated `@available(iOS 16.0, *)` (App target deploys 15; the owner's device is far newer).
- Wired into the App target via `add_widget_target.rb` (the script that already adds App-target Swift), so CI + the Mac build compile it.

## Why a custom scheme, not OpenURLIntent
`OpenURLIntent` only accepts universal links; `UIApplication.shared.open` is the documented path for a custom scheme like `btts://`. Verified against Apple's App Intents docs.

## Needs a shell build + on-device
This is native code → reaches the phone via a TestFlight build (the web app is untouched). After install: assign the shortcut to the Action Button (Settings → Action Button → Shortcut → "Voice Chat"), then test Siri + the button. Watch the one caveat: a gesture-less launch may have iOS withhold the mic in the WKWebView; if so the chat shows its mic error and a tap arms it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)