### PR TITLE
chore: re-deploy to sync rotated MISTRAL_API_KEY (BrewLog workspace)

### DIFF
--- a/.deploy-trigger
+++ b/.deploy-trigger
@@ -1,0 +1,6 @@
+# Bump this file to trigger a Hetzner deploy when no app code changed — e.g. to
+# re-sync a rotated GitHub secret (MISTRAL_API_KEY) onto the VPS .env. deploy.yml
+# paths-ignore excludes docs/**, **/*.md, .github/** and native/**, so a
+# root-level marker like this is the deliberate "just deploy" lever: change the
+# value below and merge to main.
+redeploy: 2026-06-30.1  # re-sync MISTRAL_API_KEY (BrewLog-workspace key)


### PR DESCRIPTION
Bumps a new root-level `.deploy-trigger` marker so the Hetzner deploy runs and re-syncs the rotated `MISTRAL_API_KEY` GitHub secret (now the cost-separated **BrewLog** Mistral workspace key) onto the VPS `.env`. No app code changed; this is the deliberate "just deploy" lever since `deploy.yml` paths-ignores docs/`.github`/native.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9XyzNYTTqqBDgnLrGRP2G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9XyzNYTTqqBDgnLrGRP2G)_