### PR TITLE
fix: shorten flow-coach cues so they don't wrap in the inset

### DIFF
--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -335,7 +335,7 @@ function CoachCue({ coach }: { coach: FlowComparison }) {
       <div className="flex items-baseline justify-between gap-3">
         {/* Left: coach message + the live pour rate inline */}
         <div className="flex items-baseline gap-2 min-w-0">
-          <span className={`font-fraunces text-[20px] leading-none ${messageColor}`}>
+          <span className={`font-fraunces text-[20px] leading-none whitespace-nowrap ${messageColor}`}>
             {coach.message}
           </span>
           {coach.liveRateGPS != null && (

--- a/src/lib/brew/flowCoach.ts
+++ b/src/lib/brew/flowCoach.ts
@@ -188,7 +188,7 @@ export function coachFlow(
     return {
       ...partial,
       cue: "hold",
-      message: isBloom ? "Bloom set — swirl & wait" : "Hold — let it draw down",
+      message: isBloom ? "Swirl" : "Hold",
       state: "on-track",
     };
   }
@@ -196,20 +196,20 @@ export function coachFlow(
   // Still pouring toward the target — coach the rate.
   const r = rate ?? 0;
   let cue: FlowCue = isBloom ? "bloom" : "steady";
-  let message = isBloom ? "Bloom — gentle" : "Steady";
+  let message = isBloom ? "Gentle" : "Steady";
   let state: FlowComparison["state"] = "on-track";
 
   if (r < STALL_RATE) {
     cue = "keep-flow";
-    message = "Keep the flow going";
+    message = "Keep going";
     state = "behind";
   } else if (r > Math.max(targetRate * FAST_MULT, FAST_ABS)) {
     cue = "pour-slower";
-    message = "Pour slower";
+    message = "Slower";
     state = "ahead";
   } else if (r < Math.min(targetRate * SLOW_MULT, SLOW_ABS) && remaining > EASE_OFF_G) {
     cue = "pour-faster";
-    message = "Pour faster";
+    message = "Faster";
     state = "behind";
   } else if (remaining <= EASE_OFF_G) {
     cue = "ease-off";

--- a/tests/dataflow/brew-flowcoach.test.mjs
+++ b/tests/dataflow/brew-flowcoach.test.mjs
@@ -105,7 +105,7 @@ test("near the target → ease-off", () => {
 test("reached the target → hold", () => {
   const c = coachFlow(PERC, ELAPSED_MID, true, 180, ramp(0));
   assert.equal(c.cue, "hold");
-  assert.match(c.message, /draw/i);
+  assert.match(c.message, /hold/i);
 });
 
 test("past the target → overshot with +Xg", () => {


### PR DESCRIPTION
## What

The scale-coach inset on the brew timer showed long messages that wrapped to two or three lines (ugly): "Keep the flow going", "Hold — let it draw down", "Bloom set — swirl & wait", "Bloom — gentle". Shorten every cue to a single short word (or a short two-word phrase) and add `whitespace-nowrap` so nothing ever breaks across lines.

## Terms (owner-approved)

| When it fires | Old | New |
|---|---|---|
| Good rate | Steady | **Steady** |
| Too fast | Pour slower | **Slower** |
| Too slow | Pour faster | **Faster** |
| Stalled | Keep the flow going | **Keep going** |
| Near target | Ease off | **Ease off** |
| Target reached (draw down) | Hold — let it draw down | **Hold** |
| Bloom reached | Bloom set — swirl & wait | **Swirl** |
| Bloom pour | Bloom — gentle | **Gentle** |
| Past target | Overshot | **Overshot** |

## Changes
- `src/lib/brew/flowCoach.ts` — only the `message` strings change; `cue`/`state`/`detail` and all the rate/grams logic are untouched.
- `src/components/flow/LightStepBrew.tsx` — add `whitespace-nowrap` to the `CoachCue` message span (belt-and-suspenders against wrap on narrow screens).
- `tests/dataflow/brew-flowcoach.test.mjs` — the one assertion coupled to message text (hold: `/draw/i` → `/hold/i`).

## Verification
- `npx tsc --noEmit` — clean
- `node --test` — 154/154 green
- On the deployed PWA (force-quit/reopen first): start a brew with the Acaia connected and confirm each cue is a single short word on one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KhyBsD8o9UgdmjwoEZwBAz

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhyBsD8o9UgdmjwoEZwBAz)_