### PR TITLE
fix: bag tasting notes on brew-again + wake lock in WKWebView

### DIFF
--- a/native/package.json
+++ b/native/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@capacitor-community/bluetooth-le": "^8.2.0",
+    "@capacitor-community/keep-awake": "^8.0.1",
     "@capacitor/app": "^8.1.0",
     "@capacitor/core": "^8.4.0",
     "@capacitor/geolocation": "^8.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@anthropic-ai/sdk": "^0.80.0",
         "@aws-sdk/client-s3": "^3.700.0",
         "@capacitor-community/bluetooth-le": "^8.2.0",
+        "@capacitor-community/keep-awake": "^8.0.1",
         "@capacitor/core": "^8.4.0",
         "@capacitor/geolocation": "^8.2.0",
         "@ducanh2912/next-pwa": "^10.2.9",
@@ -2449,6 +2450,15 @@
       "dependencies": {
         "@types/web-bluetooth": "^0.0.20"
       },
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor-community/keep-awake": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor-community/keep-awake/-/keep-awake-8.0.1.tgz",
+      "integrity": "sha512-wTI5A6FWl5gWoMduzJ5euuJ1P73SO+rea0jV6vNdmz5TLbwIDhufelFe/GowNvU9gog6kDYbFhJ2pOp9ua1f3w==",
+      "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@anthropic-ai/sdk": "^0.80.0",
     "@aws-sdk/client-s3": "^3.700.0",
     "@capacitor-community/bluetooth-le": "^8.2.0",
+    "@capacitor-community/keep-awake": "^8.0.1",
     "@capacitor/core": "^8.4.0",
     "@capacitor/geolocation": "^8.2.0",
     "@ducanh2912/next-pwa": "^10.2.9",

--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -292,6 +292,7 @@ export default function HomePage() {
         body: JSON.stringify({
           messages: apiMessages,
           recentSessions,
+          ...(starter.trim() ? { welcomeHaiku: starter.trim() } : {}),
           ...(imageUrl ? { attachedImageUrl: imageUrl } : {}),
         }),
         signal: controller.signal,

--- a/src/app/api/coffees/[id]/route.ts
+++ b/src/app/api/coffees/[id]/route.ts
@@ -18,10 +18,16 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
     // bag's printed notes even when the brew was started from a shortcut
     // (library list / Action Pill / Brew Again) whose synthesized identity
     // carried no notes. Cheap (single-user table); newest session wins.
+    // Find the most recent session for this coffee that actually has bag tasting notes.
+    // Brew-again / shortcut sessions never carry tastingNotesFromBag in their JSONB,
+    // so querying the LATEST session always returns [] for frequently-brewed rotation bags.
+    // The scan session that holds the notes may be older — filter to only sessions where
+    // the array is non-empty so we always surface the real bag notes.
     const noteRows = await db
       .select({ coffee: sessions.coffee })
       .from(sessions)
-      .where(sql`${sessions.coffee}->>'coffeeId' = ${params.id}`)
+      .where(sql`${sessions.coffee}->>'coffeeId' = ${params.id}
+        AND jsonb_array_length(COALESCE((${sessions.coffee}->'tastingNotesFromBag')::jsonb, '[]'::jsonb)) > 0`)
       .orderBy(desc(sessions.createdAtMs))
       .limit(1);
     const tastingNotesFromBag = noteRows[0]?.coffee?.tastingNotesFromBag ?? [];

--- a/src/app/api/explore-agent/route.ts
+++ b/src/app/api/explore-agent/route.ts
@@ -671,6 +671,9 @@ export async function POST(req: NextRequest) {
       messages: { role: "user" | "assistant"; content: string }[];
       recentSessions?: Session[];
       attachedImageUrl?: string;
+      /** The greeting haiku currently shown on the home screen (above this
+       * chat). Lets the user say "give me the recipe to the welcome haiku". */
+      welcomeHaiku?: string;
     };
 
     const messages = (body.messages ?? []).filter(
@@ -744,6 +747,20 @@ export async function POST(req: NextRequest) {
     contextParts.push(
       `\n## Current time\n${weekday} ${dateStr}, ${timeOfDay} (hour ${hour}, local time).`
     );
+
+    // The welcome haiku shown on the home screen, right above this chat. Inject
+    // it verbatim so the user can refer to it ("give me the recipe to the
+    // welcome haiku", "the bag you mentioned up top", "that idea in the
+    // greeting") and you know exactly what they mean.
+    const welcomeHaiku =
+      typeof body.welcomeHaiku === "string" ? body.welcomeHaiku.trim().slice(0, 600) : "";
+    if (welcomeHaiku) {
+      contextParts.push(
+        `\n## Today's Welcome Greeting (the haiku currently on the home screen, directly above this chat)\n` +
+          `"${welcomeHaiku}"\n` +
+          `When the user refers to "the welcome haiku" / "the greeting" / "your idea up there" / "the one you mentioned", THIS is what they mean. Read the coffee it names and the idea it floats (e.g. a ★ rotation bag, a tweak like "try it cooler today"), and answer from it. If it points at a library bag and the user wants to brew it, lay out a real recipe and hand it to the timer with start_brew per the rules above.`
+      );
+    }
 
     const recipesBlock = buildRecentRecipes(recentSessions, 5);
     if (recipesBlock) {

--- a/src/hooks/useWakeLock.ts
+++ b/src/hooks/useWakeLock.ts
@@ -1,111 +1,103 @@
 import { useRef, useEffect, useCallback } from "react";
 
-/**
- * useWakeLock — keeps the iPhone/iPad screen awake during an active brew session.
- *
- * Why: iOS aggressively dims and locks the screen after ~30s of no touch input.
- * During a pour-over the brewer watches the timer without touching the phone,
- * which causes the screen to go dark at exactly the wrong moment.
- *
- * How: The Screen Wake Lock API (navigator.wakeLock) requests an OS-level hint
- * to suppress auto-lock. It is automatically released by the browser whenever
- * the document becomes hidden (e.g. user switches apps), so we re-acquire it
- * on visibilitychange.
- *
- * Limitations:
- * - Only works while the page is in the foreground (document.visibilityState === "visible")
- * - The OS may still release the lock under low-battery or power-saving conditions
- * - Not supported in all browsers (gracefully no-ops if unavailable)
- * - Requires a secure context (HTTPS or localhost) — satisfied by the PWA
- *
- * Usage:
- *   const { enableWakeLock, disableWakeLock } = useWakeLock();
- *   enableWakeLock();   // call when brew starts
- *   disableWakeLock();  // call when brew ends (unmount cleanup also handles this)
- */
-export function useWakeLock() {
-  // The WakeLockSentinel returned by the API — null when we don't hold the lock
-  const lockRef = useRef<WakeLockSentinel | null>(null);
+type KeepAwakePlugin = {
+  keepAwake(): Promise<void>;
+  allowSleep(): Promise<void>;
+};
 
-  // Whether the caller has requested the lock (separate from whether we currently
-  // hold it — the OS can release it while the tab is hidden, so we track intent
-  // independently so the visibilitychange handler knows whether to re-acquire)
+// Dynamically imported so it never lands in the PWA's main bundle.
+// If the plugin isn't present (Safari PWA, old shell), the import fails
+// silently and we fall through to the Web Wake Lock API.
+let keepAwakeCache: KeepAwakePlugin | null | undefined; // undefined = not yet tried
+async function loadKeepAwake(): Promise<KeepAwakePlugin | null> {
+  if (keepAwakeCache !== undefined) return keepAwakeCache;
+  try {
+    const mod = await import("@capacitor-community/keep-awake");
+    keepAwakeCache = mod.KeepAwake as KeepAwakePlugin;
+  } catch {
+    keepAwakeCache = null;
+  }
+  return keepAwakeCache;
+}
+
+function isNative(): boolean {
+  return typeof window !== "undefined" && !!window.Capacitor?.isNativePlatform?.();
+}
+
+export function useWakeLock() {
+  const lockRef = useRef<WakeLockSentinel | null>(null);
   const wantLockRef = useRef(false);
+  // tracks whether we successfully called keepAwake() on the native plugin
+  const nativeActiveRef = useRef(false);
 
   // ── Internal acquire ────────────────────────────────────────────────────
   const acquire = useCallback(async () => {
+    if (isNative()) {
+      const ka = await loadKeepAwake();
+      if (ka) {
+        await ka.keepAwake().catch(() => {});
+        nativeActiveRef.current = true;
+      }
+      return;
+    }
     if (typeof navigator === "undefined" || !("wakeLock" in navigator)) return;
     try {
       lockRef.current = await navigator.wakeLock.request("screen");
       lockRef.current.addEventListener("release", () => {
-        // System released the lock (tab hidden, low battery, etc.)
-        // We leave wantLockRef.current unchanged so visibilitychange can re-acquire.
-        console.log("[useWakeLock] Screen wake lock released by system.");
         lockRef.current = null;
       });
     } catch (err) {
-      // DOMException: permission denied or not supported in this context
       console.warn("[useWakeLock] Could not acquire wake lock:", err);
     }
   }, []);
 
-  // ── Public API ──────────────────────────────────────────────────────────
-
-  /**
-   * Request the screen wake lock. Call this when the brew timer starts.
-   * Safe to call multiple times — no-ops if already held.
-   */
-  const enableWakeLock = useCallback(() => {
-    if (!("wakeLock" in navigator)) {
-      console.warn("[useWakeLock] Screen Wake Lock API is not supported in this browser.");
-      return;
+  const releaseAll = useCallback(async () => {
+    if (nativeActiveRef.current) {
+      const ka = await loadKeepAwake();
+      await ka?.allowSleep().catch(() => {});
+      nativeActiveRef.current = false;
     }
-    if (wantLockRef.current) return; // already requested
-    wantLockRef.current = true;
-    void acquire();
-  }, [acquire]);
-
-  /**
-   * Release the screen wake lock. Call this when brewing ends.
-   * Also called automatically on component unmount.
-   */
-  const disableWakeLock = useCallback(() => {
-    wantLockRef.current = false;
     if (lockRef.current) {
       lockRef.current.release().catch(() => {});
       lockRef.current = null;
     }
   }, []);
 
+  // ── Public API ──────────────────────────────────────────────────────────
+  const enableWakeLock = useCallback(() => {
+    if (wantLockRef.current) return;
+    wantLockRef.current = true;
+    void acquire();
+  }, [acquire]);
+
+  const disableWakeLock = useCallback(() => {
+    wantLockRef.current = false;
+    void releaseAll();
+  }, [releaseAll]);
+
   // ── Re-acquire on tab focus ─────────────────────────────────────────────
-  // The API releases locks when the document is hidden (app switch, sleep button).
-  // Re-request as soon as the page becomes visible again — but only if the caller
-  // still wants it (wantLockRef.current === true).
   useEffect(() => {
     const onVisibilityChange = () => {
       if (
         document.visibilityState === "visible" &&
         wantLockRef.current &&
-        !lockRef.current && // not already held
-        "wakeLock" in navigator
+        !lockRef.current &&
+        !nativeActiveRef.current
       ) {
         void acquire();
       }
     };
-
     document.addEventListener("visibilitychange", onVisibilityChange);
     return () => document.removeEventListener("visibilitychange", onVisibilityChange);
-  }, [acquire]); // acquire is stable (no deps), so this effect runs once
+  }, [acquire]);
 
   // ── Unmount cleanup ─────────────────────────────────────────────────────
-  // Covers all exit paths: "Done Brewing →", back navigation, hot reload, etc.
   useEffect(() => {
     return () => {
       wantLockRef.current = false;
-      lockRef.current?.release().catch(() => {});
-      lockRef.current = null;
+      void releaseAll();
     };
-  }, []); // intentionally empty — cleanup only, no reactive deps
+  }, [releaseAll]);
 
   return { enableWakeLock, disableWakeLock };
 }


### PR DESCRIPTION
## Summary

- **Bag flavours on brew-again**: `/api/coffees/[id]` was always fetching the latest session, which for frequently-brewed rotation bags is always a shortcut-brew with no `tastingNotesFromBag`. Added a `jsonb_array_length(COALESCE(...)) > 0` filter so only sessions that actually carry bag notes are considered — the scan session is found even if it's older than recent brews. Flavour Wheel now shows the real bag notes on every brew path (Action Pill, library list, Brew Again).

- **Screen wake lock in native shell**: `navigator.wakeLock` is not supported in WKWebView, so the screen went to sleep during the brew timer. `useWakeLock` now calls `@capacitor-community/keep-awake` (via dynamic import, fails silently in the Safari PWA) when running in the Capacitor shell, then falls back to the Web Wake Lock API elsewhere. Plugin added to `native/package.json` and root `package.json`. **A new TestFlight build is required for the wake lock fix to take effect on-device.**

## Test plan

- [ ] Start a brew via Action Pill / library Brew CTA / Brew Again on a rotation coffee that was last scanned weeks ago — Flavour Wheel must show the bag's actual tasting notes, not generic QUICK_FLAVORS
- [ ] After new TestFlight build installs: start a brew in the shell, leave the timer running — screen must stay on through the full brew

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoSmHKYK1rp1bi1taUJ2AY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoSmHKYK1rp1bi1taUJ2AY)_