### PR TITLE
feat: spike round 3 — variation-stress (Summer Time, fast shot, volume capacity)

### DIFF
--- a/.github/recommend-spike-trigger
+++ b/.github/recommend-spike-trigger
@@ -1,3 +1,3 @@
 # Bump this file (any change) on main to fire .github/workflows/recommend-spike.yml.
 # Route-around for Claude Code, whose token can't dispatch workflow_dispatch.
-# Run 1 — broadened: 6 beans, Mistral x2, full prose + cost summary
+# Run 2 — variation-stress: Summer Time, Time=special, volumes 210/450/520 + capacity/ice detector

--- a/docs/recommend-spike-run2.md
+++ b/docs/recommend-spike-run2.md
@@ -1,0 +1,493 @@
+<!-- Generierter Spike-Report (scripts/recommend-model-spike.mjs, Lauf #2). Nicht von Hand editieren. -->
+
+# /recommend — Modellvergleich (Spike, breit)
+Generiert: 2026-06-30T10:36:26.801Z
+
+6 Bohnen-Profile. Gleicher echter Prompt (SYSTEM_PROMPT + injizierter Korpus) an alle Modelle. Mistral läuft 2× pro Bohne (Schwankung sichtbar machen), die Claude-Baselines 1×. `drift` = objektiver Fabrikations-Detektor (reconcileToReference): wich das Modell beim `basedOn`-Referenzrezept in Grind/Temp/Zeit ab. `staged-temp` = verbotene Mehrtemperatur. Jedes Rezept steht unten im Volltext.
+
+
+---
+
+## Washed Ethiopian, light, very fresh — goal high-clarity
+
+| Modell | Kandidat | Methode | basedOn | Dose | Water | Ratio | Temp | Grind | Zeit | staged | drift |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| Opus | Restricted-flow clarity anchor | Orea Apex | Own recipe | 22g | 350g | 1:15.9 | 95°C | 405° | 3:30 | nein | — |
+| Opus | Fast flat-bed transparency | Origami (wave) | Du 2019 — Origami Wave | 23g | 350g | 1:15.2 | 94°C | 402° | 3:00 | nein | — |
+| Mistral·r1 | Apex Floral Precision | Orea Apex | Own recipe (inspired by Du 2019 Origami Wave) | 22g | 350g | 1:15.9 | 95°C | 405° | 3:30 | nein | — |
+| Mistral·r1 | Immersion Clarity Test | Clever Dripper | Own recipe (inspired by Hoffmann Clever Extended) | 22g | 350g | 1:15.9 | 96°C | 425° | 4:00 | nein | — |
+| Mistral·r2 | Apex Floral Isolation | Orea Apex | Own recipe (inspired by Du 2019 Origami Wave) | 23g | 350g | 1:15.2 | 95°C | 405° | 3:30 | nein | — |
+| Mistral·r2 | Hedrick High-Extraction Test | V60 | Hedrick High-Extraction V60 (LH Variation) | 23g | 350g | 1:15.2 | 98°C | 398° | 3:20 | nein | — |
+| Sonnet | Apex Clarity Percolation | Orea Apex | Orea Apex clarity | 21g | 336g | 1:16.0 | 95°C | 404° | 3:30 | nein | — |
+| Sonnet | Extended Immersion Clarity Test | Clever Dripper | Clever Extended | 20g | 300g | 1:15.0 | 93°C | 424° | 5:30 | nein | — |
+
+<details><summary><b>Volltext der Rezepte Washed Ethiopian, light, very fresh — goal high-clarity</b></summary>
+
+
+#### Opus 4-7 (status quo)
+> You're meeting a peak-window Friedhats Yirgacheffe on the clarity blend — the lot Hendon's water chemistry was practically written for — so the real question this morning isn't whether to chase clarity but HOW: do you want it through Gagné's longer-contact restricted-flow route (Apex) or Du's fast flat-bed route (Origami wave)? Watch how the florals behave between the two cups.
+
+**Restricted-flow clarity anchor** — Orea Apex · basedOn: Own recipe
+Rezept: 22g : 350g (1:15.9) · 95°C · Grind 405° · 3:30
+- *Warum:* The most restricted Orea bottom plus minimal agitation gives the longest, most even contact for full extraction without turbulence.
+- *Hypothese:* Restricted drawdown + bloom-only agitation lets a high-density Yirgacheffe reach full Zone-2 extraction while the slow, calm flow preserves fragile Zone-1 florals.
+- *Erwartete Tasse:* Translucent, tea-like body with jasmine and bergamot in the foreground, lemon acidity opening as it cools.
+- *Worauf achten:* Whether the cup keeps its floral lift all the way down the cup or fades into a generic citrus middle — fading means the Apex is over-restricting at this grind.
+- *pourSteps:* 1) Bloom (bloom, 50g, 45s) — Slow spiral from centre out — wet every ground  2) Light stir (stir, 5s) — 1–2 gentle passes to settle the bed, then leave it alone  3) Pour 2 (pour, 160g, 25s) — Gentle spiral, keep off the wall  4) Pour 3 (pour, 260g, 25s)  5) Final pour (final, 350g, 25s)  6) Drawdown (drain, 85s)
+
+**Fast flat-bed transparency** — Origami (wave) · basedOn: Du 2019 — Origami Wave
+Rezept: 23g : 350g (1:15.2) · 94°C · Grind 402° · 3:00
+- *Warum:* A shallow flat bed with fast, even drawdown tests a totally different extraction physics than the Apex — short contact, high evenness.
+- *Hypothese:* A thin Kalita-wave bed in a fast-draining Origami extracts evenly in a short window — keeping the cup bright and transparent rather than building depth.
+- *Erwartete Tasse:* Sharper, more linear acidity than the Apex; vivid lemon and bergamot up front, lighter body, faster finish.
+- *Worauf achten:* Whether you prefer the Apex's longer, rounder floral arc or the Origami's brighter, sharper attack — this tells you which extraction profile suits this lot.
+- *pourSteps:* 1) Bloom (bloom, 60g, 40s) — Saturate evenly, swirl once gently to settle  2) Pour 2 (pour, 170g, 20s) — Flat-bed spiral, no wall contact  3) Rest (wait, 15s) — Let surface draw to a moist sheen  4) Pour 3 (pour, 260g, 20s)  5) Final pour (final, 350g, 20s)  6) Drawdown (drain, 65s)
+
+
+#### Mistral Large 3 (sovereign)
+> This washed Yirgacheffe’s defining tension is balancing its high solubility with its fragility—its jasmine and bergamot notes extract early (Zone 1) but dissipate quickly under turbulence or extended contact, per Gagné’s solubility sequence. You’ll test two contrasting methods: Orea Apex’s slow percolation with minimal agitation to preserve clarity, and Clever Dripper’s immersion to see if full saturation can extract the florals without muddying them. Watch how each method handles the coffee’s volatility as it cools.
+
+**Apex Floral Precision** — Orea Apex · basedOn: Own recipe (inspired by Du 2019 Origami Wave)
+Rezept: 22g : 350g (1:15.9) · 95°C · Grind 405° · 3:30
+- *Warum:* Orea Apex’s restricted flow and minimal agitation are ideal for preserving the delicate florals of this washed Ethiopian.
+- *Hypothese:* A slow, even percolation with near-zero turbulence will extract the jasmine and bergamot notes cleanly while avoiding astringency.
+- *Erwartete Tasse:* A tea-like cup with pronounced jasmine and bergamot aromatics, lemon brightness, and a silky mouthfeel.
+- *Worauf achten:* How the aromatics evolve as the coffee cools—do they sharpen or fade?
+- *pourSteps:* 1) Bloom (bloom, 45g, 45s) — Slow spiral from centre out, wet all grounds evenly  2) Light stir (stir, 3s) — 1–2 gentle stirs to settle the bed—no turbulence  3) Pour 2 (pour, 150g, 30s) — Centre-focused, avoid the walls  4) Pour 3 (pour, 250g, 30s) — Spiral outward to the edge  5) Final pour (final, 350g, 30s) — Fill to 350g, no agitation after this point  6) Drawdown (drain, 72s)
+
+**Immersion Clarity Test** — Clever Dripper · basedOn: Own recipe (inspired by Hoffmann Clever Extended)
+Rezept: 22g : 350g (1:15.9) · 96°C · Grind 425° · 4:00
+- *Warum:* Clever Dripper’s immersion method tests whether full saturation can extract the coffee’s florals without the turbulence of percolation.
+- *Hypothese:* A controlled immersion with gentle swirls will extract the jasmine and bergamot notes evenly, avoiding the channeling risk of percolation.
+- *Erwartete Tasse:* A rounder, more integrated cup with the same floral notes but slightly more body than the Orea Apex.
+- *Worauf achten:* Does the immersion method preserve the clarity of the florals, or does it introduce muddiness?
+- *pourSteps:* 1) Pour water (pour, 350g, 15s) — Add all water in one go, centre-focused  2) Swirl (swirl, 5s) — Gentle swirl to saturate all grounds  3) Steep (wait, 200s) — Let the coffee steep undisturbed  4) Swirl (swirl, 5s) — Gentle swirl to refresh the bed  5) Drain (drain, 15s) — Place on a cup and open the valve
+
+
+#### Sonnet 4-6 (cheaper Claude)
+> This washed Yirgacheffe heirloom puts Gagné's Zone 1 solubility sequence front and centre: jasmine and bergamot aromatics are the first compounds to dissolve and the first to volatilize above 95°C or under turbulence, so both candidates are built around preserving that fragile top layer — the single thing to watch is whether those florals arrive vivid and intact, or whether they read muted, which tells you exactly where the extraction is failing.
+
+**Apex Clarity Percolation** — Orea Apex · basedOn: Orea Apex clarity
+Rezept: 21g : 336g (1:16.0) · 95°C · Grind 404° · 3:30
+- *Warum:* The Orea Apex's most-restricted bottom plate maximizes contact time and bed evenness without any agitation, which is precisely what a fragile washed Yirgacheffe's Zone 1 aromatics need to survive to the cup.
+- *Hypothese:* A slow, even percolation through the Apex bottom with minimal agitation will extract Zone 1 jasmine and bergamot aromatics fully while the 95°C ceiling and clarity-blend water prevent buffering from flattening them.
+- *Erwartete Tasse:* Transparent, tea-like cup with vivid jasmine and bergamot in the top notes, bright lemon acidity in the mid-palate, and a clean, light body that lets the floral register dominate.
+- *Worauf achten:* Whether the jasmine and bergamot arrive clearly in the aroma and first sip, or whether the cup feels bright but thin — that tells you if Zone 1 was fully developed or if the contact time still fell short.
+- *pourSteps:* 1) Bloom (bloom, 42g, 45s) — Slow spiral from centre out — wet every ground evenly, no aggression  2) Stir (stir, 5s) — Light 1–2× stir only — just enough to settle the bloom bed flat  3) Pour 2 (pour, 140g, 25s) — Steady central spiral, keep the pour gentle and even  4) Pour 3 (pour, 238g, 25s) — Same gentle spiral — no turbulence at the bed surface  5) Final pour (final, 336g, 25s) — Finish with a flat, unhurried spiral — let the bed settle cleanly  6) Drawdown (drain, 85s) — Apex bottom restricts flow — allow full passive drain, no swirl
+
+**Extended Immersion Clarity Test** — Clever Dripper · basedOn: Clever Extended
+Rezept: 20g : 300g (1:15.0) · 93°C · Grind 424° · 5:30
+- *Warum:* Full immersion extracts compounds simultaneously rather than sequentially, which tests whether this coffee's sweetness and body can emerge alongside its florals — a genuinely different extraction physics from the Apex percolation.
+- *Hypothese:* A 5-minute immersion at 93°C in a closed vessel will allow even, unhurried extraction of both Zone 1 aromatics and Zone 2 sweetness compounds, with the lower temperature protecting delicate florals from volatilizing during the longer contact.
+- *Erwartete Tasse:* Rounder, slightly fuller body than the Apex with bergamot and lemon still present but integrated into a more tea-like sweetness — less knife-edge clarity, more complete cup weight.
+- *Worauf achten:* Whether the extended immersion adds perceptible sweetness and body relative to the Apex, or whether it merely softens the florals without adding anything — that comparison tells you how much this coffee gives to immersion methods.
+- *pourSteps:* 1) Pour water (pour, 300g, 15s) — Pour all 300g in a steady spiral — valve closed, full immersion begins now  2) Swirl (swirl, 5s) — Gentle swirl to wet all grounds evenly — never stir, the filter will collapse  3) Steep (wait, 240s) — Lid on, leave undisturbed — full immersion doing its work  4) Swirl (swirl, 5s) — One gentle swirl before opening the valve  5) Drain (drain, 65s) — Open valve onto your cup — clean, even drain through the paper
+
+</details>
+
+---
+
+## Natural Brazil, medium-light, mid-age — goal balanced
+
+| Modell | Kandidat | Methode | basedOn | Dose | Water | Ratio | Temp | Grind | Zeit | staged | drift |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| Opus | Active V60 Baseline | V60 | Kasuya 4:6 | 23g | 350g | 1:15.2 | 93°C | 414° | 3:30 | nein | — |
+| Opus | Hoffmann Immersion Contrast | Clever Dripper | Hoffmann Ultimate Clever | 23g | 350g | 1:15.2 | 96°C | 424° | 4:00 | nein | — |
+| Mistral·r1 | Apex Clarity Baseline | Orea Apex | Own recipe (inspired by April's style and Wölfl's Orea Apex clarity focus) | 23g | 350g | 1:15.2 | 95°C | 405° | 3:30 | nein | — |
+| Mistral·r1 | Kasuya 4:6 Sweetness Dial | V60 (no Assist) | Kasuya 4:6 (adapted for natural process and April's agitation sensitivity) | 23g | 350g | 1:15.2 | 92°C | 408° | 3:45 | nein | — |
+| Mistral·r2 | Apex Clarity Baseline | Orea Apex | Own recipe | 23g | 350g | 1:15.2 | 96°C | 405° | 3:30 | nein | — |
+| Mistral·r2 | Clever Sweetness Immersion | Clever Dripper | Hoffmann Ultimate Clever | 23g | 350g | 1:15.2 | 95°C | 420° | 4:30 | nein | — |
+| Sonnet | Kasuya Phase-Separated V60 | V60 | Kasuya 2016 — 4:6 Method | 20g | 300g | 1:15.0 | 93°C | 415° | 3:30 | nein | — |
+| Sonnet | Hoffmann Immersion Sweetness Build | Clever Dripper | Hoffmann Ultimate Clever | 20g | 300g | 1:15.0 | 93°C | 425° | 5:00 | nein | ⚠️ total time 300s vs published 240s (±48s allowed); temp 93° vs published 100° |
+
+<details><summary><b>Volltext der Rezepte Natural Brazil, medium-light, mid-age — goal balanced</b></summary>
+
+
+#### Opus 4-7 (status quo)
+> You're meeting this Daterra Yellow Bourbon for the first time, and the interesting tension is that April's clarity-house-style prior is pulling one way while a Brazilian natural at 24 days with chocolate/hazelnut bag notes is pulling another — so following Gagné's solubility logic, I've set up a percolation-vs-immersion comparison at identical ratio so you can hear what this coffee actually wants. Watch which cup carries the sweetness.
+
+**Active V60 Baseline** — V60 · basedOn: Kasuya 4:6
+Rezept: 23g : 350g (1:15.2) · 93°C · Grind 414° · 3:30
+- *Warum:* Tests whether April's clarity-forward technique still serves a chocolate-leaning Brazilian natural at a 1:15.2 ratio.
+- *Hypothese:* Phase-separated pours at 93°C will keep fermentation esters in check while the strength phase builds peach and chocolate sweetness from Zone 2.
+- *Erwartete Tasse:* Clean cup with peach acidity up front, milk chocolate mid-palate, hazelnut on the finish, medium body.
+- *Worauf achten:* Does the cup feel hollow (push grind to 411°) or muddy/winey (back to 416° and gentler swirl)?
+- *pourSteps:* 1) Bloom (bloom, 70g, 45s) — Pour to 70g in slow spiral, gentle swirl to wet evenly  2) Pour 2 (acid phase) (pour, 140g, 10s) — Steady centre-out spiral  3) Rest (wait, 35s)  4) Pour 3 (strength) (pour, 210g, 10s)  5) Rest (wait, 25s)  6) Pour 4 (pour, 280g, 10s)  7) Rest (wait, 15s)  8) Final pour (final, 350g, 10s)  9) Drawdown (drain, 50s)
+
+**Hoffmann Immersion Contrast** — Clever Dripper · basedOn: Hoffmann Ultimate Clever
+Rezept: 23g : 350g (1:15.2) · 96°C · Grind 424° · 4:00
+- *Warum:* Tests how this natural reads under full immersion — body and sweetness without the agitation of pour-over.
+- *Hypothese:* Water-first immersion at 96°C with a 2-minute steep will extract Zone 2 sugars evenly, giving more body and rounded chocolate than the V60 baseline.
+- *Erwartete Tasse:* Heavier body, dominant milk chocolate and hazelnut, peach softer and more integrated, less acidic lift.
+- *Worauf achten:* Compare side-by-side: which cup is sweeter? Which has more clarity? That tells you what this coffee wants.
+- *pourSteps:* 1) Pour water first (pour, 350g, 15s) — Off the boil into empty Clever, valve closed  2) Add coffee + stir to mix (stir, 5s) — Pour 23g grounds on top, single gentle stir to submerge  3) Steep (wait, 120s)  4) Break the crust (swirl, 5s) — Gentle swirl to break crust  5) Settle (wait, 30s)  6) Drain onto carafe (drain, 65s)
+
+
+#### Mistral Large 3 (sovereign)
+> This Yellow Bourbon Natural from Daterra sits at the intersection of varietal delicacy and process-driven sweetness, demanding a portfolio that tests how method choice shapes the balance between origin clarity and fermentation notes—grounded in Kasuya's phase-separated extraction theory and April's clarity-focused roaster style, the key thing to watch is whether the cup's sweetness feels integrated or dominated by the natural process's esters.
+
+**Apex Clarity Baseline** — Orea Apex · basedOn: Own recipe (inspired by April's style and Wölfl's Orea Apex clarity focus)
+Rezept: 23g : 350g (1:15.2) · 95°C · Grind 405° · 3:30
+- *Warum:* Orea Apex is April's signature method for clarity, and its restricted flow maximizes contact time without over-agitating the natural process's soluble sugars.
+- *Hypothese:* The Apex's slow, even extraction will highlight the Yellow Bourbon's delicate honey and peach notes while keeping fermentation esters in check, producing a transparent yet sweet cup.
+- *Erwartete Tasse:* Clean, tea-like clarity with pronounced peach and hazelnut, moderate body, and a lingering honeyed sweetness—fermentation notes will be present but integrated, not dominant.
+- *Worauf achten:* Notice how the peach and hazelnut notes separate in the cup—do they feel distinct or muddled?
+- *pourSteps:* 1) Bloom (bloom, 46g, 45s) — Gentle swirl to saturate evenly—avoid stirring to prevent channeling  2) Swirl (swirl, 5s) — Light swirl to settle the bed, no vigorous agitation  3) Pour 2 (pour, 140g, 30s) — Slow, steady spiral from center to edge  4) Pour 3 (pour, 235g, 30s) — Maintain even flow, avoid disturbing the bed  5) Final pour (final, 350g, 30s) — Gentle top-up, keep water level consistent  6) Drawdown (drain, 30s) — Let the Apex's restricted flow do the work—no agitation
+
+**Kasuya 4:6 Sweetness Dial** — V60 (no Assist) · basedOn: Kasuya 4:6 (adapted for natural process and April's agitation sensitivity)
+Rezept: 23g : 350g (1:15.2) · 92°C · Grind 408° · 3:45
+- *Warum:* Kasuya 4:6's phase-separated pouring lets you dial sweetness independently of acidity, ideal for exploring the natural process's fermentation sugars without over-extracting.
+- *Hypothese:* The 4:6 method's strength phase (last 60%) will amplify the natural process's honey and peach sweetness, while the cooler 92°C temp and swirl-not-stir agitation prevent fermentation esters from turning volatile.
+- *Erwartete Tasse:* Rounded, juicy peach sweetness with a creamy hazelnut body, moderate acidity, and a balanced chocolate finish—fermentation notes will be present but smooth, not sharp.
+- *Worauf achten:* Pay attention to how the cup's sweetness evolves—does it feel integrated or does the peach note dominate?
+- *pourSteps:* 1) Bloom (bloom, 46g, 45s) — Gentle swirl to saturate—no stir, per April's agitation sensitivity  2) Pour 2 (Acid/Sweet Phase) (pour, 140g, 30s) — Slow, steady pour to the edge—this phase controls brightness  3) Pour 3 (Acid/Sweet Phase) (pour, 210g, 30s) — Maintain even flow, avoid disturbing the bed  4) Pour 4 (Strength Phase) (pour, 280g, 30s) — This phase builds body and sweetness—pour gently  5) Final pour (Strength Phase) (final, 350g, 30s) — Top up evenly, keep water level consistent  6) Drawdown (drain, 15s) — Let the V60's natural flow finish the brew
+
+
+#### Sonnet 4-6 (cheaper Claude)
+> This Brazilian Natural Yellow Bourbon at 24 days demands a first-brew question rather than a first-brew answer — Kasuya's phase-separated structure will tell you where in the solubility sequence (Gagné) this coffee lives, while Hoffmann's immersion build tests whether its maillard sweetness needs contact time that percolation's faster drawdown cuts short; the single variable to track across both cups is body weight and whether the milk chocolate note feels developed or truncated.
+
+**Kasuya Phase-Separated V60** — V60 · basedOn: Kasuya 2016 — 4:6 Method
+Rezept: 20g : 300g (1:15.0) · 93°C · Grind 415° · 3:30
+- *Warum:* Kasuya's phase-separated structure lets you read this coffee's acid/sweet axis and body independently in one brew, which is exactly what a characterization session needs.
+- *Hypothese:* Separating the first 40% (brightness and sweetness from Zone 1–2 acids and sugars) from the last 60% (body and strength from Zone 2–3 maillard compounds) will reveal where this Yellow Bourbon's character peaks — whether it's in the bright peach notes or in the chocolate body.
+- *Erwartete Tasse:* Soft peach acidity up front, rolling into milk chocolate sweetness and hazelnut body with a clean finish — medium weight, balanced.
+- *Worauf achten:* Notice whether the cup tastes brighter and fruitier or rounder and chocolatey — that tells you which phase this coffee lives in and where to push next session.
+- *pourSteps:* 1) Pour 1 — Acid/Sweet A (bloom, 60g, 10s) — First pour doubles as the bloom — gentle spiral from centre out  2) Wait (wait, 25s) — Let the bed degas quietly — no agitation  3) Gentle swirl (swirl, 5s) — One soft swirl at about 0:30 to level the bed — no vigorous stir  4) Pour 2 — Acid/Sweet B (pour, 120g, 10s) — Steady spiral pour — keep it gentle  5) Wait (wait, 35s) — Let the first 40% drain down before entering the strength phase  6) Pour 3 — Strength 1 (pour, 180g, 10s) — Even spiral — bed should be nearly drained before each pour  7) Wait (wait, 20s) — Short rest between strength pours  8) Pour 4 — Strength 2 (pour, 240g, 10s) — Same even spiral  9) Wait (wait, 20s) — Short rest  10) Pour 5 — Strength 3 (final, 300g, 10s) — Final pour — same pace  11) Drawdown (drain, 55s) — Total brew time ~3:30 — watch the drawdown speed as a grind indicator
+
+**Hoffmann Immersion Sweetness Build** — Clever Dripper · basedOn: Hoffmann Ultimate Clever
+Rezept: 20g : 300g (1:15.0) · 93°C · Grind 425° · 5:00 · ⚠️ drift: total time 300s vs published 240s (±48s allowed); temp 93° vs published 100°
+- *Warum:* Full immersion holds all the water against the grounds for the same contact time, which is a fundamentally different extraction mechanism than percolation — it builds more even sweetness and body from this Natural's sugar compounds without the agitation risk.
+- *Hypothese:* Holding 93°C water in contact with the grounds for a controlled 5-minute immersion will extract deeply into Zone 2 sugar and maillard territory, building the milk chocolate and hazelnut body that percolation's faster drawdown might skim past.
+- *Erwartete Tasse:* Rounder and heavier than the Kasuya — more milk chocolate forward, softer peach, creamy hazelnut body, lower perceived acidity.
+- *Worauf achten:* Notice the body and mouthfeel versus the Kasuya — if this cup is noticeably richer and rounder, this coffee responds well to immersion; if it feels flat or muddy, percolation is the better home.
+- *pourSteps:* 1) Water first (pour, 300g, 15s) — Pour 300g of 93°C water into the Clever before adding coffee — this is the Workshop Coffee water-first technique  2) Add coffee and stir (stir, 5s) — Add 20g coffee on top of the water, gentle stir to wet all grounds evenly — never a vigorous stir  3) Steep (wait, 175s) — Leave undisturbed — full immersion does the work  4) Swirl to break crust (swirl, 5s) — Single gentle swirl to break the grounds crust on the surface  5) Settle (wait, 35s) — Let grounds sink before placing on the carafe  6) Drain (drain, 65s) — Place on carafe and let drain — water-first means this should be fast and clean
+
+</details>
+
+---
+
+## Washed Kenyan SL28, light, fresh — goal body-forward
+
+| Modell | Kandidat | Methode | basedOn | Dose | Water | Ratio | Temp | Grind | Zeit | staged | drift |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| Opus | Origami Wave Body Build | Origami (wave) | Own recipe | 23g | 350g | 1:15.2 | 96°C | 401° | 3:30 | nein | — |
+| Opus | Hoffmann Clever Full Immersion | Clever Dripper | Own recipe | 23g | 350g | 1:15.2 | 95°C | 423° | 5:00 | nein | — |
+| Mistral·r1 | Deep Bed Sweetness | Origami Air M | Own recipe | 23g | 350g | 1:15.2 | 96°C | 403° | 3:30 | nein | — |
+| Mistral·r1 | Immersion Body Control | Clever Dripper | Own recipe | 23g | 350g | 1:15.2 | 95°C | 421° | 5:00 | nein | — |
+| Mistral·r2 | Deep-Bed Immersion Body | Origami Air M | Own recipe | 23g | 350g | 1:15.2 | 96°C | 403° | 4:00 | nein | — |
+| Mistral·r2 | Turbulent Fast-Drain Clarity | Orea Fast | Wölfl 2024 Orea FAST | 23g | 350g | 1:15.2 | 98°C | 408° | 2:30 | nein | — |
+| Sonnet | Flat-Bed SL28 Body Build | Origami Air M | Origami Air M sweet | 23g | 345g | 1:15.0 | 96°C | 405° | 3:00 | nein | — |
+| Sonnet | Full-Immersion SL28 Depth | Clever Dripper | Clever Extended | 23g | 345g | 1:15.0 | 94°C | 424° | 5:30 | nein | — |
+
+<details><summary><b>Volltext der Rezepte Washed Kenyan SL28, light, fresh — goal body-forward</b></summary>
+
+
+#### Opus 4-7 (status quo)
+> Your first brew of a Kenyan SL28 from Nyeri at peak freshness, asking for body — so the science question is geometry, not parameters: as Hoffmann frames it, immersion and percolation produce structurally different cups from the same coffee, and SL28's density rewards extended contact in both. Watch the mid-palate weight across the two cups, because that's where the body actually lives.
+
+**Origami Wave Body Build** — Origami (wave) · basedOn: Own recipe
+Rezept: 23g : 350g (1:15.2) · 96°C · Grind 401° · 3:30
+- *Warum:* Wave filter on the Origami gives a flat, even bed with longer contact than a cone — body without muddiness.
+- *Hypothese:* Flat-bed geometry + four-pour cadence at 96°C extends Zone-2 sugar/maillard extraction on dense SL28 without invading Zone 3.
+- *Erwartete Tasse:* Round, syrupy body with blackcurrant intact, savoury depth, red-wine finish on the cooling cup.
+- *Worauf achten:* Notice mouthfeel weight on the mid-palate and whether the finish lingers or drops off quickly.
+- *pourSteps:* 1) Bloom (bloom, 50g, 40s) — Wet all grounds evenly, slow circles  2) Swirl (swirl, 5s) — Gentle swirl to settle the bed — never stir a wave filter  3) Pour 2 (pour, 150g, 25s) — Slow spiral, keep water off the filter wall  4) Pour 3 (pour, 250g, 25s)  5) Final pour (final, 350g, 25s)  6) Drawdown (drain, 90s)
+
+**Hoffmann Clever Full Immersion** — Clever Dripper · basedOn: Own recipe
+Rezept: 23g : 350g (1:15.2) · 95°C · Grind 423° · 5:00
+- *Warum:* Full immersion gives every ground equal contact with all the water — the deepest body extraction physics available to you for 350ml.
+- *Hypothese:* Hoffmann-style immersion at 95°C over a 5-minute total brew pulls full sugar and texture development from dense SL28 without the percolation channeling risk that limits body.
+- *Erwartete Tasse:* Heavier, more syrupy than the Origami; tomato and red-wine notes more present than vivid blackcurrant; long, weighty finish.
+- *Worauf achten:* Compare side-by-side: does the immersion cup feel heavier on the tongue, and does it sacrifice any of the bright blackcurrant top note?
+- *pourSteps:* 1) Pour water (pour, 350g, 20s) — Pour all 350g in one steady stream over the grounds  2) Swirl (swirl, 5s) — Gentle swirl to fully submerge the grounds and break any crust  3) Steep (wait, 130s) — Let it sit — extraction is happening passively  4) Swirl (swirl, 5s) — Halfway swirl to redistribute the bed and even out extraction  5) Steep (wait, 80s) — Continue steeping until ready to drain  6) Drain (drain, 60s) — Place on cup to release the valve — drain into the server
+
+
+#### Mistral Large 3 (sovereign)
+> Kiriga SL28’s high density and washed process create a tension between its intense savory complexity and the body-forward goal—SL28 can handle aggressive extraction, but its acidity risks becoming harsh if Zone 3 compounds dominate. Perger’s agitation theory suggests that controlled contact time (Origami Air M) or full immersion (Clever Dripper) will build body without over-extraction, while the daily 220ppm water’s moderate buffering will round the acidity slightly. Watch how the two methods balance body and clarity in the cup.
+
+**Deep Bed Sweetness** — Origami Air M · basedOn: Own recipe
+Rezept: 23g : 350g (1:15.2) · 96°C · Grind 403° · 3:30
+- *Warum:* Origami Air M’s deep, flat bed and extended contact time are ideal for building body in high-density washed coffees like SL28.
+- *Hypothese:* The deep bed and moderate agitation will extract Zone 2 sweetness and body compounds efficiently, while the 3:30 total time avoids Zone 3 harshness.
+- *Erwartete Tasse:* Rich, syrupy body with pronounced blackcurrant sweetness and a lingering tomato-like savory finish.
+- *Worauf achten:* How the body develops in the mid-palate and whether the savory notes remain balanced or become muddled.
+- *pourSteps:* 1) Bloom (bloom, 50g, 45s) — Gentle spiral from center out, saturate all grounds evenly  2) Stir (stir, 5s) — Light stir 1–2× to settle the bed  3) Pour 2 (pour, 150g, 30s) — Slow, steady spiral to maintain bed depth  4) Pour 3 (pour, 250g, 30s) — Keep the bed flat and even  5) Final pour (final, 350g, 30s) — Gentle swirl after final pour to level the bed  6) Drawdown (drain, 30s)
+
+**Immersion Body Control** — Clever Dripper · basedOn: Own recipe
+Rezept: 23g : 350g (1:15.2) · 95°C · Grind 421° · 5:00
+- *Warum:* Clever Dripper’s full immersion and controlled steep time allow precise extraction of body and sweetness without agitation-induced harshness.
+- *Hypothese:* The 5-minute immersion will extract ample body and sweetness, while the coarse grind and gentle swirls prevent over-extraction of Zone 3 compounds.
+- *Erwartete Tasse:* Smooth, velvety body with a pronounced blackcurrant sweetness and a clean, savory finish.
+- *Worauf achten:* Whether the immersion method preserves the coffee’s savory complexity while enhancing body.
+- *pourSteps:* 1) Pour water (pour, 15s) — Add all water in one go, saturate evenly  2) Swirl (swirl, 5s) — Gentle swirl to settle the bed  3) Steep (wait, 240s) — Let the coffee steep undisturbed  4) Swirl (swirl, 5s) — Gentle swirl to break the crust  5) Drain (drain, 35s) — Place on a cup and let it drain fully
+
+
+#### Sonnet 4-6 (cheaper Claude)
+> SL28's defining tension on a first body-forward brew is that its high density and solubility (Gagné's solubility sequence) mean Zone 2 body compounds are genuinely accessible — but the 220ppm daily water's bicarbonate buffering partially mutes the blackcurrant, so both candidates must build body through extraction physics rather than rely on mineral lift; watch whether the mouthfeel reads as round-savoury or tips toward astringent across these two fundamentally different contact geometries.
+
+**Flat-Bed SL28 Body Build** — Origami Air M · basedOn: Origami Air M sweet
+Rezept: 23g : 345g (1:15.0) · 96°C · Grind 405° · 3:00
+- *Warum:* The Origami Air M's deep flat bed and full ridged walls create maximum even contact per gram, exactly what body-forward extraction on a dense washed variety needs.
+- *Hypothese:* A shallow-agitation flat bed on the Air M will hold water in the Zone 2 sugar-maillard window long enough to build savoury body without tipping into Zone 3 phenolics.
+- *Erwartete Tasse:* Full-bodied blackcurrant and tomato with a savoury-sweet mid-register, moderate brightness kept in check by the 96°C ceiling and the 220ppm water's buffering
+- *Worauf achten:* Notice whether the body feels round and savoury-sweet or tips toward astringency — that is the Zone 2 / Zone 3 boundary for this lot
+- *pourSteps:* 1) Bloom (bloom, 46g, 40s) — Slow spiral to wet all grounds evenly — SL28 is dense, take the full 40s  2) Stir (stir, 5s) — 1–2 light strokes to break any dry clumps — no vigorous agitation  3) Pour 2 (pour, 138g, 25s) — Steady spiral, keep the bed flat  4) Pour 3 (pour, 240g, 25s) — Continue same gentle spiral  5) Final Pour (final, 345g, 25s) — Finish with a slow pour to keep the bed surface undisturbed  6) Drawdown (drain, 60s) — Watch the drawdown pace — target full drain by 3:00
+
+**Full-Immersion SL28 Depth** — Clever Dripper · basedOn: Clever Extended
+Rezept: 23g : 345g (1:15.0) · 94°C · Grind 424° · 5:30
+- *Warum:* Immersion physics are fundamentally different from percolation — every gram of SL28 steeps in the same water for the full 5:30 contact time, which builds body through uniform prolonged extraction rather than through bed geometry.
+- *Hypothese:* A 5:30 immersion at 94°C will drive Zone 2 extraction uniformly across the whole bed, producing a heavier, rounder body than the Air M percolation while the lower temperature restrains Zone 3 phenolics.
+- *Erwartete Tasse:* Heavier mouthfeel than the Air M, more red-wine and savoury depth, lower acidity, with some sweetness from extended sugar contact — this is the richer end of what SL28 can offer
+- *Worauf achten:* Compare mouthfeel weight and the savoury depth directly against the Air M — if this feels muddy rather than full, the steep is too long or the grind is too fine
+- *pourSteps:* 1) Pour (pour, 345g, 15s) — Pour steadily over all the grounds — no need to be gentle, immersion is forgiving  2) Swirl (swirl, 5s) — Gentle circular swirl to ensure full saturation — never stir  3) Steep (wait, 260s) — Lid on; all grounds stay submerged for the full 4:20 — this is where body builds  4) Swirl (swirl, 5s) — Short swirl to re-suspend any settled fines before drain  5) Drain (drain, 45s) — Set on cup and let gravity drain — do not press or agitate
+
+</details>
+
+---
+
+## Geisha, Panama, light, fresh — goal aromatic
+
+| Modell | Kandidat | Methode | basedOn | Dose | Water | Ratio | Temp | Grind | Zeit | staged | drift |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| Opus | Apex Aromatic Restraint | Orea Apex | Orea Apex clarity | 22g | 350g | 1:15.9 | 94°C | 405° | 3:30 | nein | — |
+| Opus | Du-Style Wave Transparency | Origami (wave) | Du 2019 — Origami Wave | 23g | 345g | 1:15.0 | 94°C | 402° | 2:45 | nein | — |
+| Mistral·r1 | Du-Adapted Wave Clarity | Origami (wave) | Du 2019 — Origami Wave | 22g | 330g | 1:15.0 | 94°C | 398° | 2:45 | nein | — |
+| Mistral·r1 | Jura Ultra-Short Aromatic | AeroPress | Jura 2009 — Ultra-Short AeroPress | 19g | 190g | 1:10.0 | 75°C | 388° | 0:15 | nein | — |
+| Mistral·r2 | Championship Clarity Apex | Orea Apex | Own recipe (inspired by Manhattan’s Geisha protocol) | 23g | 350g | 1:15.2 | 96°C | 403° | 3:30 | nein | — |
+| Mistral·r2 | Ultra-Short Aromatic Shot | AeroPress (inverted) | Jura 2009 — Ultra-Short AeroPress | 23g | 230g | 1:10.0 | 78°C | 388° | 0:30 | nein | — |
+| Sonnet | Apex Minimal-Agitation Clarity | Orea Apex | Orea Apex clarity | 17g | 272g | 1:16.0 | 95°C | 404° | 3:30 | nein | — |
+| Sonnet | Du-Adapted Wave Clarity | Origami (wave) | Du 2019 — Origami Wave | 17g | 255g | 1:15.0 | 94°C | 400° | 1:45 | nein | — |
+
+<details><summary><b>Volltext der Rezepte Geisha, Panama, light, fresh — goal aromatic</b></summary>
+
+
+#### Opus 4-7 (status quo)
+> You're meeting a Panamanian Geisha on near-perfect water at peak freshness, so the only real question is which aromatic-preservation philosophy this lot rewards — Gagné's solubility sequence says Zone 1 volatiles disappear above ~96°C and under heavy agitation, so both candidates hold 94°C and stay quiet on the bed; watch whether deep Apex contact or Du's fast wave transparency does more for the jasmine.
+
+**Apex Aromatic Restraint** — Orea Apex · basedOn: Orea Apex clarity
+Rezept: 22g : 350g (1:15.9) · 94°C · Grind 405° · 3:30
+- *Warum:* The Apex bottom is the most aromatic-preserving setup you own — restricted flow, deep contact, zero post-bloom agitation.
+- *Hypothese:* Holding water below 95°C with minimal agitation keeps Zone 1 volatiles intact while the longer Apex contact builds enough Zone 2 sweetness to frame the florals.
+- *Erwartete Tasse:* Jasmine and bergamot lifted on top, white peach mid-palate, lemon zest on the finish, light tea-like body.
+- *Worauf achten:* Does the floral top note arrive immediately on the first sip, or does it only appear as the cup cools?
+- *pourSteps:* 1) Bloom (bloom, 55g, 40s) — Slow circles from centre, wet all grounds gently  2) Light stir (stir, 5s) — 1–2 gentle passes to settle the bed, then no more agitation  3) Bloom rest (wait, 5s)  4) Pour 2 (pour, 175g, 25s) — Steady spiral, keep off the filter wall  5) Pour 3 (pour, 265g, 25s)  6) Final pour (final, 350g, 25s) — Gentle, central  7) Drawdown (drain, 85s)
+
+**Du-Style Wave Transparency** — Origami (wave) · basedOn: Du 2019 — Origami Wave
+Rezept: 23g : 345g (1:15.0) · 94°C · Grind 402° · 2:45
+- *Warum:* Du's 2019 WBrC-winning setup was built around a 90+ washed Gesha — a thin, fast-draining wave bed gives radically different physics from the deep Apex contact.
+- *Hypothese:* A shallow flat bed with a quick ~2:45 drawdown keeps total contact short, so acidity stays vivid and the cup reads as transparent rather than developed.
+- *Erwartete Tasse:* Crystalline lemon-zest acidity, jasmine high notes, lighter body than the Apex, peach more in outline than flesh.
+- *Worauf achten:* Is acidity sharper and more pointed than the Apex, and does it come at the cost of mid-palate sweetness?
+- *pourSteps:* 1) Bloom (bloom, 85g, 10s) — Du pours bloom quickly — wet all grounds in ~10s  2) Swirl (swirl, 5s) — Gentle swirl to settle — never stir a wave bed  3) Bloom rest (wait, 25s)  4) Pour 2 (pour, 200g, 20s) — Steady stream, flat bed  5) Rest (wait, 20s) — Let bed draw to a moist surface before final  6) Final pour (final, 345g, 20s)  7) Drawdown (drain, 65s)
+
+
+#### Mistral Large 3 (sovereign)
+> This Geisha's defining tension is its heat-sensitive aromatic compounds versus its need for sweetness; Gagné's solubility sequence predicts that Zone 1 florals dissipate above 96°C, so we test two extremes—Jura's 75°C ultra-short AeroPress to isolate aromatics, and Du's 94°C Origami Wave to balance clarity and sweetness—while watching how the cup's top notes evolve as it cools.
+
+**Du-Adapted Wave Clarity** — Origami (wave) · basedOn: Du 2019 — Origami Wave
+Rezept: 22g : 330g (1:15.0) · 94°C · Grind 398° · 2:45
+- *Warum:* The Origami Wave's flat bed and fast drawdown are ideal for Geisha's clarity, while Du's double-grind logic (even particle distribution) ensures uniform extraction.
+- *Hypothese:* A thin, fast-draining bed with minimal agitation will preserve Geisha's volatile aromatics while keeping extraction in Zone 1–2.
+- *Erwartete Tasse:* Bright, tea-like clarity with pronounced jasmine and bergamot, moderate body, and a clean lemon zest finish.
+- *Worauf achten:* How the aromatics hold up during the quick 2:45 drawdown—do they fade or intensify as the cup cools?
+- *pourSteps:* 1) Bloom (bloom, 45g, 10s) — Gentle spiral from center out, wet all grounds evenly  2) Swirl (swirl, 5s) — Light swirl to settle the bed, no stirring  3) Pour 2 (pour, 165g, 20s) — Slow, steady spiral from center to edge  4) Wait (wait, 20s) — Let the bed draw to a moist surface  5) Final pour (final, 330g, 20s) — Center pour to maintain flat bed  6) Drawdown (drain, 90s)
+
+**Jura Ultra-Short Aromatic** — AeroPress · basedOn: Jura 2009 — Ultra-Short AeroPress
+Rezept: 19g : 190g (1:10.0) · 75°C · Grind 388° · 0:15
+- *Warum:* Jura's 2009 recipe isolates aromatic compounds by using ultra-low temperature and a 15-second contact time, perfect for Geisha's volatile notes.
+- *Hypothese:* Below 80°C, only the most soluble aromatic compounds extract, while body and bitterness remain underdeveloped.
+- *Erwartete Tasse:* Intensely aromatic with jasmine and bergamot dominating, light body, and a sharp, almost tea-like acidity.
+- *Worauf achten:* How the aromatics compare to the Origami cup—are they more pronounced or one-dimensional?
+- *pourSteps:* 1) Invert (invert) — Secure filter cap, place plunger just below the 4 mark  2) Add water (pour, 190g, 3s) — Pour all water quickly to saturate grounds  3) Stir (stir, 3s) — Stir 4× vigorously to ensure even wetting  4) Secure filter (wait, 4s) — Place filter cap and secure tightly  5) Flip and press (flip) — Flip onto cup, press gently and steadily  6) Press (press, 5s) — Press for 5 seconds to complete extraction
+
+
+#### Sonnet 4-6 (cheaper Claude)
+> This Panama Geisha's jasmine and bergamot are Zone-1 compounds that Gagné shows extract first but volatilize above 96°C and disappear under agitation — both candidates keep temperature at or below 95°C and use near-zero agitation, so the single variable separating them is contact time: watch whether the Apex's slower restricted drawdown (~3:30) or Du's ultra-fast flat-bed wave (~1:45) captures more aromatic intensity in the cup.
+
+**Apex Minimal-Agitation Clarity** — Orea Apex · basedOn: Orea Apex clarity
+Rezept: 17g : 272g (1:16.0) · 95°C · Grind 404° · 3:30
+- *Warum:* The Orea Apex's most-restricted bottom maximizes contact time while the near-zero agitation and 95°C ceiling protect the jasmine and bergamot compounds from heat destruction and mechanical disruption.
+- *Hypothese:* Minimal agitation plus the Apex's slow drawdown keeps extraction even without turbulence, allowing Zone-1 aromatics to fully transfer before any Zone-3 phenolics intrude.
+- *Erwartete Tasse:* Vivid jasmine and bergamot up front, white peach in the mid-palate, lemon zest on the finish — light body, high clarity, delicate and tea-like.
+- *Worauf achten:* Notice whether the jasmine and bergamot arrive immediately on the nose while the cup is still hot — if they're absent or flat, temperature or agitation erased them.
+- *pourSteps:* 1) Bloom (bloom, 34g, 45s) — Slow spiral from centre, 2× dose — wet all grounds gently, no disturbance  2) Light stir (stir, 5s) — 1–2 gentle passes only — enough to settle the bed, not agitate it  3) Pour 2 (pour, 112g, 20s) — Slow spiral pour, keep the kettle low and close to the bed  4) Pour 3 (pour, 192g, 20s) — Same gentle spiral, no agitation  5) Final pour (final, 272g, 20s) — Continue gentle spiral — do not chase the walls  6) Drawdown (drain, 100s) — Let the Apex's restricted bottom do the work — do not tap or swirl
+
+**Du-Adapted Wave Clarity** — Origami (wave) · basedOn: Du 2019 — Origami Wave
+Rezept: 17g : 255g (1:15.0) · 94°C · Grind 400° · 1:45
+- *Warum:* Du's 2019 WBrC-winning recipe was built specifically for a washed Gesha — the thin flat bed of the Origami wave filter plus a fast three-pour rhythm produces extreme aromatic clarity in under two minutes of total contact.
+- *Hypothese:* A shallow, fast-draining bed keeps total contact time to roughly 105 seconds, extracting deep into Zone 1 without reaching Zone 2 body compounds, producing a radically transparent aromatic snapshot of this Geisha.
+- *Erwartete Tasse:* Intensely floral and citrus-forward with a tea-like transparency — less body than the Apex but potentially more vivid top-note intensity, almost like a perfume in a cup.
+- *Worauf achten:* Compare the aromatic intensity directly against the Apex — does the faster drawdown give sharper, brighter florals, or does the shorter contact leave the cup thin and underdeveloped?
+- *pourSteps:* 1) Bloom (bloom, 34g, 10s) — 2× dose bloom, gentle central pour — wet all grounds evenly  2) Rest (wait, 20s) — Let CO₂ degas; watch for even bloom doming across the flat bed  3) Pour 2 (pour, 119g, 20s) — Gentle spiral pour over the flat bed — no agitation  4) Rest (wait, 20s) — Let the bed draw down to a moist surface before the final pour  5) Final pour (final, 255g, 20s) — Same gentle spiral — stay off the filter walls  6) Drawdown (drain, 15s) — The Origami wave filter drains fast — the cup is done quickly, locking in the aromatics
+
+</details>
+
+---
+
+## Washed Pink Bourbon, Colombia, light, fresh — goal high-clarity
+
+| Modell | Kandidat | Methode | basedOn | Dose | Water | Ratio | Temp | Grind | Zeit | staged | drift |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| Opus | Du-Style Wave Clarity | Origami (wave) | Du 2019 — Origami Wave | 23g | 350g | 1:15.2 | 94°C | 402° | 2:45 | nein | — |
+| Opus | Double-Bloom V60 | V60 | Standout — Double-Bloom V60 | 23g | 350g | 1:15.2 | 94°C | 400° | 3:30 | nein | — |
+| Mistral·r1 | Wölfl-Turbo Clarity | Orea Fast | Wölfl 2024 — Orea V4 Fast | 23g | 350g | 1:15.2 | 93°C | 406° | 2:25 | nein | — |
+| Mistral·r1 | Hoffmann-Style Immersion Clarity | Clever Dripper | Own recipe | 23g | 350g | 1:15.2 | 94°C | 421° | 4:30 | nein | — |
+| Mistral·r2 | Du Wave Clarity | Origami (wave) | Du 2019 — Origami Wave | 23g | 350g | 1:15.2 | 94°C | 402° | 2:45 | nein | — |
+| Mistral·r2 | Minimal Agitation Immersion | Clever Dripper | Own recipe | 23g | 350g | 1:15.2 | 94°C | 421° | 4:30 | nein | — |
+| Sonnet | Apex Floral Clarity | Orea Apex | Own recipe | 23g | 345g | 1:15.0 | 94°C | 404° | 3:45 | nein | — |
+| Sonnet | Double-Bloom V60 Baseline | V60 | Standout — Double-Bloom V60 | 23g | 345g | 1:15.0 | 94°C | 399° | 3:30 | nein | — |
+
+<details><summary><b>Volltext der Rezepte Washed Pink Bourbon, Colombia, light, fresh — goal high-clarity</b></summary>
+
+
+#### Opus 4-7 (status quo)
+> You're meeting a Pink Bourbon — genetically a near-Ethiopian landrace per WCR 2024, not a true Bourbon — at 14 days off roast on your 73ppm clarity blend, which is the optimal stage to find out where this lot's character lives; Gagné's solubility sequence says the jasmine and lemon-pith arrive in Zone 1 within the first 90 seconds, so across both candidates watch when the florals show on the nose and whether they survive into the second sip.
+
+**Du-Style Wave Clarity** — Origami (wave) · basedOn: Du 2019 — Origami Wave
+Rezept: 23g : 350g (1:15.2) · 94°C · Grind 402° · 2:45
+- *Warum:* The Origami + Kalita-wave geometry gives the fastest, thinnest, most even bed in your kit — the maximum-clarity vessel for a landrace-leaning lot.
+- *Hypothese:* A shallow flat bed plus a sub-3-minute total time keeps extraction inside Zone 1–2, so jasmine and lemon pith reach the cup before any phenolic bitterness develops.
+- *Erwartete Tasse:* Tea-like body, pronounced jasmine top-note, lemon-pith acidity, peach in the finish as it cools.
+- *Worauf achten:* Whether the florals arrive on the nose before the first sip — if yes, this geometry is right for this lot.
+- *pourSteps:* 1) Bloom (bloom, 85g, 40s) — Gentle spiral, saturate evenly  2) Swirl (swirl, 5s) — Light swirl to settle the bed — no stir  3) Rest (wait, 5s)  4) Pour 2 (pour, 200g, 20s) — Gentle spiral to edge and back  5) Rest (wait, 20s) — Let bed draw to a moist surface  6) Final pour (final, 350g, 25s)  7) Drawdown (drain, 50s)
+
+**Double-Bloom V60** — V60 · basedOn: Standout — Double-Bloom V60
+Rezept: 23g : 350g (1:15.2) · 94°C · Grind 400° · 3:30
+- *Warum:* A deeper conical bed with a double-bloom and longer total contact tests whether this lot rewards more developed sweetness, or whether the extra contact time muddies the florals.
+- *Hypothese:* Two small saturation pours fully degas a 14-day-fresh bed before the main extraction, producing a more even percolation and pulling sweeter Zone-2 sugars without sacrificing Zone-1 aromatics.
+- *Erwartete Tasse:* Rounder body than the Origami, peach more forward than jasmine, citrus acidity present but softer, longer finish.
+- *Worauf achten:* Which cup keeps you more engaged as it cools — the bright transparent Origami or the rounder V60.
+- *pourSteps:* 1) Bloom 1 (bloom, 40g, 5s) — Small first saturation pour  2) Wait (wait, 25s) — Let CO₂ vent  3) Bloom 2 (pour, 80g, 5s) — Second small bloom — wets remaining dry pockets  4) Stir (stir, 5s) — Light stir 1–2× to settle (washed coffee tolerates this)  5) Wait (wait, 20s)  6) Pour 3 (pour, 215g, 30s) — Gentle spiral, keep off the filter wall  7) Wait (wait, 20s)  8) Final pour (final, 350g, 30s)  9) Drawdown (drain, 70s)
+
+
+#### Mistral Large 3 (sovereign)
+> This Pink Bourbon’s genetic proximity to Ethiopian landraces and its washed processing create a tension between aromatic intensity and extraction restraint—Gagné’s solubility sequence predicts its Zone 1 florals will dissipate if contact time or temperature exceed 95°C and 3 minutes, so you’ll test whether Wölfl’s fast, turbulent Orea or Hoffmann’s gentle immersion best preserves them while avoiding Zone 3 harshness.
+
+**Wölfl-Turbo Clarity** — Orea Fast · basedOn: Wölfl 2024 — Orea V4 Fast
+Rezept: 23g : 350g (1:15.2) · 93°C · Grind 406° · 2:25
+- *Warum:* The Orea Fast’s rapid drainage and Wölfl’s turbulent pours paradoxically deliver clarity on delicate washed coffees by keeping contact time short and extraction in Zone 1–2.
+- *Hypothese:* High agitation paired with fast flow prevents over-extraction of the Pink Bourbon’s fermentation-sensitive florals, preserving jasmine and lemon-pith brightness.
+- *Erwartete Tasse:* A vibrant, tea-like cup with pronounced jasmine and citrus zest, minimal body, and a clean, lingering peach finish.
+- *Worauf achten:* Whether the fast drawdown and turbulent pours amplify or mute the floral top notes compared to a gentler method.
+- *pourSteps:* 1) WDT (agitate-bed, 5s) — Needle the dry bed to break clumps and ensure even wetting  2) Bloom (bloom, 60g, 40s) — Pour via Melodrip or slow spiral to minimize turbulence  3) Pour 2 (pour, 120g, 10s) — Melodrip or slow centre pour to maintain bed flatness  4) Rest (wait, 30s) — Let the bed draw down to a moist surface before next pour  5) Pour 3 (pour, 170g, 10s) — Melodrip or slow centre pour  6) Rest (wait, 30s) — Final rest to ensure even extraction before last pour  7) Final pour (final, 350g, 15s) — Melodrip or slow spiral to finish  8) Drawdown (drain, 5s) — Fast open-bed drawdown—expect ~5s
+
+**Hoffmann-Style Immersion Clarity** — Clever Dripper · basedOn: Own recipe
+Rezept: 23g : 350g (1:15.2) · 94°C · Grind 421° · 4:30
+- *Warum:* Immersion’s even extraction and minimal agitation are ideal for washed coffees, but the Clever’s longer contact time risks over-extracting delicate florals if grind or temperature aren’t precise.
+- *Hypothese:* A coarser grind and shorter steep than typical immersion recipes will keep extraction in Zone 1–2, preserving the Pink Bourbon’s jasmine and lemon-pith without muddiness.
+- *Erwartete Tasse:* A silky, balanced cup with pronounced floral and citric notes, medium body, and a smooth, lingering sweetness—less aromatic than the Orea but more textured.
+- *Worauf achten:* Whether the immersion’s even extraction amplifies the peach sweetness or flattens the jasmine brightness compared to the Orea’s fast percolation.
+- *pourSteps:* 1) Pour water (pour, 350g, 15s) — Add all water in one slow, circular motion to saturate evenly  2) Swirl (swirl, 5s) — Gentle swirl to ensure all grounds are submerged  3) Steep (wait, 220s) — Steep undisturbed—no agitation during this phase  4) Swirl (swirl, 5s) — Final swirl to settle the bed before draining  5) Drain (drain, 25s) — Place on a cup and open the valve—expect ~25s drawdown
+
+
+#### Sonnet 4-6 (cheaper Claude)
+> This Pink Bourbon sits at the fragile intersection Gagné describes — high aromatic solubility in Zone 1 means the jasmine and peach extract quickly but also volatilize quickly above 96°C — so both candidates hold 94°C constant and the single thing to watch across both cups is whether the floral top note survives into the glass or disappears, leaving only acid structure behind.
+
+**Apex Floral Clarity** — Orea Apex · basedOn: Own recipe
+Rezept: 23g : 345g (1:15.0) · 94°C · Grind 404° · 3:45
+- *Warum:* The Orea Apex's most-restricted bottom maximizes bed-contact time without any agitation, giving the highest possible clarity ceiling for a floral washed coffee.
+- *Hypothese:* Minimal post-bloom agitation plus the Apex's slow drain keeps extraction in Zones 1–2 for longer, preserving jasmine and peach aromatics that would dissipate under turbulence.
+- *Erwartete Tasse:* Transparent and floral-forward — jasmine and peach up front, lemon-pith brightness in the middle, delicate body, very clean finish.
+- *Worauf achten:* Notice whether the jasmine arrives in the aroma before you sip — if it's absent in the nose but the cup tastes acidic and flat, extraction stalled in Zone 1 before the florals fully developed.
+- *pourSteps:* 1) Bloom (bloom, 46g, 45s) — Slow spiral from centre out — 2× dose, wet every grain gently  2) Bloom stir (stir, 5s) — 1–2 light strokes only — just enough to settle dry pockets, no turbulence  3) Pour 2 (pour, 140g, 25s) — Gentle central spiral, keep the bed flat  4) Pour 3 (pour, 245g, 25s) — Same gentle spiral — no swirl after  5) Final pour (final, 345g, 25s) — No agitation after this pour — let the restricted Apex bottom do the work  6) Drawdown (drain, 100s) — The Apex's restricted bottom extends contact — watch the clock; if it runs past 4:00 total, go 1° coarser next time
+
+**Double-Bloom V60 Baseline** — V60 · basedOn: Standout — Double-Bloom V60
+Rezept: 23g : 345g (1:15.0) · 94°C · Grind 399° · 3:30
+- *Warum:* The V60's faster, more open drain provides genuinely different extraction physics from the Apex — higher agitation potential and shorter contact time — making the cup comparison directly informative about how this coffee responds to bed dynamics.
+- *Hypothese:* A double bloom fully degasses the fresh bed before main extraction, so the two main pours hit a fully saturated, even bed and extract cleanly without channeling, giving a brighter and slightly more structured cup than the Apex.
+- *Erwartete Tasse:* Bright and structured — vivid lemon-pith acidity, peach sweetness in the mid-palate, jasmine in the nose, slightly more body than the Apex due to a faster extraction pace.
+- *Worauf achten:* Compare the lemon-pith acidity directly against the Apex cup — if the V60 reads sharper and brighter, the faster drain is pulling more Zone 1 acids; if they taste similar, the water chemistry is doing more work than the bed geometry.
+- *pourSteps:* 1) Bloom 1 (bloom, 35g, 10s) — ~1.5× dose — slow central spiral, just wet the bed  2) Wait 1 (wait, 25s) — Let CO₂ vent — you should see bubbling subside  3) Bloom 2 (bloom, 70g, 10s) — Second small pour — saturates the grounds the first bloom didn't reach  4) Wait 2 (wait, 25s) — Bed should now be evenly saturated and nearly static  5) Pour 1 (pour, 210g, 40s) — Slow spiral covering the full bed — 140g added in one smooth pour  6) Wait 3 (wait, 20s) — Brief pause to let the bed settle before final pour  7) Final pour (final, 345g, 30s) — Gentle spiral — no swirl or stir after  8) Drawdown (drain, 50s) — V60 should drain cleanly; if it runs long, go 1° coarser
+
+</details>
+
+---
+
+## Honey Catuai, Costa Rica, medium, fresh — goal sweetness-forward
+
+| Modell | Kandidat | Methode | basedOn | Dose | Water | Ratio | Temp | Grind | Zeit | staged | drift |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| Opus | Orea Classic Sweetness Build | Orea Classic | Kasuya 4:6 — Strong (sweetness-up split) | 23g | 350g | 1:15.2 | 95°C | 408° | 3:30 | nein | — |
+| Opus | Hoffmann Water-First Immersion | Clever Dripper | Hoffmann Ultimate Clever | 23g | 350g | 1:15.2 | 96°C | 421° | 4:00 | nein | — |
+| Mistral·r1 | Gentle Percolation Sweetness | Orea Classic | Own recipe | 23g | 350g | 1:15.2 | 94°C | 408° | 3:30 | nein | — |
+| Mistral·r1 | Immersion Sweetness & Body | Clever Dripper | Hoffmann Ultimate Clever | 23g | 350g | 1:15.2 | 96°C | 420° | 4:30 | nein | — |
+| Mistral·r2 | Origami Wave Sweetness | Origami (wave) | Origami with Kalita Wave Paper | 23g | 350g | 1:15.2 | 94°C | 402° | 3:30 | nein | — |
+| Mistral·r2 | Clever Immersion Sweetness | Clever Dripper | Hoffmann Ultimate Clever | 23g | 350g | 1:15.2 | 96°C | 418° | 4:00 | nein | — |
+| Sonnet | Immersion Sweetness Steep | Clever Dripper | Hoffmann Ultimate Clever | 23g | 345g | 1:15.0 | 94°C | 419° | 5:00 | nein | ⚠️ total time 300s vs published 240s (±59s allowed) |
+| Sonnet | Wave-Bed Sweetness Build | Origami (wave) | Origami with Kalita Wave Paper | 23g | 345g | 1:15.0 | 93°C | 401° | 3:30 | nein | — |
+
+<details><summary><b>Volltext der Rezepte Honey Catuai, Costa Rica, medium, fresh — goal sweetness-forward</b></summary>
+
+
+#### Opus 4-7 (status quo)
+> Your first brew of this April Catuai honey sits at a real tension — Catuai's variety prior loves forgiving immersion, but April roasts at the edge of light where Hoffmann and Perger both warn that passive technique reads sour and thin. I'm pairing an active Orea Classic with a water-first Clever so the side-by-side tells you which prior dominates this lot; watch the body-versus-aromatic balance across both cups.
+
+**Orea Classic Sweetness Build** — Orea Classic · basedOn: Kasuya 4:6 — Strong (sweetness-up split)
+Rezept: 23g : 350g (1:15.2) · 95°C · Grind 408° · 3:30
+- *Warum:* Orea Classic's medium-restricted bottom holds contact time for Zone-2 sugar development, and Kasuya's sweet-split first phase doubles down on the caramel/apple register the bag promises.
+- *Hypothese:* Splitting the first 40% as 70+70 (instead of bloom + one big pour) raises sweetness extraction while the three equal back-half pours keep strength controlled and clarity intact.
+- *Erwartete Tasse:* Brown sugar and red apple forward, almond on the finish, medium body, gentle acidity — the honey process speaking clearly.
+- *Worauf achten:* Notice whether the brown-sugar sweetness arrives mid-sip or only as the cup cools — early sweetness = the split worked.
+- *pourSteps:* 1) Bloom (bloom, 70g, 40s) — Wet all grounds with slow spiral from centre out  2) Swirl (swirl, 5s) — Gentle swirl to settle the bed — no stir  3) Sweet-split pour 2 (pour, 140g, 15s) — Second half of the 4:6 first phase — sweetness emphasis  4) Pour 3 (pour, 210g, 15s)  5) Pour 4 (pour, 280g, 15s)  6) Final pour (final, 350g, 15s)  7) Settle swirl (swirl, 5s) — Gentle swirl to level the bed for an even drawdown  8) Drawdown (drain, 100s)
+
+**Hoffmann Water-First Immersion** — Clever Dripper · basedOn: Hoffmann Ultimate Clever
+Rezept: 23g : 350g (1:15.2) · 96°C · Grind 421° · 4:00
+- *Warum:* Catuai's variety prior says it rewards immersion, and full-immersion gives you Zone-2 sugars across the entire dose evenly — the cleanest test of whether body or clarity dominates this lot.
+- *Hypothese:* Water-first technique halves the paper-clog drawdown (Workshop Coffee's discovery), so a 2-minute steep stays in Zone-1/Zone-2 territory without invading bitter Zone-3 — full immersion body with paper-filter clarity.
+- *Erwartete Tasse:* Rounder body than the Orea, almond more prominent, red apple softer, brown sugar as a syrupy mid-palate — possibly slightly less aromatic top-note than the percolation.
+- *Worauf achten:* Compare body weight against the Orea: heavier mouthfeel here confirms Catuai's immersion affinity; if the cup reads flat, the April roast wanted more agitation than immersion gives.
+- *pourSteps:* 1) Pour water first (pour, 350g, 15s) — Valve closed. Pour all 350g into empty Clever first  2) Add coffee + stir (stir, 5s) — Add 23g grounds on top, stir gently to mix  3) Steep (wait, 120s) — Lid optional — Hoffmann skips it  4) Break the crust (swirl, 5s) — Gentle swirl to break the floating crust  5) Settle (wait, 30s) — Let grounds settle to the bottom before draining  6) Drain (drain, 65s) — Place on carafe — valve opens automatically
+
+
+#### Mistral Large 3 (sovereign)
+> This Tarrazú Honey from April is a medium-roast Catuai with fermentation-derived sweetness, but its clarity-focused roast demands active extraction to avoid a flat cup—Gagné’s solubility sequence tells us that honey process coffees extract quickly in Zone 2, so the challenge is to develop sweetness without invading Zone 3. Today’s portfolio tests whether sweetness shines brighter with gentle percolation (Orea Classic) or extended immersion (Clever), and the key variable to watch is how each method handles the coffee’s sticky mucilage without over-extracting.
+
+**Gentle Percolation Sweetness** — Orea Classic · basedOn: Own recipe
+Rezept: 23g : 350g (1:15.2) · 94°C · Grind 408° · 3:30
+- *Warum:* Orea Classic’s medium flow rate and gentle agitation are ideal for honey process coffees, balancing sweetness development with clarity.
+- *Hypothese:* A 3:30 percolation with minimal agitation will extract the honey’s sugars (Zone 2) while preserving the coffee’s inherent balance and avoiding fermentation overtones.
+- *Erwartete Tasse:* Red apple and brown sugar will dominate, with a silky mouthfeel and a clean almond finish.
+- *Worauf achten:* Whether the sweetness feels integrated or cloying—if the latter, the coffee may need less contact time.
+- *pourSteps:* 1) Bloom (bloom, 46g, 45s) — Gentle spiral from centre out, saturate all grounds evenly  2) Swirl (swirl, 5s) — Light swirl to settle the bed, no vigorous stir  3) Pour 2 (pour, 150g, 30s) — Slow, steady spiral from centre to edge  4) Pour 3 (pour, 250g, 30s) — Maintain even bed saturation, avoid disturbing grounds  5) Final pour (final, 350g, 30s) — Gentle top-up, keep water level below the rim  6) Drawdown (drain, 30s) — Let the bed drain fully, no agitation
+
+**Immersion Sweetness & Body** — Clever Dripper · basedOn: Hoffmann Ultimate Clever
+Rezept: 23g : 350g (1:15.2) · 96°C · Grind 420° · 4:30
+- *Warum:* Immersion methods like the Clever can build body and sweetness by extending contact time, a contrast to the Orea’s percolation approach.
+- *Hypothese:* A 4:30 immersion with a coarse grind will extract the honey’s sugars and develop body without over-extracting, thanks to the water-first technique’s even saturation.
+- *Erwartete Tasse:* Brown sugar and almond will be more pronounced, with a heavier mouthfeel and a lingering sweetness.
+- *Worauf achten:* Whether the body enhances the sweetness or masks the coffee’s clarity—if the latter, the grind may need to be coarser.
+- *pourSteps:* 1) Pour water (pour, 350g, 15s) — Off-boil water, pour slowly to avoid disturbing the paper  2) Add coffee (agitate-bed, 5s) — Sprinkle grounds evenly, no stir  3) Steep (wait, 180s) — Let the coffee steep undisturbed  4) Swirl (swirl, 5s) — Gentle swirl to break the crust  5) Settle (wait, 30s) — Let grounds settle before draining  6) Drain (drain, 35s) — Place on carafe, let the valve release fully
+
+
+#### Sonnet 4-6 (cheaper Claude)
+> This honey Catuai demands you answer a first-principles question that Gagné's solubility sequence makes explicit: does this coffee's sweetness — built from partial mucilage fermentation and a medium roast — open up best through sustained immersion contact (Zone 2 saturation) or through Kasuya-style repeated percolation cycles that build body incrementally, and the single thing to watch across both cups is whether the brown sugar note feels round and integrated or flat and one-dimensional.
+
+**Immersion Sweetness Steep** — Clever Dripper · basedOn: Hoffmann Ultimate Clever
+Rezept: 23g : 345g (1:15.0) · 94°C · Grind 419° · 5:00 · ⚠️ drift: total time 300s vs published 240s (±59s allowed)
+- *Warum:* Full immersion gives this honey Catuai uninterrupted contact time in Zone 2, letting the brown sugar and caramel compounds saturate the brew without the turbulence of repeated pours.
+- *Hypothese:* A 5-minute water-first immersion at 94°C will reach sugar-zone equilibrium and produce a rounded, body-forward cup where the honey process sweetness is the dominant character.
+- *Erwartete Tasse:* Brown sugar upfront, mild red apple in the finish, almond in the texture, medium body with clean paper-filtered clarity — syrupy but not heavy.
+- *Worauf achten:* Notice whether the sweetness feels integrated and round, or whether the cup reads flat and one-dimensional — flat means Zone 2 was reached but Zone 1 aromatics were left behind.
+- *pourSteps:* 1) Water in (pour, 345g, 15s) — Pour all water into the empty Clever first — water-first technique prevents paper clog and halves drawdown time  2) Add coffee and stir (stir, 5s) — Add 23g on top and stir gently to submerge all grounds — no vigorous agitation  3) Steep (wait, 120s) — Lid off — let the immersion do the work; sugars and maillard compounds migrate at their own pace  4) Break crust (agitate-bed, 5s) — Gently break the floating crust with a spoon — one pass, no stirring  5) Settle (wait, 30s) — Grounds fall to the bottom — this is what gives the Clever its paper-filtered clarity despite being a steep brew  6) Drain (drain, 125s) — Set on your cup or server — valve opens and draws down through the paper; watch for a clean, syrupy flow
+
+**Wave-Bed Sweetness Build** — Origami (wave) · basedOn: Origami with Kalita Wave Paper
+Rezept: 23g : 345g (1:15.0) · 93°C · Grind 401° · 3:30
+- *Warum:* The Origami with wave paper creates a flat extraction bed that builds body through each percolation cycle while the ribs maintain enough flow-through character to preserve the red apple brightness — a middle path between V60 clarity and full immersion sweetness.
+- *Hypothese:* Three measured pours over a flat wave-paper bed at 93°C will build mouthfeel incrementally through repeated sugar-zone contact while the Origami's open rib architecture keeps the cup from going dull.
+- *Erwartete Tasse:* Caramel and almond forward, medium body with a cleaner finish than the immersion, red apple acidity present but softer — structured sweetness rather than saturated sweetness.
+- *Worauf achten:* Notice whether the sweetness feels layered and developing cup-by-cup as it cools, which would indicate the percolation cycles are building Zone 2 compounds progressively rather than all at once.
+- *pourSteps:* 1) Bloom (bloom, 50g, 8s) — Pour slowly from centre — 50g, just enough to saturate all grounds  2) Swirl (swirl, 5s) — Gentle swirl to level the bed — no stir, the flat wave paper channels if disturbed  3) Bloom wait (wait, 35s) — Allow CO₂ to outgas and grounds to saturate evenly  4) Pour 2 (pour, 160g, 25s) — Slow spiral pour to 160g — stay off the filter walls  5) Pour 3 (pour, 255g, 20s) — Continue spiral to 255g — keep the bed level  6) Final pour (final, 345g, 20s) — Complete to 345g — pour gently to avoid disturbing the settled bed  7) Swirl (swirl, 7s) — One gentle swirl after the final pour to level the bed before drawdown  8) Drawdown (drain, 90s) — Watch the drain rate — Origami's ribs under the wave paper give a slower drawdown than a pure Kalita; aim for finish around 3:30
+
+</details>
+
+---
+
+## Kosten pro `/recommend`-Call (gemessen × Listenpreis)
+
+| Modell | Calls | Ø Tokens in/out | Ø $/Call | drift gesamt | staged gesamt |
+|---|---|---|---|---|---|
+| Opus 4-7 (status quo) | 6 | 26117/2996 | $0.205 | 0 | 0 |
+| Mistral Large 3 (sovereign) | 12 | 19036/1996 | $0.050 | 0 | 0 |
+| Sonnet 4-6 (cheaper Claude) | 6 | 18886/2871 | $0.100 | 2 | 0 |
+
+_Hinweis: Spike-Calls sind uncached. Produktiv senkt Prompt-Caching die Opus-Input-Kosten; Mistral-Caching ist nicht eingerechnet (konservativ). Ø $/Call × monatliche /recommend-Frequenz = der echte Hebel._

--- a/scripts/recommend-model-spike.mjs
+++ b/scripts/recommend-model-spike.mjs
@@ -94,70 +94,72 @@ const ResponseSchema = z.object({
   coffeeAssessment: z.string().optional(),
 });
 
-// ── Test beans (representative archetypes, not real-product claims) ───────────
-// Three profiles that exercise different reasoning paths: a delicate washed
-// light (clarity), a soluble natural (don't over-sweeten), a structured Kenyan
-// (body). Roasters chosen to also exercise the roaster-prior injection.
+// ── Test scenarios (round 3: variation-stress) ───────────────────────────────
+// Deliberately exercises the harder routing/constraint paths, not just hot pour-
+// over: Summer Time (iced/flash → must set iceGrams, split hot/ice), Time =
+// "special" (fast shot ≤150s), and non-default volumes (210 / 450 / 520 ml) that
+// trip the HARD CAPACITY rules (AeroPress ≤230, Clever ≤450, Origami ≤450,
+// Moccamaster ≥500). The probe adds a capacity-violation + iced-sanity detector.
 const BEANS = [
   {
-    label: "Washed Ethiopian, light, very fresh — goal high-clarity",
+    label: "Summer Time · 210ml custom — washed Ethiopian, high-clarity (iced + small)",
     coffee: {
       roaster: "Friedhats", name: "Yirga (test)", origin: "Ethiopia", region: "Yirgacheffe",
       variety: "Heirloom", process: "Washed", roastLevel: "Light",
       roastDate: daysAgo(9), tastingNotesFromBag: ["jasmine", "bergamot", "lemon", "black tea"],
       aiExtracted: true,
     },
-    context: ctx({ occasion: "morning-ritual", intent: "high-clarity", waterSource: "championship" }),
+    context: ctx({ occasion: "summer-time", amount: "custom", customWaterMl: 210, intent: "high-clarity", waterSource: "championship" }),
   },
   {
-    label: "Natural Brazil, medium-light, mid-age — goal balanced",
+    label: "Summer Time · 520ml big — natural Brazil, balanced (iced + big)",
     coffee: {
       roaster: "April", name: "Daterra (test)", origin: "Brazil", region: "Cerrado",
       variety: "Yellow Bourbon", process: "Natural", roastLevel: "Medium-Light",
       roastDate: daysAgo(24), tastingNotesFromBag: ["milk chocolate", "peach", "hazelnut"],
       aiExtracted: true,
     },
-    context: ctx({ occasion: "focus", intent: "balanced", waterSource: "tap" }),
+    context: ctx({ occasion: "summer-time", amount: "big", intent: "balanced", waterSource: "tap" }),
   },
   {
-    label: "Washed Kenyan SL28, light, fresh — goal body-forward",
+    label: "Special/short · 350ml — washed Kenyan SL28, body-forward (fast shot)",
     coffee: {
       roaster: "Cloud Picker", name: "Kiriga (test)", origin: "Kenya", region: "Nyeri",
       variety: "SL28", process: "Washed", roastLevel: "Light",
       roastDate: daysAgo(12), tastingNotesFromBag: ["blackcurrant", "tomato", "red wine"],
       aiExtracted: true,
     },
-    context: ctx({ occasion: "experiment", intent: "body-forward", waterSource: "tap" }),
+    context: ctx({ occasion: "experiment", amount: "small", timeAvailable: "special", intent: "body-forward", waterSource: "tap" }),
   },
   {
-    label: "Geisha, Panama, light, fresh — goal aromatic",
+    label: "Special/short · 210ml custom — Geisha, aromatic (fast + small)",
     coffee: {
       roaster: "Manhattan", name: "Esmeralda (test)", origin: "Panama", region: "Boquete",
       variety: "Geisha", process: "Washed", roastLevel: "Light",
       roastDate: daysAgo(11), tastingNotesFromBag: ["jasmine", "bergamot", "white peach", "lemon zest"],
       aiExtracted: true,
     },
-    context: ctx({ occasion: "morning-ritual", intent: "aromatic", waterSource: "championship" }),
+    context: ctx({ occasion: "morning-ritual", amount: "custom", customWaterMl: 210, timeAvailable: "special", intent: "aromatic", waterSource: "championship" }),
   },
   {
-    label: "Washed Pink Bourbon, Colombia, light, fresh — goal high-clarity",
+    label: "Normal · 450ml custom — washed Pink Bourbon, high-clarity (Clever-at-max edge)",
     coffee: {
       roaster: "Cloud Picker", name: "Huila (test)", origin: "Colombia", region: "Huila",
       variety: "Pink Bourbon", process: "Washed", roastLevel: "Light",
       roastDate: daysAgo(14), tastingNotesFromBag: ["jasmine", "peach", "lemon pith", "floral"],
       aiExtracted: true,
     },
-    context: ctx({ occasion: "focus", intent: "high-clarity", waterSource: "championship" }),
+    context: ctx({ occasion: "focus", amount: "custom", customWaterMl: 450, intent: "high-clarity", waterSource: "championship" }),
   },
   {
-    label: "Honey Catuai, Costa Rica, medium, fresh — goal sweetness-forward",
+    label: "Normal · 520ml big — Honey Catuai, sweetness-forward (big-volume capacity)",
     coffee: {
       roaster: "April", name: "Tarrazú (test)", origin: "Costa Rica", region: "Tarrazú",
       variety: "Catuai", process: "Honey", roastLevel: "Medium",
       roastDate: daysAgo(16), tastingNotesFromBag: ["red apple", "brown sugar", "almond"],
       aiExtracted: true,
     },
-    context: ctx({ occasion: "social", intent: "sweetness-forward", waterSource: "tap" }),
+    context: ctx({ occasion: "social", amount: "big", intent: "sweetness-forward", waterSource: "tap" }),
   },
 ];
 
@@ -170,6 +172,57 @@ function ctx(over) {
 }
 function daysAgo(n) {
   return new Date(Date.now() - n * 86_400_000).toISOString().slice(0, 10);
+}
+
+// Target drink volume (ml) for the chosen amount — ported from recommend.ts.
+function targetMlOf(c) {
+  return c.amount === "custom" ? (c.customWaterMl ?? 350)
+    : c.amount === "big" ? 520
+    : c.amount === "small" ? 350
+    : c.amount === "batch" ? 750
+    : null;
+}
+
+// Amount guide text — ported from recommend.ts amountGuide, incl. the Summer-Time
+// iced custom split (60% hot brew / 40% ice + mandatory iceGrams).
+function buildGuide(c) {
+  const ml = c.customWaterMl ?? 350;
+  const guides = {
+    small: "target ~350g water / 23g dose (1:15.2). Suitable: V60, Orea, Clever Dripper (350ml < 450ml ✓), Kalita, Chemex, Origami Air M. NOT AeroPress (max 230ml). NOT Moccamaster (batch only).",
+    big: "target ~520g water / 34g dose (1:15.3). Suitable: V60, Orea, Kalita, Chemex. NOT Origami Air M (34g exceeds 30g dose limit ✗). NOT Clever Dripper (520ml > 450ml ✗). NOT AeroPress (520ml > 230ml ✗). NOT Moccamaster (batch only).",
+    batch: "target ~750g water — Moccamaster ONLY; scale dose to ~50g.",
+    surprise: "SURPRISE MODE: full creative freedom on method and recipe — hard capacity limits still apply.",
+    open: "standard single-cup dose (23g:350ml)",
+  };
+  if (c.amount === "custom") {
+    return c.occasion === "summer-time"
+      ? `ICED + custom volume: the user typed ${ml}ml as the FINAL drink (hot brew + melted ice). Split it ~60% hot brew / ~40% ice — waterGrams (hot brew) ≈ ${Math.round(ml * 0.6)}g (±30g), and the recipe MUST set iceGrams ≈ ${Math.round(ml * 0.4)}g. Dose at 1:15 against the HOT portion (~${Math.round((ml * 0.6) / 15)}g). BOTH candidates respect this split AND both include iceGrams. Reference iced recipes (Hoffmann Immersion Iced, AeroPress Iced) supply the TECHNIQUE — scale dose+water+ice proportionally.`
+      : `target exactly ${ml}ml for BOTH candidates — tolerance ±30ml. Reference recipes supply technique/ratio, scale dose so waterGrams lands within 30ml of ${ml}. Default 1:15 (so ~${Math.round(ml / 15)}g dose). Capacity tensions handled in the HARD CAPACITY CONSTRAINT block.`;
+  }
+  return guides[c.amount] ?? "target ~350g water / 23g dose";
+}
+
+// HARD CAPACITY CONSTRAINT block — ported from recommend.ts (no method-lock path).
+function buildCapacity(c) {
+  const ml = targetMlOf(c);
+  if (!ml) return "";
+  const v = [];
+  if (ml > 230) v.push("AeroPress (max 230ml)");
+  if (ml > 450) v.push("Clever Dripper (max 450ml)");
+  if (ml > 450) v.push("Origami Air M (30g dose limit → max ~450ml)");
+  if (ml < 500) v.push("Moccamaster (batch only, min 500ml)");
+  return v.length ? `\nHARD CAPACITY CONSTRAINT — target ${ml}ml: FORBIDDEN methods: ${v.join(", ")}.` : "";
+}
+
+// Does a candidate's method violate the hard capacity rule for this volume?
+function capacityViolation(method, ml) {
+  if (!ml || !method) return null;
+  const m = method.toLowerCase();
+  if (/aeropress/.test(m) && ml > 230) return `AeroPress @${ml}ml (>230)`;
+  if (/clever/.test(m) && ml > 450) return `Clever @${ml}ml (>450)`;
+  if (/origami/.test(m) && ml > 450) return `Origami @${ml}ml (>450)`;
+  if (/moccamaster/.test(m) && ml < 500) return `Moccamaster @${ml}ml (<500)`;
+  return null;
 }
 
 const PREFS = {
@@ -191,7 +244,9 @@ function buildUserMessage(coffee, context, preferences) {
     daysOld < 35 ? "slightly past peak" :
     daysOld < 60 ? "past peak, flavors softening" : "likely stale";
 
-  const guide = "target ~350g water / 23g dose (1:15.2). Suitable: V60, Orea, Clever, Kalita, Chemex, Origami Air M. NOT AeroPress (max 230ml). NOT Moccamaster (batch only).";
+  const targetMl = targetMlOf(context);
+  const guide = buildGuide(context);
+  const capacityConstraint = buildCapacity(context);
   const sessionGrinder = context.grinder || preferences.grinder || "Niche Zero";
   const grinderNote = `Grinder: ${sessionGrinder} → grindSize must be ONE specific Niche° value (e.g. "406°"). NO ranges. NEVER clicks.`;
   const waterNote =
@@ -214,7 +269,7 @@ function buildUserMessage(coffee, context, preferences) {
     variety: coffee.variety,
     goal: K.normaliseGoal(context.intent),
     occasion: context.occasion,
-    maxWaterMl: 350,
+    maxWaterMl: context.occasion === "cold-brew" ? undefined : (targetMl ?? undefined),
   }, 4);
   const recipesBlock = selectedRecipes.length ? `\n${K.formatRecipesForPrompt(selectedRecipes)}` : "";
 
@@ -238,7 +293,7 @@ Context:
 - Amount: ${context.amount} (${guide})
 - Time available: ${context.timeAvailable}
 - Grinder: ${sessionGrinder}
-- Water: ${waterNote}${goalNote}
+- Water: ${waterNote}${capacityConstraint}${goalNote}
 
 Equipment available: ${preferences.equipment.join(", ")}
 ${grinderNote}
@@ -326,7 +381,7 @@ function fmtStep(s) {
   return s?.notes ? `${head} — ${s.notes}` : head;
 }
 
-function probeCandidate(c) {
+function probeCandidate(c, opts = {}) {
   const r = c.recipe || {};
   const dose = num(r.doseGrams), water = num(r.waterGrams);
   const ratio = dose && water ? (water / dose).toFixed(1) : "?";
@@ -347,11 +402,16 @@ function probeCandidate(c) {
     if (res?.changed) drift = { reference: res.reference, reasons: res.reasons };
   } catch { /* non-verified ref or unscalable — no signal */ }
 
+  // Capacity-rule violation (method vs the target volume) + iced sanity.
+  const cap = capacityViolation(c.method, opts.targetMl);
+  const iceGrams = num(r.iceGrams);
+  const iceMiss = opts.occasion === "summer-time" && iceGrams === null;
+
   return {
     title: c.title, method: c.method, basedOn: c.basedOn || "—",
     dose, water, ratio, temp: baseTemp, grind: r.grindSize ?? "?",
     targetTimeSec: num(r.targetTimeSec), nSteps: steps.length,
-    staged, drift,
+    staged, drift, cap, iceGrams, iceMiss,
     // full prose for reading "what the model actually wrote"
     whyChosen: c.whyChosen, hypothesis: c.hypothesis,
     predictedCupProfile: c.predictedCupProfile, whatToObserve: c.whatToObserve,
@@ -366,9 +426,9 @@ const log = (s = "") => { lines.push(s); console.log(s); };
 const fmtTime = (sec) => sec ? `${Math.floor(sec / 60)}:${String(sec % 60).padStart(2, "0")}` : "?";
 const tally = {}; // model id → { calls, inTok, outTok, cost, drift, staged }
 
-log(`# /recommend — Modellvergleich (Spike, breit)`);
+log(`# /recommend — Modellvergleich (Spike, Variation-Stress)`);
 log(`Generiert: ${new Date().toISOString()}`);
-log(`\n${BEANS.length} Bohnen-Profile. Gleicher echter Prompt (SYSTEM_PROMPT + injizierter Korpus) an alle Modelle. Mistral läuft ${MODELS.find(m=>m.id.includes("mistral"))?.reps}× pro Bohne (Schwankung sichtbar machen), die Claude-Baselines 1×. \`drift\` = objektiver Fabrikations-Detektor (reconcileToReference): wich das Modell beim \`basedOn\`-Referenzrezept in Grind/Temp/Zeit ab. \`staged-temp\` = verbotene Mehrtemperatur. Jedes Rezept steht unten im Volltext.\n`);
+log(`\n${BEANS.length} Szenarien mit harten Pfaden: **Summer Time** (iced → muss iceGrams setzen + hot/ice splitten), **Time=special** (fast shot ≤150s), und Volumen **210/450/520 ml** (triggern die Kapazitätsregeln). Gleicher echter Prompt (SYSTEM_PROMPT + injizierter Korpus) an alle Modelle. Mistral läuft ${MODELS.find(m=>m.id.includes("mistral"))?.reps}× pro Szenario, Claude-Baselines 1×.\n\nFlags (alle objektiv): \`drift\` = Fabrikation (reconcileToReference: Abweichung vom \`basedOn\`-Referenzrezept) · \`staged\` = verbotene Mehrtemperatur · \`cap\` = **Kapazitätsverletzung** (z.B. AeroPress >230ml, Clever >450ml, Moccamaster <500ml) · \`ice\` = bei Summer Time fehlt \`iceGrams\` (⚠️ FEHLT) oder der gesetzte Wert. Jedes Rezept steht unten im Volltext.\n`);
 
 if (DRY_RUN) {
   log(`\n> DRY RUN — kein API-Call. ${BEANS.length} Bohnen × Modelle. Beispiel-Prompt für Bohne 1:\n`);
@@ -381,6 +441,7 @@ if (DRY_RUN) {
   for (const bean of BEANS) {
     log(`\n---\n\n## ${bean.label}`);
     const userMessage = buildUserMessage(bean.coffee, bean.context, PREFS);
+    const probeOpts = { targetMl: targetMlOf(bean.context), occasion: bean.context.occasion };
     const runs = []; // { tag, label, ms, inTok, outTok, parsed, cands }
 
     for (const M of MODELS) {
@@ -389,12 +450,12 @@ if (DRY_RUN) {
         const tag = M.reps > 1 ? `${shortTag(M.id)}·r${rep}` : shortTag(M.id);
         try {
           const { text, ms, inTok, outTok } = await M.run(M.id, userMessage);
-          const t = (tally[M.id] ??= { calls: 0, inTok: 0, outTok: 0, cost: 0, drift: 0, staged: 0 });
+          const t = (tally[M.id] ??= { calls: 0, inTok: 0, outTok: 0, cost: 0, drift: 0, staged: 0, cap: 0, iceMiss: 0 });
           t.calls++; t.inTok += inTok; t.outTok += outTok;
           t.cost += (inTok * M.price[0] + outTok * M.price[1]) / 1e6;
           const parsed = K.parseClaudeJson(text, ResponseSchema);
-          const cands = parsed ? parsed.candidates.map(probeCandidate) : null;
-          if (cands) for (const c of cands) { if (c.drift) t.drift++; if (c.staged) t.staged++; }
+          const cands = parsed ? parsed.candidates.map((c) => probeCandidate(c, probeOpts)) : null;
+          if (cands) for (const c of cands) { if (c.drift) t.drift++; if (c.staged) t.staged++; if (c.cap) t.cap++; if (c.iceMiss) t.iceMiss++; }
           runs.push({ tag, label: M.label, ms, inTok, outTok, parsed, cands, raw: text });
         } catch (e) {
           runs.push({ tag, label: M.label, error: String(e.message || e) });
@@ -404,14 +465,16 @@ if (DRY_RUN) {
 
     // Overview table — every (model, rep, candidate) row
     log("");
-    log("| Modell | Kandidat | Methode | basedOn | Dose | Water | Ratio | Temp | Grind | Zeit | staged | drift |");
-    log("|---|---|---|---|---|---|---|---|---|---|---|---|");
+    log("| Modell | Kandidat | Methode | basedOn | Dose | Water | Ratio | Temp | Grind | Zeit | staged | drift | cap | ice |");
+    log("|---|---|---|---|---|---|---|---|---|---|---|---|---|---|");
     for (const r of runs) {
-      if (r.error) { log(`| ${r.tag} | **FEHLER** | ${r.error.slice(0, 60)} | | | | | | | | | |`); continue; }
-      if (!r.cands) { log(`| ${r.tag} | **Schema NEIN** | (siehe Rohtext unten) | | | | | | | | | |`); continue; }
+      if (r.error) { log(`| ${r.tag} | **FEHLER** | ${r.error.slice(0, 60)} | | | | | | | | | | | |`); continue; }
+      if (!r.cands) { log(`| ${r.tag} | **Schema NEIN** | (siehe Rohtext unten) | | | | | | | | | | | |`); continue; }
       for (const c of r.cands) {
         const driftCell = c.drift ? `⚠️ ${c.drift.reasons.join("; ")}` : "—";
-        log(`| ${r.tag} | ${c.title} | ${c.method} | ${c.basedOn} | ${c.dose ?? "?"}g | ${c.water ?? "?"}g | 1:${c.ratio} | ${c.temp ?? "?"}°C | ${c.grind} | ${fmtTime(c.targetTimeSec)} | ${c.staged ? "⚠️ JA" : "nein"} | ${driftCell} |`);
+        const capCell = c.cap ? `⚠️ ${c.cap}` : "—";
+        const iceCell = c.iceMiss ? "⚠️ FEHLT" : (c.iceGrams != null ? `${c.iceGrams}g` : "—");
+        log(`| ${r.tag} | ${c.title} | ${c.method} | ${c.basedOn} | ${c.dose ?? "?"}g | ${c.water ?? "?"}g | 1:${c.ratio} | ${c.temp ?? "?"}°C | ${c.grind} | ${fmtTime(c.targetTimeSec)} | ${c.staged ? "⚠️ JA" : "nein"} | ${driftCell} | ${capCell} | ${iceCell} |`);
       }
     }
 
@@ -442,12 +505,12 @@ if (DRY_RUN) {
   // ── Cost summary (measured tokens × list price) ─────────────────────────────
   log(`\n---\n\n## Kosten pro \`/recommend\`-Call (gemessen × Listenpreis)`);
   log("");
-  log("| Modell | Calls | Ø Tokens in/out | Ø $/Call | drift gesamt | staged gesamt |");
-  log("|---|---|---|---|---|---|");
+  log("| Modell | Calls | Ø Tokens in/out | Ø $/Call | drift | staged | cap-Verstöße | ice-Fehler |");
+  log("|---|---|---|---|---|---|---|---|");
   for (const M of MODELS) {
     const t = tally[M.id];
     if (!t) continue;
-    log(`| ${M.label} | ${t.calls} | ${Math.round(t.inTok / t.calls)}/${Math.round(t.outTok / t.calls)} | $${(t.cost / t.calls).toFixed(3)} | ${t.drift} | ${t.staged} |`);
+    log(`| ${M.label} | ${t.calls} | ${Math.round(t.inTok / t.calls)}/${Math.round(t.outTok / t.calls)} | $${(t.cost / t.calls).toFixed(3)} | ${t.drift} | ${t.staged} | ${t.cap} | ${t.iceMiss} |`);
   }
   log(`\n_Hinweis: Spike-Calls sind uncached. Produktiv senkt Prompt-Caching die Opus-Input-Kosten; Mistral-Caching ist nicht eingerechnet (konservativ). Ø $/Call × monatliche /recommend-Frequenz = der echte Hebel._`);
 }


### PR DESCRIPTION
Round 3 of the `/recommend` model spike — stress-tests the harder routing/constraint paths the hot-pour-over rounds didn't touch, per owner request (more variation).

**6 scenarios:** Summer Time × 210ml + 520ml (iced — must split hot/ice, set `iceGrams`), Time = `special` × 350ml + 210ml (fast shot), Normal × 450ml (Clever-at-max) + 520ml (big-volume capacity).

**Two new objective detectors** added to the probe:
- **`cap`** — capacity-rule violation (method vs volume: AeroPress >230, Clever >450, Origami >450, Moccamaster <500).
- **`ice`** — Summer Time recipe missing `iceGrams`.

`buildGuide`/`buildCapacity` ported from `recommend.ts` so the prompt matches production on these paths. Also commits the run #2 results doc (`docs/recommend-spike-run2.md`). No production code touched. Merging bumps the trigger → fires the run (~24 calls, ~20 min); results posted to issue #453.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9XyzNYTTqqBDgnLrGRP2G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9XyzNYTTqqBDgnLrGRP2G)_