### PR TITLE
fix(brew): monotonic step selection — fixes the step jumping backwards

### DIFF
--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -92,6 +92,12 @@ export default function LightStepBrew() {
   const brewStartMsRef = useRef(0);
   const lastSampleMsRef = useRef(0);
   const lastCurveMsRef = useRef(0);
+  // Monotonic peak weight for STEP SELECTION. The scale dips when you shift thumb
+  // / cup pressure; that must NEVER turn a finished pour back into an unfinished
+  // one and jump the active step backwards (#3 regression). Water on the brewer
+  // only rises as you pour, so we drive the active-step + coach selection off the
+  // PEAK weight seen this brew, not the jittery instantaneous value.
+  const peakGramsRef = useRef<number | null>(null);
   const pushSample = useCallback((grams: number, atMs: number) => {
     // Live-coach window: ~5 Hz, keep the last 6 s.
     if (atMs - lastSampleMsRef.current >= 200) {
@@ -121,8 +127,17 @@ export default function LightStepBrew() {
       fullCurveRef.current = [];
       brewStartMsRef.current = 0;
       lastCurveMsRef.current = 0;
+      peakGramsRef.current = null;
     }
   }, [elapsed]);
+
+  // Advance the monotonic peak as the brew runs (water only goes up).
+  if (started && elapsed > 0 && scale.weight != null) {
+    peakGramsRef.current = Math.max(peakGramsRef.current ?? 0, scale.weight);
+  }
+  // Grams that drive step selection: the monotonic peak during the brew (so a
+  // weight dip can't jump the step back), the raw weight before it starts.
+  const progressGrams = started && elapsed > 0 ? peakGramsRef.current : scale.weight;
 
   // The current timeline, in a ref, so handleDone can analyse without being
   // re-created every render (timeline is a fresh object each render).
@@ -194,7 +209,7 @@ export default function LightStepBrew() {
 
   // Live pour-flow comparison. Off the native shell / immersion / no weight yet
   // → cue "none", so the coach UI renders nothing (no-scale path unchanged).
-  const coach = coachFlow(timeline, elapsed, started, scale.weight, samplesRef.current);
+  const coach = coachFlow(timeline, elapsed, started, progressGrams, samplesRef.current);
   // Hand the whole step schedule to the paired Apple Watch at brew start; the
   // watch app runs the timeline and buzzes the wrist per step via a
   // physical-therapy extended-runtime session (fires screen-off / wrist-down,


### PR DESCRIPTION
Forward-fix for the regression reported on #438 (keeps all the features, no revert).

**Root cause of the "step jumps back":** the weight-gated step selection read the *instantaneous* scale weight every render, so a weight dip (shifting thumb/cup pressure) un-completed a finished pour and the active step bounced backwards. That on-screen bounce also desynced the time-based watch buzz + vibration, so it read as "watch/vibration broken".

**Fix:** step selection now uses the **monotonic peak weight** seen during the brew (water only rises as you pour). A dip can't move the step back; the time index still caps it so it can't race ahead. The top ScalePanel keeps showing the raw live weight (drops normally) — only the step/progress selection is monotonic.

This is expected to also settle the watch/vibration desync (which followed the bouncing step). The Acaia connection and chat-recipe pour guidance I could not reproduce from the code — if either still misbehaves after a clean deploy + PWA force-quit, a specific recipe/scenario will let me reproduce and fix it.

tsc clean; src (50) + tests/ (114) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhY86rB32JJoq2M4HmEyLs)_