### PR TITLE
chore: deploy to sync MISTRAL_COACH_API_KEY onto the VPS

### DIFF
--- a/.deploy-trigger
+++ b/.deploy-trigger
@@ -3,4 +3,4 @@
 # paths-ignore excludes docs/**, **/*.md, .github/** and native/**, so a
 # root-level marker like this is the deliberate "just deploy" lever: change the
 # value below and merge to main.
-redeploy: 2026-06-30.2  # re-sync MISTRAL_API_KEY (BrewLog-workspace key, 2nd attempt)
+redeploy: 2026-06-30.3  # sync MISTRAL_COACH_API_KEY onto VPS .env → coach flips to Mistral (PR #463)


### PR DESCRIPTION
Owner added the `MISTRAL_COACH_API_KEY` secret. Bumps `.deploy-trigger` so `deploy.yml` runs and always-syncs both Mistral keys into the VPS `.env` — this activates the coach (insights + per-coffee card) on Mistral (#463).

No app code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGHEjxPcdYCqHLpLVrSfzX)_