### PR TITLE
fix(brew): step weight ignores tap/swirl spikes + harden wake lock

### DIFF
--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -23,7 +23,7 @@ import { boundariesFromTimeline } from "@/lib/native/brewNotifications";
 import { ScalePanel } from "@/components/flow/ScalePanel";
 import ColdBrewSteep from "@/components/flow/ColdBrewSteep";
 import { useAcaiaScale } from "@/hooks/useAcaiaScale";
-import { coachFlow, type WeightSample, type FlowComparison } from "@/lib/brew/flowCoach";
+import { coachFlow, settledGrams, type WeightSample, type FlowComparison } from "@/lib/brew/flowCoach";
 import { analyzeFlow, type FlowCurvePoint } from "@/lib/brew/flowAnalysis";
 
 /**
@@ -92,11 +92,14 @@ export default function LightStepBrew() {
   const brewStartMsRef = useRef(0);
   const lastSampleMsRef = useRef(0);
   const lastCurveMsRef = useRef(0);
-  // Monotonic peak weight for STEP SELECTION. The scale dips when you shift thumb
-  // / cup pressure; that must NEVER turn a finished pour back into an unfinished
-  // one and jump the active step backwards (#3 regression). Water on the brewer
-  // only rises as you pour, so we drive the active-step + coach selection off the
-  // PEAK weight seen this brew, not the jittery instantaneous value.
+  // Monotonic peak weight for STEP SELECTION + the coach readout. Two transients
+  // must not corrupt it: a DIP (shifting thumb/cup pressure) must never un-complete
+  // a finished pour and jump the step backwards (#440); a brief force SPIKE from a
+  // swirl/stir/TAP on the brewer must never be mistaken for water (it froze the raw
+  // running-max forever → the coach stuck on "Overshot +Xg"). So the peak is the
+  // running max of the SETTLED (median-of-recent) weight: the median outvotes both
+  // transients, the max keeps it monotonic. Water only rises as you pour, so this
+  // tracks real cumulative water and the dip-immunity from #440 is preserved.
   const peakGramsRef = useRef<number | null>(null);
   const pushSample = useCallback((grams: number, atMs: number) => {
     // Live-coach window: ~5 Hz, keep the last 6 s.
@@ -131,12 +134,19 @@ export default function LightStepBrew() {
     }
   }, [elapsed]);
 
-  // Advance the monotonic peak as the brew runs (water only goes up).
+  // Advance the monotonic peak as the brew runs (water only goes up) — off the
+  // SETTLED (median) weight, not the raw value, so a swirl/stir/tap force-spike
+  // never enters the peak. Gated on a live reading so a mid-brew disconnect freezes
+  // the peak (as before) rather than ageing it off the sample buffer.
   if (started && elapsed > 0 && scale.weight != null) {
-    peakGramsRef.current = Math.max(peakGramsRef.current ?? 0, scale.weight);
+    const settled = settledGrams(samplesRef.current);
+    if (settled != null) {
+      peakGramsRef.current = Math.max(peakGramsRef.current ?? 0, settled);
+    }
   }
-  // Grams that drive step selection: the monotonic peak during the brew (so a
-  // weight dip can't jump the step back), the raw weight before it starts.
+  // Grams that drive step selection + the coach readout: the spike-free monotonic
+  // peak during the brew (so neither a dip nor a tap moves the step / freezes
+  // "Overshot"), the raw weight before it starts.
   const progressGrams = started && elapsed > 0 ? peakGramsRef.current : scale.weight;
 
   // The current timeline, in a ref, so handleDone can analyse without being

--- a/src/hooks/useWakeLock.ts
+++ b/src/hooks/useWakeLock.ts
@@ -50,6 +50,11 @@ export function useWakeLock() {
       }
     }
     if (typeof navigator === "undefined" || !("wakeLock" in navigator)) return;
+    // Idempotent: never request a second sentinel while one is held — that would
+    // leak the first (it's never released) and is what made the periodic re-assert
+    // below unsafe. iOS auto-releases the sentinel on hide and the "release"
+    // listener nulls this, so a re-assert on regain correctly requests a fresh one.
+    if (lockRef.current) return;
     try {
       lockRef.current = await navigator.wakeLock.request("screen");
       lockRef.current.addEventListener("release", () => {
@@ -85,19 +90,33 @@ export function useWakeLock() {
   }, [releaseAll]);
 
   // ── Re-acquire on tab focus ─────────────────────────────────────────────
+  // Always re-assert when we come back visible and still want the lock —
+  // INCLUDING the native path. iOS clears `isIdleTimerDisabled` when the app
+  // backgrounds, so on foreground the screen would start sleeping again unless we
+  // call keepAwake() afresh (this was the "screen geht wieder aus" gap). acquire()
+  // is idempotent, so re-asserting is safe.
   useEffect(() => {
     const onVisibilityChange = () => {
-      if (
-        document.visibilityState === "visible" &&
-        wantLockRef.current &&
-        !lockRef.current &&
-        !nativeActiveRef.current
-      ) {
+      if (document.visibilityState === "visible" && wantLockRef.current) {
         void acquire();
       }
     };
     document.addEventListener("visibilitychange", onVisibilityChange);
     return () => document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, [acquire]);
+
+  // ── Periodic keep-alive re-assert ────────────────────────────────────────
+  // Belt-and-suspenders: while a lock is wanted and the screen is visible,
+  // re-assert every 15 s. If the OS quietly drops the assertion (a known iOS
+  // quirk) the screen self-recovers within one tick instead of sleeping for the
+  // rest of the brew. No-op when nothing wants the lock; acquire() is idempotent.
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (wantLockRef.current && document.visibilityState === "visible") {
+        void acquire();
+      }
+    }, 15_000);
+    return () => clearInterval(id);
   }, [acquire]);
 
   // ── Unmount cleanup ─────────────────────────────────────────────────────

--- a/src/lib/brew/flowCoach.ts
+++ b/src/lib/brew/flowCoach.ts
@@ -107,6 +107,30 @@ export function flowRateGPS(samples: WeightSample[], windowMs = 1500): number | 
   return (n * sxy - sx * sy) / denom;
 }
 
+/**
+ * Spike-/dip-robust "settled" weight = the MEDIAN of the samples in the trailing
+ * `windowMs`. This — not the raw instantaneous weight — is what the brew screen's
+ * running peak is built from.
+ *
+ * Why: a swirl/stir, and especially a TAP on the brewer, make the scale read a
+ * brief FORCE spike (the impact, not water). The raw running-max captured that
+ * spike and froze it forever, so the coach was permanently stuck on
+ * "Overshot +Xg" (the bug the owner hit). A spike lasts a fraction of the window,
+ * so the median outvotes it — only real, sustained water passes through — while a
+ * brief dip (shifting thumb/cup pressure) is outvoted the same way. Returns null
+ * until there's at least one sample inside the window.
+ */
+export function settledGrams(samples: WeightSample[], windowMs = 1500): number | null {
+  if (samples.length === 0) return null;
+  const latest = samples[samples.length - 1].atMs;
+  const win: number[] = [];
+  for (const s of samples) if (latest - s.atMs <= windowMs) win.push(s.grams);
+  if (win.length === 0) return null;
+  win.sort((a, b) => a - b);
+  const mid = win.length >> 1;
+  return win.length % 2 ? win[mid] : (win[mid - 1] + win[mid]) / 2;
+}
+
 function fmtDetail(remaining: number, rate: number | null): string {
   const left = `${Math.max(0, Math.round(remaining))}g to go`;
   return rate != null ? `${left} · ${rate.toFixed(1)} g/s` : left;

--- a/tests/dataflow/brew-flowcoach.test.mjs
+++ b/tests/dataflow/brew-flowcoach.test.mjs
@@ -19,7 +19,7 @@ import path from "node:path";
 
 const ROOT = process.cwd();
 const entry = `
-export { coachFlow, flowRateGPS } from ${JSON.stringify(path.join(ROOT, "src/lib/brew/flowCoach.ts"))};
+export { coachFlow, flowRateGPS, settledGrams } from ${JSON.stringify(path.join(ROOT, "src/lib/brew/flowCoach.ts"))};
 export { buildBrewTimeline } from ${JSON.stringify(path.join(ROOT, "src/lib/brew/timeline.ts"))};
 `;
 const dir = await mkdtemp(join(tmpdir(), "flowcoach-"));
@@ -32,7 +32,7 @@ await build({
   outfile: out,
   logLevel: "silent",
 });
-const { coachFlow, flowRateGPS, buildBrewTimeline } = await import(pathToFileURL(out).href);
+const { coachFlow, flowRateGPS, settledGrams, buildBrewTimeline } = await import(pathToFileURL(out).href);
 
 const ROAST = "2026-06-01";
 const NOW = new Date("2026-06-16T08:00:00Z").getTime();
@@ -67,6 +67,46 @@ test("flowRateGPS = least-squares slope of the sample window", () => {
   assert.ok(Math.abs(flowRateGPS(ramp(8)) - 8) < 0.01);
   assert.ok(Math.abs(flowRateGPS(ramp(4)) - 4) < 0.01);
   assert.equal(flowRateGPS([{ atMs: 1, grams: 5 }]), null); // need ≥2
+});
+
+// ── settledGrams — the spike-/dip-robust weight that feeds the brew peak ──────
+// 5 Hz samples (200 ms apart) holding `base` g, with `outlier` injected into the
+// final `nOut` samples (a tap/swirl force-spike, or a thumb-pressure dip).
+function held(base, outlier, nOut) {
+  const out = [];
+  for (let i = 0; i < 8; i++) out.push({ atMs: 200000 + i * 200, grams: base });
+  for (let k = 0; k < nOut; k++) out[out.length - 1 - k].grams = outlier;
+  return out;
+}
+
+test("settledGrams ignores a brief TAP spike (the Overshot-freeze bug)", () => {
+  // Sitting at 250 g, a tap spikes the scale to 340 g for 2 of 8 samples (~0.4 s).
+  assert.equal(settledGrams(held(250, 340, 2)), 250);
+});
+
+test("settledGrams ignores a brief pressure DIP", () => {
+  assert.equal(settledGrams(held(250, 210, 2)), 250);
+});
+
+test("settledGrams tracks real (sustained) water", () => {
+  // A genuine pour to 300 g held across the whole window passes straight through.
+  assert.equal(settledGrams(held(300, 300, 0)), 300);
+});
+
+test("running max of settled never captures a tap spike", () => {
+  // The brew screen does peak = max(peak, settledGrams(window)). Simulate the
+  // window during/after a tap and confirm the peak stays at the real water, so
+  // the coach can't get stuck on a frozen "Overshot".
+  let peak = 0;
+  for (const window of [held(250, 250, 0), held(250, 340, 2), held(250, 340, 1), held(250, 250, 0)]) {
+    const s = settledGrams(window);
+    if (s != null) peak = Math.max(peak, s);
+  }
+  assert.equal(peak, 250);
+});
+
+test("settledGrams is null with no samples", () => {
+  assert.equal(settledGrams([]), null);
 });
 
 // Mid-pour on step 1 (target 180g): elapsed in [45,93), plenty remaining.


### PR DESCRIPTION
Fixes two daily-use timer-screen bugs the owner hit on the morning V60.

## 1. "Always Overshot" (the main one)

The monotonic peak from #440 was the running **MAX of the raw scale weight**. A swirl/stir — and especially a **tap** on the brewer — make the scale read a brief **force spike** (the impact, not water). The raw max captured that spike and **froze it forever**, so `remaining = target − peak` stayed hugely negative and the coach was permanently stuck on **"Overshot +Xg"** (and the displayed grams sat at the spiked value).

**Fix:** build the peak from a **settled weight = median of the last ~1.5 s of samples** instead of the raw instantaneous value.
- The median **outvotes** any sub-window transient — a tap/swirl spike *or* a thumb/cup-pressure dip — so only real, sustained water enters the peak.
- The running **max** keeps it monotonic, so **#440's dip-immunity is preserved** (a finished pour never un-completes → the step never jumps backwards).

New pure `settledGrams()` in `flowCoach.ts`, unit-tested (spike ignored, dip ignored, real water tracked, running-max never captures a spike).

The top `ScalePanel` still shows the **raw** live weight (drops/spikes normally) — only step/progress selection + the coach readout use the spike-free peak.

## 2. "Screen goes off again"

The wake lock only re-asserted on tab focus, and it **skipped the native path**. iOS clears `isIdleTimerDisabled` when the app backgrounds, so on foreground the screen started sleeping again. Now:
- `acquire()` is idempotent (never leaks a second web sentinel).
- It re-asserts on every visibility regain **including native `keepAwake()`**.
- A 15 s keep-alive interval self-recovers if the OS quietly drops the assertion mid-brew.

## Verification
- `npx tsc --noEmit` clean
- `src` suite: 50 pass
- `dataflow` suite: 119 pass (+5 new `settledGrams` cases)

Note: the wake lock's native path still depends on the installed TestFlight shell carrying the keep-awake plugin (build from #426). This change makes the assertion *robust* once that build is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZfaPP97ARvZBNXs7yxX9x)_