### PR TITLE
fix: final pour no longer vanishes mid-pour + log suggests the bag's flavors

### DIFF
--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -8,6 +8,7 @@ import { useWakeLock } from "@/hooks/useWakeLock";
 import {
   getActiveIdx,
   isAgitationPourAction,
+  poursCompleteAtSec,
   type PourStep,
   type GuideStep,
 } from "@/lib/utils/pourSequence";
@@ -360,11 +361,11 @@ function LivePourSequence({ steps, elapsed, targetTimeSec, started, coach }: Liv
   const activeStep = activeIdx >= 0 ? steps[activeIdx] : null;
   const nextStep = activeIdx >= 0 && activeIdx < steps.length - 1 ? steps[activeIdx + 1] : null;
   const nextCountdown = nextStep ? Math.max(0, nextStep.startTimeSec - elapsed) : null;
-  // The last step is the final pour OR a trailing tap/swirl after it — either
-  // way, draining begins once we're a grace beyond it.
-  const lastStepStart = steps[steps.length - 1].startTimeSec;
-  const pourGraceSec = Math.min(20, Math.round((targetTimeSec - lastStepStart) * 0.35));
-  const allPoursDone = started && elapsed >= lastStepStart + pourGraceSec;
+  // Draining begins once we're a grace beyond the last step. The grace covers
+  // the time to physically pour the last step's water — a flat 20 s cap used to
+  // cut big final pours short (the "last pour disappears too fast" bug). See
+  // poursCompleteAtSec.
+  const allPoursDone = started && elapsed >= poursCompleteAtSec(steps, targetTimeSec);
 
   const [flashKey, setFlashKey] = useState(0);
   useEffect(() => {

--- a/src/components/flow/LightStepLog.tsx
+++ b/src/components/flow/LightStepLog.tsx
@@ -59,6 +59,15 @@ export default function LightStepLog() {
     (selIdx != null ? rec?.candidates?.[selIdx]?.recipe : undefined) ??
     rec?.primaryRecipe;
 
+  // Suggested flavor chips (shown before you open a wheel category) = the
+  // flavors DOCUMENTED ON THE BAG for this coffee, not a generic list. Fall
+  // back to the generic QUICK_FLAVORS only when the bag has none (external
+  // brews, un-scanned coffees). The user taps these to confirm what they taste.
+  const bagFlavors = (draft.coffee?.tastingNotesFromBag ?? [])
+    .map((f) => f?.trim())
+    .filter((f): f is string => !!f);
+  const suggestedFlavors = bagFlavors.length > 0 ? bagFlavors : QUICK_FLAVORS;
+
   const [heroQuestion, setHeroQuestion] = useState("");
   useEffect(() => {
     setHeroQuestion(nextHeroQuestion("log", LOG_QUESTIONS));
@@ -361,14 +370,19 @@ export default function LightStepLog() {
             </div>
           ) : (
             <div className="space-y-2 mt-3">
+              {bagFlavors.length > 0 && <p className="label-eyebrow px-1">On the bag</p>}
               <div className="flex flex-wrap gap-2">
-                {QUICK_FLAVORS.map((f) => (
+                {suggestedFlavors.map((f) => (
                   <Chip key={f} size="sm" selected={selectedFlavors.includes(f)} onClick={() => toggleFlavor(f)}>
                     {f}
                   </Chip>
                 ))}
               </div>
-              <p className="text-[12px] text-light-muted-foreground px-1 mt-1">Tap the wheel to explore by category</p>
+              <p className="text-[12px] text-light-muted-foreground px-1 mt-1">
+                {bagFlavors.length > 0
+                  ? "From the bag — tap what you taste, or open the wheel to explore"
+                  : "Tap the wheel to explore by category"}
+              </p>
             </div>
           )}
 

--- a/src/lib/utils/pourSequence.test.mjs
+++ b/src/lib/utils/pourSequence.test.mjs
@@ -19,7 +19,8 @@ const ROOT = process.cwd();
 const entry = `
 export {
   getBloomDuration, parsePourSteps, pourStepsFromStructured, buildGuideSteps,
-  hasImmersionShape, getActiveIdx, isAgitationPourAction, pourDurationSec, POUR_RATE_GPS,
+  hasImmersionShape, getActiveIdx, isAgitationPourAction, pourDurationSec,
+  poursCompleteAtSec, POUR_RATE_GPS,
 } from ${JSON.stringify(path.join(ROOT, "src/lib/utils/pourSequence.ts"))};
 `;
 const dir = await mkdtemp(join(tmpdir(), "pourseq-"));
@@ -41,6 +42,7 @@ const {
   getActiveIdx,
   isAgitationPourAction,
   pourDurationSec,
+  poursCompleteAtSec,
   POUR_RATE_GPS,
 } = await import(pathToFileURL(out).href);
 
@@ -477,4 +479,42 @@ test("brewedRecipeName: 'Own recipe' gives the bare title, no (based on …)", (
 test("brewedRecipeName: a real reference is appended", () => {
   const name = brewedRecipeName({ title: "My morning V60", basedOn: "Kasuya 4:6" });
   assert.equal(name, "My morning V60 (based on Kasuya 4:6)");
+});
+
+// ── poursCompleteAtSec (the "last pour disappears too fast" fix) ─────────────
+
+test("poursCompleteAtSec: a BIG final pour stays active long enough to pour it (not the old 20s cap)", () => {
+  // Asser-style 60–120–240 @ 220s: final pour adds 120g, which needs 30s at 4g/s.
+  const steps = parsePourSteps("60 – 120 – 240", 220, peakRoast, NOW);
+  const last = steps[steps.length - 1];
+  assert.equal(last.action, "final");
+  assert.equal(last.pourGrams, 120);
+  const doneAt = poursCompleteAtSec(steps, 220);
+  const grace = doneAt - last.startTimeSec;
+  assert.equal(doneAt, 177); // 147 (final start) + 30s pour time
+  assert.equal(grace, pourDurationSec(120)); // grace == physical pour time (30s)
+  assert.ok(grace > 20, "a big final pour must exceed the old flat 20s cap");
+});
+
+test("poursCompleteAtSec: a SMALL final pour keeps the ≤20s grace (unchanged behaviour)", () => {
+  const steps = parsePourSteps("50 – 100 – 150 – 200 – 250 – 300", 210, peakRoast, NOW);
+  const last = steps[steps.length - 1];
+  assert.equal(last.pourGrams, 50);
+  const grace = poursCompleteAtSec(steps, 210) - last.startTimeSec;
+  assert.equal(grace, 20); // 35%-of-drawdown grace, capped at 20 as before
+  assert.ok(grace >= pourDurationSec(50), "still long enough to pour 50g");
+});
+
+test("poursCompleteAtSec: a trailing swirl near target uses the short agitation grace", () => {
+  const steps = [
+    { index: 0, label: "Bloom", cumulativeGrams: 50, pourGrams: 50, startTimeSec: 0, action: "bloom" },
+    { index: 1, label: "Final pour", cumulativeGrams: 240, pourGrams: 190, startTimeSec: 120, action: "final" },
+    { index: 2, label: "Swirl", cumulativeGrams: 240, pourGrams: 0, startTimeSec: 185, action: "swirl" },
+  ];
+  assert.ok(isAgitationPourAction(steps[steps.length - 1].action));
+  assert.equal(poursCompleteAtSec(steps, 200), 195); // 185 + 10s agitation grace
+});
+
+test("poursCompleteAtSec: empty steps → 0 (no crash)", () => {
+  assert.equal(poursCompleteAtSec([], 200), 0);
 });

--- a/src/lib/utils/pourSequence.ts
+++ b/src/lib/utils/pourSequence.ts
@@ -71,6 +71,29 @@ export function isAgitationPourAction(a: PourStep["action"]): a is AgitationActi
   return a === "swirl" || a === "stir" || a === "tap";
 }
 
+/**
+ * Elapsed second at which all pours are complete and the brew enters drawdown —
+ * i.e. when the live pour card should stop showing the last step and switch to
+ * "draining". The grace after the last step MUST cover the time to physically
+ * pour its water (`grams ÷ POUR_RATE_GPS`): a flat 20 s cap used to cut big
+ * final pours short (a 120 g final pour needs ~30 s at 4 g/s but the card
+ * flipped to "draining" after 20 s while you were still pouring). A trailing
+ * swirl/stir/tap is quick (~10 s). Otherwise keep the prior ≤20 s /
+ * 35 %-of-drawdown grace. Pure so it's unit-tested alongside the pour math.
+ */
+export function poursCompleteAtSec(steps: PourStep[], targetTimeSec: number): number {
+  if (steps.length === 0) return 0;
+  const last = steps[steps.length - 1];
+  const lastWork = isAgitationPourAction(last.action)
+    ? 10
+    : pourDurationSec(last.pourGrams);
+  const grace = Math.max(
+    lastWork,
+    Math.min(20, Math.round((targetTimeSec - last.startTimeSec) * 0.35)),
+  );
+  return last.startTimeSec + grace;
+}
+
 /** A timed, action-aware step for non-percolation methods (immersion,
  * AeroPress, inverted, iced). Setup steps (invert / load / assemble) carry
  * `isSetup` and live outside the timeline. */


### PR DESCRIPTION
Two brew-flow fixes the owner reported.

## 1. The final pour step vanished before you'd finished pouring

`LivePourSequence` flipped the active pour card to **"draining"** once `elapsed` passed `lastStepStart + min(20, 0.35 × drawdownReserve)`. That **flat 20 s cap ignored how much water the last pour adds** — a 120 g final pour needs ~30 s at 4 g/s, but the card disappeared after 20 s while you were still pouring. (The owner's exact report: "I still have to pour 120 ml at 4–6 ml/s, the pour step can't disappear after 15 s.")

**Central fix → corrects every recipe at once** (no per-recipe edits): extracted the grace into a pure, tested `poursCompleteAtSec(steps, targetTimeSec)` in `pourSequence.ts`. The grace is now **never shorter than the time to physically pour the last step's water** (`grams ÷ POUR_RATE_GPS`); a trailing swirl/stir/tap stays a quick ~10 s; small final pours keep the prior ≤20 s behaviour.

Regression tests (4) in `pourSequence.test.mjs`: a big final pour exceeds the old 20 s cap and equals its pour time (`60–120–240 @ 220s` → done at 177 s, a 30 s grace = `pourDurationSec(120)`); a small final pour keeps ≤20 s; a trailing swirl uses the short grace; empty input → 0.

## 2. Log step now suggests the coffee bag's documented flavors

Under the flavor wheel (before you open a category) the log step showed the static generic `QUICK_FLAVORS`. It now shows the coffee's own **`tastingNotesFromBag`** — the flavors printed on the bag — as the tap-to-confirm chips, under an **"On the bag"** label. Falls back to `QUICK_FLAVORS` only when the bag has none (external / un-scanned coffees).

## Checks

- `npx tsc --noEmit` — clean
- `node --test` — **152/152** (was 148; +4 new)
- `node tests/recipes/validate.mjs` — 0 errors / 0 warnings

## Files

- `src/lib/utils/pourSequence.ts` — new `poursCompleteAtSec`
- `src/components/flow/LightStepBrew.tsx` — use it for `allPoursDone`
- `src/lib/utils/pourSequence.test.mjs` — 4 regression tests
- `src/components/flow/LightStepLog.tsx` — bag-flavor suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoSmHKYK1rp1bi1taUJ2AY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoSmHKYK1rp1bi1taUJ2AY)_