### PR TITLE
feat: retroactively translate existing scanned flavour notes to English

### DIFF
--- a/.github/translate-flavor-notes-trigger
+++ b/.github/translate-flavor-notes-trigger
@@ -1,0 +1,2 @@
+bump to fire the one-shot retroactive flavour-note translation
+2026-07-03 run 1

--- a/.github/workflows/translate-flavor-notes.yml
+++ b/.github/workflows/translate-flavor-notes.yml
@@ -1,0 +1,73 @@
+name: Translate flavour notes
+
+# One-shot retroactive translation of existing scanned flavour notes to English
+# (src/app/api/admin/translate-flavor-notes) — for bags scanned BEFORE PR #471
+# started translating at scan time. SSHes into the VPS with the SAME deploy key
+# the Deploy workflow uses and triggers the route from INSIDE the app container,
+# reading the container's own CRON_SECRET — exactly like the field-zones re-map.
+# No new secrets. Re-running is safe (English → English is a no-op).
+#
+# Fires manually (Actions tab / `gh workflow run`) OR when
+# `.github/translate-flavor-notes-trigger` changes on main. The trigger-file path
+# exists because the GitHub integration token can't `workflow_dispatch` via the
+# API (403) — bumping that file in a PR and merging is the house-standard way to
+# fire a one-shot job hands-free.
+#
+# The curl RETRIES for a few minutes: this same merge also runs Deploy, which
+# recreates the app container, so the route may 404 for the first minute or two.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/translate-flavor-notes-trigger"
+
+concurrency:
+  group: translate-flavor-notes
+  cancel-in-progress: false
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger translation on the VPS
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${{ secrets.DEPLOY_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+          # Retry: the same merge also deploys, which recreates the app container,
+          # so the route can 404 briefly. Try for ~5 min before giving up.
+          rc=1
+          for attempt in $(seq 1 15); do
+            set +e
+            ssh -i ~/.ssh/deploy_key ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} bash <<'REMOTE' > /tmp/resp.json 2>/tmp/resp.err
+          cd ${{ secrets.DEPLOY_PATH }}
+          docker compose exec -T app sh -c 'curl -fsS -X POST http://localhost:3000/api/admin/translate-flavor-notes -H "Authorization: Bearer $CRON_SECRET"'
+          REMOTE
+            rc=$?
+            set -e
+            if [ "$rc" -eq 0 ]; then break; fi
+            echo "attempt $attempt: route not ready (exit $rc) — waiting for deploy…"
+            sleep 20
+          done
+
+          echo "----- raw response -----"
+          cat /tmp/resp.json
+
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::translate failed (ssh/curl exit $rc)"
+            cat /tmp/resp.err
+            exit 1
+          fi
+
+          echo
+          echo "----- audit -----"
+          jq -r '
+            "counts: \(.total) rows · \(.translated) translated · \(.unchanged) unchanged · \(.empty) empty",
+            "",
+            "TRANSLATED (\(.translated)):",
+            (.results[] | select(.status == "translated") | "  + [\(.table)] \(.name): \(.from)  →  \(.to)")
+          ' /tmp/resp.json || echo "(could not format JSON; see raw response above)"

--- a/src/app/api/admin/translate-flavor-notes/route.ts
+++ b/src/app/api/admin/translate-flavor-notes/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { coffees, dripBags } from "@/lib/db/schema";
+import { translateNotesToEnglish } from "@/lib/scan/translateNotes";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300; // 5min — ~50 coffees × ~1s Haiku each, big headroom.
+
+/**
+ * One-shot retroactive translation: rewrite existing scanned flavour notes to
+ * English for bags scanned BEFORE PR #471 made the scan paths translate at
+ * extraction time. Covers the two first-class scanned-flavour fields:
+ *   - coffees.bag_flavors   (the library's printed-bag flavours)
+ *   - drip_bags.bag_notes   (AI-extracted drip-bag flavours)
+ *
+ * Does NOT touch commonNotes (the user's OWN tasted words) or drip flavorNotes
+ * (picked from the English taxonomy) — only the machine-scanned bag flavours the
+ * fix was about. Writes a row ONLY when translation actually changed it, targeted
+ * by id (never a broad update, never a wipe). Idempotent: re-running an
+ * already-English library translates English→English → no writes.
+ *
+ * Auth: CRON_SECRET bearer, same as the other /api/admin routes.
+ * Trigger: the `translate-flavor-notes` GitHub Action (SSH → docker compose exec
+ * → curl with the container's own CRON_SECRET). Never run by hand.
+ */
+export async function POST(req: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  const auth = req.headers.get("authorization");
+  if (!secret || auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const changed = (a: string[], b: string[]) => JSON.stringify(a) !== JSON.stringify(b);
+
+  try {
+    const results: Array<{
+      table: "coffees" | "drip_bags";
+      id: string;
+      name: string;
+      status: "translated" | "unchanged" | "empty";
+      from?: string;
+      to?: string;
+    }> = [];
+
+    // Library coffees — bag_flavors.
+    const coffeeRows = await db.select().from(coffees);
+    for (const row of coffeeRows) {
+      const notes = (row.bagFlavors ?? []).filter(
+        (n): n is string => typeof n === "string" && n.trim().length > 0,
+      );
+      if (notes.length === 0) {
+        results.push({ table: "coffees", id: row.id, name: row.name, status: "empty" });
+        continue;
+      }
+      const translated = await translateNotesToEnglish(notes);
+      if (changed(notes, translated)) {
+        await db.update(coffees).set({ bagFlavors: translated }).where(eq(coffees.id, row.id));
+        results.push({ table: "coffees", id: row.id, name: row.name, status: "translated", from: notes.join(", "), to: translated.join(", ") });
+      } else {
+        results.push({ table: "coffees", id: row.id, name: row.name, status: "unchanged" });
+      }
+    }
+
+    // Drip bags — bag_notes (AI-extracted); flavor_notes stay (taxonomy = English).
+    const dripRows = await db.select().from(dripBags);
+    for (const row of dripRows) {
+      const notes = (row.bagNotes ?? []).filter(
+        (n): n is string => typeof n === "string" && n.trim().length > 0,
+      );
+      if (notes.length === 0) {
+        results.push({ table: "drip_bags", id: row.id, name: row.name, status: "empty" });
+        continue;
+      }
+      const translated = await translateNotesToEnglish(notes);
+      if (changed(notes, translated)) {
+        await db.update(dripBags).set({ bagNotes: translated }).where(eq(dripBags.id, row.id));
+        results.push({ table: "drip_bags", id: row.id, name: row.name, status: "translated", from: notes.join(", "), to: translated.join(", ") });
+      } else {
+        results.push({ table: "drip_bags", id: row.id, name: row.name, status: "unchanged" });
+      }
+    }
+
+    const summary = {
+      total: results.length,
+      translated: results.filter((r) => r.status === "translated").length,
+      unchanged: results.filter((r) => r.status === "unchanged").length,
+      empty: results.filter((r) => r.status === "empty").length,
+      results,
+    };
+    return NextResponse.json(summary);
+  } catch (err) {
+    console.error("translate-flavor-notes error:", err);
+    return NextResponse.json(
+      { error: "Translate failed", detail: (err as Error).message },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/scan/translateNotes.ts
+++ b/src/lib/scan/translateNotes.ts
@@ -1,0 +1,42 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+/**
+ * Translate coffee tasting-note descriptors to English. Already-English notes
+ * come back unchanged. This backs the retroactive backfill for bags scanned
+ * BEFORE the scan paths started translating at extraction time (PR #471).
+ *
+ * Never invents, merges, splits, reorders, or drops a note: the result is the
+ * same length + order as the (non-empty) input, or — on ANY model / parse
+ * failure or a length mismatch — the original array verbatim. It's a display
+ * nicety, so it must never lose or fabricate data (the never-fabricate rule).
+ */
+export async function translateNotesToEnglish(notes: string[]): Promise<string[]> {
+  const clean = notes.filter((n) => typeof n === "string" && n.trim().length > 0);
+  if (clean.length === 0) return clean;
+  try {
+    const resp = await client.messages.create({
+      model: "claude-haiku-4-5",
+      max_tokens: 500,
+      messages: [
+        {
+          role: "user",
+          content: `Translate each of these coffee tasting notes to its standard English specialty-coffee descriptor (e.g. "Groseille" → "Redcurrant", "Cassis" → "Blackcurrant", "Rhabarber" → "Rhubarb", "Agrumes" → "Citrus", "Myrtille" → "Blueberry", "Noisette" → "Hazelnut"). If a note is ALREADY English, return it unchanged. Do NOT invent, merge, split, reorder, or drop any note. Return ONLY a JSON array of strings — the SAME length and order as the input.
+
+Input: ${JSON.stringify(clean)}`,
+        },
+      ],
+    });
+    const text = resp.content[0].type === "text" ? resp.content[0].text : "";
+    const match = text.match(/\[[\s\S]*\]/);
+    if (!match) return clean;
+    const parsed = JSON.parse(match[0]);
+    if (!Array.isArray(parsed) || parsed.length !== clean.length) return clean;
+    const out = parsed.map((v) => (typeof v === "string" ? v.trim() : ""));
+    if (out.some((s) => s.length === 0)) return clean; // any blank → don't trust it
+    return out;
+  } catch {
+    return clean;
+  }
+}


### PR DESCRIPTION
Follow-up to PR #471. That fix made new scans translate flavour notes at extraction time; this backfills the ones already in the DB (e.g. French "Groseille, Rhubarbe, Agrumes" → "Redcurrant, Rhubarb, Citrus").

Since the production DB isn't reachable from a session, this uses the established `remap-field-zones` pattern: a CRON_SECRET admin route + a trigger workflow that SSHes in and curls it from inside the app container.

- **`src/lib/scan/translateNotes.ts`** — `translateNotesToEnglish()` (Haiku). Never invents/merges/splits/reorders/drops; on any model or parse failure it returns the original array verbatim, so it can't lose or fabricate data.
- **`POST /api/admin/translate-flavor-notes`** (CRON_SECRET) — rewrites the two *scanned* flavour fields, `coffees.bag_flavors` + `drip_bags.bag_notes`, writing a row **only when translation actually changed it**, targeted by id (never a broad update or wipe). Leaves `commonNotes` (the user's own tasted words) and drip `flavor_notes` (already English taxonomy) untouched. Idempotent — an already-English library is a no-op.
- **`.github/workflows/translate-flavor-notes.yml`** + trigger file — same SSH → `docker compose exec` → curl mechanism as `field-zones-remap`, with a ~5-min curl retry so it survives the app container being recreated by the deploy that the same merge triggers.

`tsc` clean, YAML validated. Merging deploys the route and fires the one-shot translation automatically; the workflow run's audit log lists every `from → to` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URoEUeJPqm3m4NrFieikch

---
_Generated by [Claude Code](https://claude.ai/code/session_01URoEUeJPqm3m4NrFieikch)_