### PR TITLE
fix: retrieve bag flavors by sessionIds, not the missing coffeeId

### DIFF
--- a/src/app/(light)/coffees/[id]/page.tsx
+++ b/src/app/(light)/coffees/[id]/page.tsx
@@ -173,7 +173,12 @@ export default function CoffeeDetailPage() {
   const process = latestCoffee?.process || coffee.process;
   const fermentationStyle = latestCoffee?.fermentationStyle;
   const cuppingScore = latestCoffee?.cuppingScore;
-  const tastingNotes = latestCoffee?.tastingNotesFromBag ?? [];
+  // Bag flavors live on the SCAN session's identity; brew-again/shortcut
+  // sessions carry none, so reading only sessions[0] hides them after a rebrew.
+  // Take the most recent session that actually has notes (newest-first sorted).
+  const tastingNotes =
+    sessions.find((s) => (s.coffee?.tastingNotesFromBag?.length ?? 0) > 0)?.coffee
+      ?.tastingNotesFromBag ?? [];
   const commonNotes = coffee.commonNotes ?? [];
   const origin = latestCoffee?.origin || coffee.origin;
 

--- a/src/app/api/coffees/[id]/route.ts
+++ b/src/app/api/coffees/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { eq, sql, desc } from "drizzle-orm";
+import { eq, and, inArray, sql, desc } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import { coffees, sessions } from "@/lib/db/schema";
 import { rowToCoffee } from "@/lib/db/helpers";
@@ -12,25 +12,36 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
     const rows = await db.select().from(coffees).where(eq(coffees.id, params.id)).limit(1);
     if (rows.length === 0) return NextResponse.json(null, { status: 404 });
 
-    // The documented bag flavors live in the scanned identity on the coffee's
-    // latest session — the `coffees` row's `common_notes` is unpopulated in
-    // production. Surface them so the brew-log flavor suggestions can show THIS
-    // bag's printed notes even when the brew was started from a shortcut
-    // (library list / Action Pill / Brew Again) whose synthesized identity
-    // carried no notes. Cheap (single-user table); newest session wins.
-    // Find the most recent session for this coffee that actually has bag tasting notes.
-    // Brew-again / shortcut sessions never carry tastingNotesFromBag in their JSONB,
-    // so querying the LATEST session always returns [] for frequently-brewed rotation bags.
-    // The scan session that holds the notes may be older — filter to only sessions where
-    // the array is non-empty so we always surface the real bag notes.
-    const noteRows = await db
-      .select({ coffee: sessions.coffee })
-      .from(sessions)
-      .where(sql`${sessions.coffee}->>'coffeeId' = ${params.id}
-        AND jsonb_array_length(COALESCE((${sessions.coffee}->'tastingNotesFromBag')::jsonb, '[]'::jsonb)) > 0`)
-      .orderBy(desc(sessions.createdAtMs))
-      .limit(1);
-    const tastingNotesFromBag = noteRows[0]?.coffee?.tastingNotesFromBag ?? [];
+    // The documented bag flavors live in the scanned identity on this coffee's
+    // SCAN session — the `coffees` row's `common_notes` is unpopulated in
+    // production, so the session JSONB is the only source. Surface them so the
+    // brew-log flavor suggestions + the detail page can show THIS bag's printed
+    // notes even when the brew was started from a shortcut (library list /
+    // Action Pill / Brew Again) whose synthesized identity carried no notes.
+    //
+    // IMPORTANT: the scan session is created BEFORE the coffee row exists, so
+    // its `coffee` JSONB has NO `coffeeId`. Matching notes on
+    // `coffee->>'coffeeId' = id` (what we used to do) therefore matched NOTHING
+    // for every bag — the only notes-bearing session is the scan, and it has no
+    // coffeeId. Match on the coffee row's own `sessionIds` instead (which always
+    // includes the scan session), then take the most recent of those sessions
+    // that actually carries notes (brew-again/shortcut sessions carry none).
+    const sessionIds = rows[0].sessionIds ?? [];
+    let tastingNotesFromBag: string[] = [];
+    if (sessionIds.length > 0) {
+      const noteRows = await db
+        .select({ coffee: sessions.coffee })
+        .from(sessions)
+        .where(
+          and(
+            inArray(sessions.id, sessionIds),
+            sql`jsonb_array_length(COALESCE((${sessions.coffee}->'tastingNotesFromBag')::jsonb, '[]'::jsonb)) > 0`,
+          ),
+        )
+        .orderBy(desc(sessions.createdAtMs))
+        .limit(1);
+      tastingNotesFromBag = noteRows[0]?.coffee?.tastingNotesFromBag ?? [];
+    }
 
     return NextResponse.json({ ...rowToCoffee(rows[0]), tastingNotesFromBag });
   } catch (err) {


### PR DESCRIPTION
## The real bug (root cause)

Bag tasting notes are persisted **only** on the **scan session's** `coffee` JSONB (`tastingNotesFromBag`). There is no flavors column on the `coffees` row (`commonNotes` exists but is never written).

That scan session is created **before** the coffee row exists, so its JSONB has **no `coffeeId`**. But `/api/coffees/[id]` matched notes with `WHERE coffee->>'coffeeId' = id` — so it matched **nothing** for every bag you've brewed, and returned `[]`. The notes were in the database the whole time; the lookup was joining on a field the scan session doesn't have.

Two symptoms, same root cause:
- Brew-log step ("On the bag" chips) — fetched `/api/coffees/[id]` → got `[]` → no flavors.
- Coffee Library detail page — read only the *newest* session, which carries no notes after a "Brew Again" → showed nothing.

## Fix (no migration — retrieval only)

- `/api/coffees/[id]`: match the notes-bearing session by the coffee row's own **`sessionIds`** (always includes the scan session), newest non-empty wins — instead of the missing `coffeeId`.
- Coffee detail page: derive flavors from the most recent session that **actually has** notes, not just `sessions[0]`.

The flavors were already stored; only the read path was wrong, so no data migration is needed — this surfaces them for existing coffees immediately.

## Verification
- `tsc --noEmit` clean; full `node --test` suite green (154/154).
- Surgical: two read paths only; nothing about saving, the wheel, or the rest of the flow changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tJjkAVfQdVscX6Xyk1PSw

---
_Generated by [Claude Code](https://claude.ai/code/session_018tJjkAVfQdVscX6Xyk1PSw)_