### PR TITLE
fix: sync native/package-lock.json so the TestFlight build runs

### DIFF
--- a/native/package-lock.json
+++ b/native/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@capacitor-community/bluetooth-le": "^8.2.0",
+        "@capacitor-community/keep-awake": "^8.0.1",
         "@capacitor/app": "^8.1.0",
         "@capacitor/core": "^8.4.0",
         "@capacitor/geolocation": "^8.2.0",
@@ -54,6 +55,15 @@
       "dependencies": {
         "@types/web-bluetooth": "^0.0.20"
       },
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor-community/keep-awake": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@capacitor-community/keep-awake/-/keep-awake-8.0.1.tgz",
+      "integrity": "sha512-wTI5A6FWl5gWoMduzJ5euuJ1P73SO+rea0jV6vNdmz5TLbwIDhufelFe/GowNvU9gog6kDYbFhJ2pOp9ua1f3w==",
+      "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
       }


### PR DESCRIPTION
## Summary

The TestFlight build (`ios-testflight.yml`) failed because PR #424 added `@capacitor-community/keep-awake` to `native/package.json` but never regenerated `native/package-lock.json`. CI runs `npm ci` in `native/`, which hard-fails when the manifest and lock are out of sync:

```
npm error Missing: @capacitor-community/keep-awake@8.0.1 from lock file
```

This regenerates `native/package-lock.json` so the dep is present. Verified `npm ci` now exits 0 in both `native/` and the repo root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoSmHKYK1rp1bi1taUJ2AY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoSmHKYK1rp1bi1taUJ2AY)_