### PR TITLE
ci(field): fire the field-zones re-map via a trigger-file push

### DIFF
--- a/.github/field-zones-remap-trigger
+++ b/.github/field-zones-remap-trigger
@@ -1,0 +1,5 @@
+# Bump this file (and merge to main) to fire the "Re-map field zones" workflow.
+# The GitHub integration token can't workflow_dispatch via the API, so a push to
+# this path is how the re-map is triggered hands-free. Safe to re-run anytime.
+
+run: 2026-06-29 — initial cool-berry blue re-map after the Big-Sur Field pass

--- a/.github/workflows/field-zones-remap.yml
+++ b/.github/workflows/field-zones-remap.yml
@@ -9,11 +9,19 @@ name: Re-map field zones
 # loading-insights refresh. No new secrets. A missed run is harmless; re-running
 # is safe (it just recomputes the same compositions).
 #
-# Manual only — there's nothing to schedule. Run it once from the Actions tab
-# (or via `gh workflow run`) after the deploy lands.
+# Fires two ways: manually (Actions tab / `gh workflow run`), OR automatically
+# when `.github/field-zones-remap-trigger` changes on main. The trigger-file path
+# exists because the GitHub integration token can't `workflow_dispatch` via the
+# API (403 "Resource not accessible by integration") — bumping that file in a PR
+# and merging is the house-standard way to fire a one-shot job hands-free (same
+# pattern as `.github/ios-build-trigger`).
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/field-zones-remap-trigger"
 
 concurrency:
   group: field-zones-remap


### PR DESCRIPTION
Follow-up to #445. The re-map workflow can only be `workflow_dispatch`-ed, but the GitHub integration token can't dispatch via the API (403 "Resource not accessible by integration"). So this adds a push trigger on `.github/field-zones-remap-trigger` — the same hands-free pattern as `.github/ios-build-trigger`.

Merging this fires the **Re-map field zones** workflow once, which recomputes `field_zones` for every existing coffee so blueberry/blackcurrant bags pick up the new `cool-berry` blue (the Big-Sur intensity is already live for every coffee from #445). Safe to re-run anytime by bumping the trigger file again.

`.github/`-only change — `deploy.yml` ignores `.github/**`, so no redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgADgAfX2auGJJPQy1bjgd)_