### PR TITLE
fix: really stop LiquidHeadline clipping descenders (drop the animation class at rest)

### DIFF
--- a/src/components/ui/light/LiquidHeadline.tsx
+++ b/src/components/ui/light/LiquidHeadline.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, type CSSProperties } from "react";
+import { useMemo, useState, useEffect, type CSSProperties } from "react";
 import { usePresence } from "@/hooks/usePresence";
 
 /**
@@ -104,6 +104,34 @@ export default function LiquidHeadline({
   const { mounted, state } = usePresence(show, liquidExitMs(wordCount, resolvedExitMs, staggerMs));
   const exiting = state === "exit";
 
+  // Once the entrance has finished, DROP the animation class from every word so
+  // it renders in the normal (non-composited) paint path. This is THE fix for
+  // the clipped Fraunces descenders (g/y/j/p): a word that keeps an assigned
+  // `animation` (even with `fill-mode: both` ending on transform/filter: none)
+  // stays on a WebKit/iOS compositing layer whose backing store is clipped to
+  // the line-height box, cutting the descenders that overflow it. Zeroing the
+  // final keyframe (#467, #471) did NOT help because the animation is still
+  // assigned. HaikuStarter never clips precisely because it drops the class
+  // after settling — do the same here. At rest a word is a plain inline-block:
+  // no animation, no transform, no filter, no layer → descenders paint in full.
+  const [settled, setSettled] = useState(false);
+  // Reset synchronously when the headline text changes (React's "adjust state on
+  // prop change" pattern) so a new insight starts un-settled in the SAME render —
+  // no one-frame flash of the fully-formed word before its entrance replays.
+  const [settledFor, setSettledFor] = useState(text);
+  if (settledFor !== text) {
+    setSettledFor(text);
+    setSettled(false);
+  }
+  useEffect(() => {
+    if (exiting) return; // leaving → keep the exit animation, don't settle
+    const t = setTimeout(
+      () => setSettled(true),
+      liquidEntranceMs(wordCount, popMs, staggerMs) + 60,
+    );
+    return () => clearTimeout(t);
+  }, [text, exiting, wordCount, popMs, staggerMs]);
+
   let wi = -1;
   return (
     <>
@@ -193,6 +221,15 @@ export default function LiquidHeadline({
           {tokens.map((w, i) => {
             if (w.trim() === "") return <span key={i}>{w}</span>;
             wi += 1;
+            // Settled + not leaving → a plain inline-block word, NO animation
+            // class → no compositing layer → descenders never clipped.
+            if (settled && !exiting) {
+              return (
+                <span key={i} className="inline-block">
+                  {w}
+                </span>
+              );
+            }
             const variant = (wi % 3) + 1;
             const cls = exiting ? `lh-out-${variant}-${dissolveDir}` : `lh-pop-${variant}`;
             const dur = exiting ? resolvedExitMs : popMs;


### PR DESCRIPTION
Third attempt at the clipped Fraunces descenders (g/y/j/p) on the recipe-crafting insight + Hero questions — this time the real root cause.

**Why #467 and #471 didn't fix it:** a word that keeps an *assigned* CSS `animation` (with `animation-fill-mode: both`) stays on a WebKit/iOS compositing layer, and that layer's backing store is clipped to the word's line-height box — cutting any descender that overflows it. Zeroing the final keyframe's `filter` (#467) then `transform` (#471) never helped, because the animation was still assigned, so the layer persisted regardless of the final values.

**The fix:** do exactly what `HaikuStarter` does (it never clips) — **drop the animation class once the entrance settles**. A `settled` flag flips one entrance-duration after mount and renders each word as a plain `inline-block` with no animation/transform/filter → no compositing layer → descenders paint in full. It's reset synchronously on a text change (React's adjust-state-on-prop-change pattern) so a new insight doesn't flash before its entrance, and the flag is bypassed during the exit animation so leaving still animates.

`tsc` clean, `next build` clean, 146 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URoEUeJPqm3m4NrFieikch

---
_Generated by [Claude Code](https://claude.ai/code/session_01URoEUeJPqm3m4NrFieikch)_