### PR TITLE
fix: bag flavors in the log for in-rotation brews + live scale total in the step window

### DIFF
--- a/src/app/api/coffees/[id]/route.ts
+++ b/src/app/api/coffees/[id]/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { eq } from "drizzle-orm";
+import { eq, sql, desc } from "drizzle-orm";
 import { db } from "@/lib/db/client";
-import { coffees } from "@/lib/db/schema";
+import { coffees, sessions } from "@/lib/db/schema";
 import { rowToCoffee } from "@/lib/db/helpers";
 
 export const dynamic = "force-dynamic";
@@ -11,7 +11,22 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
   try {
     const rows = await db.select().from(coffees).where(eq(coffees.id, params.id)).limit(1);
     if (rows.length === 0) return NextResponse.json(null, { status: 404 });
-    return NextResponse.json(rowToCoffee(rows[0]));
+
+    // The documented bag flavors live in the scanned identity on the coffee's
+    // latest session — the `coffees` row's `common_notes` is unpopulated in
+    // production. Surface them so the brew-log flavor suggestions can show THIS
+    // bag's printed notes even when the brew was started from a shortcut
+    // (library list / Action Pill / Brew Again) whose synthesized identity
+    // carried no notes. Cheap (single-user table); newest session wins.
+    const noteRows = await db
+      .select({ coffee: sessions.coffee })
+      .from(sessions)
+      .where(sql`${sessions.coffee}->>'coffeeId' = ${params.id}`)
+      .orderBy(desc(sessions.createdAtMs))
+      .limit(1);
+    const tastingNotesFromBag = noteRows[0]?.coffee?.tastingNotesFromBag ?? [];
+
+    return NextResponse.json({ ...rowToCoffee(rows[0]), tastingNotesFromBag });
   } catch (err) {
     console.error("coffee GET error:", err);
     return NextResponse.json(null, { status: 500 });

--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -351,6 +351,26 @@ function showsCoach(coach?: FlowComparison | null): coach is FlowComparison {
   return !!coach && coach.cue !== "none" && coach.cue !== "agitate";
 }
 
+/** Persistent live total from the connected scale, pinned at the top of the
+ * step window so you read "147 / 240 g" without scrolling back up to ScalePanel
+ * mid-brew — the cue card alone only shows grams while a pour cue is firing.
+ * `target` is the active step's cumulative goal. Renders only while a weight is
+ * streaming (coach.liveGrams != null → scale connected); no scale → nothing. */
+function LiveScaleTotal({ grams, target }: { grams: number; target?: number | null }) {
+  return (
+    <div className="flex items-baseline justify-between rounded-2xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 px-4 py-2.5">
+      <span className="label-eyebrow">On the scale</span>
+      <span className="font-mono-num font-semibold text-light-foreground">
+        <span className="text-[22px]">{Math.round(grams)}</span>
+        <span className="text-[13px] text-light-muted-foreground"> g</span>
+        {target != null && (
+          <span className="text-[13px] text-light-muted-foreground"> / {target} g</span>
+        )}
+      </span>
+    </div>
+  );
+}
+
 /** Short SwirlButton label for an agitation step. */
 function agitationButtonLabel(action: PourStep["action"]): string {
   return action === "stir" ? "Stir" : action === "tap" ? "Tap" : "Swirl";
@@ -441,6 +461,9 @@ function LivePourSequence({ steps, elapsed, targetTimeSec, started, coach }: Liv
 
   return (
     <div className="space-y-3">
+      {coach?.liveGrams != null && (
+        <LiveScaleTotal grams={coach.liveGrams} target={activeStep?.cumulativeGrams ?? null} />
+      )}
       {activeStep && !allPoursDone && isAgitationPourAction(activeStep.action) && (
         // Agitation step — its own prominent moment (the cue the 3-2-1 buzz lands on).
         <div
@@ -825,6 +848,9 @@ function StepGuide({
 
   return (
     <div className="space-y-3">
+      {coach?.liveGrams != null && (
+        <LiveScaleTotal grams={coach.liveGrams} target={current?.cumulativeGrams ?? null} />
+      )}
       {setupSteps.length > 0 && (
         <div className="rounded-3xl bg-light-card-default backdrop-blur-light-card backdrop-saturate-150 px-4 py-3">
           <p className="label-eyebrow mb-1">Setup</p>

--- a/src/components/flow/LightStepLog.tsx
+++ b/src/components/flow/LightStepLog.tsx
@@ -60,12 +60,39 @@ export default function LightStepLog() {
     rec?.primaryRecipe;
 
   // Suggested flavor chips (shown before you open a wheel category) = the
-  // flavors DOCUMENTED ON THE BAG for this coffee, not a generic list. Fall
-  // back to the generic QUICK_FLAVORS only when the bag has none (external
-  // brews, un-scanned coffees). The user taps these to confirm what they taste.
-  const bagFlavors = (draft.coffee?.tastingNotesFromBag ?? [])
+  // flavors DOCUMENTED ON THE BAG for this coffee, not a generic list. The
+  // fresh-scan + coffee-detail paths carry them on the draft identity; brews
+  // started from a shortcut (library list / Action Pill / "Brew Again" on an
+  // in-rotation bag) DON'T — so when the draft has none we fetch this coffee's
+  // bag notes by id (/api/coffees/[id] returns the latest session's notes).
+  // Generic QUICK_FLAVORS is the last resort (external / un-scanned coffees).
+  const draftBagFlavors = (draft.coffee?.tastingNotesFromBag ?? [])
     .map((f) => f?.trim())
     .filter((f): f is string => !!f);
+  const [fetchedBagFlavors, setFetchedBagFlavors] = useState<string[]>([]);
+  const coffeeId = draft.coffee?.coffeeId;
+  useEffect(() => {
+    if (draftBagFlavors.length > 0 || !coffeeId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/coffees/${coffeeId}`, { cache: "no-store" });
+        if (!res.ok) return;
+        const data = await res.json();
+        const notes = Array.isArray(data?.tastingNotesFromBag)
+          ? (data.tastingNotesFromBag as unknown[]).map((s) => String(s).trim()).filter(Boolean)
+          : [];
+        if (!cancelled && notes.length > 0) setFetchedBagFlavors(notes);
+      } catch {
+        /* keep the generic fallback */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [coffeeId, draftBagFlavors.length]);
+
+  const bagFlavors = draftBagFlavors.length > 0 ? draftBagFlavors : fetchedBagFlavors;
   const suggestedFlavors = bagFlavors.length > 0 ? bagFlavors : QUICK_FLAVORS;
 
   const [heroQuestion, setHeroQuestion] = useState("");


### PR DESCRIPTION
Two fixes from the owner's report — and yes, both prior changes **are** deployed (deploy runs for `9a4c8b5` + `bc68a25` both succeeded); the flavor one was a real gap, not just cache.

## 1. Bag flavors now show when logging an IN-ROTATION brew (the real bug)

The log step's flavor suggestions read `draft.coffee.tastingNotesFromBag`, which is only populated by a **fresh scan** or the **coffee-detail** "Brew this" path. Brews started from a **shortcut** — the `/coffees` library list, the home **Action Pill**, any **"Brew Again" on an in-rotation bag** — synthesize the identity from the coffee aggregate, which carries **no notes** (the `coffees.common_notes` column is empty in production; the real bag notes live in the latest session's `coffee` JSONB). So those brews fell back to the generic `QUICK_FLAVORS` — the "generic crap" the owner kept seeing, on iOS, regardless of cache.

**Fixed at one robust point** instead of patching every brew-again call site:
- `/api/coffees/[id]` GET now also returns the latest session's `tastingNotesFromBag`.
- the log step fetches it by `coffeeId` when the draft has none.

Every brew-again path sets `coffeeId`, so this covers the library list, Action Pill, Brew Again, and the offline fallback. Fresh-scan / detail brews already have the notes on the draft → no fetch. `QUICK_FLAVORS` stays only as the last resort (external / un-scanned coffees).

## 2. Live scale total pinned in the step-by-step window

When the Acaia is connected, the running total only lived in `ScalePanel` at the **top** of the brew screen (and briefly inside the pour-cue card, only while a cue was firing). Mid-brew you had to scroll up past the recipe card + timer to see your total — exactly when your hands are busy and you're watching the app, not the scale.

New persistent **"On the scale — 147 / 240 g"** badge at the top of both the percolation (`LivePourSequence`) and immersion (`StepGuide`) step views — live weight vs the active step's cumulative target. Renders only while a weight is streaming (scale connected); no scale → invisible, exactly as before.

## Checks

- `npx tsc --noEmit` — clean
- `node --test` — 152/152

## Files

- `src/app/api/coffees/[id]/route.ts` — return latest-session bag notes
- `src/components/flow/LightStepLog.tsx` — fetch bag notes by coffeeId when the draft has none
- `src/components/flow/LightStepBrew.tsx` — `LiveScaleTotal` badge in both step renderers

> Note on iOS: this is a genuine code+data fix, so a fresh load shows the bag flavors. The shell's WKWebView still caches the JS bundle like any web view — one force-quit + reopen of the app after the deploy pulls the new bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoSmHKYK1rp1bi1taUJ2AY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoSmHKYK1rp1bi1taUJ2AY)_