### PR TITLE
chore: re-sync MISTRAL_API_KEY (BrewLog-workspace key, 2nd attempt)

### DIFF
--- a/.deploy-trigger
+++ b/.deploy-trigger
@@ -3,4 +3,4 @@
 # paths-ignore excludes docs/**, **/*.md, .github/** and native/**, so a
 # root-level marker like this is the deliberate "just deploy" lever: change the
 # value below and merge to main.
-redeploy: 2026-06-30.1  # re-sync MISTRAL_API_KEY (BrewLog-workspace key)
+redeploy: 2026-06-30.2  # re-sync MISTRAL_API_KEY (BrewLog-workspace key, 2nd attempt)


### PR DESCRIPTION
Bumps `.deploy-trigger` to re-run the Hetzner deploy so the corrected BrewLog-workspace Mistral key now in the `MISTRAL_API_KEY` secret is synced onto the VPS `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9XyzNYTTqqBDgnLrGRP2G

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9XyzNYTTqqBDgnLrGRP2G)_