### PR TITLE
fix: keep brew screen awake — fall back to Web Wake Lock when native keep-awake is a no-op

### DIFF
--- a/src/hooks/useWakeLock.ts
+++ b/src/hooks/useWakeLock.ts
@@ -32,13 +32,22 @@ export function useWakeLock() {
 
   // ── Internal acquire ────────────────────────────────────────────────────
   const acquire = useCallback(async () => {
+    // Native keep-awake (real OS idle-timer disable in the iOS shell). If the
+    // plugin isn't in the installed build / the call rejects, fall THROUGH to the
+    // Web Wake Lock API rather than giving up — that path kept the screen awake
+    // before the native plugin existed (regression: PR #424 returned early and
+    // skipped it, so the brew screen slept whenever native keep-awake was a no-op).
     if (isNative()) {
       const ka = await loadKeepAwake();
       if (ka) {
-        await ka.keepAwake().catch(() => {});
-        nativeActiveRef.current = true;
+        try {
+          await ka.keepAwake();
+          nativeActiveRef.current = true;
+          return; // native handled it — don't also take a web lock
+        } catch {
+          /* plugin not implemented in this build → fall back to web wake lock */
+        }
       }
-      return;
     }
     if (typeof navigator === "undefined" || !("wakeLock" in navigator)) return;
     try {


### PR DESCRIPTION
## What & why

The brew-timer screen stopped keeping the iPhone awake — the screen went dark mid-brew.

**Root cause:** PR #424 rewrote `useWakeLock` to add a native `@capacitor-community/keep-awake` path for the iOS shell, but it `return`ed early **even when the native call did nothing** (the installed TestFlight build doesn't carry the plugin yet, or the call rejects). That skipped the `navigator.wakeLock` fallback the shell relied on before (supported in WKWebView on iOS 16.4+), so the screen started sleeping mid-brew. The Safari PWA path was byte-identical to before, so this was specifically a shell regression.

## The fix (surgical — one function in one file)

`src/hooks/useWakeLock.ts` `acquire()`: only `return` after native `keepAwake()` **actually succeeds**; otherwise fall **through** to the existing Web Wake Lock path (the pre-#424 behavior). `nativeActiveRef` is set only on success so `releaseAll()` and the `visibilitychange` re-acquire stay correct.

Behavior by surface:
- **Safari PWA** — Web Wake Lock, exactly as before. Unchanged.
- **iOS shell, native plugin present** — native `keepAwake()` succeeds → returns. Best case.
- **iOS shell, native plugin absent/failing** — falls back to `navigator.wakeLock` → screen stays awake again. **The regression fix.**
- Never holds both locks at once.

Reaches the shell immediately via the live remote URL — **no new TestFlight build required**. The native plugin still wins when present in the installed build.

No public-API change, so both consumers (`LightStepBrew` timer, `LightStepRecommend` recipe-crafting wait) are untouched at the call site.

## Verification

- `npx tsc --noEmit` — clean.
- `node --test` — 154/154 pass.
- On-device: start a brew, set the phone down untouched past the ~30 s auto-lock window → screen stays awake for the whole brew (both Safari PWA and TestFlight app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J89Ng3eQMAsR1DwCU2eELP

---
_Generated by [Claude Code](https://claude.ai/code/session_01J89Ng3eQMAsR1DwCU2eELP)_