### PR TITLE
fix: stop LiquidHeadline clipping Fraunces descenders (g/y/j)

### DIFF
--- a/docs/liquid-design.md
+++ b/docs/liquid-design.md
@@ -295,6 +295,14 @@ When adding any new motion, add its selector to that globals.css block in the sa
 - **Animating a blurred full-viewport `background` div stutters on iOS** — never animate the base
   gradient's `background` or slide the whole base. Float transform-only blob layers over a static
   base instead (the core architecture). (Original plan.)
+- **A persistent `filter` on an inline-block word clips Fraunces' descenders (g/y/j)** — `LiquidHeadline`
+  words carry `animation-fill-mode: both`, so the 100% keyframe is held at rest. When that frame ended
+  on `filter: blur(0)`, the (zero-radius) filter region clipped painting to the inline-block's
+  line-height box — shorter than the deep descenders of the Fraunces display serif — so g/y/j were cut
+  off flat at the baseline in the rotating recipe insight + Hero questions. The haiku never showed it
+  because `HaikuStarter` drops the animation class after settling (no filter at rest). Fix: the
+  `lh-pop-*` 100% keyframes end on `filter: none`; the blur lives only mid-flight. Keep rest-state
+  filter: none. (PR #467.)
 
 ---
 

--- a/src/components/ui/light/LiquidHeadline.tsx
+++ b/src/components/ui/light/LiquidHeadline.tsx
@@ -111,17 +111,17 @@ export default function LiquidHeadline({
         @keyframes lh-pop-1 {
           0% { opacity: 0; filter: blur(10px); transform: translate(-7px, 12px) scale(0.84) rotate(-3deg); }
           60% { opacity: 1; filter: blur(0); transform: translate(0, -2px) scale(1.07) rotate(1deg); }
-          100% { opacity: 1; filter: blur(0); transform: translate(0, 0) scale(1) rotate(0deg); }
+          100% { opacity: 1; filter: none; transform: translate(0, 0) scale(1) rotate(0deg); }
         }
         @keyframes lh-pop-2 {
           0% { opacity: 0; filter: blur(12px); transform: translate(9px, -10px) scale(0.8) rotate(4deg); }
           58% { opacity: 1; filter: blur(0); transform: translate(-1px, 1px) scale(1.08) rotate(-1deg); }
-          100% { opacity: 1; filter: blur(0); transform: translate(0, 0) scale(1) rotate(0deg); }
+          100% { opacity: 1; filter: none; transform: translate(0, 0) scale(1) rotate(0deg); }
         }
         @keyframes lh-pop-3 {
           0% { opacity: 0; filter: blur(9px); transform: translateY(16px) scale(0.9); }
           62% { opacity: 1; filter: blur(0); transform: translateY(-3px) scale(1.05); }
-          100% { opacity: 1; filter: blur(0); transform: translateY(0) scale(1); }
+          100% { opacity: 1; filter: none; transform: translateY(0) scale(1); }
         }
         /* Exit = the entrance in reverse: settle → slight anticipation → scatter out. */
         @keyframes lh-out-1-down {
@@ -154,6 +154,10 @@ export default function LiquidHeadline({
           35% { opacity: 1; filter: blur(0); transform: translateY(4px) scale(1.05); }
           100% { opacity: 0; filter: blur(9px); transform: translateY(-24px) scale(1.05); }
         }
+        /* fill-mode: both pins the 100% keyframe at rest. That state MUST end on
+           filter: none — a persistent filter (even blur(0)) clips painting to the
+           inline-block's line-height box, cutting Fraunces' deep descenders
+           (g/y/j). Keep rest-state filter: none; the blur lives only mid-flight. */
         .lh-word {
           animation-fill-mode: both;
           animation-duration: var(--lh-dur, ${LH_POP_MS}ms);


### PR DESCRIPTION
## Bug
On the recipe-crafting insight screen (and the Hero questions), the descenders of **g / y / j** are cut off flat at the baseline (e.g. "just", "enjoy"). Owner-reported with screenshots.

## Cause
`LiquidHeadline` renders each word as an `inline-block` span with `animation-fill-mode: both`, so the **100% keyframe is held at rest**. That frame ended on `filter: blur(0)`. A persistent CSS `filter` — even at zero radius — clips painting to the element's box, and the inline-block box is only as tall as the `leading` line-height, which is shorter than the deep descenders of the Fraunces display serif. So the bottoms of g/y/j get clipped.

The welcome haiku never showed this because `HaikuStarter` drops its animation class after settling → no filter at rest.

## Fix
The `lh-pop-*` 100% keyframes now end on `filter: none` (blur stays only mid-animation). Layout-neutral; fixes every `LiquidHeadline` consumer at once. Added a co-located comment + a Stolperstein in `docs/liquid-design.md` so it isn't reverted.

## Verify
`tsc` clean. The real check is on-device after deploy — **force-quit + reopen the PWA** (stale-cache rule) → open a recipe craft / a Hero question with a descender word; g/y/j should be whole. (CI screenshots can't catch it reliably — it's a settled-frame render detail.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGHEjxPcdYCqHLpLVrSfzX)_