### PR TITLE
feat(field): directional flowing gradients + murmuration motion + rotating combos

### DIFF
--- a/docs/liquid-design.md
+++ b/docs/liquid-design.md
@@ -17,10 +17,19 @@
 
 *Updated at the end of every advancing session. Read this first.*
 
-- **Shipped & live:** living Field background (static base gradient + 4 drifting colour blobs +
-  film grain + finger-following bloom) and the liquid welcome-haiku (shimmer → scattered
-  per-word spring entrance → soft dissolve → per-word touch lens). All motion is on the GPU
-  compositor; React is never in the per-frame loop. Reduced-motion gracefully static.
+- **Shipped & live:** living Field background (directional diagonal base + soft corner masses +
+  pale light-ribbon, with colour masses riding ONE shared slow "murmuration" sweep) and the
+  liquid welcome-haiku (shimmer → scattered per-word spring entrance → soft dissolve → per-word
+  touch lens). All motion is on the GPU compositor; React is never in the per-frame loop.
+  Reduced-motion gracefully static.
+- **Last tuned (2026-06-29, "Big-Sur + murmuration"):** Field cranked to full saturation; berries
+  recoloured blue (cool-berry hue 210–244); the composition rebuilt from 5 scattered radial
+  hotspots → a directional diagonal blend + 2 corner masses + a pale light-ribbon
+  (`composeGradient.ts`); the 4 independent blob drifts → all masses on one shared `field-flow`
+  sweep (120 s) + small per-mass `murmur-*` drift (`FieldBlobs.tsx`); general/home backgrounds
+  cycle through `CURATED_FIELDS` (2–3-flavour combos) per app-open (`curatedFields.ts` +
+  `FieldContext.tsx`). Dials: `field-flow` amplitude/period + disc size/blur in `FieldBlobs.tsx`;
+  the base angle + mass/ribbon positions in `composeGradient.ts`.
 - **Last tuned (2026-06-12):** extracted the haiku entrance into a reusable `LiquidHeadline` —
   the Hero questions ("What are you brewing today?", "What's the vibe?") now scatter in, and the
   recipe-crafting screen dropped the bean glow + "Did you know?" for a big rotating insight

--- a/src/components/ui/light/FieldBlobs.tsx
+++ b/src/components/ui/light/FieldBlobs.tsx
@@ -4,94 +4,114 @@ import { useMemo } from "react";
 import { fieldBlobColors } from "@/lib/field/composeGradient";
 import type { FieldZones } from "@/lib/field/types";
 
-// Co-prime-ish durations + negative start-delays so the four drifts never sit
-// at 0% together and the composite doesn't visibly re-sync.
-const DRIFT = [
-  "blobflow-1 23s ease-in-out -6s infinite",
-  "blobflow-2 29s ease-in-out -15s infinite",
-  "blobflow-3 26s ease-in-out -4s infinite",
-  "blobflow-4 33s ease-in-out -21s infinite",
+// Round-2 rework — "murmuration". The old version drifted four discs on
+// independent co-prime timers, which read as scattered blobs ("too crazy
+// bunt"). Now ALL masses ride one SHARED slow sweep (`field-flow`) so they move
+// together like a flock and the whole colour field slowly turns direction
+// (diagonal → vertical → other diagonal) over a long cycle. Each mass adds only
+// a small, slow individual drift (`murmur-*`) for gentle internal life — the
+// dominant motion stays coherent. Bigger + softer discs than before so they
+// dissolve into one continuous directional gradient, not dots.
+//
+// Keyframes are co-located HERE (styled-jsx global), never globals.css — an
+// installed PWA serves a stale cached globals.css and the motion would silently
+// die (see docs/liquid-design.md). data-field-blob marks the animated nodes so
+// the reduced-motion block in globals.css can freeze them.
+
+// Small per-mass drifts: long, low-amplitude, varied so the flock shimmers
+// without breaking the shared sweep's coherence.
+const MURMUR = [
+  "murmur-1 41s ease-in-out -7s infinite",
+  "murmur-2 47s ease-in-out -19s infinite",
+  "murmur-3 43s ease-in-out -3s infinite",
+  "murmur-4 53s ease-in-out -28s infinite",
 ];
 
-/**
- * The drifting colour blobs of the living Field. The keyframes are co-located
- * HERE (styled-jsx global) — the same path as the haiku entrance, which renders
- * reliably — instead of globals.css, so an installed PWA can never animate the
- * blobs against a stale cached stylesheet (the cause of "haiku moves, blobs
- * dead"). Three nested layers: the outer leans from the --field-* vars, the
- * middle runs the transform-only drift keyframe (GPU compositor, no filter), the
- * inner is the blurred colour disc — painted once and merely moved. Tuned big
- * and slow (large discs, wide vmax travel, 23–33s cycles) for a STARIS-style
- * mesh that flows in large areas across the pale field. See docs/liquid-design.md
- * ("Tuning dials") to push the scale further — colours are NOT a dial here.
- */
 export default function FieldBlobs({ fieldZones }: { fieldZones: FieldZones }) {
   const blobs = useMemo(() => fieldBlobColors(fieldZones), [fieldZones]);
 
   return (
     <>
       <style jsx global>{`
-        @keyframes blobflow-1 {
+        /* The shared murmuration sweep — slow, coordinated, turns direction. */
+        @keyframes field-flow {
+          0% { transform: translate3d(-8vmax, 5vmax, 0) rotate(-9deg) scale(1.05); }
+          25% { transform: translate3d(6vmax, -4vmax, 0) rotate(5deg) scale(1.12); }
+          50% { transform: translate3d(9vmax, 7vmax, 0) rotate(10deg) scale(1.06); }
+          75% { transform: translate3d(-5vmax, -6vmax, 0) rotate(-4deg) scale(1.13); }
+          100% { transform: translate3d(-8vmax, 5vmax, 0) rotate(-9deg) scale(1.05); }
+        }
+        /* Per-mass internal life — small amplitude so the flock stays coherent. */
+        @keyframes murmur-1 {
           0% { transform: translate3d(0, 0, 0) scale(1); }
-          33% { transform: translate3d(30vmax, -24vmax, 0) scale(1.24); }
-          66% { transform: translate3d(-24vmax, 30vmax, 0) scale(0.82); }
+          50% { transform: translate3d(7vmax, -6vmax, 0) scale(1.08); }
           100% { transform: translate3d(0, 0, 0) scale(1); }
         }
-        @keyframes blobflow-2 {
-          0% { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
-          50% { transform: translate3d(-26vmax, -32vmax, 0) rotate(14deg) scale(1.22); }
-          100% { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
-        }
-        @keyframes blobflow-3 {
+        @keyframes murmur-2 {
           0% { transform: translate3d(0, 0, 0) scale(1); }
-          40% { transform: translate3d(24vmax, 30vmax, 0) scale(1.16); }
-          75% { transform: translate3d(-28vmax, -24vmax, 0) scale(0.84); }
+          50% { transform: translate3d(-8vmax, 6vmax, 0) scale(0.93); }
           100% { transform: translate3d(0, 0, 0) scale(1); }
         }
-        @keyframes blobflow-4 {
-          0% { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
-          50% { transform: translate3d(28vmax, -26vmax, 0) rotate(-12deg) scale(1.26); }
-          100% { transform: translate3d(0, 0, 0) rotate(0deg) scale(1); }
+        @keyframes murmur-3 {
+          0% { transform: translate3d(0, 0, 0) scale(1); }
+          50% { transform: translate3d(6vmax, 7vmax, 0) scale(1.07); }
+          100% { transform: translate3d(0, 0, 0) scale(1); }
+        }
+        @keyframes murmur-4 {
+          0% { transform: translate3d(0, 0, 0) scale(1); }
+          50% { transform: translate3d(-7vmax, -7vmax, 0) scale(0.94); }
+          100% { transform: translate3d(0, 0, 0) scale(1); }
         }
       `}</style>
-      {blobs.map((b, i) => (
+      {/* Lean wrapper — follows the finger via the --field-* vars (whole field
+          leans together, which reinforces the coordinated feel). */}
+      <div
+        className="absolute inset-0"
+        style={{
+          transform:
+            "translate(var(--field-drift-x, 0px), var(--field-drift-y, 0px)) rotate(var(--field-tilt, 0deg)) scale(calc(1 + var(--field-pulse, 0) * 0.05))",
+        }}
+      >
+        {/* Shared sweep — carries every mass together (the murmuration). */}
         <div
-          key={i}
-          aria-hidden
-          className="absolute"
+          data-field-blob
+          className="absolute inset-0"
           style={{
-            left: `${b.cx}%`,
-            top: `${b.cy}%`,
-            transform:
-              "translate(var(--field-drift-x, 0px), var(--field-drift-y, 0px)) rotate(var(--field-tilt, 0deg)) scale(calc(1 + var(--field-pulse, 0) * 0.05))",
+            transformOrigin: "50% 50%",
+            willChange: "transform",
+            animation: "field-flow 120s ease-in-out infinite",
           }}
         >
-          <div
-            data-field-blob
-            style={{
-              position: "absolute",
-              left: 0,
-              top: 0,
-              willChange: "transform",
-              animation: DRIFT[i % DRIFT.length],
-            }}
-          >
+          {blobs.map((b, i) => (
             <div
+              key={i}
+              data-field-blob
+              aria-hidden
+              className="absolute"
               style={{
-                position: "absolute",
-                left: 0,
-                top: 0,
-                width: "78vmax",
-                height: "78vmax",
-                transform: "translate(-50%, -50%)",
-                borderRadius: "50%",
-                background: `radial-gradient(circle, ${b.color} 0%, transparent 68%)`,
-                filter: "blur(38px)",
+                left: `${b.cx}%`,
+                top: `${b.cy}%`,
+                willChange: "transform",
+                animation: MURMUR[i % MURMUR.length],
               }}
-            />
-          </div>
+            >
+              <div
+                style={{
+                  position: "absolute",
+                  left: 0,
+                  top: 0,
+                  width: "104vmax",
+                  height: "104vmax",
+                  transform: "translate(-50%, -50%)",
+                  borderRadius: "50%",
+                  background: `radial-gradient(circle, ${b.color} 0%, transparent 64%)`,
+                  filter: "blur(56px)",
+                }}
+              />
+            </div>
+          ))}
         </div>
-      ))}
+      </div>
     </>
   );
 }

--- a/src/lib/field/FieldContext.tsx
+++ b/src/lib/field/FieldContext.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
 import { DEFAULT_FIELD_ZONES } from "./defaultZones";
+import { getGeneralField } from "./curatedFields";
 import type { FieldZones } from "./types";
 
 /**
@@ -50,6 +51,16 @@ export function FieldProvider({ children }: { children: ReactNode }) {
   const [config, setConfig] = useState<FieldConfig>(DEFAULT_CONFIG);
   const setFieldConfig = useCallback((next: FieldConfig) => setConfig(next), []);
 
+  // On the client, swap the static default for this app-open's curated combo —
+  // but only if no page has already set its own Field (child page effects run
+  // before this parent effect, so a coffee page that called useFieldConfig has
+  // already replaced the default and we leave it). SSR keeps the static default
+  // → no hydration mismatch.
+  useEffect(() => {
+    const general = getGeneralField();
+    setConfig((prev) => (prev === DEFAULT_CONFIG ? { fieldZones: general, rotation: 0 } : prev));
+  }, []);
+
   return (
     <FieldContext.Provider value={{ ...config, setFieldConfig }}>{children}</FieldContext.Provider>
   );
@@ -71,9 +82,11 @@ export function useFieldConfig(config: FieldConfig | null | undefined): void {
     if (stableZones) {
       setFieldConfig({ fieldZones: stableZones, rotation: stableRotation });
     } else {
-      setFieldConfig(DEFAULT_CONFIG);
+      setFieldConfig({ fieldZones: getGeneralField(), rotation: 0 });
     }
-    return () => setFieldConfig(DEFAULT_CONFIG);
+    // Reset to the general curated combo (not the static default) on unmount, so
+    // leaving a coffee page lands the general backgrounds on a nice combo.
+    return () => setFieldConfig({ fieldZones: getGeneralField(), rotation: 0 });
     // Re-run when the actual zones or rotation change. Object identity
     // is a fine equality proxy because callers either pass a stable
     // reference or a freshly-derived one only when the underlying

--- a/src/lib/field/composeGradient.ts
+++ b/src/lib/field/composeGradient.ts
@@ -157,58 +157,42 @@ export function composeFieldGradient(fieldZones: FieldZones, rotationDeg = 0): s
   const z1: ZoneWeight = zones[1] ?? zones[0];
   const z2: ZoneWeight | null = zones[2] ?? null;
 
-  // ── Layer 1 — linear base (135° rotated by rotationDeg) ──────────
-  // Three-stop interpolation across the top-3 weighted zones, dim and
-  // desaturated. With <3 zones we pad by repeating the highest.
-  const baseAngle = (135 + rotationDeg) % 360;
-  const baseTops: ZoneWeight[] = [z0, z1, z2 ?? z0];
-  const baseStops = baseTops.map((zw, i) => {
-    const baseColour = sampleZone(zw.id, 0.5, 0.5, 0.5);
-    const dimmed: Hsl = {
-      h: baseColour.h,
-      s: clamp(baseColour.s - BASE_DESAT, 0, 100),
-      l: clamp(baseColour.l - BASE_DIM, 0, 100),
-    };
-    const final = applyMods(dimmed, mods);
-    const pos = baseTops.length === 1 ? 0 : (i * 100) / (baseTops.length - 1);
-    return `${hslToCss(final)} ${pos.toFixed(0)}%`;
-  });
-  const layer1 = `linear-gradient(${baseAngle.toFixed(0)}deg, ${baseStops.join(", ")})`;
+  // ── DIRECTIONAL composition (the "Mac wallpaper" structure) ───────
+  // Round-2 rework: the old version scattered FIVE small radial hotspots,
+  // which read as spotty "too crazy bunt" blobs. Replaced by a broad
+  // DIAGONAL blend of the 2–3 dominant zones meeting along ONE soft seam,
+  // edge-to-edge — plus two large corner masses that anchor that seam and a
+  // pale light-ribbon sweeping across (the lilac highlight in the reference).
+  // Up to 3 colours (coffee bags list ~3 flavours), but arranged as gradients,
+  // not dots. The living motion lives in FieldBlobs (coordinated murmuration).
 
-  // ── Layer 2 — bottom-left hotspot ─────────────────────────────────
-  const l2Colour = applyMods(sampleZone(z0.id, 0.5, 1.0, 0.5), mods);
-  const l2Pos = rotatePos(12, 92, rotationDeg);
-  const layer2 = `radial-gradient(circle at ${l2Pos.x.toFixed(0)}% ${l2Pos.y.toFixed(0)}%, ${hslToCss(l2Colour, boostAlpha(0.8))} 0%, transparent 60%)`;
+  // Base — diagonal sweep z0 → z1 → (faint z2). Full strength (BASE_* small).
+  const baseAngle = (118 + rotationDeg) % 360;
+  const baseDim = (h: Hsl): Hsl =>
+    applyMods({ h: h.h, s: clamp(h.s - BASE_DESAT, 0, 100), l: clamp(h.l - BASE_DIM, 0, 100) }, mods);
+  const cA = baseDim(sampleZone(z0.id, 0.5, 0.85, 0.52));
+  const cB = baseDim(sampleZone(z1.id, 0.5, 0.85, 0.6));
+  const cC = z2 ? baseDim(sampleZone(z2.id, 0.5, 0.7, 0.6)) : cB;
+  const layerBase = `linear-gradient(${baseAngle.toFixed(0)}deg, ${hslToCss(cA)} 0%, ${hslToCss(cB)} 58%, ${hslToCss(cC)} 100%)`;
 
-  // ── Layer 3 — mid-right warm ──────────────────────────────────────
-  const l3Colour = applyMods(sampleZone(z1.id, 0.5, 0.5, 1.0), mods);
-  const l3Pos = rotatePos(95, 45, rotationDeg);
-  const layer3 = `radial-gradient(circle at ${l3Pos.x.toFixed(0)}% ${l3Pos.y.toFixed(0)}%, ${hslToCss(l3Colour, boostAlpha(0.7))} 0%, transparent 50%)`;
+  // Corner mass A — deepen one end, set the diagonal seam (large + soft).
+  const massA = applyMods(sampleZone(z0.id, 0.5, 1.0, 0.5), mods);
+  const massAPos = rotatePos(16, 86, rotationDeg);
+  const layerMassA = `radial-gradient(circle at ${massAPos.x.toFixed(0)}% ${massAPos.y.toFixed(0)}%, ${hslToCss(massA, boostAlpha(0.78))} 0%, transparent 72%)`;
 
-  // ── Layer 4 — mid-left anchor ─────────────────────────────────────
-  // Third zone if present, else echo of highest with hue rotated +10°.
-  const l4Colour = z2
-    ? applyMods(sampleZone(z2.id, 0.5, 0.5, 1.0), mods)
-    : applyMods(sampleZone(z0.id, 0.5, 0.5, 1.0, /* hueOffset */ 10), mods);
-  const l4Pos = rotatePos(18, 50, rotationDeg);
-  const layer4 = `radial-gradient(circle at ${l4Pos.x.toFixed(0)}% ${l4Pos.y.toFixed(0)}%, ${hslToCss(l4Colour, boostAlpha(0.85))} 0%, transparent 55%)`;
+  // Corner mass B — the second dominant colour into the opposite corner.
+  const massB = applyMods(sampleZone(z1.id, 0.5, 0.95, 0.62), mods);
+  const massBPos = rotatePos(88, 24, rotationDeg);
+  const layerMassB = `radial-gradient(circle at ${massBPos.x.toFixed(0)}% ${massBPos.y.toFixed(0)}%, ${hslToCss(massB, boostAlpha(0.68))} 0%, transparent 66%)`;
 
-  // ── Layer 5 — upper-mid cool mauve ────────────────────────────────
-  const l5Colour = applyMods(sampleZone(z0.id, 0.5, 0.0, 1.0), mods);
-  const l5Pos = rotatePos(55, 25, rotationDeg);
-  const layer5 = `radial-gradient(circle at ${l5Pos.x.toFixed(0)}% ${l5Pos.y.toFixed(0)}%, ${hslToCss(l5Colour, boostAlpha(0.55))} 0%, transparent 50%)`;
+  // Pale light-ribbon — broad soft highlight sweeping diagonally (depth).
+  const ribbon = applyMods({ h: sampleZone(z0.id, 0.5, 0.5, 0.5).h, s: 38, l: 90 }, mods);
+  const ribbonPos = rotatePos(58, 20, rotationDeg);
+  const layerRibbon = `radial-gradient(ellipse 78% 50% at ${ribbonPos.x.toFixed(0)}% ${ribbonPos.y.toFixed(0)}%, ${hslToCss(ribbon, 0.55)} 0%, transparent 60%)`;
 
-  // ── Layer 6 — top-right highlight (the "lit ceiling") ─────────────
-  const l6Colour = applyMods(sampleZone(z0.id, 0.5, 1.0, 1.0), mods);
-  const l6Pos = rotatePos(92, 8, rotationDeg);
-  const layer6 = `radial-gradient(circle at ${l6Pos.x.toFixed(0)}% ${l6Pos.y.toFixed(0)}%, ${hslToCss(l6Colour)} 0%, transparent 60%)`;
-
-  // CSS stacks gradients top-to-bottom in source order. Spec §2.1 lists
-  // Layer 1 as the base (painted first, at the bottom), Layer 6 as the
-  // top highlight (painted last, on top). CSS background-image is
-  // *reverse* painter — the first item in the comma list paints last
-  // (on top). So we list Layer 6 FIRST and Layer 1 LAST.
-  return [layer6, layer5, layer4, layer3, layer2, layer1].join(", ");
+  // CSS background-image is reverse-painter (first item = on top): ribbon
+  // over the two masses over the diagonal base.
+  return [layerRibbon, layerMassB, layerMassA, layerBase].join(", ");
 }
 
 export interface FieldBlob {

--- a/src/lib/field/curatedFields.ts
+++ b/src/lib/field/curatedFields.ts
@@ -1,0 +1,105 @@
+/**
+ * Curated general-background Field compositions.
+ *
+ * The home screen (and every general/non-coffee background) used to render one
+ * static default composition. The owner wants it to "present the colours of the
+ * flavours in a changing manner — not one pattern with ALL colours, always nice
+ * combinations, like the Mac desktop." So instead of one fixed palette, the
+ * general background picks one of these hand-curated 2–3-flavour combos, and
+ * advances to the next one each time the app is opened.
+ *
+ * Each combo leans into a few zones that look good together as a DIRECTIONAL
+ * blend (the composition + motion live in composeGradient/FieldBlobs) — never a
+ * muddy all-colours mix. Coffee bags list ~3 flavours, so 2–3 zones is the
+ * natural count; the elegance comes from the pairing + the directional flow, not
+ * from cutting colours.
+ *
+ * Pure data + a per-app-open picker. Deterministic per load (module-memoized),
+ * SSR-safe (returns the static default on the server so there's no hydration
+ * mismatch — the client effect swaps in the curated pick on mount).
+ */
+
+import { DEFAULT_FIELD_ZONES } from "./defaultZones";
+import type { FieldZones } from "./types";
+
+const SENTINEL = "1970-01-01T00:00:00.000Z";
+
+function field(zones: FieldZones["zones"]): FieldZones {
+  return {
+    version: 1,
+    zones,
+    modifiers: { saturation: 0, lightness: 0 },
+    source: "default",
+    computedAt: SENTINEL,
+  };
+}
+
+// Hand-picked elegant pairings. Names in comments are the flavour read.
+export const CURATED_FIELDS: FieldZones[] = [
+  // Blue + magenta — the reference wallpaper (blueberry meets floral).
+  field([
+    { id: "cool-berry", weight: 0.5 },
+    { id: "floral", weight: 0.5 },
+  ]),
+  // Raspberry + vanilla.
+  field([
+    { id: "fruity-bright", weight: 0.55 },
+    { id: "sweet-caramel", weight: 0.45 },
+  ]),
+  // Blueberry + caramel — cool/warm contrast.
+  field([
+    { id: "cool-berry", weight: 0.5 },
+    { id: "sweet-caramel", weight: 0.5 },
+  ]),
+  // Plum + caramel.
+  field([
+    { id: "fruity-deep", weight: 0.5 },
+    { id: "sweet-caramel", weight: 0.5 },
+  ]),
+  // Peach + jasmine + honey.
+  field([
+    { id: "fruity-bright", weight: 0.4 },
+    { id: "floral", weight: 0.35 },
+    { id: "sweet-caramel", weight: 0.25 },
+  ]),
+  // Berry + floral + caramel.
+  field([
+    { id: "cool-berry", weight: 0.4 },
+    { id: "floral", weight: 0.35 },
+    { id: "sweet-caramel", weight: 0.25 },
+  ]),
+  // Cocoa + cherry — a warm, deep one.
+  field([
+    { id: "nutty-cocoa", weight: 0.5 },
+    { id: "fruity-deep", weight: 0.5 },
+  ]),
+  // Pink + red — floral meets bright fruit.
+  field([
+    { id: "floral", weight: 0.5 },
+    { id: "fruity-bright", weight: 0.5 },
+  ]),
+];
+
+const STORAGE_KEY = "btts.field.rotation.v1";
+
+let memo: FieldZones | null = null;
+
+/**
+ * The general-background composition for this app load. Advances by one each
+ * time the app is opened (a localStorage counter), so every launch lands on the
+ * next nice combo; stays stable while you navigate (module-memoized). SSR-safe:
+ * returns the static default on the server, where there's no localStorage.
+ */
+export function getGeneralField(): FieldZones {
+  if (memo) return memo;
+  if (typeof window === "undefined") return DEFAULT_FIELD_ZONES;
+  let n = 0;
+  try {
+    n = parseInt(window.localStorage.getItem(STORAGE_KEY) ?? "0", 10) || 0;
+    window.localStorage.setItem(STORAGE_KEY, String((n + 1) % 1_000_000));
+  } catch {
+    // Private mode / storage disabled — fall through with n = 0.
+  }
+  memo = CURATED_FIELDS[((n % CURATED_FIELDS.length) + CURATED_FIELDS.length) % CURATED_FIELDS.length];
+  return memo;
+}

--- a/tests/dataflow/field-gradient.test.mjs
+++ b/tests/dataflow/field-gradient.test.mjs
@@ -28,6 +28,9 @@ export { composeFieldGradient, fieldBlobColors } from ${JSON.stringify(
 export { DEFAULT_FIELD_ZONES } from ${JSON.stringify(
   path.join(ROOT, "src/lib/field/defaultZones.ts"),
 )};
+export { CURATED_FIELDS } from ${JSON.stringify(
+  path.join(ROOT, "src/lib/field/curatedFields.ts"),
+)};
 `;
 const dir = await mkdtemp(join(tmpdir(), "field-"));
 const out = join(dir, "f.mjs");
@@ -39,16 +42,18 @@ await build({
   outfile: out,
   logLevel: "silent",
 });
-const { composeFieldGradient, fieldBlobColors, DEFAULT_FIELD_ZONES } = await import(
+const { composeFieldGradient, fieldBlobColors, DEFAULT_FIELD_ZONES, CURATED_FIELDS } = await import(
   pathToFileURL(out).href
 );
 
-test("composeFieldGradient: 6-layer string, pure + deterministic", () => {
+test("composeFieldGradient: directional string (1 linear base + 3 radials), pure + deterministic", () => {
   const a = composeFieldGradient(DEFAULT_FIELD_ZONES, 0);
   const b = composeFieldGradient(DEFAULT_FIELD_ZONES, 0);
   assert.equal(typeof a, "string");
   assert.equal(a, b); // same input → identical output
-  assert.equal((a.match(/radial-gradient/g) || []).length, 5);
+  // Round-2 directional rework: a diagonal linear base + two corner masses + a
+  // pale light-ribbon (was 5 scattered radial hotspots).
+  assert.equal((a.match(/radial-gradient/g) || []).length, 3);
   assert.equal((a.match(/linear-gradient/g) || []).length, 1);
 });
 
@@ -95,6 +100,20 @@ test("cool-berry renders a real BLUE hue (berries are blue, not purple)", () => 
   for (const b of fieldBlobColors(blue)) {
     const h = Number(b.color.match(/hsl\((\d+)\s/)[1]);
     assert.ok(h >= 206 && h <= 246, `blob hue ${h}° should be blue`);
+  }
+});
+
+test("CURATED_FIELDS: each is a valid 2–3-zone combo that composes deterministically", () => {
+  assert.ok(CURATED_FIELDS.length >= 4, "expected several curated combos");
+  for (const f of CURATED_FIELDS) {
+    assert.ok(f.zones.length >= 2 && f.zones.length <= 3, "2–3 zones (elegant, not all-colours)");
+    const sum = f.zones.reduce((a, z) => a + z.weight, 0);
+    assert.ok(Math.abs(sum - 1) < 0.001, `weights sum to 1 (got ${sum})`);
+    const css = composeFieldGradient(f, 0);
+    assert.equal(typeof css, "string");
+    assert.equal(css, composeFieldGradient(f, 0)); // deterministic
+    assert.equal((css.match(/radial-gradient/g) || []).length, 3);
+    assert.equal((css.match(/linear-gradient/g) || []).length, 1);
   }
 });
 


### PR DESCRIPTION
Round 2, part 2. After the Big-Sur saturation went live, the Field read "too crazy bunt" and spotty. The Mac wallpaper it's modelled on is only **2–3 colours** arranged as **broad directional gradients** meeting along a soft diagonal seam, flowing as one coherent mass — a **murmuration** — not scattered blobs. This reworks how the Field composes and moves.

## What changed
- **`composeGradient.ts` — directional, not spotty.** The 5 scattered radial hotspots → a diagonal linear blend of the 2–3 dominant zones + two large soft corner masses that anchor one diagonal seam + a pale light-ribbon highlight (the lilac sweep in the reference). Up to 3 colours (bags list ~3 flavours) but arranged as gradients. Keeps the round-1 saturation.
- **`FieldBlobs.tsx` — murmuration.** The 4 independently-drifting discs → all masses ride **one shared slow sweep** (`field-flow`, 120 s) so they move together and the whole field slowly turns direction; each mass adds only a small slow `murmur-*` drift for gentle internal life. Bigger, softer discs that dissolve into one continuous gradient. Keyframes stay co-located (PWA stale-cache rule); animated nodes tagged `data-field-blob` for reduced-motion.
- **`curatedFields.ts` + `FieldContext.tsx` — rotating combos.** `CURATED_FIELDS` = 8 elegant 2–3-flavour pairings; `getGeneralField()` advances one per app-open (localStorage, module-memoized, SSR-safe). Every general/non-coffee background (home, library, taste, cafés) now cycles; coffee pages still override with their own colours, rendered in the new directional style.

`tsc` clean; 159 tests green (gradient layer count + curated-combo validity updated). Web-only → reaches the iOS shell on deploy, nothing native.

**This is the iterative one** — every value is a one-line dial (`field-flow` amplitude/period, disc size/blur, base angle, mass/ribbon positions). Easy to tune harder/softer/slower once it's seen on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BgADgAfX2auGJJPQy1bjgd)_