### PR TITLE
fix: descenders clipped DURING the per-word entrance (recipe insight + home haiku)

### DIFF
--- a/src/components/ui/light/HaikuStarter.tsx
+++ b/src/components/ui/light/HaikuStarter.tsx
@@ -12,6 +12,19 @@ const DISTURB_FALLOFF = 85; // px — radius of the blur "lens" around the finge
 const P_CLASS =
   "font-fraunces text-[40px] font-semibold leading-[1.05] tracking-[-0.01em] text-light-foreground";
 
+// Transparent vertical room so descenders (g/y/j/p) + the entrance blur halo are
+// inside each word's box — otherwise, while a word animates (transform/filter)
+// it's on a compositing layer clipped to the line-height box and the descenders
+// are sheared off DURING the whole per-word build-up. Equal negative margin
+// cancels the layout + baseline effect (getBoundingClientRect's centre is
+// unchanged, so the touch-lens is unaffected).
+const WORD_BOX = {
+  paddingTop: "0.5em",
+  paddingBottom: "0.5em",
+  marginTop: "-0.5em",
+  marginBottom: "-0.5em",
+} as const;
+
 // Deterministic scatter: a delay (ms) per word so they pop in a shuffled,
 // non-left-to-right order — spontaneous, not a typewriter. Same text → same
 // scatter (an LCG-shuffled permutation), so it's stable across re-renders.
@@ -175,8 +188,9 @@ export default function HaikuStarter({ text, show }: { text: string; show: boole
                 className="haiku-word inline-block"
                 style={
                   ready
-                    ? undefined
+                    ? WORD_BOX
                     : {
+                        ...WORD_BOX,
                         animation: `haiku-pop-${variant} ${POP_MS}ms ease-out both`,
                         animationDelay: `${delays[wi] ?? 0}ms`,
                       }

--- a/src/components/ui/light/LiquidHeadline.tsx
+++ b/src/components/ui/light/LiquidHeadline.tsx
@@ -29,6 +29,20 @@ import { usePresence } from "@/hooks/usePresence";
 export const LH_POP_MS = 770; // default per-word entrance duration
 export const LH_STAGGER_MS = 64; // default gap between words
 
+// Transparent vertical room around every word so the descenders (g/y/j/p) + the
+// entrance blur halo are ALWAYS inside the element's box. While a word animates
+// (transform/filter) it's on a WebKit/iOS compositing layer whose backing store
+// is rasterized from this box — without the room the layer is the line-height
+// box and the descenders get sheared off DURING the whole build-up (not just at
+// rest). The equal negative margin cancels the layout + baseline effect, so this
+// is invisible except that the descenders now paint in full at every frame.
+const WORD_BOX = {
+  paddingTop: "0.5em",
+  paddingBottom: "0.5em",
+  marginTop: "-0.5em",
+  marginBottom: "-0.5em",
+} as const;
+
 /** Time from mount until the whole line has settled, for a given word count. */
 export function liquidEntranceMs(
   wordCount: number,
@@ -225,7 +239,7 @@ export default function LiquidHeadline({
             // class → no compositing layer → descenders never clipped.
             if (settled && !exiting) {
               return (
-                <span key={i} className="inline-block">
+                <span key={i} className="inline-block" style={WORD_BOX}>
                   {w}
                 </span>
               );
@@ -240,6 +254,7 @@ export default function LiquidHeadline({
                 className={`lh-word ${cls} inline-block`}
                 style={
                   {
+                    ...WORD_BOX,
                     "--lh-dur": `${dur}ms`,
                     animationDelay: `${delay ?? 0}ms`,
                   } as CSSProperties


### PR DESCRIPTION
The actual complaint (my earlier fixes missed it): the descender clip is visible **throughout the word-by-word build-up**, not just at rest — and on **both** the recipe-crafting insight and the Home welcome haiku.

**Cause:** while a word animates (`transform`/`filter`), it's on a WebKit/iOS compositing layer whose backing store is rasterized from the line-height box. Fraunces' descenders (g/y/j/p) overflow that box, so they're sheared off at every frame of the entrance. Dropping the animation class (last PR) only fixed the *settled* word; the entrance still clipped.

**Fix:** give every word transparent vertical room — `padding: 0.5em` top + bottom — so the descenders and the entrance blur halo are inside the box the layer rasterizes. An equal negative margin cancels the layout + baseline effect (and leaves `getBoundingClientRect`'s centre unchanged, so HaikuStarter's touch-lens is unaffected). Invisible except that the descenders now paint in full at every frame. Applied to `LiquidHeadline` (all states) and `HaikuStarter`.

`tsc` clean, `next build` clean, 146 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URoEUeJPqm3m4NrFieikch

---
_Generated by [Claude Code](https://claude.ai/code/session_01URoEUeJPqm3m4NrFieikch)_