### PR TITLE
ci: bump verify-cache trigger to run the live cache check

### DIFF
--- a/.github/verify-cache-trigger
+++ b/.github/verify-cache-trigger
@@ -4,4 +4,4 @@
 # actions:write), so a push-path trigger on this file is the route-around. Mirrors
 # .github/ios-build-trigger. Each run = one bump.
 
-run: 1 — 2026-06-24 — first live cache verification after extraction (PR #428)
+run: 2 — 2026-06-24 — live cache verification now that the ANTHROPIC_API_KEY secret is set


### PR DESCRIPTION
Bumps `.github/verify-cache-trigger` to fire the **Verify recommend cache** workflow now that the `ANTHROPIC_API_KEY` repo secret is set. The previous run skipped (no secret); merging this fires the run with the key present, so the log will show the empirical proof: call 1 writes the cache (`cache_creation_input_tokens > 0`), call 2 reads it (`cache_read_input_tokens > 0`, `cache_creation_input_tokens == 0`), plus the real prefix token count.

Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BBrvuuwKLt6ftr2khV94iN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBrvuuwKLt6ftr2khV94iN)_