### PR TITLE
fix(deploy): always-sync MISTRAL_API_KEY so a rotated key takes effect

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,14 +74,26 @@ jobs:
                 < src/lib/db/migrations/0017_add_insight_snooze.sql
             fi
 
-            # Make MISTRAL_API_KEY available to compose so /recommend runs on
-            # Mistral Large (≈¼ the Opus per-call cost; issue #453). APPEND-ONLY and
-            # guarded: only writes when a .env exists AND the key isn't already there,
-            # so it never rewrites/clobbers the production .env. Absent key → no-op →
-            # /recommend simply stays on Opus (the code auto-detects).
-            if [ -f .env ] && ! grep -q '^MISTRAL_API_KEY=' .env; then
-              printf 'MISTRAL_API_KEY=%s\n' '${{ secrets.MISTRAL_API_KEY }}' >> .env
-              echo "Added MISTRAL_API_KEY to .env"
+            # Sync MISTRAL_API_KEY into the VPS .env from the GitHub secret so
+            # /recommend runs on Mistral Large (≈¼ the Opus per-call cost; issue
+            # #453) AND a ROTATED key actually takes effect. The earlier append-only
+            # version only wrote when no key was present, so rotating the secret (e.g.
+            # moving it from the Default Mistral workspace to a cost-separated BrewLog
+            # workspace) left the stale key live on the VPS. This replaces ONLY the
+            # MISTRAL_API_KEY line — every other var is preserved — and commits the
+            # result only when those other vars survived (wc -l > 1), so it can never
+            # clobber the production .env. Absent .env → no-op → /recommend stays on
+            # Opus (the code auto-detects).
+            if [ -f .env ]; then
+              grep -v '^MISTRAL_API_KEY=' .env > .env.tmp 2>/dev/null || true
+              printf 'MISTRAL_API_KEY=%s\n' '${{ secrets.MISTRAL_API_KEY }}' >> .env.tmp
+              if [ "$(wc -l < .env.tmp)" -gt 1 ]; then
+                mv .env.tmp .env
+                echo "Synced MISTRAL_API_KEY in .env"
+              else
+                rm -f .env.tmp
+                echo "WARNING: MISTRAL_API_KEY sync skipped (would have dropped other vars)"
+              fi
             fi
 
             docker compose build app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       # /recommend runs on Mistral Large when MISTRAL_API_KEY is set (≈¼ the Opus
       # cost; see issue #453). Until then it stays on Opus. Set RECOMMEND_PROVIDER
       # to "anthropic" to force-rollback to Opus, or "mistral" to force Mistral.
+      # The key lives in a cost-separated "BrewLog" Mistral workspace; deploy.yml
+      # always-syncs it from the GitHub secret so a rotated key takes effect.
       MISTRAL_API_KEY: ${MISTRAL_API_KEY:-}
       RECOMMEND_PROVIDER: ${RECOMMEND_PROVIDER:-}
       S3_ENDPOINT: ${S3_ENDPOINT}


### PR DESCRIPTION
## Why

You rotated the Mistral API key — moving it from the **Default** Mistral workspace to a cost-separated **BrewLog** workspace — and updated the GitHub secret. But the deploy step that injects the key into the VPS `.env` was **append-only**: it only wrote `MISTRAL_API_KEY` when none was present. Since the VPS already had the old Default-workspace key, the new BrewLog key would never have reached production — `/recommend` would keep billing the wrong workspace.

## What changed

- **`.github/workflows/deploy.yml`** — the injection now **always-syncs**: strip any existing `MISTRAL_API_KEY=` line, append the current secret, and commit the result **only when the other vars survived** (`wc -l > 1`), so it can never clobber the production `.env`. A rotated secret now takes effect on the next deploy.
- **`docker-compose.yml`** — clarifying comment (also the non-paths-ignored change that actually triggers this deploy; `.github/**` alone is ignored).

## After merge

This deploy reads the updated secret and syncs the BrewLog-workspace key into the VPS `.env`, then rebuilds `app`. Verify the next recipe shows up under **Usage** in the BrewLog Mistral workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9XyzNYTTqqBDgnLrGRP2G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9XyzNYTTqqBDgnLrGRP2G)_