### PR TITLE
feat: route BTTS Coach (insights + per-coffee card) through Mistral

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,14 @@ ANTHROPIC_API_KEY=sk-ant-...
 MISTRAL_API_KEY=
 RECOMMEND_PROVIDER=
 
+# ── Mistral — BTTS Coach (insights + per-coffee card) runs on Mistral when set ───
+# Separate key from MISTRAL_API_KEY, minted in its own "BrewLog-Coach" Mistral
+# workspace so the coach's spend is billed apart from /recommend (Mistral isolates
+# usage + billing per workspace). Leave empty to keep the coach on Opus.
+# COACH_PROVIDER overrides: "mistral" / "anthropic" (instant rollback); empty = auto.
+MISTRAL_COACH_API_KEY=
+COACH_PROVIDER=
+
 # ── Voice (Explore voice mode) ────────────────────────────────────────────────
 # ElevenLabs handles both speech-to-text (Scribe) and spoken responses (TTS).
 # One key, one vendor. Default voice id below is Rachel.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,25 +74,27 @@ jobs:
                 < src/lib/db/migrations/0017_add_insight_snooze.sql
             fi
 
-            # Sync MISTRAL_API_KEY into the VPS .env from the GitHub secret so
-            # /recommend runs on Mistral Large (≈¼ the Opus per-call cost; issue
-            # #453) AND a ROTATED key actually takes effect. The earlier append-only
-            # version only wrote when no key was present, so rotating the secret (e.g.
-            # moving it from the Default Mistral workspace to a cost-separated BrewLog
-            # workspace) left the stale key live on the VPS. This replaces ONLY the
-            # MISTRAL_API_KEY line — every other var is preserved — and commits the
-            # result only when those other vars survived (wc -l > 1), so it can never
-            # clobber the production .env. Absent .env → no-op → /recommend stays on
-            # Opus (the code auto-detects).
+            # Sync the Mistral keys into the VPS .env from the GitHub secrets so
+            # /recommend (MISTRAL_API_KEY) AND the coach (MISTRAL_COACH_API_KEY)
+            # run on Mistral Large (≈¼ the Opus per-call cost; issue #453) AND a
+            # ROTATED key actually takes effect. The earlier append-only version
+            # only wrote when no key was present, so rotating the secret (e.g.
+            # moving it to a cost-separated Mistral workspace) left the stale key
+            # live on the VPS. This replaces ONLY those two lines — every other var
+            # is preserved — and commits the result only when those other vars
+            # survived (wc -l > 2, the two lines we append), so it can never clobber
+            # the production .env. An empty secret writes an empty line → the code
+            # auto-detects no key → that surface stays on Opus. Absent .env → no-op.
             if [ -f .env ]; then
-              grep -v '^MISTRAL_API_KEY=' .env > .env.tmp 2>/dev/null || true
+              grep -v -e '^MISTRAL_API_KEY=' -e '^MISTRAL_COACH_API_KEY=' .env > .env.tmp 2>/dev/null || true
               printf 'MISTRAL_API_KEY=%s\n' '${{ secrets.MISTRAL_API_KEY }}' >> .env.tmp
-              if [ "$(wc -l < .env.tmp)" -gt 1 ]; then
+              printf 'MISTRAL_COACH_API_KEY=%s\n' '${{ secrets.MISTRAL_COACH_API_KEY }}' >> .env.tmp
+              if [ "$(wc -l < .env.tmp)" -gt 2 ]; then
                 mv .env.tmp .env
-                echo "Synced MISTRAL_API_KEY in .env"
+                echo "Synced MISTRAL_API_KEY + MISTRAL_COACH_API_KEY in .env"
               else
                 rm -f .env.tmp
-                echo "WARNING: MISTRAL_API_KEY sync skipped (would have dropped other vars)"
+                echo "WARNING: Mistral key sync skipped (would have dropped other vars)"
               fi
             fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,13 @@ services:
       # always-syncs it from the GitHub secret so a rotated key takes effect.
       MISTRAL_API_KEY: ${MISTRAL_API_KEY:-}
       RECOMMEND_PROVIDER: ${RECOMMEND_PROVIDER:-}
+      # The BTTS Coach (corpus insights + per-coffee card) runs on Mistral Large
+      # when MISTRAL_COACH_API_KEY is set, else stays on Opus. Its OWN key (a
+      # separate "BrewLog-Coach" Mistral workspace) so its spend is billed apart
+      # from /recommend. COACH_PROVIDER=anthropic force-rolls back to Opus.
+      # deploy.yml always-syncs the key from the GitHub secret.
+      MISTRAL_COACH_API_KEY: ${MISTRAL_COACH_API_KEY:-}
+      COACH_PROVIDER: ${COACH_PROVIDER:-}
       S3_ENDPOINT: ${S3_ENDPOINT}
       S3_REGION: ${S3_REGION}
       S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID}

--- a/src/lib/ai/coachProvider.ts
+++ b/src/lib/ai/coachProvider.ts
@@ -1,0 +1,135 @@
+// Provider abstraction for the BTTS Coach Opus calls.
+//
+// Background: /recommend moved off Opus to Mistral Large in June 2026 (≈¼ the
+// per-call cost; issue #453). That left two Opus surfaces — the corpus-wide
+// coach (src/lib/claude/insights.ts) and the per-coffee coach card
+// (src/lib/claude/coffeeInsight.ts). Both are single-shot, structured-JSON
+// generations (no tool-use loop), so they port the same way /recommend did.
+// This module is the ONLY place that decides which model answers a coach
+// generation and how each provider is called. Both prompts stay byte-identical
+// across providers — only the transport + model change.
+//
+// NOT here on purpose: the chat (explore-agent). It runs on Sonnet (not Opus)
+// and is an Anthropic-format tool-use agent loop, a different and riskier
+// migration — keep it on Claude.
+//
+// Cost separation: the coach uses its OWN key (MISTRAL_COACH_API_KEY), minted in
+// a separate "BrewLog-Coach" Mistral workspace, so its spend is billed apart
+// from /recommend's MISTRAL_API_KEY — Mistral isolates usage + billing per
+// workspace, so a distinct workspace (not just a distinct key) is what gives the
+// clean split.
+//
+// Selection + safety (identical discipline to recommendProvider):
+//   - COACH_PROVIDER=mistral|anthropic forces a provider (instant rollback to
+//     Opus via env, no code change).
+//   - With no override, Mistral is used when MISTRAL_COACH_API_KEY is present,
+//     else Opus — so deploying this code can NEVER break the coach: until the VPS
+//     has the key it stays on Opus, and it flips to Mistral the moment the key is
+//     added.
+//   - A Mistral failure falls back to Opus for THAT request, so a coach
+//     generation never goes down even if Mistral is unreachable.
+
+import Anthropic from "@anthropic-ai/sdk";
+
+/** Mistral's flagship, EU-hosted on La Plateforme. */
+const MISTRAL_MODEL = "mistral-large-latest";
+/** The Opus model both coach surfaces ran on before this migration. */
+const COACH_OPUS_MODEL = "claude-opus-4-7";
+
+export type CoachUsage = { input_tokens: number; output_tokens: number };
+export type CoachResult = { text: string; usage: CoachUsage; provider: string };
+
+export interface CoachCall {
+  /** System prompt — byte-identical across providers. */
+  system: string;
+  /** The per-turn user message (the serialised evidence). */
+  user: string;
+  /** Output budget for this generation. */
+  maxTokens: number;
+}
+
+export function selectCoachProvider(): "mistral" | "anthropic" {
+  const forced = process.env.COACH_PROVIDER?.toLowerCase().trim();
+  if (forced === "mistral" || forced === "anthropic") return forced;
+  return process.env.MISTRAL_COACH_API_KEY ? "mistral" : "anthropic";
+}
+
+let anthropicClient: Anthropic | null = null;
+function anthropic(): Anthropic {
+  if (!anthropicClient) {
+    anthropicClient = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY, timeout: 120_000 });
+  }
+  return anthropicClient;
+}
+
+async function callAnthropic({ system, user, maxTokens }: CoachCall): Promise<{ text: string; usage: CoachUsage }> {
+  const res = await anthropic().messages.create({
+    model: COACH_OPUS_MODEL,
+    max_tokens: maxTokens,
+    system: [{ type: "text", text: system, cache_control: { type: "ephemeral" } }],
+    messages: [{ role: "user", content: user }],
+  });
+  const text = res.content
+    .filter((b): b is Anthropic.Messages.TextBlock => b.type === "text")
+    .map((b) => b.text)
+    .join("\n");
+  return { text, usage: { input_tokens: res.usage.input_tokens, output_tokens: res.usage.output_tokens } };
+}
+
+async function callMistral({ system, user, maxTokens }: CoachCall): Promise<{ text: string; usage: CoachUsage }> {
+  const res = await fetch("https://api.mistral.ai/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.MISTRAL_COACH_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: MISTRAL_MODEL,
+      max_tokens: maxTokens,
+      // JSON mode keeps the structured output the Zod parser expects (both coach
+      // prompts already instruct "JSON only"). Mistral runs its own caching, so
+      // no cache_control on the system block.
+      response_format: { type: "json_object" },
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: user },
+      ],
+    }),
+    signal: AbortSignal.timeout(120_000),
+  });
+  if (!res.ok) {
+    throw new Error(`Mistral HTTP ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  }
+  const j = (await res.json()) as {
+    choices?: { message?: { content?: string } }[];
+    usage?: { prompt_tokens?: number; completion_tokens?: number };
+  };
+  return {
+    text: j.choices?.[0]?.message?.content ?? "{}",
+    usage: {
+      input_tokens: j.usage?.prompt_tokens ?? 0,
+      output_tokens: j.usage?.completion_tokens ?? 0,
+    },
+  };
+}
+
+/**
+ * Run a coach generation for `call`. Picks the provider per the rules above and
+ * falls back to Opus on a Mistral error. The caller parses + validates the
+ * returned `text` with its own Zod schema exactly as before (provider-agnostic).
+ */
+export async function callCoachModel(call: CoachCall): Promise<CoachResult> {
+  if (selectCoachProvider() === "anthropic") {
+    return { ...(await callAnthropic(call)), provider: "anthropic" };
+  }
+  try {
+    return { ...(await callMistral(call)), provider: "mistral" };
+  } catch (err) {
+    console.warn(
+      `[coach] Mistral call failed, falling back to Opus for this request: ${String(
+        (err as Error)?.message ?? err,
+      ).slice(0, 160)}`,
+    );
+    return { ...(await callAnthropic(call)), provider: "anthropic-fallback" };
+  }
+}

--- a/src/lib/claude/coffeeInsight.ts
+++ b/src/lib/claude/coffeeInsight.ts
@@ -1,4 +1,3 @@
-import Anthropic from "@anthropic-ai/sdk";
 import { z } from "zod";
 import { parseClaudeJson } from "./parseJson";
 import type { Coffee } from "@/lib/types/coffee";
@@ -6,8 +5,7 @@ import type { Session } from "@/lib/types/session";
 import { resolveBrewedRecipe } from "@/lib/utils/resolveRecipe";
 import { getRoasterPrior, formatRoasterPriorForPrompt } from "@/lib/roasters/priors";
 import { getVarietyPriorsForBag } from "@/lib/knowledge/varieties";
-
-const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+import { callCoachModel } from "@/lib/ai/coachProvider";
 
 /**
  * Per-coffee coach insight.
@@ -162,20 +160,13 @@ export async function generateCoffeeInsight(
 ): Promise<GeneratedCoffeeInsight | null> {
   try {
     const userMessage = buildUserPrompt(coffee, sessionsForCoffee);
-    const response = await client.messages.create({
-      model: "claude-opus-4-7",
-      max_tokens: 1200,
-      system: [
-        { type: "text", text: SYSTEM_PROMPT, cache_control: { type: "ephemeral" } },
-      ],
-      messages: [{ role: "user", content: userMessage }],
+    // Routes through coachProvider (Mistral Large when the coach key is set,
+    // else Opus; auto-fallback to Opus on a Mistral error).
+    const { text } = await callCoachModel({
+      system: SYSTEM_PROMPT,
+      user: userMessage,
+      maxTokens: 1200,
     });
-    const text = response.content
-      .filter(
-        (b): b is Anthropic.Messages.TextBlock => b.type === "text",
-      )
-      .map((b) => b.text)
-      .join("\n");
     return parseClaudeJson(text, InsightSchema);
   } catch (err) {
     console.error("coffeeInsight generation failed:", err);

--- a/src/lib/claude/insights.ts
+++ b/src/lib/claude/insights.ts
@@ -24,7 +24,6 @@
  * compares it against the corpus's latest session and only re-runs Opus
  * when new brews have arrived since.
  */
-import Anthropic from "@anthropic-ai/sdk";
 import { randomUUID } from "crypto";
 import { desc, gte, inArray } from "drizzle-orm";
 import { db } from "@/lib/db/client";
@@ -37,8 +36,7 @@ import { buildSignatures } from "./brewSignature";
 import { extract, serialiseForEscher } from "./extractor";
 import { detectPatterns } from "./patterns";
 import type { PatternAnalysis } from "./patterns";
-
-const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+import { callCoachModel } from "@/lib/ai/coachProvider";
 
 const InsightItemSchema = z.object({
   observation: z.string().min(10).max(400),
@@ -339,12 +337,12 @@ export async function getOrGenerateInsights(): Promise<GenerateInsightsResult> {
 
   const userMessage = promptSections.join("\n");
 
-  // 6. Opus call. Multivariate reasoning, not summarisation — Haiku
-  // flattens. Per CLAUDE.md, /recommend is the Opus-engineered surface;
-  // insights joins it.
-  const newItems = await callOpusForInsights(userMessage);
+  // 6. Coach model call. Multivariate reasoning, not summarisation — Haiku
+  // flattens. Routes through coachProvider (Mistral Large when the coach key
+  // is set, else Opus; auto-fallback to Opus on a Mistral error).
+  const newItems = await callCoachForInsights(userMessage);
   if (newItems == null) {
-    // Opus call failed — return what we have (cached rows are still
+    // Model call failed — return what we have (cached rows are still
     // useful, and the next page-mount will retry).
     return {
       insights: existing,
@@ -374,22 +372,17 @@ export async function getOrGenerateInsights(): Promise<GenerateInsightsResult> {
   };
 }
 
-async function callOpusForInsights(userMessage: string): Promise<InsightItem[] | null> {
+async function callCoachForInsights(userMessage: string): Promise<InsightItem[] | null> {
   try {
-    const msg = await client.messages.create({
-      model: "claude-opus-4-7",
-      max_tokens: 3000,
+    const { text } = await callCoachModel({
       system: SYSTEM_PROMPT,
-      messages: [{ role: "user", content: userMessage }],
+      user: userMessage,
+      maxTokens: 3000,
     });
-    const text = msg.content
-      .filter((b): b is Anthropic.Messages.TextBlock => b.type === "text")
-      .map((b) => b.text)
-      .join("\n");
     const parsed = parseClaudeJson(text, InsightsResponseSchema);
     return parsed?.insights ?? null;
   } catch (err) {
-    console.error("insights Opus call failed:", err);
+    console.error("insights coach call failed:", err);
     return null;
   }
 }

--- a/tests/dataflow/coach-provider.test.mjs
+++ b/tests/dataflow/coach-provider.test.mjs
@@ -1,0 +1,86 @@
+// Coach-provider selection tests — bundles the REAL src/lib/ai/coachProvider.ts
+// with esbuild so the test tracks the actual selection rule. This guards the
+// load-bearing safety property of the Opus→Mistral coach migration: with no
+// coach key the coach MUST stay on Opus (deploying the code can never break it),
+// and COACH_PROVIDER force-overrides either way (instant rollback).
+//
+//   node --test tests/dataflow/coach-provider.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const entry = `export { selectCoachProvider } from ${JSON.stringify(
+  path.join(ROOT, "src/lib/ai/coachProvider.ts"),
+)};`;
+const dir = await mkdtemp(join(tmpdir(), "coach-"));
+const out = join(dir, "b.mjs");
+await build({
+  stdin: { contents: entry, resolveDir: ROOT, loader: "ts" },
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  outfile: out,
+  logLevel: "silent",
+});
+const { selectCoachProvider } = await import(pathToFileURL(out).href);
+
+function withEnv(env, fn) {
+  const saved = {
+    COACH_PROVIDER: process.env.COACH_PROVIDER,
+    MISTRAL_COACH_API_KEY: process.env.MISTRAL_COACH_API_KEY,
+  };
+  for (const k of Object.keys(saved)) delete process.env[k];
+  Object.assign(process.env, env);
+  try {
+    return fn();
+  } finally {
+    for (const k of Object.keys(saved)) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  }
+}
+
+test("no coach key → Opus (deploying the code can't break the coach)", () => {
+  withEnv({}, () => assert.equal(selectCoachProvider(), "anthropic"));
+});
+
+test("coach key present → Mistral (auto)", () => {
+  withEnv({ MISTRAL_COACH_API_KEY: "sk-coach" }, () =>
+    assert.equal(selectCoachProvider(), "mistral"),
+  );
+});
+
+test("COACH_PROVIDER=anthropic forces Opus even with a key (rollback lever)", () => {
+  withEnv({ MISTRAL_COACH_API_KEY: "sk-coach", COACH_PROVIDER: "anthropic" }, () =>
+    assert.equal(selectCoachProvider(), "anthropic"),
+  );
+});
+
+test("COACH_PROVIDER=mistral forces Mistral even with no key", () => {
+  withEnv({ COACH_PROVIDER: "mistral" }, () =>
+    assert.equal(selectCoachProvider(), "mistral"),
+  );
+});
+
+test("COACH_PROVIDER is case/space tolerant", () => {
+  withEnv({ COACH_PROVIDER: "  ANTHROPIC  ", MISTRAL_COACH_API_KEY: "sk-coach" }, () =>
+    assert.equal(selectCoachProvider(), "anthropic"),
+  );
+});
+
+test("an unknown COACH_PROVIDER value falls through to auto-detect", () => {
+  withEnv({ COACH_PROVIDER: "gpt", MISTRAL_COACH_API_KEY: "sk-coach" }, () =>
+    assert.equal(selectCoachProvider(), "mistral"),
+  );
+  withEnv({ COACH_PROVIDER: "gpt" }, () =>
+    assert.equal(selectCoachProvider(), "anthropic"),
+  );
+});


### PR DESCRIPTION
## What

Moves the two remaining **Opus** surfaces onto Mistral Large, the same way `/recommend` migrated in June 2026:

- **Corpus-wide coach** — `src/lib/claude/insights.ts`
- **Per-coffee coach card** — `src/lib/claude/coffeeInsight.ts`

Both are single-shot, structured-JSON generations (no tool-use loop), so they port cleanly. The **chat** (`explore-agent`) is **deliberately left on Sonnet** — it's a tool-use agent loop, a riskier port that saves little (it's not Opus).

## How

New `src/lib/ai/coachProvider.ts` mirrors `recommendProvider.ts` — the single place that picks the coach model:

- `COACH_PROVIDER=mistral|anthropic` forces a side (instant rollback).
- Else **Mistral when `MISTRAL_COACH_API_KEY` is set, else Opus** — so deploying this can never break the coach; until the VPS has the key it stays on Opus, and flips the moment the key lands.
- A Mistral error **falls back to Opus per-request**.
- Both `SYSTEM_PROMPT`s are byte-identical across providers.

## Cost separation

The coach uses its **own** key (`MISTRAL_COACH_API_KEY`), minted in a separate **"BrewLog-Coach"** Mistral workspace, so its spend is billed apart from `/recommend` — Mistral isolates usage + billing per workspace.

## Changes

- `coachProvider.ts` — selection + Mistral/Opus call + auto-fallback
- `insights.ts` / `coffeeInsight.ts` — route through `callCoachModel`, drop the direct Anthropic client
- `docker-compose.yml` + `.env.example` — `MISTRAL_COACH_API_KEY` + `COACH_PROVIDER`
- `deploy.yml` — always-sync both Mistral keys into the VPS `.env`
- `tests/dataflow/coach-provider.test.mjs` — selection-logic safety guards

## Owner action (then it auto-flips to Mistral)

1. Mistral console → new workspace **"BrewLog-Coach"** → *then* create a key (switch workspace first, or it bills the wrong one).
2. GitHub repo secret `MISTRAL_COACH_API_KEY` = that key.

Until then everything stays on Opus — nothing breaks.

## Verification

`npx tsc --noEmit` clean; full `node --test` suite green (175 tests, incl. 6 new selection-logic guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGHEjxPcdYCqHLpLVrSfzX)_