### PR TITLE
fix(brew): remove weight-freeze (time-based steps) + real native screen-on

### DIFF
--- a/.github/ios-build-trigger
+++ b/.github/ios-build-trigger
@@ -1,4 +1,4 @@
 # Bump this file (change the line below) and merge to main to kick an iOS
 # TestFlight build — see the `push` trigger in .github/workflows/ios-testflight.yml.
 # Used when a session can't reach the Actions "Run workflow" UI / workflow_dispatch.
-build: 2026-06-24T15 — keep-awake wake-lock plugin (#424) + native lockfile sync (#425)
+build: 2026-06-28T00 — app-local ScreenAwake plugin (real isIdleTimerDisabled, fixes screen-off)

--- a/native/ios/App/App/MainViewController.swift
+++ b/native/ios/App/App/MainViewController.swift
@@ -22,5 +22,6 @@ class MainViewController: CAPBridgeViewController {
         bridge?.registerPluginInstance(BrewWatchPlugin())
         bridge?.registerPluginInstance(WidgetBridgePlugin())
         bridge?.registerPluginInstance(LiveActivityPlugin())
+        bridge?.registerPluginInstance(ScreenAwakePlugin())
     }
 }

--- a/native/ios/App/App/ScreenAwakePlugin.swift
+++ b/native/ios/App/App/ScreenAwakePlugin.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Capacitor
+import UIKit
+
+/**
+ ScreenAwake — keep the iPhone screen on during a brew.
+
+ An APP-LOCAL Capacitor plugin (registered explicitly in
+ `MainViewController.capacitorDidLoad`), NOT the npm `@capacitor-community/keep-awake`
+ plugin. The npm plugin is in package.json but was NEVER linked into the binary —
+ it's absent from `CapApp-SPM/Package.swift` — so its `keepAwake()` had no native
+ implementation, `useWakeLock` silently fell back to the Web Wake Lock API (which
+ WKWebView doesn't support), and the brew screen slept. A sleeping screen suspends
+ the WKWebView JS, which pauses the Acaia's 1 s heartbeat timer → the scale drops.
+
+ This sidesteps all of that: an app-local plugin is compiled in and registered for
+ certain, so flipping `isIdleTimerDisabled` can't be a no-op. The web side calls
+ `ScreenAwake.keep()` while a brew screen is open and `ScreenAwake.allow()` when it
+ closes (`src/hooks/useWakeLock.ts`). iOS resets `isIdleTimerDisabled` to false when
+ the app backgrounds, so the web layer re-asserts `keep()` on every foreground.
+ */
+@objc(ScreenAwakePlugin)
+public class ScreenAwakePlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "ScreenAwakePlugin"
+    public let jsName = "ScreenAwake"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "keep", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "allow", returnType: CAPPluginReturnPromise),
+    ]
+
+    @objc func keep(_ call: CAPPluginCall) {
+        // UIApplication state must be touched on the main thread.
+        DispatchQueue.main.async {
+            UIApplication.shared.isIdleTimerDisabled = true
+            call.resolve()
+        }
+    }
+
+    @objc func allow(_ call: CAPPluginCall) {
+        DispatchQueue.main.async {
+            UIApplication.shared.isIdleTimerDisabled = false
+            call.resolve()
+        }
+    }
+}

--- a/native/scripts/add_watch_target.rb
+++ b/native/scripts/add_watch_target.rb
@@ -35,7 +35,7 @@ end
 # app-local plugin is NOT auto-discovered by Capacitor (only npm plugins land
 # in packageClassList), so without this registration the JS side sees
 # window.Capacitor.Plugins.BrewWatch as undefined and never reaches the watch.
-APP_SWIFT_FILES = %w[BrewWatchPlugin.swift MainViewController.swift]
+APP_SWIFT_FILES = %w[BrewWatchPlugin.swift ScreenAwakePlugin.swift MainViewController.swift]
 app_group = project.main_group["App"] or abort("App group not found")
 APP_SWIFT_FILES.each do |name|
   if (old = app_group.files.find { |f| f.display_name == name })

--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -8,8 +8,7 @@ import { useWakeLock } from "@/hooks/useWakeLock";
 import {
   isAgitationPourAction,
   poursCompleteAtSec,
-  weightedActiveIdx,
-  REACH_TOL_G,
+  getActiveIdx,
   type PourStep,
   type GuideStep,
 } from "@/lib/utils/pourSequence";
@@ -23,20 +22,21 @@ import { boundariesFromTimeline } from "@/lib/native/brewNotifications";
 import { ScalePanel } from "@/components/flow/ScalePanel";
 import ColdBrewSteep from "@/components/flow/ColdBrewSteep";
 import { useAcaiaScale } from "@/hooks/useAcaiaScale";
-import { coachFlow, settledGrams, type WeightSample, type FlowComparison } from "@/lib/brew/flowCoach";
+import { coachFlow, type WeightSample, type FlowComparison } from "@/lib/brew/flowCoach";
 import { analyzeFlow, type FlowCurvePoint } from "@/lib/brew/flowAnalysis";
 
 /**
  * Light System fork of /components/flow/StepBrew.tsx (the Dark original is gone).
  *
  * This is the highest daily-use-risk screen (Markus' morning brew runs on this
- * timer), so treat it with care. The active pour-over step is WEIGHT-/POUR-AWARE
- * (`weightedActiveIdx`): a pour keeps its card until the pour is actually finished
- * — its grams target reached on the Acaia, or its physical pour time elapsed
- * off-scale — instead of flipping on a fixed time interval. The live coach
- * (`coachFlow`) picks the SAME step, so the in-card weight box never drifts from
- * the card. Wake lock is held for the WHOLE time this screen is open (mount →
- * unmount), not just once the timer starts.
+ * timer), so treat it with care. The active pour-over step advances on the recipe's
+ * TIME schedule (`getActiveIdx`); every step shows a LIVE weight box vs its target,
+ * so the card needn't wait for the pour — if you pour slow you still see what you've
+ * poured against the goal. The displayed weight is the RAW live scale value (no
+ * peak, no smoothing); the live coach (`coachFlow`) reads the same value and picks
+ * the same time-based step, so the in-card numbers match the card. Wake lock is held
+ * for the WHOLE time this screen is open (mount → unmount), not just once the timer
+ * starts.
  *
  * Mounted only by /app/(light)/brew/new when step === "brew".
  */
@@ -92,15 +92,6 @@ export default function LightStepBrew() {
   const brewStartMsRef = useRef(0);
   const lastSampleMsRef = useRef(0);
   const lastCurveMsRef = useRef(0);
-  // Monotonic peak weight for STEP SELECTION + the coach readout. Two transients
-  // must not corrupt it: a DIP (shifting thumb/cup pressure) must never un-complete
-  // a finished pour and jump the step backwards (#440); a brief force SPIKE from a
-  // swirl/stir/TAP on the brewer must never be mistaken for water (it froze the raw
-  // running-max forever → the coach stuck on "Overshot +Xg"). So the peak is the
-  // running max of the SETTLED (median-of-recent) weight: the median outvotes both
-  // transients, the max keeps it monotonic. Water only rises as you pour, so this
-  // tracks real cumulative water and the dip-immunity from #440 is preserved.
-  const peakGramsRef = useRef<number | null>(null);
   const pushSample = useCallback((grams: number, atMs: number) => {
     // Live-coach window: ~5 Hz, keep the last 6 s.
     if (atMs - lastSampleMsRef.current >= 200) {
@@ -130,24 +121,14 @@ export default function LightStepBrew() {
       fullCurveRef.current = [];
       brewStartMsRef.current = 0;
       lastCurveMsRef.current = 0;
-      peakGramsRef.current = null;
     }
   }, [elapsed]);
 
-  // Advance the monotonic peak as the brew runs (water only goes up) — off the
-  // SETTLED (median) weight, not the raw value, so a swirl/stir/tap force-spike
-  // never enters the peak. Gated on a live reading so a mid-brew disconnect freezes
-  // the peak (as before) rather than ageing it off the sample buffer.
-  if (started && elapsed > 0 && scale.weight != null) {
-    const settled = settledGrams(samplesRef.current);
-    if (settled != null) {
-      peakGramsRef.current = Math.max(peakGramsRef.current ?? 0, settled);
-    }
-  }
-  // Grams that drive step selection + the coach readout: the spike-free monotonic
-  // peak during the brew (so neither a dip nor a tap moves the step / freezes
-  // "Overshot"), the raw weight before it starts.
-  const progressGrams = started && elapsed > 0 ? peakGramsRef.current : scale.weight;
+  // The weight shown + fed to the coach is the RAW live scale value — it drops and
+  // spikes naturally (a tap/swirl flickers for a moment, then settles), exactly like
+  // the top ScalePanel. No peak, no median: the step advances on time, so there is
+  // nothing to "freeze".
+  const progressGrams = scale.weight;
 
   // The current timeline, in a ref, so handleDone can analyse without being
   // re-created every render (timeline is a fresh object each render).
@@ -481,22 +462,18 @@ function agitationButtonLabel(action: PourStep["action"]): string {
 }
 
 function LivePourSequence({ steps, elapsed, targetTimeSec, started, waterGrams, coach }: LivePourSequenceProps) {
-  const liveGrams = coach?.liveGrams ?? null;
-  // Weight-/pour-aware active step: a long pour KEEPS its card until the pour is
-  // actually finished (weight reached, or its physical pour time elapsed off-scale)
-  // instead of flipping after a fixed interval. Never races ahead of the schedule.
-  const activeIdx = started ? weightedActiveIdx(steps, elapsed, liveGrams) : -1;
+  // Time-based active step: the card follows the recipe's pour schedule (which already
+  // gives big pours proportionally more time). The live weight box on every step shows
+  // what you've actually poured vs the target, so a slow pour still reads correctly even
+  // after the card advances. Never bounces, never freezes.
+  const activeIdx = started ? getActiveIdx(elapsed, steps) : -1;
   const activeStep = activeIdx >= 0 ? steps[activeIdx] : null;
   const nextStep = activeIdx >= 0 && activeIdx < steps.length - 1 ? steps[activeIdx + 1] : null;
   const nextCountdown = nextStep ? Math.max(0, nextStep.startTimeSec - elapsed) : null;
-  // Draining begins once we're a grace beyond the last step (poursCompleteAtSec
-  // covers the time to physically pour it) AND — when the scale is connected — the
-  // final target is actually reached, so the drain card never pre-empts a final pour
-  // you're still pouring. Off-scale (liveGrams null) it's purely the time grace.
+  // Draining begins a grace beyond the last step (poursCompleteAtSec covers the time to
+  // physically pour it) — purely time-based, so it never waits on a weight reading.
   const drainStartSec = poursCompleteAtSec(steps, targetTimeSec);
-  const finalTarget = steps.length > 0 ? steps[steps.length - 1].cumulativeGrams : 0;
-  const weightReached = liveGrams == null || liveGrams >= finalTarget - REACH_TOL_G;
-  const allPoursDone = started && elapsed >= drainStartSec && weightReached;
+  const allPoursDone = started && elapsed >= drainStartSec;
 
   const [flashKey, setFlashKey] = useState(0);
   useEffect(() => {

--- a/src/hooks/useWakeLock.ts
+++ b/src/hooks/useWakeLock.ts
@@ -1,27 +1,27 @@
 import { useRef, useEffect, useCallback } from "react";
 
-type KeepAwakePlugin = {
-  keepAwake(): Promise<void>;
-  allowSleep(): Promise<void>;
-};
-
-// Dynamically imported so it never lands in the PWA's main bundle.
-// If the plugin isn't present (Safari PWA, old shell), the import fails
-// silently and we fall through to the Web Wake Lock API.
-let keepAwakeCache: KeepAwakePlugin | null | undefined; // undefined = not yet tried
-async function loadKeepAwake(): Promise<KeepAwakePlugin | null> {
-  if (keepAwakeCache !== undefined) return keepAwakeCache;
-  try {
-    const mod = await import("@capacitor-community/keep-awake");
-    keepAwakeCache = mod.KeepAwake as KeepAwakePlugin;
-  } catch {
-    keepAwakeCache = null;
-  }
-  return keepAwakeCache;
+// App-local Capacitor plugin (`native/ios/App/App/ScreenAwakePlugin.swift`,
+// registered in MainViewController.capacitorDidLoad). It flips iOS's
+// `isIdleTimerDisabled`. We read it off the injected `window.Capacitor.Plugins`
+// (the same pattern as brewWatch.ts) rather than importing the npm
+// `@capacitor-community/keep-awake` plugin — that one was never linked into the
+// iOS binary (absent from CapApp-SPM/Package.swift), so its call was a silent
+// no-op and the screen slept. This app-local plugin is compiled in for certain.
+// Undefined on the Safari PWA / a shell built before this plugin → we fall
+// through to the Web Wake Lock API.
+interface ScreenAwakePluginLike {
+  keep(): Promise<void>;
+  allow(): Promise<void>;
 }
-
-function isNative(): boolean {
-  return typeof window !== "undefined" && !!window.Capacitor?.isNativePlatform?.();
+interface CapacitorLike {
+  isNativePlatform?: () => boolean;
+  Plugins?: { ScreenAwake?: ScreenAwakePluginLike };
+}
+function getScreenAwake(): ScreenAwakePluginLike | null {
+  if (typeof window === "undefined") return null;
+  const cap = (window as unknown as { Capacitor?: CapacitorLike }).Capacitor;
+  if (!cap?.isNativePlatform?.()) return null;
+  return cap.Plugins?.ScreenAwake ?? null;
 }
 
 export function useWakeLock() {
@@ -32,21 +32,19 @@ export function useWakeLock() {
 
   // ── Internal acquire ────────────────────────────────────────────────────
   const acquire = useCallback(async () => {
-    // Native keep-awake (real OS idle-timer disable in the iOS shell). If the
+    // Native screen-awake (real OS idle-timer disable in the iOS shell). If the
     // plugin isn't in the installed build / the call rejects, fall THROUGH to the
     // Web Wake Lock API rather than giving up — that path kept the screen awake
     // before the native plugin existed (regression: PR #424 returned early and
     // skipped it, so the brew screen slept whenever native keep-awake was a no-op).
-    if (isNative()) {
-      const ka = await loadKeepAwake();
-      if (ka) {
-        try {
-          await ka.keepAwake();
-          nativeActiveRef.current = true;
-          return; // native handled it — don't also take a web lock
-        } catch {
-          /* plugin not implemented in this build → fall back to web wake lock */
-        }
+    const sa = getScreenAwake();
+    if (sa) {
+      try {
+        await sa.keep();
+        nativeActiveRef.current = true;
+        return; // native handled it — don't also take a web lock
+      } catch {
+        /* plugin not present in this build → fall back to web wake lock */
       }
     }
     if (typeof navigator === "undefined" || !("wakeLock" in navigator)) return;
@@ -67,8 +65,7 @@ export function useWakeLock() {
 
   const releaseAll = useCallback(async () => {
     if (nativeActiveRef.current) {
-      const ka = await loadKeepAwake();
-      await ka?.allowSleep().catch(() => {});
+      await getScreenAwake()?.allow().catch(() => {});
       nativeActiveRef.current = false;
     }
     if (lockRef.current) {

--- a/src/lib/brew/flowCoach.ts
+++ b/src/lib/brew/flowCoach.ts
@@ -16,7 +16,7 @@
  * guidance, never presented as hard law.
  */
 import { activeStepAt, expectedGramsAt, type BrewTimeline } from "@/lib/brew/timeline";
-import { pourDurationSec, weightedActiveIdx } from "@/lib/utils/pourSequence";
+import { pourDurationSec } from "@/lib/utils/pourSequence";
 
 export interface WeightSample {
   /** Wall-clock ms when the sample was read. */
@@ -107,30 +107,6 @@ export function flowRateGPS(samples: WeightSample[], windowMs = 1500): number | 
   return (n * sxy - sx * sy) / denom;
 }
 
-/**
- * Spike-/dip-robust "settled" weight = the MEDIAN of the samples in the trailing
- * `windowMs`. This — not the raw instantaneous weight — is what the brew screen's
- * running peak is built from.
- *
- * Why: a swirl/stir, and especially a TAP on the brewer, make the scale read a
- * brief FORCE spike (the impact, not water). The raw running-max captured that
- * spike and froze it forever, so the coach was permanently stuck on
- * "Overshot +Xg" (the bug the owner hit). A spike lasts a fraction of the window,
- * so the median outvotes it — only real, sustained water passes through — while a
- * brief dip (shifting thumb/cup pressure) is outvoted the same way. Returns null
- * until there's at least one sample inside the window.
- */
-export function settledGrams(samples: WeightSample[], windowMs = 1500): number | null {
-  if (samples.length === 0) return null;
-  const latest = samples[samples.length - 1].atMs;
-  const win: number[] = [];
-  for (const s of samples) if (latest - s.atMs <= windowMs) win.push(s.grams);
-  if (win.length === 0) return null;
-  win.sort((a, b) => a - b);
-  const mid = win.length >> 1;
-  return win.length % 2 ? win[mid] : (win[mid - 1] + win[mid]) / 2;
-}
-
 function fmtDetail(remaining: number, rate: number | null): string {
   const left = `${Math.max(0, Math.round(remaining))}g to go`;
   return rate != null ? `${left} · ${rate.toFixed(1)} g/s` : left;
@@ -157,15 +133,10 @@ export function coachFlow(
 
   const targetGramsNow = expectedGramsAt(timeline, elapsed);
   const rate = flowRateGPS(samples);
-  // Pick the SAME active step the brew screen displays: on a grams curve
-  // (percolation) the step is weight-/pour-aware (held on an unfinished pour),
-  // so the cue + numbers never drift from the card. `timeline.steps` and
-  // `timeline.pourSteps` share indices for percolation. Immersion/prose keep the
-  // time-based pick. (liveGrams is non-null here — guarded by the early return.)
-  const idx =
-    timeline.hasGramsCurve && timeline.pourSteps
-      ? weightedActiveIdx(timeline.pourSteps, elapsed, liveGrams)
-      : activeStepAt(timeline, elapsed, started);
+  // Pick the SAME active step the brew screen displays — the TIME-based index, for
+  // both percolation and immersion — so the coach cue + numbers always match the
+  // highlighted card. (liveGrams is non-null here — guarded by the early return.)
+  const idx = activeStepAt(timeline, elapsed, started);
   const step = idx >= 0 ? timeline.steps[idx] : null;
   if (!step) {
     return { ...NO_DATA, liveGrams, targetGramsNow, liveRateGPS: rate };

--- a/src/lib/utils/pourSequence.test.mjs
+++ b/src/lib/utils/pourSequence.test.mjs
@@ -20,7 +20,7 @@ const entry = `
 export {
   getBloomDuration, parsePourSteps, pourStepsFromStructured, buildGuideSteps,
   hasImmersionShape, getActiveIdx, isAgitationPourAction, pourDurationSec,
-  poursCompleteAtSec, POUR_RATE_GPS, weightedActiveIdx, REACH_TOL_G, AGITATION_DWELL_SEC,
+  poursCompleteAtSec, POUR_RATE_GPS,
 } from ${JSON.stringify(path.join(ROOT, "src/lib/utils/pourSequence.ts"))};
 `;
 const dir = await mkdtemp(join(tmpdir(), "pourseq-"));
@@ -44,9 +44,6 @@ const {
   pourDurationSec,
   poursCompleteAtSec,
   POUR_RATE_GPS,
-  weightedActiveIdx,
-  REACH_TOL_G,
-  AGITATION_DWELL_SEC,
 } = await import(pathToFileURL(out).href);
 
 // Fixed clock: Apr 17 2026. Lets roast-date branches be exercised deterministically.
@@ -562,71 +559,7 @@ test("proportional spacing: the final pour still lands at target − reserve", (
   }
 });
 
-// ── weightedActiveIdx (the "step won't advance off an unfinished pour" fix) ───
-
-const PEAK_STEPS = () => parsePourSteps("50 – 180 – 320 – 500", 270, peakRoast, NOW); // [0,45,110,181]
-
-test("weightedActiveIdx: scale connected — holds the pour until its target is reached", () => {
-  const steps = PEAK_STEPS();
-  // At t=120, time alone would be on pour index 2 (110s ≤ 120 < 181). But only 180g
-  // is on the scale, so pour index 1 (target 180g) is NOT yet complete → hold on 1.
-  assert.equal(getActiveIdx(120, steps), 2); // pure time
-  assert.equal(weightedActiveIdx(steps, 120, 175), 1); // behind on weight → held on the pour
-});
-
-test("weightedActiveIdx: advances once the pour's target is reached (within tolerance)", () => {
-  const steps = PEAK_STEPS();
-  // 320g reached (pour index 2 target) → not held back by weight; time at 120 is on idx 2.
-  assert.equal(weightedActiveIdx(steps, 120, 320), 2);
-  // Within REACH_TOL_G of the 180g target counts as reached → free to follow time.
-  assert.equal(weightedActiveIdx(steps, 120, 180 - REACH_TOL_G), 2);
-});
-
-test("weightedActiveIdx: never races AHEAD of the time schedule", () => {
-  const steps = PEAK_STEPS();
-  // Even if the whole 500g is already poured, at t=50 the card stays where time is
-  // (idx 1), never jumping to a future step.
-  assert.equal(weightedActiveIdx(steps, 50, 500), 1);
-  assert.ok(weightedActiveIdx(steps, 50, 500) <= getActiveIdx(50, steps));
-});
-
-test("weightedActiveIdx: no scale — holds each pour for its physical pour duration", () => {
-  const steps = PEAK_STEPS();
-  // pour index 1 starts @45 and adds 130g → ~33s to pour (pourDurationSec(130)).
-  const dur = pourDurationSec(130);
-  // Just before that pour is physically done, even though time has reached pour 2's
-  // start (110s), the card holds on pour 1.
-  assert.equal(weightedActiveIdx(steps, 45 + dur - 1, null), 1);
-  // After its physical pour time, time (110s) governs again.
-  assert.equal(weightedActiveIdx(steps, 110, null), 2);
-});
-
-test("weightedActiveIdx: agitation step holds for its dwell, then time governs", () => {
-  const recipe = {
-    targetTimeSec: 240,
-    pourSteps: [
-      { label: "Bloom", action: "bloom", waterGramsAtEnd: 50 },
-      { label: "Pour 2", action: "pour", waterGramsAtEnd: 200 },
-      { label: "Final", action: "final", waterGramsAtEnd: 300 },
-      { label: "Swirl", action: "swirl" },
-      { label: "Drawdown", action: "drain", durationSec: 40 },
-    ],
-  };
-  const steps = pourStepsFromStructured(recipe, peakRoast, NOW); // bloom0/pour45/final161/swirl186
-  const swirl = steps.findIndex((s) => s.action === "swirl");
-  const sStart = steps[swirl].startTimeSec;
-  // Weight reached for all pours; at swirl start the swirl is the active step and
-  // holds through its dwell window.
-  assert.equal(weightedActiveIdx(steps, sStart, 300), swirl);
-  assert.equal(weightedActiveIdx(steps, sStart + AGITATION_DWELL_SEC - 1, 300), swirl);
-});
-
-test("weightedActiveIdx: all steps complete → the last step (drain handoff)", () => {
-  const steps = PEAK_STEPS();
-  // Past target with the full pour on the scale → last index.
-  assert.equal(weightedActiveIdx(steps, 500, 500), steps.length - 1);
-});
-
-test("weightedActiveIdx: empty steps → -1", () => {
-  assert.equal(weightedActiveIdx([], 10, 100), -1);
-});
+// NOTE: the weight-gated `weightedActiveIdx` was removed — the active step now
+// advances purely on the recipe's TIME schedule (`getActiveIdx`, tested above),
+// with the live weight box on each step showing poured-vs-target. No peak, no
+// weight-hold, so there is nothing to "freeze".

--- a/src/lib/utils/pourSequence.ts
+++ b/src/lib/utils/pourSequence.ts
@@ -353,53 +353,6 @@ export function getActiveIdx(elapsed: number, steps: { startTimeSec: number }[])
   return idx;
 }
 
-/** Live grams within this of a pour's cumulative target = "reached" (matches
- * flowCoach's TOL_G). */
-export const REACH_TOL_G = 4;
-/** Seconds an agitation step stays active before the timeline may advance past it. */
-export const AGITATION_DWELL_SEC = 8;
-
-/**
- * Weight-/pour-aware active step index — the fix for "the step vanishes after 15 s
- * while I'm still pouring". Unlike `getActiveIdx` (pure elapsed time), this never
- * advances OFF a pour until that pour is actually FINISHED. A step counts complete:
- *   - pour step + a live weight (scale on) → `liveGrams ≥ cumulativeGrams − REACH_TOL_G`
- *   - pour step, no weight (scale off)     → `elapsed ≥ startTimeSec + pourDurationSec(pourGrams)`
- *   - agitation step                       → `elapsed ≥ startTimeSec + AGITATION_DWELL_SEC`
- *
- * Returns `min(timeIdx, firstIncompleteIdx)`: if elapsed ran ahead of an unfinished
- * pour, hold on that pour (the bug fix); if you poured ahead of schedule, follow the
- * schedule (never race the card ahead). Crucially `result ≤ getActiveIdx`, so a step
- * is never SKIPPED — only held longer. Because total weight rises monotonically as
- * you pour later steps, an under-poured earlier step self-completes once you pour on,
- * so the card can't get permanently stuck. `liveGrams` null ⇒ the no-scale branch.
- */
-export function weightedActiveIdx(
-  steps: PourStep[],
-  elapsed: number,
-  liveGrams: number | null,
-): number {
-  if (steps.length === 0) return -1;
-  const timeIdx = getActiveIdx(elapsed, steps);
-
-  let firstIncomplete = steps.length; // sentinel: all steps complete
-  for (let i = 0; i < steps.length; i++) {
-    const s = steps[i];
-    let complete: boolean;
-    if (isAgitationPourAction(s.action)) {
-      complete = elapsed >= s.startTimeSec + AGITATION_DWELL_SEC;
-    } else if (liveGrams != null) {
-      complete = liveGrams >= s.cumulativeGrams - REACH_TOL_G;
-    } else {
-      complete = elapsed >= s.startTimeSec + pourDurationSec(s.pourGrams);
-    }
-    if (!complete) {
-      firstIncomplete = i;
-      break;
-    }
-  }
-  return Math.min(timeIdx, firstIncomplete);
-}
 
 // ── Immersion / AeroPress / staged guide ─────────────────────────────────────
 

--- a/tests/dataflow/brew-flowcoach.test.mjs
+++ b/tests/dataflow/brew-flowcoach.test.mjs
@@ -19,7 +19,7 @@ import path from "node:path";
 
 const ROOT = process.cwd();
 const entry = `
-export { coachFlow, flowRateGPS, settledGrams } from ${JSON.stringify(path.join(ROOT, "src/lib/brew/flowCoach.ts"))};
+export { coachFlow, flowRateGPS } from ${JSON.stringify(path.join(ROOT, "src/lib/brew/flowCoach.ts"))};
 export { buildBrewTimeline } from ${JSON.stringify(path.join(ROOT, "src/lib/brew/timeline.ts"))};
 `;
 const dir = await mkdtemp(join(tmpdir(), "flowcoach-"));
@@ -32,7 +32,7 @@ await build({
   outfile: out,
   logLevel: "silent",
 });
-const { coachFlow, flowRateGPS, settledGrams, buildBrewTimeline } = await import(pathToFileURL(out).href);
+const { coachFlow, flowRateGPS, buildBrewTimeline } = await import(pathToFileURL(out).href);
 
 const ROAST = "2026-06-01";
 const NOW = new Date("2026-06-16T08:00:00Z").getTime();
@@ -67,46 +67,6 @@ test("flowRateGPS = least-squares slope of the sample window", () => {
   assert.ok(Math.abs(flowRateGPS(ramp(8)) - 8) < 0.01);
   assert.ok(Math.abs(flowRateGPS(ramp(4)) - 4) < 0.01);
   assert.equal(flowRateGPS([{ atMs: 1, grams: 5 }]), null); // need ≥2
-});
-
-// ── settledGrams — the spike-/dip-robust weight that feeds the brew peak ──────
-// 5 Hz samples (200 ms apart) holding `base` g, with `outlier` injected into the
-// final `nOut` samples (a tap/swirl force-spike, or a thumb-pressure dip).
-function held(base, outlier, nOut) {
-  const out = [];
-  for (let i = 0; i < 8; i++) out.push({ atMs: 200000 + i * 200, grams: base });
-  for (let k = 0; k < nOut; k++) out[out.length - 1 - k].grams = outlier;
-  return out;
-}
-
-test("settledGrams ignores a brief TAP spike (the Overshot-freeze bug)", () => {
-  // Sitting at 250 g, a tap spikes the scale to 340 g for 2 of 8 samples (~0.4 s).
-  assert.equal(settledGrams(held(250, 340, 2)), 250);
-});
-
-test("settledGrams ignores a brief pressure DIP", () => {
-  assert.equal(settledGrams(held(250, 210, 2)), 250);
-});
-
-test("settledGrams tracks real (sustained) water", () => {
-  // A genuine pour to 300 g held across the whole window passes straight through.
-  assert.equal(settledGrams(held(300, 300, 0)), 300);
-});
-
-test("running max of settled never captures a tap spike", () => {
-  // The brew screen does peak = max(peak, settledGrams(window)). Simulate the
-  // window during/after a tap and confirm the peak stays at the real water, so
-  // the coach can't get stuck on a frozen "Overshot".
-  let peak = 0;
-  for (const window of [held(250, 250, 0), held(250, 340, 2), held(250, 340, 1), held(250, 250, 0)]) {
-    const s = settledGrams(window);
-    if (s != null) peak = Math.max(peak, s);
-  }
-  assert.equal(peak, 250);
-});
-
-test("settledGrams is null with no samples", () => {
-  assert.equal(settledGrams([]), null);
 });
 
 // Mid-pour on step 1 (target 180g): elapsed in [45,93), plenty remaining.


### PR DESCRIPTION
Two coupled fixes for the iOS TestFlight brew screen. **Net −276 / +68 lines — simpler code, not more clever.**

## 1. Weight-freeze REMOVED (web — deploys instantly)
The chain #438→#440→#442 kept over-correcting. #440 tracked the running **MAX** weight ("peak") to stop a dip jumping the step backward — but a tap/swirl **force spike** got frozen into the peak → permanent **"Overshot"**; my #442 median made it laggy/stiff. The peak's only job was preventing the backwards-jump.

**Per owner decision:** the active step now advances purely on the recipe's **TIME** schedule (`getActiveIdx`). Every step already shows a live weight box vs its target, so the card needn't wait for the pour — if you pour slow you still see "50 / 60g" on the next card. The displayed weight + the coach read the **RAW live scale value** (no peak, no median); `coachFlow` picks the same time-based index so its numbers match the highlighted card. Drain is time-based too.

Deleted: `peakGramsRef`, `settledGrams`, `weightedActiveIdx`, `REACH_TOL_G`/`AGITATION_DWELL_SEC` + their tests.

## 2. Screen-on FIXED (native — needs the new TestFlight build)
**Root cause of the screen sleeping** — and therefore the flaky Acaia (a sleeping screen suspends the WKWebView JS, which pauses the scale's 1 s heartbeat): `@capacitor-community/keep-awake` is in npm but **absent from `CapApp-SPM/Package.swift`**, so the native `keepAwake()` was never compiled into the binary → `useWakeLock` fell back to the Web Wake Lock API → **WKWebView doesn't support it** → no-op.

**Fix:** a new **app-local** plugin `ScreenAwakePlugin` (flips `UIApplication.isIdleTimerDisabled`), registered explicitly in `MainViewController` and added to the App target via `add_watch_target.rb` — the same guaranteed-compiled-in pattern as BrewWatch / Widget / LiveActivity. `useWakeLock` now calls `window.Capacitor.Plugins.ScreenAwake` (typed accessor), keeping the Web Wake Lock fallback + the visibility / 15 s re-assert (iOS clears `isIdleTimerDisabled` on background).

**Scale/BLE code untouched** — it stabilizes purely from the screen staying on. Version-skew-safe: on an old shell `Plugins.ScreenAwake` is undefined → falls back to today's behavior, so the web half can deploy before the build is installed.

Bumps `.github/ios-build-trigger` so merging fires the TestFlight build.

## Verification
- `npx tsc --noEmit` clean
- `src` suite: 43 pass · `dataflow` suite: 114 pass
- **Owner on-device (after the new build installs):** real brew left untouched → screen stays on the whole brew; Acaia stays connected; cards advance on time; the live weight box shows the REAL value on every step (no stuck "Overshot", no backwards jump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZfaPP97ARvZBNXs7yxX9x)_