### PR TITLE
build: kick iOS TestFlight for keep-awake wake-lock plugin

### DIFF
--- a/.github/ios-build-trigger
+++ b/.github/ios-build-trigger
@@ -1,4 +1,4 @@
 # Bump this file (change the line below) and merge to main to kick an iOS
 # TestFlight build — see the `push` trigger in .github/workflows/ios-testflight.yml.
 # Used when a session can't reach the Actions "Run workflow" UI / workflow_dispatch.
-build: 2026-06-20T01 — Acaia heartbeat keepalive (#408) + flow coach (#407)
+build: 2026-06-24T15 — keep-awake wake-lock plugin (#424) + native lockfile sync (#425)


### PR DESCRIPTION
Bumps `.github/ios-build-trigger` to fire the TestFlight build via the push-trigger escape hatch (this session can't `workflow_dispatch` — the API 403s).

Picks up the `@capacitor-community/keep-awake` plugin from #424 now that the native lock file is synced (#425), so the brew-timer screen stays awake in the iOS shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CoSmHKYK1rp1bi1taUJ2AY

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoSmHKYK1rp1bi1taUJ2AY)_