### PR TITLE
feat(field): berries render blue + darken grey secondary text

### DIFF
--- a/src/app/(light)/brew/[id]/page.tsx
+++ b/src/app/(light)/brew/[id]/page.tsx
@@ -157,7 +157,7 @@ export default function SessionDetailPage() {
             session detail; coffee name + date sit as context underneath. */}
         <div className={`${sessionCoffee?.bagPhotoUrl ? "absolute bottom-0 left-0 right-0" : ""} p-5`}>
           {mode === "external" && place?.name && (
-            <p className="text-light-foreground/50 text-xs tracking-widest uppercase mb-1">{place.name}</p>
+            <p className="text-light-foreground/75 text-xs tracking-widest uppercase mb-1">{place.name}</p>
           )}
           <div className="flex items-center gap-2">
             <BrewMethodIcon method={method} className="w-6 h-6 opacity-90" />
@@ -172,7 +172,7 @@ export default function SessionDetailPage() {
               {sessionCoffee.roaster ? ` · ${sessionCoffee.roaster}` : ""}
             </p>
           )}
-          <p className="text-light-foreground/40 text-xs mt-0.5">{formatDate(createdAt)}</p>
+          <p className="text-light-foreground/70 text-xs mt-0.5">{formatDate(createdAt)}</p>
         </div>
       </div>
 

--- a/src/app/(light)/coffees/[id]/page.tsx
+++ b/src/app/(light)/coffees/[id]/page.tsx
@@ -238,12 +238,12 @@ export default function CoffeeDetailPage() {
           <BagPhoto url={coffee.bagPhotoUrl} alt={coffee.name}>
             <div className="absolute bottom-0 left-0 right-0 p-5">
               {coffee.process && (
-                <p className="text-light-foreground/50 text-xs tracking-widest uppercase mb-1">{coffee.process}</p>
+                <p className="text-light-foreground/75 text-xs tracking-widest uppercase mb-1">{coffee.process}</p>
               )}
               <h1 className="font-fraunces text-3xl text-light-foreground">{coffee.name}</h1>
               <p className="text-light-foreground/60 text-sm mt-1">{coffee.roaster}{origin ? ` · ${origin}` : ""}</p>
               {roastDate && (
-                <p className="text-light-foreground/40 text-xs mt-0.5">
+                <p className="text-light-foreground/70 text-xs mt-0.5">
                   Roasted {new Date(roastDate).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })}
                 </p>
               )}
@@ -258,12 +258,12 @@ export default function CoffeeDetailPage() {
             </div>
             <div className="pt-4">
               {coffee.process && (
-                <p className="text-light-foreground/50 text-xs tracking-widest uppercase mb-1">{coffee.process}</p>
+                <p className="text-light-foreground/75 text-xs tracking-widest uppercase mb-1">{coffee.process}</p>
               )}
               <h1 className="font-fraunces text-3xl text-light-foreground">{coffee.name}</h1>
               <p className="text-light-foreground/60 text-sm mt-1">{coffee.roaster}{origin ? ` · ${origin}` : ""}</p>
               {roastDate && (
-                <p className="text-light-foreground/40 text-xs mt-0.5">
+                <p className="text-light-foreground/70 text-xs mt-0.5">
                   Roasted {new Date(roastDate).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })}
                 </p>
               )}
@@ -401,7 +401,7 @@ export default function CoffeeDetailPage() {
               )}
               <p className="text-light-foreground/80 text-sm leading-relaxed">{roasterInfo.styleSummary}</p>
               {roasterInfo.notes && (
-                <p className="text-light-foreground/40 text-xs mt-2 leading-relaxed">{roasterInfo.notes}</p>
+                <p className="text-light-foreground/70 text-xs mt-2 leading-relaxed">{roasterInfo.notes}</p>
               )}
             </>
           ) : null}
@@ -576,7 +576,7 @@ function OfflineCoffeeDetail({
 
         <div className={`${identity.bagPhotoUrl ? "absolute bottom-0 left-0 right-0" : ""} p-5`}>
           {identity.process && (
-            <p className="text-light-foreground/50 text-xs tracking-widest uppercase mb-1">{identity.process}</p>
+            <p className="text-light-foreground/75 text-xs tracking-widest uppercase mb-1">{identity.process}</p>
           )}
           <h1 className="font-fraunces text-3xl text-light-foreground">{identity.name}</h1>
           <p className="text-light-foreground/60 text-sm mt-1">

--- a/src/app/(light)/coffees/drip/[id]/page.tsx
+++ b/src/app/(light)/coffees/drip/[id]/page.tsx
@@ -127,7 +127,7 @@ export default function DripBagDetailPage() {
 
         {/* Title overlay */}
         <div className={`${bag.bagPhotoUrl ? "absolute bottom-0 left-0 right-0" : ""} p-5`}>
-          <p className="text-light-foreground/50 text-xs tracking-widest uppercase mb-1">Drip bag</p>
+          <p className="text-light-foreground/75 text-xs tracking-widest uppercase mb-1">Drip bag</p>
           <h1 className="font-fraunces text-3xl text-light-foreground">{bag.name}</h1>
           <p className="text-light-foreground/60 text-sm mt-1">
             {bag.roaster}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -208,7 +208,7 @@
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.14em;
-    color: hsl(0 0% 14% / 0.7);
+    color: hsl(0 0% 14% / 0.9);
   }
 
   /* Light System — suppress @tailwindcss/forms blue focus ring inside the

--- a/src/lib/field/zones.ts
+++ b/src/lib/field/zones.ts
@@ -88,13 +88,15 @@ export const ZONES: Record<ZoneId, Zone> = {
     lightnessRange: [60, 80],
   },
   // The ONE cool zone — breaks the original "warm envelope" rule on purpose.
-  // Blueberry / blackcurrant / cassis / dark berries were rendering orange-red
-  // through fruity-bright; they belong here as blue-violet→indigo. The wide
-  // lightness span lets this zone be both an electric periwinkle highlight and a
-  // deep-indigo shadow — that magenta-↔-blue contrast is the Big-Sur "pop".
+  // Blueberry / blackberry / blackcurrant / cassis are BERRIES → real BLUE
+  // (owner: "blue for berries; purple is for grape/plum"). Hue ~210–244 is
+  // azure→cornflower→blue-violet (midpoint ~227 = a clean blue), NOT the purple
+  // 250–290 it used to be. Wide lightness span = electric cornflower highlight →
+  // deep indigo shadow; that blue-↔-magenta contrast is the Big-Sur "pop".
+  // Grape/plum stay warm-red in fruity-deep for now (no separate purple zone).
   "cool-berry": {
     id: "cool-berry",
-    hueRange: [250, 290],
+    hueRange: [210, 244],
     saturationRange: [72, 96],
     lightnessRange: [40, 80],
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -49,7 +49,11 @@ const config: Config = {
         // cream Glass.
         light: {
           foreground: "hsl(0 0% 14% / <alpha-value>)",
-          "muted-foreground": "hsl(0 0% 40% / <alpha-value>)",
+          // Owner ask (round 2): the light-grey secondary text was hard to read
+          // on the now-saturated Field — make it dark/near-black (was 40% grey).
+          // Pill text never uses this token (pills use `text-on-dark` cream), so
+          // darkening it globally is safe.
+          "muted-foreground": "hsl(0 0% 16% / <alpha-value>)",
           "card-default": "hsl(36 55% 96% / 0.55)",
           "card-selected": "hsl(28 22% 84% / 0.7)",
           // Cream label that sits on `bg-light-foreground` (anthracite)

--- a/tests/dataflow/field-gradient.test.mjs
+++ b/tests/dataflow/field-gradient.test.mjs
@@ -75,7 +75,7 @@ test("fieldBlobColors: four blobs, valid hsl, explicit in-range alpha, pure", ()
   }
 });
 
-test("cool-berry renders a real blue-violet hue (not the warm-envelope orange-red)", () => {
+test("cool-berry renders a real BLUE hue (berries are blue, not purple)", () => {
   const blue = {
     version: 1,
     zones: [{ id: "cool-berry", weight: 1 }],
@@ -84,17 +84,17 @@ test("cool-berry renders a real blue-violet hue (not the warm-envelope orange-re
     computedAt: "1970-01-01T00:00:00.000Z",
   };
   const css = composeFieldGradient(blue, 0);
-  // Every colour stop should sit in the cool 250–290° band — proves the new
-  // zone escaped the warm envelope (the whole point of the blueberry fix).
+  // Every colour stop should sit in the blue 210–244° band (+ small hue offsets
+  // some layers/blobs add) — proves berries read blue, not the old purple 250+.
   const hues = [...css.matchAll(/hsl\((\d+)\s/g)].map((m) => Number(m[1]));
   assert.ok(hues.length > 0, "expected hsl() stops in the gradient");
   for (const h of hues) {
-    assert.ok(h >= 248 && h <= 292, `hue ${h}° should be blue-violet (cool-berry)`);
+    assert.ok(h >= 206 && h <= 246, `hue ${h}° should be blue (cool-berry)`);
   }
-  // And its blobs carry the same cool hue.
+  // And its blobs carry the same blue hue.
   for (const b of fieldBlobColors(blue)) {
     const h = Number(b.color.match(/hsl\((\d+)\s/)[1]);
-    assert.ok(h >= 248 && h <= 292, `blob hue ${h}° should be blue-violet`);
+    assert.ok(h >= 206 && h <= 246, `blob hue ${h}° should be blue`);
   }
 });
 


### PR DESCRIPTION
Two quick owner-requested fixes after the Big-Sur Field went live (round 2, part 1 of 2 — the Field "murmuration" rework follows as a separate PR).

## Berries blue, not purple
`cool-berry` was hue 250–290 (reads purple). Owner: *"blue for berries; purple is for grape/plum."* Retuned to hue **210–244** (cornflower/azure, midpoint ~227). Blueberry / blackberry / blackcurrant / cassis now read **blue**; grape/plum stay warm-red in `fruity-deep`. It's a pure hue retune (hues are read live from `zones.ts`), so it applies to **every coffee instantly — no re-map**. Test hue band updated.

## Dark secondary text
The light-grey `light-muted-foreground` (40% grey) was hard to read on the now-saturated Field. Darkened the token to **16% near-black** — verified safe because grey is never used inside a dark pill (pills use the cream `text-on-dark` token). Also: `.label-eyebrow` 0.7→0.9, and raised the faint `text-light-foreground/40`–`/50` eyebrows/dates/notes on the coffee / brew / drip detail pages to `/70`–`/75`. Left decorative icons, unselected-state styles, and the loading wordmark untouched.

`tsc` clean; field-gradient tests green (incl. the updated blue-hue assertion). iOS shell picks this up automatically on deploy (web-only, nothing native).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgADgAfX2auGJJPQy1bjgd)_