### PR TITLE
fix: honor the requested brew volume — no more too-small-vessel recipes

### DIFF
--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -1,5 +1,5 @@
 import { callRecommendModel } from "../ai/recommendProvider";
-import { vesselOverflow } from "../utils/vesselCapacity";
+import { vesselOverflow, vesselTooSmallForTarget } from "../utils/vesselCapacity";
 import { stripProactiveDripAssist } from "../utils/dripAssist";
 import type {
   CoffeeIdentity,
@@ -113,6 +113,45 @@ function guardVesselCapacity(
     const reason = vesselOverflow(c.method, c.recipe?.waterGrams as number | undefined);
     if (reason) console.warn(`[recommend] capacity guard dropped "${c.title}" — ${reason}`);
     return !reason;
+  });
+  return safe.length ? safe : candidates;
+}
+
+/**
+ * Deterministic volume-fidelity backstop: the user asked for a specific brew
+ * volume, so drop any candidate that can't honour it — a vessel too small to
+ * serve the target (the "450ml request → 180ml AeroPress" bug, where the model
+ * picked a small vessel and clamped the water down to fit it), or a recipe that
+ * grossly under-pours the target on an otherwise-capable vessel. The prompt's
+ * HARD CAPACITY CONSTRAINT already forbids the too-small vessel, but Mistral
+ * leaks buried negatives where Opus held (#453) — this enforces it in code.
+ *
+ * Skipped entirely for iced (waterGrams is only the hot portion, ~60% of the
+ * drink) and cold brew (concentrate + dilution), and when a method is locked
+ * (the capacityConstraint USER OVERRIDE deliberately honours the user's vessel
+ * AND volume together). Never returns empty — if every candidate fails, keep
+ * them and log loudly rather than fail the recommendation.
+ */
+function guardVolumeTarget(
+  candidates: RecommendationCandidate[],
+  targetMl: number | undefined,
+  skip: boolean,
+): RecommendationCandidate[] {
+  if (!targetMl || skip) return candidates;
+  const safe = candidates.filter((c) => {
+    const tooSmall = vesselTooSmallForTarget(c.method, targetMl);
+    if (tooSmall) {
+      console.warn(`[recommend] volume guard dropped "${c.title}" — ${tooSmall}`);
+      return false;
+    }
+    const water = c.recipe?.waterGrams as number | undefined;
+    if (typeof water === "number" && Number.isFinite(water) && water < targetMl * 0.7) {
+      console.warn(
+        `[recommend] volume guard dropped "${c.title}" — pours ${water}g but you asked for ${targetMl}ml`,
+      );
+      return false;
+    }
+    return true;
   });
   return safe.length ? safe : candidates;
 }
@@ -440,6 +479,16 @@ export async function generateRecommendation(
       // Cold brew batches in a jar — the small/big DRINK amount must not filter
       // out the 1L reference recipes; vessel capacity is enforced in the prompt.
       maxWaterMl: context.occasion === "cold-brew" ? undefined : targetWaterMl,
+      // Exclude vessels too small to serve the requested volume — but only for
+      // plain hot brews. Iced (vessel holds the hot portion only), cold brew
+      // (concentrate + dilution) and a locked method (USER OVERRIDE honours the
+      // vessel + volume together) all opt out.
+      serveVolumeMl:
+        context.occasion === "summer-time" ||
+        context.occasion === "cold-brew" ||
+        lockedBrewers.size > 0
+          ? undefined
+          : targetWaterMl,
     },
     4
   );
@@ -546,11 +595,23 @@ Return valid JSON only.`;
     ...(c.brewingLesson ? { brewingLesson: c.brewingLesson } : {}),
   }));
 
-  // Two deterministic backstops over what the model returned: drop
-  // over-capacity vessels, then strip any proactively-suggested Drip Assist
-  // (the prompt forbids both, but a weaker model can still leak them — #453).
+  // Three deterministic backstops over what the model returned (the prompt
+  // forbids all three, but a weaker model can still leak them — #453):
+  //   1. over-capacity vessels (too small for the water it pours);
+  //   2. vessels too small to SERVE the requested volume, or a recipe that
+  //      grossly under-pours it (the "450ml → 180ml AeroPress" bug);
+  //   3. any proactively-suggested Drip Assist.
   const capped = guardVesselCapacity(mapped);
-  const candidates = stripProactiveDripAssist(capped, Boolean(dripAssistLocked));
+  const volumeSafe = guardVolumeTarget(
+    capped,
+    targetWaterMl,
+    // Skip when the model's volume semantics differ from the plain target, or
+    // when the user locked a method (USER OVERRIDE honours vessel + volume).
+    context.occasion === "summer-time" ||
+      context.occasion === "cold-brew" ||
+      Boolean(lockedMethodBase),
+  );
+  const candidates = stripProactiveDripAssist(volumeSafe, Boolean(dripAssistLocked));
 
   return {
     recommendation: {

--- a/src/lib/knowledge/recipes/helpers.ts
+++ b/src/lib/knowledge/recipes/helpers.ts
@@ -5,6 +5,7 @@ import type {
   Process,
   Goal,
 } from "./types";
+import { vesselTooSmallForTarget } from "../../utils/vesselCapacity";
 import { CHAMPIONSHIP_RECIPES } from "./championship";
 import { REFERENCE_RECIPES } from "./reference";
 import { EXPANDED_RECIPES } from "./expanded";
@@ -224,6 +225,13 @@ export interface RecipeSelectionInput {
   occasion?: string;
   maxWaterMl?: number;
   /**
+   * The exact drink volume the user asked for (ml). When set, recipes on a
+   * vessel that physically can't serve it are hard-excluded (e.g. AeroPress for
+   * 450ml). Set ONLY for plain hot brews — omitted for iced / cold brew (vessel
+   * holds less than the drink) and when a method is locked (USER OVERRIDE).
+   */
+  serveVolumeMl?: number;
+  /**
    * When the user locks a specific brew method in the flow (preferredMethod),
    * pass the resolved BrewerType(s) here. Selection is then HARD-FILTERED to
    * those brewers and the per-brewer diversity cap is lifted — the user wants
@@ -273,6 +281,17 @@ function scoreRecipe(
   // exceeds it by more than 20% (some recipes have published variants at
   // larger doses).
   if (input.maxWaterMl && recipe.water.grams > input.maxWaterMl * 1.2) {
+    return null;
+  }
+
+  // Hard filter: exclude vessels that physically can't SERVE the requested
+  // drink volume (e.g. an AeroPress for a 450ml brew) so the model is never
+  // handed a forbidden-vessel reference and tempted to clamp the water down to
+  // fit it (the "450ml request → 180ml AeroPress" bug). Mirrors the prompt's
+  // HARD CAPACITY CONSTRAINT. The caller only sets serveVolumeMl for plain hot
+  // brews (omitted for iced / cold brew, where the vessel holds less than the
+  // drink volume) and never when a method is locked (USER OVERRIDE).
+  if (input.serveVolumeMl && vesselTooSmallForTarget(recipe.brewer, input.serveVolumeMl)) {
     return null;
   }
 

--- a/src/lib/utils/vesselCapacity.ts
+++ b/src/lib/utils/vesselCapacity.ts
@@ -1,14 +1,43 @@
-// Deterministic vessel-capacity backstop for /recommend candidates.
+// Deterministic vessel-capacity backstops for /recommend candidates.
 //
-// The /recommend prompt already forbids over-capacity vessels for the requested
-// volume, but the Mistral spike (issue #453, docs/recommend-spike-run3.md) showed
-// a model can still occasionally pick one at large volumes (e.g. a Clever or
-// Origami for a 520ml brew). This pure check is the server-side guard recommend.ts
-// applies after generation.
+// The /recommend prompt already forbids the wrong vessel for the requested
+// volume, but the Mistral spike (issue #453, docs/recommend-spike-run3.md)
+// showed a model can still pick one — it honours buried negatives less
+// reliably than Opus did. These pure checks are the server-side guards
+// recommend.ts applies after generation.
 //
-// It compares the WATER THE BREWER ACTUALLY HOLDS (recipe.waterGrams ≈ ml) against
-// each brewer's limit — NOT the drink volume — so an iced recipe (where waterGrams
-// is only the hot portion poured into the vessel) is correctly NOT flagged.
+// Two directions are covered:
+//   - vesselOverflow          — vessel too SMALL for the water it POURS (the
+//                               520ml-in-a-Clever spike failure). Compares
+//                               recipe.waterGrams against the cap, so an iced
+//                               recipe (waterGrams = hot portion only) isn't
+//                               falsely flagged.
+//   - vesselTooSmallForTarget — vessel that physically can't SERVE the volume
+//                               the user asked for (the "450ml request → 180ml
+//                               AeroPress" bug, where the model clamped the
+//                               water down to fit a too-small vessel — invisible
+//                               to vesselOverflow because 180 < 230).
+
+/**
+ * Single source of truth for each capacity-limited vessel's max brew water
+ * (ml ≈ g). Brewers not listed (V60, Orea, Kalita, Chemex, cold-brew jar) have
+ * no hard upper limit — they scale with filter size and pour count. The
+ * Moccamaster is batch-only and handled separately (it has a MINIMUM, not a
+ * maximum). Order matters only for the human-readable label.
+ */
+const VESSEL_MAX_ML: Array<{ match: RegExp; label: string; maxMl: number }> = [
+  { match: /aeropress/, label: "AeroPress", maxMl: 230 },
+  { match: /clever/, label: "Clever", maxMl: 450 },
+  { match: /origami/, label: "Origami Air M", maxMl: 450 },
+];
+
+function vesselCap(method: string): { label: string; maxMl: number } | null {
+  const m = method.toLowerCase();
+  for (const { match, label, maxMl } of VESSEL_MAX_ML) {
+    if (match.test(m)) return { label, maxMl };
+  }
+  return null;
+}
 
 /**
  * Returns a human-readable reason if `waterGrams` doesn't fit `method`'s vessel,
@@ -19,10 +48,35 @@ export function vesselOverflow(
   waterGrams: number | undefined,
 ): string | null {
   if (!method || typeof waterGrams !== "number" || !Number.isFinite(waterGrams)) return null;
-  const m = method.toLowerCase();
-  if (/aeropress/.test(m) && waterGrams > 230) return `AeroPress holds ≤230ml, recipe pours ${waterGrams}g`;
-  if (/clever/.test(m) && waterGrams > 450) return `Clever holds ≤450ml, recipe pours ${waterGrams}g`;
-  if (/origami/.test(m) && waterGrams > 450) return `Origami Air M tops out ~450ml, recipe pours ${waterGrams}g`;
-  if (/moccamaster/.test(m) && waterGrams < 500) return `Moccamaster is batch-only (≥500ml), recipe pours ${waterGrams}g`;
+  const cap = vesselCap(method);
+  if (cap && waterGrams > cap.maxMl) {
+    return `${cap.label} holds ≤${cap.maxMl}ml, recipe pours ${waterGrams}g`;
+  }
+  if (/moccamaster/.test(method.toLowerCase()) && waterGrams < 500) {
+    return `Moccamaster is batch-only (≥500ml), recipe pours ${waterGrams}g`;
+  }
+  return null;
+}
+
+/**
+ * Returns a human-readable reason if `method`'s vessel physically can't serve
+ * `targetMl` of brew — i.e. the user asked for more than the vessel holds — or
+ * null if it fits (or the method has no hard limit). This is the UNDER-delivery
+ * counterpart to vesselOverflow: it catches a candidate that clamped its water
+ * down to fit a too-small vessel (e.g. a 180ml AeroPress when the user typed
+ * 450ml), which vesselOverflow can't see because 180 < 230. 1ml ≈ 1g.
+ *
+ * Also accepts a BrewerType id ("aeropress", "aeropress-prismo", "origami-cone",
+ * "clever") — those contain the vessel keyword, so the same regex matches.
+ */
+export function vesselTooSmallForTarget(
+  method: string | undefined,
+  targetMl: number | undefined,
+): string | null {
+  if (!method || typeof targetMl !== "number" || !Number.isFinite(targetMl)) return null;
+  const cap = vesselCap(method);
+  if (cap && targetMl > cap.maxMl) {
+    return `${cap.label} holds ≤${cap.maxMl}ml but you asked for ${targetMl}ml`;
+  }
   return null;
 }

--- a/tests/dataflow/vessel-capacity.test.mjs
+++ b/tests/dataflow/vessel-capacity.test.mjs
@@ -16,7 +16,7 @@ import { join } from "node:path";
 import path from "node:path";
 
 const ROOT = process.cwd();
-const entry = `export { vesselOverflow } from ${JSON.stringify(
+const entry = `export { vesselOverflow, vesselTooSmallForTarget } from ${JSON.stringify(
   path.join(ROOT, "src/lib/utils/vesselCapacity.ts"),
 )};`;
 const dir = await mkdtemp(join(tmpdir(), "vessel-"));
@@ -29,7 +29,7 @@ await build({
   outfile: out,
   logLevel: "silent",
 });
-const { vesselOverflow } = await import(pathToFileURL(out).href);
+const { vesselOverflow, vesselTooSmallForTarget } = await import(pathToFileURL(out).href);
 
 test("vessels within capacity pass", () => {
   assert.equal(vesselOverflow("AeroPress", 200), null);
@@ -61,4 +61,33 @@ test("missing / non-finite inputs are safe (return null)", () => {
 test("method match is case-insensitive and substring", () => {
   assert.match(vesselOverflow("clever dripper", 500) ?? "", /Clever/);
   assert.equal(vesselOverflow("V60 (no Assist)", 350), null);
+});
+
+// vesselTooSmallForTarget — the UNDER-delivery guard (the "450ml → 180ml
+// AeroPress" bug). Catches a vessel that physically can't SERVE the requested
+// volume, regardless of what water the recipe actually pours.
+test("vessel too small for the requested volume is flagged", () => {
+  // The reported bug: user asks 450ml, an AeroPress (≤230ml) can't serve it.
+  assert.match(vesselTooSmallForTarget("AeroPress", 450) ?? "", /AeroPress/);
+  assert.match(vesselTooSmallForTarget("Clever Dripper", 600) ?? "", /Clever/);
+  assert.match(vesselTooSmallForTarget("Origami Air M", 520) ?? "", /Origami/);
+});
+
+test("vessel that CAN serve the volume is not flagged", () => {
+  assert.equal(vesselTooSmallForTarget("V60", 450), null); // no hard limit
+  assert.equal(vesselTooSmallForTarget("Chemex", 750), null);
+  assert.equal(vesselTooSmallForTarget("AeroPress", 200), null);
+  assert.equal(vesselTooSmallForTarget("Clever Dripper", 450), null);
+});
+
+test("target guard accepts BrewerType ids (corpus-filter path)", () => {
+  assert.match(vesselTooSmallForTarget("aeropress-prismo", 450) ?? "", /AeroPress/);
+  assert.match(vesselTooSmallForTarget("origami-cone", 520) ?? "", /Origami/);
+  assert.equal(vesselTooSmallForTarget("v60", 450), null);
+});
+
+test("target guard: missing / non-finite inputs are safe (return null)", () => {
+  assert.equal(vesselTooSmallForTarget(undefined, 450), null);
+  assert.equal(vesselTooSmallForTarget("AeroPress", undefined), null);
+  assert.equal(vesselTooSmallForTarget("AeroPress", NaN), null);
 });


### PR DESCRIPTION
## The bug

Picking **Custom → 450 ml** could still come back as a ~180 ml AeroPress recipe. The `/recommend` prompt forbids AeroPress at that volume, but since the move to Mistral (#455) the model honours that buried negative less reliably than Opus did — it clamps the water down to fit a too-small vessel instead of choosing one that can serve the amount. The existing capacity guard only catches **over**-capacity (>230 ml in an AeroPress), so a clamped 180 ml slipped straight through.

## The fix

Two deterministic backstops, matching the existing `vesselCapacity` / `dripAssist` pattern:

1. **Corpus filter (`scoreRecipe`)** — when a plain hot brew names a target volume, exclude reference recipes on a vessel that physically can't serve it, so the model is never handed an AeroPress reference for a 450 ml brew. Verified against the real recipe data: at 450 ml the portfolio no longer contains AeroPress (Origami takes its slot); at 200 ml AeroPress is still offered.
2. **Output guard (`guardVolumeTarget`)** — drop any candidate whose vessel can't serve the requested volume, or that grossly under-pours it on a capable vessel. Never returns empty.

Both opt out for iced (`waterGrams` is the hot portion only), cold brew (concentrate + dilution), and a locked method (the USER OVERRIDE path deliberately honours the user's vessel + volume together). Capacity numbers are centralised in `vesselCapacity.ts` as one source of truth.

## Verification

- `npx tsc --noEmit` clean
- Full `node --test` suite green (195 tests), incl. new coverage for the under-capacity check
- End-to-end check against the real recipe corpus confirms AeroPress is filtered at 450 ml and still allowed at 200 ml

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQditGVpQp7EQFhJPJ7sF3)_