### PR TITLE
feat(field): make the generative Field knalliger — full Big-Sur punch + cool blueberry zone

### DIFF
--- a/.github/workflows/field-zones-remap.yml
+++ b/.github/workflows/field-zones-remap.yml
@@ -1,0 +1,64 @@
+name: Re-map field zones
+
+# One-shot re-map of coffees.field_zones (src/app/api/admin/remap-field-zones).
+# Run AFTER deploying the "cool-berry" blue zone so existing bags with blueberry/
+# blackcurrant notes pick up the new blue (the Big-Sur intensity pass already
+# applies to every coffee without a re-map). SSHes into the VPS with the SAME
+# deploy key the Deploy workflow uses and triggers the route from INSIDE the app
+# container, reading the container's own CRON_SECRET — exactly like the
+# loading-insights refresh. No new secrets. A missed run is harmless; re-running
+# is safe (it just recomputes the same compositions).
+#
+# Manual only — there's nothing to schedule. Run it once from the Actions tab
+# (or via `gh workflow run`) after the deploy lands.
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: field-zones-remap
+  cancel-in-progress: false
+
+jobs:
+  remap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger re-map on the VPS
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+          # Trigger from inside the app container so $CRON_SECRET expands from the
+          # container's own env (single quotes keep the host/SSH shells off it).
+          # -fsS makes curl non-zero on an HTTP error. Capture the JSON body so we
+          # can print a readable per-coffee audit.
+          set +e
+          ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} bash <<'REMOTE' > /tmp/resp.json 2>/tmp/resp.err
+          cd ${{ secrets.DEPLOY_PATH }}
+          docker compose exec -T app sh -c 'curl -fsS -X POST http://localhost:3000/api/admin/remap-field-zones -H "Authorization: Bearer $CRON_SECRET"'
+          REMOTE
+          rc=$?
+          set -e
+
+          echo "----- raw response -----"
+          cat /tmp/resp.json
+
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::re-map failed (ssh/curl exit $rc)"
+            cat /tmp/resp.err
+            exit 1
+          fi
+
+          echo
+          echo "----- audit -----"
+          jq -r '
+            "counts: \(.total) coffees · \(.remapped) remapped · \(.skipped) skipped · \(.failed) failed",
+            "",
+            "REMAPPED (\(.remapped)):",
+            (.results[] | select(.status == "remapped") | "  + \(.name): \(.zones)"),
+            "",
+            "SKIPPED / FAILED:",
+            (.results[] | select(.status != "remapped") | "  - [\(.status)] \(.name) (\(.reason))")
+          ' /tmp/resp.json || echo "(could not format JSON; see raw response above)"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,7 +226,7 @@ lib/
 │   # The real places dataset (6,202 rows, verified 2026-05-09) lives only in Production; no seed file in Git.
 ├── field/                     # ★ Generative Field v1.1 — coffee-driven background gradient
 │   ├── types.ts               # FieldZone, FieldZoneId, FieldConfig types
-│   ├── zones.ts               # 6-zone perceptual palette (fruity-bright, fruity-deep, floral, nutty-cocoa, spice-earth, sweet-caramel)
+│   ├── zones.ts               # 7-zone perceptual palette (fruity-bright, fruity-deep, floral, nutty-cocoa, spice-earth, sweet-caramel + cool-berry — the one cool blue-violet zone for blueberry/cassis, added in the Big-Sur punch pass)
 │   ├── defaultZones.ts        # Fallback composition for coffees with no Field yet
 │   ├── composeGradient.ts     # zones + rotation → CSS radial/conic gradient sandwich
 │   ├── schema.ts              # Zod schema for persisted field_zones
@@ -463,7 +463,7 @@ All migrations applied manually on the VPS — see migration NOTE above.
 
 **Generative Field v1.1 (PRs #78 → #100)**
 - Each coffee gets its own background gradient composition derived from tasting notes.
-- 6-zone perceptual palette (fruity-bright, fruity-deep, floral, nutty-cocoa, spice-earth, sweet-caramel); composition stored as weighted JSON in `coffees.field_zones`.
+- 7-zone perceptual palette (fruity-bright, fruity-deep, floral, nutty-cocoa, spice-earth, sweet-caramel + `cool-berry` — blue-violet/indigo for blueberry/blackcurrant, the one cool zone, added in the "Big-Sur punch" pass); composition stored as weighted JSON in `coffees.field_zones`.
 - Haiku call (`src/lib/field/mapNotesToZones.ts`) maps tasting notes → zone weights on first scan.
 - `LightFlowShell` rotates Field 25° per brew step (scan 0°, mode 0°, context 25°, recommend 50°, brew 75°, log 100°, summary 125°) — visual progress signal.
 - Brew-Again paths (ActionPill on home, `/coffees` list, `/coffees/[id]`) lift `fieldZones` from `coffees.field_zones` so the cup-specific Field travels with the user into the flow.

--- a/scripts/backfill-field-zones.mjs
+++ b/scripts/backfill-field-zones.mjs
@@ -36,6 +36,7 @@ const VALID_ZONE_IDS = new Set([
   "nutty-cocoa",
   "spice-earth",
   "sweet-caramel",
+  "cool-berry",
 ]);
 
 // Verbatim from src/lib/field/mapNotesToZones.ts so the backfill
@@ -43,8 +44,9 @@ const VALID_ZONE_IDS = new Set([
 const SYSTEM_PROMPT = `You are a perceptual aroma-to-color mapper for a specialty coffee app. Given an array of tasting notes (English or German), you return a JSON object specifying which BrewLog Field Zones the notes map to, with weights, plus optional saturation/lightness modifiers from texture descriptors. Return JSON only, no prose.
 
 Available Field Zones (id : exemplar aromas):
-- fruity-bright : citrus, lemon, orange, grapefruit, mandarin, berry, blueberry, raspberry, cherry, cranberry, peach, apricot, currant, pomegranate
+- fruity-bright : citrus, lemon, orange, grapefruit, mandarin, berry, raspberry, cherry, cranberry, strawberry, redcurrant, peach, apricot, pomegranate
 - fruity-deep : dried fruit, date, raisin, fig, prune, plum, red grape, port, wine, fermented fruit, dark cherry
+- cool-berry : blueberry, blackberry, blackcurrant, cassis, bilberry, huckleberry, boysenberry, dark/wild berry, jammy blue-purple fruit
 - floral : jasmine, rose, hibiscus, bergamot, chamomile, tea, lavender, elderflower, white flowers, floral, perfume
 - nutty-cocoa : chocolate, cocoa, milk chocolate, dark chocolate, nut, almond, hazelnut, walnut, pecan, peanut, roasted, malt
 - spice-earth : cinnamon, clove, cardamom, tobacco, leather, earth, herbs, savoury, spice, woody, cedar, smoke
@@ -66,7 +68,7 @@ Rules:
 - If a note is unfamiliar or non-aromatic (e.g. "rare", "delightful"), ignore it.
 - If ALL notes are unfamiliar, return {"zones": [], "modifiers": {"saturation": 0, "lightness": 0}}.
   The caller will treat empty zones as "fall back to default".
-- German notes are valid input: pflaumig → prune (fruity-deep), nussig → nutty-cocoa, zitronig → citrus (fruity-bright), schokoladig → chocolate (nutty-cocoa).`;
+- German notes are valid input: pflaumig → prune (fruity-deep), nussig → nutty-cocoa, zitronig → citrus (fruity-bright), schokoladig → chocolate (nutty-cocoa), heidelbeere/blaubeere → blueberry (cool-berry), cassis/schwarze johannisbeere → blackcurrant (cool-berry), brombeere → blackberry (cool-berry).`;
 
 function extractJson(text) {
   if (!text) return null;

--- a/src/app/api/admin/remap-field-zones/route.ts
+++ b/src/app/api/admin/remap-field-zones/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { coffees } from "@/lib/db/schema";
+import { mapNotesToZones } from "@/lib/field/mapNotesToZones";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300; // 5min — ~25 coffees × ~1–2s Haiku each, huge headroom.
+
+/**
+ * One-shot re-map: recompute coffees.field_zones for EVERY coffee that has
+ * printed bag notes, overwriting the existing composition.
+ *
+ * Why this exists: the "Big-Sur" intensity pass applies to every coffee
+ * instantly (it's pure render math), but the new `cool-berry` blue zone only
+ * shows once a coffee's notes are re-run through mapNotesToZones — existing
+ * rows were mapped before the zone existed, so a blueberry bag stays orange-red
+ * until re-mapped. Hit this once after deploy and the blue lands on the bags
+ * that earned it.
+ *
+ * Notes source: the first-class `bagFlavors` column (the flavours printed on the
+ * bag — exactly what the Field was always derived from), falling back to
+ * `commonNotes` (what the user has tasted) when a coffee has no bag flavours.
+ * Coffees with neither are skipped; their Field stays as-is.
+ *
+ * Unlike the prewarm-coffee-insights route this does NOT preserve any per-row
+ * state — field_zones is a derived visual, not a user-acted card, so a clean
+ * overwrite is correct. A coffee whose notes map to nothing usable keeps its
+ * old composition (we only write on a successful mapping, never null it out).
+ *
+ * Auth: same CRON_SECRET bearer pattern as the other /api/admin routes
+ * (middleware lets /api/admin through PUBLIC_PATHS, so this bearer is the gate).
+ *
+ * Trigger: the `field-zones-remap` GitHub Action (SSH → docker compose exec →
+ * curl with the container's own CRON_SECRET). Never run by hand.
+ */
+export async function POST(req: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  const auth = req.headers.get("authorization");
+  if (!secret || auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const rows = await db.select().from(coffees);
+
+    const results: Array<{
+      id: string;
+      name: string;
+      status: "remapped" | "skipped" | "failed";
+      reason?: string;
+      zones?: string;
+    }> = [];
+
+    for (const row of rows) {
+      const bag = (row.bagFlavors ?? []).filter((n): n is string => typeof n === "string" && n.trim().length > 0);
+      const common = (row.commonNotes ?? []).filter((n): n is string => typeof n === "string" && n.trim().length > 0);
+      const notes = bag.length > 0 ? bag : common;
+
+      if (notes.length === 0) {
+        results.push({ id: row.id, name: row.name, status: "skipped", reason: "no notes" });
+        continue;
+      }
+
+      const fieldZones = await mapNotesToZones(notes, "tasting-notes");
+      if (!fieldZones) {
+        // Mapping returned nothing usable — leave the existing Field untouched.
+        results.push({ id: row.id, name: row.name, status: "failed", reason: "no usable zones" });
+        continue;
+      }
+
+      await db.update(coffees).set({ fieldZones }).where(eq(coffees.id, row.id));
+      results.push({
+        id: row.id,
+        name: row.name,
+        status: "remapped",
+        zones: fieldZones.zones.map((z) => `${z.id}(${z.weight.toFixed(2)})`).join(" + "),
+      });
+    }
+
+    const summary = {
+      total: rows.length,
+      remapped: results.filter((r) => r.status === "remapped").length,
+      skipped: results.filter((r) => r.status === "skipped").length,
+      failed: results.filter((r) => r.status === "failed").length,
+      results,
+    };
+    return NextResponse.json(summary);
+  } catch (err) {
+    console.error("remap-field-zones error:", err);
+    return NextResponse.json(
+      { error: "Re-map failed", detail: (err as Error).message },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/ui/light/Field.tsx
+++ b/src/components/ui/light/Field.tsx
@@ -51,7 +51,9 @@ export default function Field() {
           className="absolute inset-[-12%]"
           style={{
             background: gradient,
-            filter: "blur(60px)",
+            // Big-Sur punch: a lighter blur lets the saturated colour read
+            // sharper instead of hazing it back toward cream (was 60px).
+            filter: "blur(46px)",
             transform: "scale(1.2)",
             transformOrigin: "center",
           }}

--- a/src/lib/field/composeGradient.ts
+++ b/src/lib/field/composeGradient.ts
@@ -14,19 +14,23 @@
 import { ZONES, type ZoneId } from "./zones";
 import type { FieldModifiers, FieldZones, ZoneWeight } from "./types";
 
-// ── Field richness dials (warm-but-richer; NO neon, NO dark theme) ──────────
-// The Field used to wash itself out: the linear base dropped 15 saturation /
-// 10 lightness and the coloured hotspots capped low. "Warm but richer" eases
-// that back a notch so the (now drifting) colour reads, while the cream still
-// dominates at rest. These six numbers are the whole richness surface — safe
-// to nudge on-device. Guardrails: keep BASE_DIM ≥ 4 and BLOB_ALPHA ≤ 0.7 so
-// the cream never tips into a saturated wash.
-const BASE_DESAT = 8; // linear-base desaturation (was the hard-coded 15)
-const BASE_DIM = 6; // linear-base dimming (was the hard-coded 10)
-const RADIAL_ALPHA_BOOST = 0.12; // added to each hotspot's alpha …
-const RADIAL_ALPHA_CAP = 0.9; // … then clamped so no hotspot blows to a hard disc
-const BLOB_ALPHA = 0.62; // alpha of the drifting FieldBlobs (the living layer)
-const BLOB_SAT_BOOST = 12; // blobs clearly more saturated than the base so the drift reads
+// ── Field richness dials (full "Big-Sur" punch — owner-requested) ───────────
+// The Field used to hold itself back to stay cream-dominant (the linear base
+// dropped saturation/lightness, the hotspots capped low, the blobs sat at 0.62
+// alpha). The owner wants the opposite now: a vivid, saturated, magenta-→-blue
+// wallpaper feel that leans AWAY from cream. So the base is no longer washed
+// out, the hotspots ride higher, and the drifting blobs are near-opaque and
+// strongly saturated. These six numbers are the whole richness surface — every
+// one is a one-line on-device dial; lower them if a screen reads too hot.
+// (The old "BASE_DIM ≥ 4 / BLOB_ALPHA ≤ 0.7 keep-cream" guardrail is the exact
+// thing being relaxed here — the punch lands in open areas; anthracite text
+// still sits on the 55%-cream backdrop-blur cards, so legibility holds.)
+const BASE_DESAT = 0; // linear-base desaturation (was 8 → now base keeps its colour)
+const BASE_DIM = 3; // linear-base dimming (was 6 → brighter, more colourful base)
+const RADIAL_ALPHA_BOOST = 0.2; // added to each hotspot's alpha …
+const RADIAL_ALPHA_CAP = 0.97; // … then clamped so a hotspot can ride near-solid
+const BLOB_ALPHA = 0.85; // alpha of the drifting FieldBlobs (the living layer)
+const BLOB_SAT_BOOST = 24; // blobs ride near the top of their saturation so the drift pops
 
 interface Hsl {
   h: number; // 0–360 (allowed to go past during interpolation, wrap at render)

--- a/src/lib/field/mapNotesToZones.ts
+++ b/src/lib/field/mapNotesToZones.ts
@@ -39,6 +39,7 @@ const FieldZonesResponseSchema = z.object({
           "nutty-cocoa",
           "spice-earth",
           "sweet-caramel",
+          "cool-berry",
         ]),
         weight: z.number().min(0).max(1),
       }),
@@ -53,8 +54,9 @@ const FieldZonesResponseSchema = z.object({
 const SYSTEM_PROMPT = `You are a perceptual aroma-to-color mapper for a specialty coffee app. Given an array of tasting notes (English or German), you return a JSON object specifying which BrewLog Field Zones the notes map to, with weights, plus optional saturation/lightness modifiers from texture descriptors. Return JSON only, no prose.
 
 Available Field Zones (id : exemplar aromas):
-- fruity-bright : citrus, lemon, orange, grapefruit, mandarin, berry, blueberry, raspberry, cherry, cranberry, peach, apricot, currant, pomegranate
+- fruity-bright : citrus, lemon, orange, grapefruit, mandarin, berry, raspberry, cherry, cranberry, strawberry, redcurrant, peach, apricot, pomegranate
 - fruity-deep : dried fruit, date, raisin, fig, prune, plum, red grape, port, wine, fermented fruit, dark cherry
+- cool-berry : blueberry, blackberry, blackcurrant, cassis, bilberry, huckleberry, boysenberry, dark/wild berry, jammy blue-purple fruit
 - floral : jasmine, rose, hibiscus, bergamot, chamomile, tea, lavender, elderflower, white flowers, floral, perfume
 - nutty-cocoa : chocolate, cocoa, milk chocolate, dark chocolate, nut, almond, hazelnut, walnut, pecan, peanut, roasted, malt
 - spice-earth : cinnamon, clove, cardamom, tobacco, leather, earth, herbs, savoury, spice, woody, cedar, smoke
@@ -76,7 +78,7 @@ Rules:
 - If a note is unfamiliar or non-aromatic (e.g. "rare", "delightful"), ignore it.
 - If ALL notes are unfamiliar, return {"zones": [], "modifiers": {"saturation": 0, "lightness": 0}}.
   The caller will treat empty zones as "fall back to default".
-- German notes are valid input: pflaumig → prune (fruity-deep), nussig → nutty-cocoa, zitronig → citrus (fruity-bright), schokoladig → chocolate (nutty-cocoa).`;
+- German notes are valid input: pflaumig → prune (fruity-deep), nussig → nutty-cocoa, zitronig → citrus (fruity-bright), schokoladig → chocolate (nutty-cocoa), heidelbeere/blaubeere → blueberry (cool-berry), cassis/schwarze johannisbeere → blackcurrant (cool-berry), brombeere → blackberry (cool-berry).`;
 
 /**
  * Run the mapping on a list of notes and return a FieldZones object,

--- a/src/lib/field/schema.ts
+++ b/src/lib/field/schema.ts
@@ -23,6 +23,7 @@ export const ZoneIdSchema = z.enum([
   "nutty-cocoa",
   "spice-earth",
   "sweet-caramel",
+  "cool-berry",
 ]);
 
 export const FieldZonesSchema = z

--- a/src/lib/field/zones.ts
+++ b/src/lib/field/zones.ts
@@ -1,11 +1,14 @@
 /**
  * Generative Field v1.1 — Zone definitions.
  *
- * Six palette specifications within the warm envelope (hues 0–60° and
- * 320–360° per spec §2). Each Zone is a perceptual band defined by
- * hue/saturation/lightness ranges. The composition algorithm samples
- * from these ranges deterministically — given the same FieldZones
- * input, the same colours come out.
+ * Seven palette specifications. Six sit in the original warm envelope
+ * (hues 0–60° and 320–360° per spec §2); `cool-berry` (hues ~250–290°)
+ * is the deliberate exception added for the Big-Sur punch so blueberry /
+ * blackcurrant notes render as real blue-violet instead of orange-red.
+ * Each Zone is a perceptual band defined by hue/saturation/lightness
+ * ranges. The composition algorithm samples from these ranges
+ * deterministically — given the same FieldZones input, the same colours
+ * come out.
  *
  * Zone overlap on the hue axis is intentional (Nutty-Cocoa and Sweet-
  * Caramel both ~30–45°; Fruity-Bright and Fruity-Deep both ~0–30°).
@@ -27,7 +30,8 @@ export type ZoneId =
   | "floral"
   | "nutty-cocoa"
   | "spice-earth"
-  | "sweet-caramel";
+  | "sweet-caramel"
+  | "cool-berry";
 
 export interface Zone {
   id: ZoneId;
@@ -82,6 +86,17 @@ export const ZONES: Record<ZoneId, Zone> = {
     hueRange: [30, 50],
     saturationRange: [70, 95],
     lightnessRange: [60, 80],
+  },
+  // The ONE cool zone — breaks the original "warm envelope" rule on purpose.
+  // Blueberry / blackcurrant / cassis / dark berries were rendering orange-red
+  // through fruity-bright; they belong here as blue-violet→indigo. The wide
+  // lightness span lets this zone be both an electric periwinkle highlight and a
+  // deep-indigo shadow — that magenta-↔-blue contrast is the Big-Sur "pop".
+  "cool-berry": {
+    id: "cool-berry",
+    hueRange: [250, 290],
+    saturationRange: [72, 96],
+    lightnessRange: [40, 80],
   },
 };
 

--- a/src/lib/field/zones.ts
+++ b/src/lib/field/zones.ts
@@ -43,7 +43,8 @@ export const ZONES: Record<ZoneId, Zone> = {
   "fruity-bright": {
     id: "fruity-bright",
     hueRange: [0, 30],
-    saturationRange: [60, 90],
+    // Big-Sur lift: saturation floor pushed up so even the muted end reads vivid.
+    saturationRange: [80, 100],
     lightnessRange: [70, 90],
   },
   "fruity-deep": {
@@ -51,31 +52,35 @@ export const ZONES: Record<ZoneId, Zone> = {
     // sample time so hue arithmetic stays linear.
     id: "fruity-deep",
     hueRange: [350, 375],
-    saturationRange: [50, 75],
+    saturationRange: [68, 92],
     lightnessRange: [50, 70],
   },
   floral: {
     id: "floral",
     hueRange: [320, 355],
-    saturationRange: [40, 70],
+    saturationRange: [62, 90],
     lightnessRange: [70, 88],
   },
+  // nutty-cocoa + spice-earth stay comparatively restrained on purpose — the
+  // Big-Sur drama is the CONTRAST between vivid fruit zones and these deep warm
+  // ones, so a chocolatey Brazilian still reads warm-deep, not neon. Modest lift
+  // only.
   "nutty-cocoa": {
     id: "nutty-cocoa",
     hueRange: [20, 40],
-    saturationRange: [35, 55],
+    saturationRange: [42, 62],
     lightnessRange: [30, 55],
   },
   "spice-earth": {
     id: "spice-earth",
     hueRange: [25, 45],
-    saturationRange: [25, 45],
+    saturationRange: [32, 52],
     lightnessRange: [28, 48],
   },
   "sweet-caramel": {
     id: "sweet-caramel",
     hueRange: [30, 50],
-    saturationRange: [55, 85],
+    saturationRange: [70, 95],
     lightnessRange: [60, 80],
   },
 };

--- a/tests/dataflow/field-gradient.test.mjs
+++ b/tests/dataflow/field-gradient.test.mjs
@@ -75,6 +75,29 @@ test("fieldBlobColors: four blobs, valid hsl, explicit in-range alpha, pure", ()
   }
 });
 
+test("cool-berry renders a real blue-violet hue (not the warm-envelope orange-red)", () => {
+  const blue = {
+    version: 1,
+    zones: [{ id: "cool-berry", weight: 1 }],
+    modifiers: { saturation: 0, lightness: 0 },
+    source: "tasting-notes",
+    computedAt: "1970-01-01T00:00:00.000Z",
+  };
+  const css = composeFieldGradient(blue, 0);
+  // Every colour stop should sit in the cool 250–290° band — proves the new
+  // zone escaped the warm envelope (the whole point of the blueberry fix).
+  const hues = [...css.matchAll(/hsl\((\d+)\s/g)].map((m) => Number(m[1]));
+  assert.ok(hues.length > 0, "expected hsl() stops in the gradient");
+  for (const h of hues) {
+    assert.ok(h >= 248 && h <= 292, `hue ${h}° should be blue-violet (cool-berry)`);
+  }
+  // And its blobs carry the same cool hue.
+  for (const b of fieldBlobColors(blue)) {
+    const h = Number(b.color.match(/hsl\((\d+)\s/)[1]);
+    assert.ok(h >= 248 && h <= 292, `blob hue ${h}° should be blue-violet`);
+  }
+});
+
 test("fieldBlobColors: empty zones → no blobs (caller falls back to the default Field)", () => {
   const empty = { ...DEFAULT_FIELD_ZONES, zones: [] };
   assert.deepEqual(fieldBlobColors(empty), []);

--- a/tests/dataflow/field-gradient.test.mjs
+++ b/tests/dataflow/field-gradient.test.mjs
@@ -4,11 +4,12 @@
 //
 //   node --test tests/dataflow/field-gradient.test.mjs
 //
-// What's locked down: the "warm but richer" refactor must keep
-// composeFieldGradient PURE + deterministic (same coffee → same Field, the
-// invariant that makes a coffee's background stable across devices and
-// re-opens) and the new fieldBlobColors must hand the motion layer four
-// blobs whose alpha stays under the cream-preserving cap.
+// What's locked down: the Field refactor must keep composeFieldGradient PURE +
+// deterministic (same coffee → same Field, the invariant that makes a coffee's
+// background stable across devices and re-opens) and fieldBlobColors must hand
+// the motion layer four blobs that each carry an explicit, in-range alpha. The
+// alpha ceiling tracks the BLOB_ALPHA dial — the old "≤0.7 keep-cream" cap was
+// deliberately relaxed for the Big-Sur punch (owner-requested).
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -58,7 +59,7 @@ test("composeFieldGradient: rotation changes the output (the per-step shift stil
   );
 });
 
-test("fieldBlobColors: four blobs, valid hsl, alpha under the cream-preserving cap, pure", () => {
+test("fieldBlobColors: four blobs, valid hsl, explicit in-range alpha, pure", () => {
   const blobs = fieldBlobColors(DEFAULT_FIELD_ZONES);
   assert.equal(blobs.length, 4);
   assert.deepEqual(blobs, fieldBlobColors(DEFAULT_FIELD_ZONES)); // deterministic
@@ -68,7 +69,9 @@ test("fieldBlobColors: four blobs, valid hsl, alpha under the cream-preserving c
     assert.equal(typeof b.cy, "number");
     const m = b.color.match(/\/\s*([0-9.]+)\s*\)/); // explicit alpha
     assert.ok(m, `blob colour should carry an alpha: ${b.color}`);
-    assert.ok(Number(m[1]) <= 0.7, `alpha ${m?.[1]} should stay ≤ 0.7`);
+    // Blobs stay translucent (< 1) so the base + grain still read through, but
+    // the old 0.7 cream-cap was relaxed for the Big-Sur punch.
+    assert.ok(Number(m[1]) > 0 && Number(m[1]) < 1, `alpha ${m?.[1]} should be in (0, 1)`);
   }
 });
 


### PR DESCRIPTION
The owner wants the generative **Field** background to get the punch of a vivid magenta→hot-pink→electric-blue macOS wallpaper, explicitly tied to fruit flavours (Blueberry, Raspberry, Papaya, Vanilla). Two levers, three commits.

## What changed

**1 — Full Big-Sur intensity** (`composeGradient.ts`, `zones.ts`, `Field.tsx`)
The Field deliberately held itself back to stay cream-dominant. Cranked the six richness dials hard (`BLOB_ALPHA 0.62→0.85`, `BLOB_SAT_BOOST 12→24`, `BASE_DESAT 8→0`, `RADIAL_ALPHA_BOOST 0.12→0.20`, cap `0.9→0.97`, `BASE_DIM 6→3`), lifted the saturation floors of the vivid zones (cocoa/earth kept restrained so the *contrast* carries the look), and dropped the base blur `60px→46px` so colour reads sharper. Applies to **every coffee instantly** — no AI re-run, no DB change.

**2 — New `cool-berry` blue/violet zone** (`zones.ts`, `schema.ts`, `mapNotesToZones.ts`)
The whole palette was warm — a **blueberry** note rendered orange-red, and the system literally couldn't do the wallpaper's blue↔magenta contrast. Added one cool zone at hue 250–290 (blue-violet→indigo, wide lightness span). Blueberry / blackcurrant / cassis / dark-berry exemplars (incl. German heidelbeere/blaubeere/cassis/brombeere) move out of `fruity-bright` into it; raspberry/cherry/strawberry stay warm.

**3 — Re-map tooling** (`/api/admin/remap-field-zones` + `field-zones-remap.yml`)
The blue only appears once a coffee's notes are re-run through the mapper. A CRON_SECRET-gated admin route recomputes `field_zones` for every coffee with bag notes (mirrors the prewarm-coffee-insights pattern), driven by a manual GitHub Action (SSH → container → curl, no new secrets). Dispatched once after this deploys.

## Verification
- `npx tsc --noEmit` clean.
- `node --test` — 115 dataflow + src suites green; new test locks `cool-berry` to a 250–290° hue and the relaxed blob-alpha bound.
- The CI **screenshots** job renders the resting Field on every screen — download the `app-screenshots` artifact to eyeball the new punch before/after merge.

Every dial is a one-line tweak for a fast follow if it should go harder/softer or the blue needs taming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgADgAfX2auGJJPQy1bjgd)_