### PR TITLE
feat: home chat knows the welcome haiku — "give me the recipe to the welcome haiku"

### DIFF
--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -292,6 +292,7 @@ export default function HomePage() {
         body: JSON.stringify({
           messages: apiMessages,
           recentSessions,
+          ...(starter.trim() ? { welcomeHaiku: starter.trim() } : {}),
           ...(imageUrl ? { attachedImageUrl: imageUrl } : {}),
         }),
         signal: controller.signal,

--- a/src/app/api/explore-agent/route.ts
+++ b/src/app/api/explore-agent/route.ts
@@ -671,6 +671,9 @@ export async function POST(req: NextRequest) {
       messages: { role: "user" | "assistant"; content: string }[];
       recentSessions?: Session[];
       attachedImageUrl?: string;
+      /** The greeting haiku currently shown on the home screen (above this
+       * chat). Lets the user say "give me the recipe to the welcome haiku". */
+      welcomeHaiku?: string;
     };
 
     const messages = (body.messages ?? []).filter(
@@ -744,6 +747,20 @@ export async function POST(req: NextRequest) {
     contextParts.push(
       `\n## Current time\n${weekday} ${dateStr}, ${timeOfDay} (hour ${hour}, local time).`
     );
+
+    // The welcome haiku shown on the home screen, right above this chat. Inject
+    // it verbatim so the user can refer to it ("give me the recipe to the
+    // welcome haiku", "the bag you mentioned up top", "that idea in the
+    // greeting") and you know exactly what they mean.
+    const welcomeHaiku =
+      typeof body.welcomeHaiku === "string" ? body.welcomeHaiku.trim().slice(0, 600) : "";
+    if (welcomeHaiku) {
+      contextParts.push(
+        `\n## Today's Welcome Greeting (the haiku currently on the home screen, directly above this chat)\n` +
+          `"${welcomeHaiku}"\n` +
+          `When the user refers to "the welcome haiku" / "the greeting" / "your idea up there" / "the one you mentioned", THIS is what they mean. Read the coffee it names and the idea it floats (e.g. a ★ rotation bag, a tweak like "try it cooler today"), and answer from it. If it points at a library bag and the user wants to brew it, lay out a real recipe and hand it to the timer with start_brew per the rules above.`
+      );
+    }
 
     const recipesBlock = buildRecentRecipes(recentSessions, 5);
     if (recipesBlock) {


### PR DESCRIPTION
## What

The home chat (`/api/explore-agent`) had no idea what the **welcome haiku** above it said, so "Give me the recipe to the welcome haiku" had nothing to anchor to. Now it knows.

- **Home page** (`page.tsx`): sends the current greeting text (`welcomeHaiku`) in the chat request when one is shown.
- **Route** (`explore-agent`): injects it verbatim as a per-turn context block — *"Today's Welcome Greeting … `<text>`"* — with a note that this is exactly what the user means by "the welcome haiku / the greeting / your idea up there". The chat reads the bag the haiku names + the tweak it floats (e.g. a ★ rotation bag, "try it cooler today") and answers from it — laying out a real recipe and handing it to the timer via `start_brew` when the user wants to brew it.

## Why it's cache-safe

The greeting goes into the **uncached dynamic-context** system block (the same one that already carries time / recent recipes / library), so the cached system prompt + profile blocks are untouched — no prompt-cache bust.

## Checks

- `npx tsc --noEmit` — clean
- `node --test` — 152/152

## Files

- `src/app/(light)/page.tsx` — send `welcomeHaiku` in the chat POST
- `src/app/api/explore-agent/route.ts` — parse it + inject the greeting context block

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoSmHKYK1rp1bi1taUJ2AY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoSmHKYK1rp1bi1taUJ2AY)_