### PR TITLE
feat: store bag flavors as a first-class column on the coffee

### DIFF
--- a/src/app/(light)/coffees/[id]/page.tsx
+++ b/src/app/(light)/coffees/[id]/page.tsx
@@ -173,12 +173,15 @@ export default function CoffeeDetailPage() {
   const process = latestCoffee?.process || coffee.process;
   const fermentationStyle = latestCoffee?.fermentationStyle;
   const cuppingScore = latestCoffee?.cuppingScore;
-  // Bag flavors live on the SCAN session's identity; brew-again/shortcut
-  // sessions carry none, so reading only sessions[0] hides them after a rebrew.
-  // Take the most recent session that actually has notes (newest-first sorted).
+  // Bag flavors: prefer the durable bag_flavors column (migration 0019). Fall
+  // back to the scan session's identity for coffees not yet backfilled/written
+  // — brew-again/shortcut sessions carry none, so take the most recent session
+  // that actually has notes (newest-first sorted), not just sessions[0].
   const tastingNotes =
-    sessions.find((s) => (s.coffee?.tastingNotesFromBag?.length ?? 0) > 0)?.coffee
-      ?.tastingNotesFromBag ?? [];
+    (coffee.bagFlavors && coffee.bagFlavors.length > 0
+      ? coffee.bagFlavors
+      : sessions.find((s) => (s.coffee?.tastingNotesFromBag?.length ?? 0) > 0)?.coffee
+          ?.tastingNotesFromBag) ?? [];
   const commonNotes = coffee.commonNotes ?? [];
   const origin = latestCoffee?.origin || coffee.origin;
 

--- a/src/app/api/coffees/[id]/route.ts
+++ b/src/app/api/coffees/[id]/route.ts
@@ -12,35 +12,34 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
     const rows = await db.select().from(coffees).where(eq(coffees.id, params.id)).limit(1);
     if (rows.length === 0) return NextResponse.json(null, { status: 404 });
 
-    // The documented bag flavors live in the scanned identity on this coffee's
-    // SCAN session — the `coffees` row's `common_notes` is unpopulated in
-    // production, so the session JSONB is the only source. Surface them so the
-    // brew-log flavor suggestions + the detail page can show THIS bag's printed
-    // notes even when the brew was started from a shortcut (library list /
-    // Action Pill / Brew Again) whose synthesized identity carried no notes.
-    //
-    // IMPORTANT: the scan session is created BEFORE the coffee row exists, so
-    // its `coffee` JSONB has NO `coffeeId`. Matching notes on
-    // `coffee->>'coffeeId' = id` (what we used to do) therefore matched NOTHING
-    // for every bag — the only notes-bearing session is the scan, and it has no
-    // coffeeId. Match on the coffee row's own `sessionIds` instead (which always
-    // includes the scan session), then take the most recent of those sessions
-    // that actually carries notes (brew-again/shortcut sessions carry none).
-    const sessionIds = rows[0].sessionIds ?? [];
-    let tastingNotesFromBag: string[] = [];
-    if (sessionIds.length > 0) {
-      const noteRows = await db
-        .select({ coffee: sessions.coffee })
-        .from(sessions)
-        .where(
-          and(
-            inArray(sessions.id, sessionIds),
-            sql`jsonb_array_length(COALESCE((${sessions.coffee}->'tastingNotesFromBag')::jsonb, '[]'::jsonb)) > 0`,
-          ),
-        )
-        .orderBy(desc(sessions.createdAtMs))
-        .limit(1);
-      tastingNotesFromBag = noteRows[0]?.coffee?.tastingNotesFromBag ?? [];
+    // Bag flavors (what's printed on the bag) now live on a first-class column
+    // (`bag_flavors`, migration 0019), written on scan-save + backfilled. Prefer
+    // it. Fall back to the scan session's JSONB for any coffee not yet
+    // backfilled/written — IMPORTANT: that scan session is created BEFORE the
+    // coffee row exists, so it has NO `coffeeId`; matching notes on
+    // `coffee->>'coffeeId' = id` matched nothing, so we match on the coffee
+    // row's own `sessionIds` (which always includes the scan) and take the most
+    // recent of those sessions that carries notes (brew-again sessions carry none).
+    const stored = Array.isArray(rows[0].bagFlavors)
+      ? rows[0].bagFlavors.map((f) => String(f).trim()).filter(Boolean)
+      : [];
+    let tastingNotesFromBag: string[] = stored;
+    if (tastingNotesFromBag.length === 0) {
+      const sessionIds = rows[0].sessionIds ?? [];
+      if (sessionIds.length > 0) {
+        const noteRows = await db
+          .select({ coffee: sessions.coffee })
+          .from(sessions)
+          .where(
+            and(
+              inArray(sessions.id, sessionIds),
+              sql`jsonb_array_length(COALESCE((${sessions.coffee}->'tastingNotesFromBag')::jsonb, '[]'::jsonb)) > 0`,
+            ),
+          )
+          .orderBy(desc(sessions.createdAtMs))
+          .limit(1);
+        tastingNotesFromBag = noteRows[0]?.coffee?.tastingNotesFromBag ?? [];
+      }
     }
 
     return NextResponse.json({ ...rowToCoffee(rows[0]), tastingNotesFromBag });

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -187,6 +187,14 @@ export async function POST(req: NextRequest) {
       const newRating = data.result?.rating;
       const hasRating = typeof newRating === "number";
 
+      // Bag flavors (what's printed on the bag) → first-class column on the
+      // coffee (migration 0019). Only write when this save actually carries
+      // them: a fresh scan does, a "Brew Again"/shortcut save doesn't — so an
+      // empty list never wipes the stored flavors on an existing coffee.
+      const bagFlavors = (data.coffee.tastingNotesFromBag ?? [])
+        .map((f) => f?.trim())
+        .filter((f): f is string => !!f);
+
       const existingRows = await db
         .select()
         .from(coffees)
@@ -216,6 +224,7 @@ export async function POST(req: NextRequest) {
           // render falls back to Default until a future re-scan with
           // notes succeeds.
           fieldZones: incomingFieldZones ?? undefined,
+          bagFlavors: bagFlavors.length > 0 ? bagFlavors : undefined,
         });
       } else {
         const sessionIds = [...(existing.sessionIds ?? []), sessionId];
@@ -241,6 +250,11 @@ export async function POST(req: NextRequest) {
         };
         if (existing.fieldZones == null && incomingFieldZones != null) {
           updates.fieldZones = incomingFieldZones;
+        }
+        // Refresh the stored bag flavors only when this save carries them
+        // (a scan / re-scan). A note-less Brew Again leaves them intact.
+        if (bagFlavors.length > 0) {
+          updates.bagFlavors = bagFlavors;
         }
 
         await db

--- a/src/lib/db/helpers.ts
+++ b/src/lib/db/helpers.ts
@@ -22,6 +22,7 @@ export function rowToCoffee(r: typeof coffees.$inferSelect): Coffee {
     writtenSummary: r.writtenSummary ?? undefined,
     lastSummarizedAt: r.lastSummarizedAt ?? undefined,
     commonNotes: r.commonNotes ?? undefined,
+    bagFlavors: r.bagFlavors ?? undefined,
     whatToExplore: r.whatToExplore ?? undefined,
     personalNotes: r.personalNotes ?? undefined,
     // JSONB column is `unknown` at the Drizzle level; trust the write

--- a/src/lib/db/migrations/0019_add_coffee_bag_flavors.sql
+++ b/src/lib/db/migrations/0019_add_coffee_bag_flavors.sql
@@ -1,0 +1,35 @@
+-- Migration 0019 — durable bag-flavors field on the coffee row.
+--
+-- Until now the flavors printed ON THE BAG lived only inside the scan
+-- session's `coffee` JSONB (tastingNotesFromBag). That scan session is created
+-- before the coffee row exists, so it carries no coffeeId and the flavors were
+-- effectively buried per-session — invisible to any lookup that joined on
+-- coffeeId, and lost from view after a "Brew Again" replaced the newest
+-- session. This promotes them to a first-class column on `coffees` so they
+-- live on the coffee itself, survive session deletion, and are read straight
+-- off the row.
+--
+-- IMPORTANT: bag_flavors (what the BAG says) is DISTINCT from common_notes
+-- (what the USER tastes, aggregated from logged sessions by
+-- /api/coffees/compact and fed to the recommend AI). Do NOT conflate them.
+
+ALTER TABLE coffees ADD COLUMN IF NOT EXISTS bag_flavors jsonb;
+
+-- Backfill: for every coffee, copy the bag notes from its MOST RECENT session
+-- that actually carries them. The scan session has no coffeeId, so match via
+-- the coffee row's own session_ids array (which always includes the scan).
+-- Only fills coffees that have such a session; the rest stay NULL. Idempotent
+-- — re-running only fills rows that are still empty.
+UPDATE coffees c
+SET bag_flavors = latest.notes
+FROM (
+  SELECT DISTINCT ON (cc.id)
+    cc.id                            AS coffee_id,
+    s.coffee->'tastingNotesFromBag'  AS notes
+  FROM coffees cc
+  JOIN sessions s ON cc.session_ids ? s.id
+  WHERE jsonb_array_length(COALESCE((s.coffee->'tastingNotesFromBag')::jsonb, '[]'::jsonb)) > 0
+  ORDER BY cc.id, s.created_at_ms DESC
+) latest
+WHERE c.id = latest.coffee_id
+  AND (c.bag_flavors IS NULL OR jsonb_array_length(c.bag_flavors) = 0);

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -72,6 +72,11 @@ export const coffees = pgTable("coffees", {
   writtenSummary: text("written_summary"),
   lastSummarizedAt: text("last_summarized_at"),
   commonNotes: jsonb("common_notes").$type<string[]>(),
+  // The flavors printed ON THE BAG, promoted from the scan session's JSONB to a
+  // first-class column (migration 0019) so they live on the coffee, survive
+  // session deletion, and are read straight off the row. DISTINCT from
+  // commonNotes (what the USER tastes, aggregated from logged sessions).
+  bagFlavors: jsonb("bag_flavors").$type<string[]>(),
   whatToExplore: text("what_to_explore"),
   personalNotes: text("personal_notes"),
   // Generative Field v1.1 — perceptual Field composition for this coffee

--- a/src/lib/types/coffee.ts
+++ b/src/lib/types/coffee.ts
@@ -18,6 +18,10 @@ export interface Coffee {
   writtenSummary?: string;
   lastSummarizedAt?: string;
   commonNotes?: string[];
+  /** The flavors printed ON THE BAG (migration 0019). Distinct from
+   * commonNotes (what the user tastes). Source of truth for the brew-log
+   * "On the bag" chips and the coffee-detail flavors. */
+  bagFlavors?: string[];
   whatToExplore?: string;
   personalNotes?: string; // free-text notes written by the user
   /** Generative Field v1.1 composition for this coffee. `null` until


### PR DESCRIPTION
## What

Promotes the bag's printed flavors to a dedicated **`bag_flavors`** column on `coffees` (migration 0019). Until now they lived only inside the scan session's JSONB; now they live on the coffee itself — survive session deletion, read straight off the row.

Kept **distinct from `common_notes`** (which already holds *what the user tastes*, aggregated from logs and fed to the recommend AI — reusing it would corrupt those).

- **Migration 0019:** add the column + backfill each coffee from its most recent notes-bearing session (matched via `session_ids`; idempotent, only fills empties; non-destructive — new column).
- **Write:** `POST /api/sessions` stores `bag_flavors` on scan-save (insert + refresh on re-scan). A note-less "Brew Again" never wipes it.
- **Read:** `/api/coffees/[id]` and the coffee detail page prefer the column, falling back to the scan-session lookup for any coffee not yet backfilled.

## ⚠️ Merge order (Drizzle is column-strict)

The migration **must run on production before this merges**, or coffee reads will 500 on the missing column. Do not enable auto-merge.

1. Run **Actions → "Run SQL Migration"** with `migration_file = 0019_add_coffee_bag_flavors.sql`, `ref = claude/amazing-cray-64onhs`.
2. Confirm it logs `ALTER TABLE` / `UPDATE N`.
3. Then merge this PR (code deploys against the now-existing column).

## Verification
- `tsc --noEmit` clean; full `node --test` suite green (154/154).
- CI applies every migration (incl. 0019) to a throwaway DB, so the screenshots job exercises the column too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tJjkAVfQdVscX6Xyk1PSw

---
_Generated by [Claude Code](https://claude.ai/code/session_018tJjkAVfQdVscX6Xyk1PSw)_