### PR TITLE
feat: push logged coffees to HealthSync as caffeine events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -89,10 +89,10 @@ AUTH_PIN=your-pin
 # One-way, fire-and-forget: BrewLog POSTs each logged coffee's volume to the
 # co-hosted HealthSync app after a successful save (caffeine only — see
 # src/lib/health/healthsyncPush.ts). Leave the SECRET empty to disable the push
-# (it no-ops). URL defaults to HealthSync's internal container address on the
-# shared "brewlog" Docker network; use the Authelia-free public URL
-# (https://health.markus-reuter.com/api/ingest/brewlog) if internal networking
-# fails. SECRET must equal HealthSync's INGEST_SECRET — deploy.yml syncs it from
-# the GitHub secret HEALTHSYNC_INGEST_SECRET.
-HEALTHSYNC_INGEST_URL=http://healthsync-healthsync-web-1:3000/api/ingest/brewlog
+# (it no-ops). URL defaults to the public, Authelia-free endpoint (works
+# regardless of Docker networking); switch to the internal container address
+# (http://healthsync-healthsync-web-1:3000/api/ingest/brewlog) once the app
+# shares HealthSync's Docker network. SECRET must equal HealthSync's
+# INGEST_SECRET — deploy.yml syncs it from the GitHub secret HEALTHSYNC_INGEST_SECRET.
+HEALTHSYNC_INGEST_URL=https://health.markus-reuter.com/api/ingest/brewlog
 HEALTHSYNC_INGEST_SECRET=

--- a/.env.example
+++ b/.env.example
@@ -84,3 +84,15 @@ WEBAUTHN_ORIGIN=https://bettertastethansorry.com
 # ── PIN fallback ──────────────────────────────────────────────────────────────
 # Used when WebAuthn fails or during domain moves. 5 attempts then 60s lockout.
 AUTH_PIN=your-pin
+
+# ── HealthSync caffeine bridge ────────────────────────────────────────────────
+# One-way, fire-and-forget: BrewLog POSTs each logged coffee's volume to the
+# co-hosted HealthSync app after a successful save (caffeine only — see
+# src/lib/health/healthsyncPush.ts). Leave the SECRET empty to disable the push
+# (it no-ops). URL defaults to HealthSync's internal container address on the
+# shared "brewlog" Docker network; use the Authelia-free public URL
+# (https://health.markus-reuter.com/api/ingest/brewlog) if internal networking
+# fails. SECRET must equal HealthSync's INGEST_SECRET — deploy.yml syncs it from
+# the GitHub secret HEALTHSYNC_INGEST_SECRET.
+HEALTHSYNC_INGEST_URL=http://healthsync-healthsync-web-1:3000/api/ingest/brewlog
+HEALTHSYNC_INGEST_SECRET=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,16 +85,27 @@ jobs:
             # survived (wc -l > 2, the two lines we append), so it can never clobber
             # the production .env. An empty secret writes an empty line → the code
             # auto-detects no key → that surface stays on Opus. Absent .env → no-op.
+            # Also sync HEALTHSYNC_INGEST_SECRET (one-way caffeine push to the
+            # co-hosted HealthSync app) the same way. An empty secret writes an
+            # empty line → the push code no-ops (surface stays off). Strip the
+            # three managed lines, re-append the current secrets, and commit only
+            # when the OTHER vars survived (wc -l > 3) so this can never clobber
+            # the production .env.
             if [ -f .env ]; then
-              grep -v -e '^MISTRAL_API_KEY=' -e '^MISTRAL_COACH_API_KEY=' .env > .env.tmp 2>/dev/null || true
+              grep -v \
+                -e '^MISTRAL_API_KEY=' \
+                -e '^MISTRAL_COACH_API_KEY=' \
+                -e '^HEALTHSYNC_INGEST_SECRET=' \
+                .env > .env.tmp 2>/dev/null || true
               printf 'MISTRAL_API_KEY=%s\n' '${{ secrets.MISTRAL_API_KEY }}' >> .env.tmp
               printf 'MISTRAL_COACH_API_KEY=%s\n' '${{ secrets.MISTRAL_COACH_API_KEY }}' >> .env.tmp
-              if [ "$(wc -l < .env.tmp)" -gt 2 ]; then
+              printf 'HEALTHSYNC_INGEST_SECRET=%s\n' '${{ secrets.HEALTHSYNC_INGEST_SECRET }}' >> .env.tmp
+              if [ "$(wc -l < .env.tmp)" -gt 3 ]; then
                 mv .env.tmp .env
-                echo "Synced MISTRAL_API_KEY + MISTRAL_COACH_API_KEY in .env"
+                echo "Synced MISTRAL_API_KEY + MISTRAL_COACH_API_KEY + HEALTHSYNC_INGEST_SECRET in .env"
               else
                 rm -f .env.tmp
-                echo "WARNING: Mistral key sync skipped (would have dropped other vars)"
+                echo "WARNING: key sync skipped (would have dropped other vars)"
               fi
             fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,15 @@ services:
       APNS_TEAM_ID: ${APNS_TEAM_ID:-}
       APNS_BUNDLE_ID: ${APNS_BUNDLE_ID:-com.roitsch.btts.watchkitapp}
       APNS_PRODUCTION: ${APNS_PRODUCTION:-true}
+      # One-way caffeine push to the co-hosted HealthSync app (same "brewlog"
+      # Docker network). BrewLog POSTs each logged coffee's volume to HealthSync's
+      # ingest endpoint. URL defaults to the internal container address (no Caddy/
+      # Authelia hop); override via .env with the public URL
+      # (https://health.markus-reuter.com/api/ingest/brewlog) if internal
+      # networking fails. SECRET must equal HealthSync's INGEST_SECRET; empty →
+      # the push no-ops. deploy.yml syncs the secret from the GitHub secret.
+      HEALTHSYNC_INGEST_URL: ${HEALTHSYNC_INGEST_URL:-http://healthsync-healthsync-web-1:3000/api/ingest/brewlog}
+      HEALTHSYNC_INGEST_SECRET: ${HEALTHSYNC_INGEST_SECRET:-}
     expose:
       - "3000"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,14 +64,14 @@ services:
       APNS_TEAM_ID: ${APNS_TEAM_ID:-}
       APNS_BUNDLE_ID: ${APNS_BUNDLE_ID:-com.roitsch.btts.watchkitapp}
       APNS_PRODUCTION: ${APNS_PRODUCTION:-true}
-      # One-way caffeine push to the co-hosted HealthSync app (same "brewlog"
-      # Docker network). BrewLog POSTs each logged coffee's volume to HealthSync's
-      # ingest endpoint. URL defaults to the internal container address (no Caddy/
-      # Authelia hop); override via .env with the public URL
-      # (https://health.markus-reuter.com/api/ingest/brewlog) if internal
-      # networking fails. SECRET must equal HealthSync's INGEST_SECRET; empty →
-      # the push no-ops. deploy.yml syncs the secret from the GitHub secret.
-      HEALTHSYNC_INGEST_URL: ${HEALTHSYNC_INGEST_URL:-http://healthsync-healthsync-web-1:3000/api/ingest/brewlog}
+      # One-way caffeine push to the co-hosted HealthSync app. BrewLog POSTs each
+      # logged coffee's volume to HealthSync's ingest endpoint. URL defaults to the
+      # public, Authelia-free endpoint (works regardless of Docker networking); to
+      # skip the Caddy hop set HEALTHSYNC_INGEST_URL in .env to the internal address
+      # (http://healthsync-healthsync-web-1:3000/api/ingest/brewlog) once the app
+      # shares HealthSync's Docker network. SECRET must equal HealthSync's
+      # INGEST_SECRET; empty → the push no-ops. deploy.yml syncs it from the secret.
+      HEALTHSYNC_INGEST_URL: ${HEALTHSYNC_INGEST_URL:-https://health.markus-reuter.com/api/ingest/brewlog}
       HEALTHSYNC_INGEST_SECRET: ${HEALTHSYNC_INGEST_SECRET:-}
     expose:
       - "3000"

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -7,6 +7,7 @@ import { sessions, coffees } from "@/lib/db/schema";
 import { rowToSession } from "@/lib/db/helpers";
 import type { Session } from "@/lib/types/session";
 import { FieldZonesSchema } from "@/lib/field/schema";
+import { pushCaffeineToHealthSync } from "@/lib/health/healthsyncPush";
 
 const SessionPostSchema = z.object({
   type: z.enum(["coffee", "wine"]),
@@ -177,6 +178,16 @@ export async function POST(req: NextRequest) {
       recommendation: data.recommendation,
       brew: data.brew,
       result: data.result,
+    });
+
+    // One-way, fire-and-forget caffeine push to the co-hosted HealthSync app.
+    // Past the dedup early-return above, so an offline-queue retry can't
+    // double-count. Best-effort: never awaited, never throws — a HealthSync
+    // outage must not block or fail this save.
+    pushCaffeineToHealthSync({
+      type: data.type,
+      createdAt: data.createdAt,
+      brew: data.brew,
     });
 
     if (data.coffee?.name) {

--- a/src/lib/health/healthsyncPush.ts
+++ b/src/lib/health/healthsyncPush.ts
@@ -1,0 +1,86 @@
+// One-way, fire-and-forget caffeine push to the co-hosted HealthSync app.
+//
+// Principle "never-switch-projects": BrewLog forwards ONLY caffeine — the drink
+// volume in ml, an optional mg figure, and the timestamp. No other health data,
+// no merge, no reverse direction. HealthSync's ingest endpoint is one-way and
+// only accepts caffeine.
+//
+// Best-effort by design: a HealthSync outage (or a missing config) must never
+// block the user or fail a brew save. We deliberately do NOT await the request
+// so it can't add HealthSync's latency to every save; BrewLog runs as a
+// long-lived Node server (docker-compose `app`), so an un-awaited fetch keeps
+// running after the save response returns.
+
+/** The exact shape HealthSync's POST /api/ingest/brewlog accepts. */
+export interface CaffeinePushPayload {
+  /** Drink volume in millilitres. Omitted when the brew carries no water figure
+   *  (e.g. a coffee-shop log with no recipe). */
+  caffeine_ml?: number;
+  /** Caffeine in milligrams — only sent when BrewLog actually has it. BrewLog
+   *  does not currently measure mg, so this is omitted rather than fabricated. */
+  caffeine_mg?: number;
+  /** ISO-8601 timestamp of the coffee. */
+  ts: string;
+  /** Always "coffee" — this bridge never forwards anything else. */
+  drink: "coffee";
+}
+
+/** Minimal view of a just-saved session that this bridge reads. */
+export interface CaffeineSource {
+  type: string;
+  createdAt: string;
+  brew?: { waterGrams?: number } | null;
+}
+
+/**
+ * Build the caffeine payload from a just-saved session, or `null` when the
+ * session carries no caffeine to report (a wine log). Pure + exported so the
+ * payload shape is unit-testable without a network.
+ */
+export function buildCaffeinePayload(session: CaffeineSource): CaffeinePushPayload | null {
+  if (session.type !== "coffee") return null;
+
+  const ts = session.createdAt || new Date().toISOString();
+  const payload: CaffeinePushPayload = { ts, drink: "coffee" };
+
+  // waterGrams ≈ the drink's ml (1 g water ≈ 1 ml). It's the best "ml of the
+  // coffee" BrewLog has; external coffee-shop logs may lack it → omit, don't
+  // invent one.
+  const ml = session.brew?.waterGrams;
+  if (typeof ml === "number" && Number.isFinite(ml) && ml > 0) {
+    payload.caffeine_ml = ml;
+  }
+
+  return payload;
+}
+
+/**
+ * Fire-and-forget: push the session's caffeine to HealthSync. No-op when the
+ * bridge isn't configured (env absent) or the session isn't a coffee. Never
+ * throws, never blocks — safe to call inline in a save handler.
+ */
+export function pushCaffeineToHealthSync(session: CaffeineSource): void {
+  const url = process.env.HEALTHSYNC_INGEST_URL;
+  const secret = process.env.HEALTHSYNC_INGEST_SECRET;
+  if (!url || !secret) return; // not wired up → silently skip
+
+  const payload = buildCaffeinePayload(session);
+  if (!payload) return;
+
+  try {
+    // Not awaited: the save response returns immediately regardless of
+    // HealthSync. AbortSignal keeps a wedged socket from lingering.
+    void fetch(url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-ingest-secret": secret,
+      },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(5000),
+    }).catch(() => {});
+  } catch {
+    // AbortSignal.timeout / fetch construction can't realistically throw here,
+    // but a caffeine push must never be able to break a brew save.
+  }
+}

--- a/tests/dataflow/healthsync-push.test.mjs
+++ b/tests/dataflow/healthsync-push.test.mjs
@@ -1,0 +1,96 @@
+// HealthSync caffeine-push payload tests — bundles the REAL
+// src/lib/health/healthsyncPush.ts with esbuild so the test tracks the actual
+// builder. This is the one-way bridge: BrewLog forwards ONLY caffeine (drink
+// volume in ml + timestamp + drink:"coffee"), never other health data.
+//
+//   node --test tests/dataflow/healthsync-push.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const entry = `export { buildCaffeinePayload } from ${JSON.stringify(
+  path.join(ROOT, "src/lib/health/healthsyncPush.ts"),
+)};`;
+
+async function load() {
+  const dir = await mkdtemp(join(tmpdir(), "healthsync-"));
+  const entryFile = join(dir, "entry.ts");
+  await writeFile(entryFile, entry);
+  const outFile = join(dir, "out.mjs");
+  await build({
+    entryPoints: [entryFile],
+    outfile: outFile,
+    bundle: true,
+    format: "esm",
+    platform: "node",
+    logLevel: "silent",
+  });
+  return import(pathToFileURL(outFile).href);
+}
+
+const { buildCaffeinePayload } = await load();
+
+test("coffee with waterGrams → caffeine_ml + ts + drink", () => {
+  const p = buildCaffeinePayload({
+    type: "coffee",
+    createdAt: "2026-07-01T08:30:00.000Z",
+    brew: { waterGrams: 250 },
+  });
+  assert.deepEqual(p, {
+    ts: "2026-07-01T08:30:00.000Z",
+    drink: "coffee",
+    caffeine_ml: 250,
+  });
+});
+
+test("never forwards mg (BrewLog doesn't measure it)", () => {
+  const p = buildCaffeinePayload({
+    type: "coffee",
+    createdAt: "2026-07-01T08:30:00.000Z",
+    brew: { waterGrams: 250 },
+  });
+  assert.equal("caffeine_mg" in p, false);
+});
+
+test("coffee without a water figure → caffeine_ml omitted, still pushes", () => {
+  const p = buildCaffeinePayload({
+    type: "coffee",
+    createdAt: "2026-07-01T08:30:00.000Z",
+    brew: undefined,
+  });
+  assert.deepEqual(p, { ts: "2026-07-01T08:30:00.000Z", drink: "coffee" });
+});
+
+test("zero / non-finite water is not sent", () => {
+  for (const waterGrams of [0, -10, NaN]) {
+    const p = buildCaffeinePayload({
+      type: "coffee",
+      createdAt: "2026-07-01T08:30:00.000Z",
+      brew: { waterGrams },
+    });
+    assert.equal("caffeine_ml" in p, false, `waterGrams=${waterGrams}`);
+  }
+});
+
+test("non-coffee (wine) → null, nothing forwarded", () => {
+  const p = buildCaffeinePayload({
+    type: "wine",
+    createdAt: "2026-07-01T20:00:00.000Z",
+    brew: { waterGrams: 150 },
+  });
+  assert.equal(p, null);
+});
+
+test("missing createdAt falls back to a valid ISO timestamp", () => {
+  const p = buildCaffeinePayload({ type: "coffee", createdAt: "", brew: { waterGrams: 200 } });
+  assert.ok(p);
+  assert.ok(!Number.isNaN(Date.parse(p.ts)));
+  assert.equal(p.drink, "coffee");
+});


### PR DESCRIPTION
One-way, fire-and-forget bridge from BrewLog to the co-hosted HealthSync app. After a session is successfully saved, BrewLog POSTs the coffee's volume to HealthSync's ingest endpoint. Caffeine only — no other health data, no merge, no reverse direction ("never-switch-projects").

## What it does
- **`src/lib/health/healthsyncPush.ts`** — `buildCaffeinePayload` (pure, unit-tested) + `pushCaffeineToHealthSync`. Sends `{ caffeine_ml, ts, drink: "coffee" }` with the `x-ingest-secret` header. `caffeine_ml` = the brew's `waterGrams` (drink volume ≈ ml — the only "ml of the coffee" BrewLog has). No `caffeine_mg` (BrewLog doesn't measure it — not fabricated).
- **`src/app/api/sessions/route.ts`** — calls it after the insert, *past* the offline-queue dedup early-return so a reconnect retry can't double-count. Coffee-only (a wine log sends nothing).
- **Best-effort:** not awaited (HealthSync latency never touches the save), `.catch(() => {})`, 5s abort, wrapped so it can't throw. A HealthSync outage or missing config → silent no-op, brew save unaffected.

## Config
- `docker-compose.yml` + `.env.example`: `HEALTHSYNC_INGEST_URL` (defaults to the public Authelia-free endpoint `https://health.markus-reuter.com/api/ingest/brewlog`; internal container URL documented as an override) + `HEALTHSYNC_INGEST_SECRET` (empty → push disabled).
- `.github/workflows/deploy.yml`: syncs `HEALTHSYNC_INGEST_SECRET` from the GitHub secret onto the VPS `.env` each deploy (same pattern as the Mistral keys), guard bumped to `wc -l > 3` so it can never clobber the other env vars.

## Verified
- `npx tsc --noEmit` clean.
- `node --test tests/dataflow/*.test.mjs` — 138/138, incl. 6 new payload cases in `tests/dataflow/healthsync-push.test.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgU6HGDm3YvWbVxatqfPcm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgU6HGDm3YvWbVxatqfPcm)_