### PR TITLE
ci: fire verify-cache via a push-trigger file

### DIFF
--- a/.github/verify-cache-trigger
+++ b/.github/verify-cache-trigger
@@ -1,0 +1,7 @@
+# Bump this file (via a PR to main) to fire the "Verify recommend cache" workflow.
+# Why this exists: Claude Code's GitHub integration token can't dispatch a
+# workflow_dispatch workflow (403 "Resource not accessible by integration" — no
+# actions:write), so a push-path trigger on this file is the route-around. Mirrors
+# .github/ios-build-trigger. Each run = one bump.
+
+run: 1 — 2026-06-24 — first live cache verification after extraction (PR #428)

--- a/.github/workflows/verify-cache.yml
+++ b/.github/workflows/verify-cache.yml
@@ -1,15 +1,26 @@
 name: Verify recommend cache
 
-# Manual-dispatch, empirical proof that the /api/recommend system prompt is actually
-# prompt-cached: call 1 writes the cache (cache_creation_input_tokens > 0), call 2
-# reads it (cache_read_input_tokens > 0, cache_creation_input_tokens == 0). Reads the
+# Empirical proof that the /api/recommend system prompt is actually prompt-cached:
+# call 1 writes the cache (cache_creation_input_tokens > 0), call 2 reads it
+# (cache_read_input_tokens > 0, cache_creation_input_tokens == 0). Reads the
 # ANTHROPIC_API_KEY repo secret and prints the token count + both usage objects +
 # PASS/FAIL to the run log (readable from the GitHub app). Skips cleanly (green) if
 # the secret is unset. The prefix SIZE is guarded offline on every PR by
 # tests/dataflow/recommend-cache-prefix.test.mjs — this is the on-demand live check.
+#
+# Triggers:
+#   - workflow_dispatch: manual "Run workflow" button (preferred when available).
+#   - push to .github/verify-cache-trigger on main: the route-around for Claude Code,
+#     whose GitHub integration token can't dispatch workflow_dispatch (403, no
+#     actions:write) — same pattern as .github/ios-build-trigger. Bump that file via
+#     a PR to fire a run.
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - .github/verify-cache-trigger
 
 jobs:
   verify:


### PR DESCRIPTION
Follow-up to #428. Claude Code's GitHub integration token can't dispatch a `workflow_dispatch` workflow (`403 Resource not accessible by integration` — no `actions:write`), so the **Verify recommend cache** workflow couldn't be run programmatically.

Adds a path-filtered `push` trigger on `.github/verify-cache-trigger` (same route-around as `.github/ios-build-trigger`). Merging this PR touches that file on `main`, which fires the verification run — whose log will show the live `cache_creation` (call 1) / `cache_read` (call 2) numbers + the real prefix token count. `workflow_dispatch` is kept for the manual "Run workflow" button.

Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BBrvuuwKLt6ftr2khV94iN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBrvuuwKLt6ftr2khV94iN)_