### PR TITLE
feat(brew): coach pour flow against each recipe's own rate, not a global 4 g/s

### DIFF
--- a/src/lib/brew/flowCoach.ts
+++ b/src/lib/brew/flowCoach.ts
@@ -16,7 +16,7 @@
  * guidance, never presented as hard law.
  */
 import { activeStepAt, expectedGramsAt, type BrewTimeline } from "@/lib/brew/timeline";
-import { pourDurationSec } from "@/lib/utils/pourSequence";
+import { intendedPourDurationSec } from "@/lib/utils/pourSequence";
 
 export interface WeightSample {
   /** Wall-clock ms when the sample was read. */
@@ -59,10 +59,17 @@ export interface FlowComparison {
 const TOL_G = 3; // within this of a pour's target = "reached"
 const EASE_OFF_G = 15; // start easing off this many grams before target
 const STALL_RATE = 0.4; // g/s — below this mid-pour = stalled
-const FAST_ABS = 6; // g/s — hard "too fast" cap
 const SLOW_ABS = 1.5; // g/s — hard "too slow" floor (while pouring)
-const FAST_MULT = 1.4; // or this × the intended rate
+const FAST_MULT = 1.5; // "too fast" = this × the RECIPE'S OWN intended rate
 const SLOW_MULT = 0.6;
+// Never cry "Slower" below this even at 1.5× a very gentle target — a genuinely
+// slow pour is never "too fast". Keeps the coach quiet on clarity brews.
+const FAST_FLOOR = 4; // g/s
+// The recipe's intended rate is clamped to this sane pour band before coaching,
+// so a mis-authored durationSec (a 1 s "pour 200 g" = 200 g/s) can't set an
+// absurd target. Wide by design — the corpus spans ~3–10 g/s on pour-overs.
+const TARGET_MIN = 2; // g/s
+const TARGET_MAX = 11; // g/s — a hard gooseneck can't gently exceed this
 
 const NO_DATA: FlowComparison = {
   cue: "none",
@@ -180,7 +187,16 @@ export function coachFlow(
   const remaining = stepTarget - liveGrams;
   const isBloom = step.action === "bloom";
   const pourGrams = step.pourGrams != null && step.pourGrams > 0 ? step.pourGrams : stepTarget;
-  const targetRate = pourGrams / pourDurationSec(Math.max(1, pourGrams)); // ≈ 4 g/s
+  // Coach against the RECIPE'S OWN intended pour rate — grams ÷ its intended
+  // pour time (Kasuya 60 g / 10 s = 6 g/s; a Hoffmann swing ~10; a clarity brew
+  // ~3–4). `intendedPourDurationSec` uses the recipe's authored time when it
+  // reads as a real pour (≥2 g/s) and falls back to the ~4 g/s house estimate
+  // otherwise (rest folded into the step, or no duration). Clamped to a sane
+  // pour band so a bad duration can't set an impossible target. This replaces
+  // the old global 4 g/s that flagged every legit fast pour as "too fast".
+  const dur = intendedPourDurationSec(pourGrams, step.pourDurationSec);
+  const rawTargetRate = pourGrams / dur;
+  const targetRate = Math.min(TARGET_MAX, Math.max(TARGET_MIN, rawTargetRate));
 
   const partial: Omit<FlowComparison, "cue" | "message" | "detail" | "state"> = {
     liveGrams,
@@ -229,7 +245,10 @@ export function coachFlow(
     cue = "keep-flow";
     message = "Keep going";
     state = "behind";
-  } else if (r > Math.max(targetRate * FAST_MULT, FAST_ABS)) {
+  } else if (r > targetRate * FAST_MULT && r > FAST_FLOOR) {
+    // Too fast RELATIVE TO THE RECIPE — >1.5× its own intended rate (and never
+    // below the gentle FAST_FLOOR). A 6 g/s Kasuya pour no longer nags; a
+    // clarity brew poured at double still does.
     cue = "pour-slower";
     message = "Slower";
     state = "ahead";

--- a/src/lib/brew/timeline.ts
+++ b/src/lib/brew/timeline.ts
@@ -25,8 +25,8 @@ import {
   buildGuideSteps,
   hasImmersionShape,
   isAgitationPourAction,
+  intendedPourDurationSec,
   parsePourSteps,
-  pourDurationSec,
   pourStepsFromStructured,
   type AgitationAction,
   type GuideStep,
@@ -50,6 +50,11 @@ export interface TimelineStep {
   targetCumulativeGrams?: number;
   /** Water added by THIS step (percolation pours only). */
   pourGrams?: number;
+  /** The recipe's OWN intended pour time for this pour (seconds), when authored.
+   * `pourGrams / pourDurationSec` is the recipe's intended pour RATE, which the
+   * flow coach coaches against instead of a global house constant. Undefined →
+   * the coach falls back to the ~4 g/s house rate. */
+  pourDurationSec?: number;
   /** Pre-brew handling (immersion invert/load/assemble) — excluded from `steps`. */
   isSetup: boolean;
   /** Swirl / stir / tap / agitate-bed. */
@@ -78,6 +83,9 @@ export interface BrewTimeline {
 const isAgitationGuideAction = (a: BrewStepAction): boolean =>
   a === "stir" || a === "swirl" || a === "agitate-bed";
 
+const isWaterGuideAction = (a: BrewStepAction): boolean =>
+  a === "bloom" || a === "pour" || a === "final" || a === "melodrip";
+
 function fromGuideStep(g: GuideStep): TimelineStep {
   return {
     index: g.index,
@@ -86,6 +94,9 @@ function fromGuideStep(g: GuideStep): TimelineStep {
     startSec: g.startTimeSec,
     endSec: g.startTimeSec + g.durationSec,
     targetCumulativeGrams: g.cumulativeGrams,
+    // On an immersion/AeroPress water pour, the authored step duration IS the
+    // intended pour time — so the coach reads the recipe's own rate here too.
+    pourDurationSec: isWaterGuideAction(g.action) ? g.durationSec : undefined,
     isSetup: g.isSetup,
     isAgitation: isAgitationGuideAction(g.action),
     temperatureC: g.temperatureC,
@@ -103,6 +114,7 @@ function fromPourStep(p: PourStep, all: PourStep[], i: number, targetTimeSec: nu
     endSec,
     targetCumulativeGrams: p.cumulativeGrams,
     pourGrams: p.pourGrams,
+    pourDurationSec: p.pourDurationSec,
     isSetup: false,
     isAgitation: isAgitationPourAction(p.action),
     temperatureC: p.temperatureC,
@@ -187,7 +199,10 @@ export function expectedGramsAt(timeline: BrewTimeline, tSec: number): number | 
   for (const s of pours) {
     const c = s.targetCumulativeGrams as number;
     const pourGrams = s.pourGrams ?? c - prevC;
-    const dur = pourDurationSec(Math.max(1, pourGrams));
+    // Ramp over the recipe's OWN intended pour time when it authored a plausible
+    // one, else the ~4 g/s house estimate — so "where you should be" matches the
+    // recipe's intended pour speed (a 6 g/s Kasuya pour fills in 10 s, not 15 s).
+    const dur = intendedPourDurationSec(pourGrams, s.pourDurationSec);
     const pourEnd = s.startSec + dur;
     if (tSec < s.startSec) {
       return prevC; // resting between the previous pour's end and this pour

--- a/src/lib/utils/pourSequence.ts
+++ b/src/lib/utils/pourSequence.ts
@@ -46,6 +46,26 @@ export function pourDurationSec(grams: number): number {
   return Math.max(1, Math.round(grams / POUR_RATE_GPS));
 }
 
+/** Slowest rate we'll believe is a real POUR time. A step whose authored
+ * `durationSec` implies less than this (e.g. a 45 g "bloom" tagged 45 s = 1 g/s)
+ * is a rest/steep window folded into the step, NOT the pour itself — so we don't
+ * coach to it. Above it, the authored time is treated as the intended pour time. */
+export const MIN_POUR_RATE_GPS = 2;
+
+/**
+ * The intended pour TIME (seconds) for a pour of `grams`: the recipe's authored
+ * value when it reads as a plausible pour time (≥ MIN_POUR_RATE_GPS), otherwise
+ * the ~POUR_RATE_GPS house estimate. This is the single source both the expected-
+ * grams curve and the live flow coach use to know how fast a pour is INTENDED to
+ * go — so a 6 g/s Kasuya pour is coached at 6, not the house 4, while a rest
+ * folded into a bloom step (or a missing duration) falls back to the estimate.
+ */
+export function intendedPourDurationSec(grams: number, authoredSec?: number): number {
+  const g = Math.max(1, grams);
+  if (authoredSec && authoredSec > 0 && g / authoredSec >= MIN_POUR_RATE_GPS) return authoredSec;
+  return pourDurationSec(g);
+}
+
 /** Discrete agitation actions that now get their OWN timed step in the
  * percolation timeline (instead of being folded onto a pour as an attribute). */
 export type AgitationAction = "swirl" | "stir" | "tap";
@@ -64,6 +84,12 @@ export interface PourStep {
   temperatureC?: number;
   /** Free-text hint shown alongside the active pour. */
   notes?: string;
+  /** The recipe's OWN intended pour time for this pour (seconds), when authored.
+   * `pourGrams / pourDurationSec` is the recipe's intended pour RATE — Kasuya
+   * pours 60 g in 10 s = 6 g/s, not the house 4 g/s. Used by the flow coach to
+   * coach against the recipe's own rate instead of a global constant. Undefined
+   * for string-parsed recipes → the coach falls back to the ~4 g/s house rate. */
+  pourDurationSec?: number;
 }
 
 /** True for the discrete agitation step actions (swirl/stir/tap). */
@@ -168,6 +194,9 @@ interface Milestone {
   agitationAfter?: AgitationAction;
   /** Optional note carried onto the agitation step. */
   agitationNote?: string;
+  /** The recipe's authored pour time for this pour (seconds), when known — the
+   * intended-rate source (grams ÷ this). Undefined for string-parsed recipes. */
+  pourDurationSec?: number;
 }
 
 const AGITATION_LABEL: Record<AgitationAction, string> = {
@@ -247,12 +276,14 @@ function buildPourOver(
       action: i === 0 ? "bloom" : i === n - 1 ? "final" : "pour",
       temperatureC: m.temperatureC,
       notes: m.notes,
+      pourDurationSec: m.pourDurationSec,
     });
 
     if (m.agitationAfter) {
-      // The pour finishes pouring `pourGrams` after `pourDurationSec` seconds.
-      // Clamp so the agitation always lands before the next pour starts (or,
-      // on the final pour, before the target finish) — never overlapping.
+      // The pour finishes pouring `pourGrams` after `pourDurationSec` seconds
+      // (the physical ~4 g/s estimate — robust to a mis-authored short duration).
+      // Clamp so the agitation always lands before the next pour starts (or, on
+      // the final pour, before the target finish) — never overlapping.
       const ceiling = (i < n - 1 ? pourStartSec(i + 1) : targetTimeSec) - 1;
       const agStart = Math.min(start + pourDurationSec(pourGrams), Math.max(start + 1, ceiling));
       out.push({
@@ -332,6 +363,7 @@ export function pourStepsFromStructured(
         grams: s.waterGramsAtEnd,
         temperatureC: s.temperatureC,
         notes: s.notes,
+        pourDurationSec: s.durationSec,
       });
       last = milestones.length - 1;
     } else if (isAgitationStep(s.action) && last >= 0) {

--- a/tests/dataflow/brew-flowcoach.test.mjs
+++ b/tests/dataflow/brew-flowcoach.test.mjs
@@ -142,6 +142,51 @@ test("immersion: steep step (no grams target) → no-data, no cue", () => {
   assert.equal(coachFlow(PERC, 60, false, 90, ramp(4)).cue, "none"); // not started
 });
 
+// A structured recipe whose pours are authored at 6 g/s (60 g in 10 s), like
+// Kasuya 4:6. The coach must target the RECIPE's own rate, not the house 4 g/s.
+const KASUYA_LIKE = buildBrewTimeline(
+  {
+    doseGrams: 20, waterGrams: 160, waterTempC: 92, grindSize: "medium-coarse", targetTimeSec: 180,
+    pourSteps: [
+      { label: "Bloom", action: "bloom", waterGramsAtEnd: 40, durationSec: 8 },
+      { label: "Rest", action: "wait", durationSec: 35 },
+      { label: "Pour 2", action: "pour", waterGramsAtEnd: 100, durationSec: 10 }, // 60g / 10s = 6 g/s
+      { label: "Rest", action: "wait", durationSec: 35 },
+      { label: "Final", action: "final", waterGramsAtEnd: 160, durationSec: 10 }, // 60g / 10s = 6 g/s
+    ],
+  },
+  ROAST,
+  NOW,
+);
+// The elapsed at which "Pour 2" (target 100, +60g at 6 g/s) is the active step,
+// picked mid-pour with plenty remaining.
+const pour2 = KASUYA_LIKE.steps.find((s) => s.targetCumulativeGrams === 100);
+const P2_MID = pour2.startSec + 1;
+
+test("recipe-derived rate: a 6 g/s pour reads its own rate, not the house 4", () => {
+  const c = coachFlow(KASUYA_LIKE, P2_MID, true, 70, ramp(6));
+  assert.ok(Math.abs(c.targetRateGPS - 6) < 0.01, `target rate should be 6, got ${c.targetRateGPS}`);
+});
+
+test("recipe-derived rate: pouring AT the recipe's 6 g/s is steady, NOT 'Slower'", () => {
+  const c = coachFlow(KASUYA_LIKE, P2_MID, true, 70, ramp(6));
+  assert.notEqual(c.cue, "pour-slower", "6 g/s must not nag when the recipe pours at 6");
+  assert.equal(c.cue, "steady");
+});
+
+test("recipe-derived rate: still catches pouring well ABOVE the recipe's rate", () => {
+  const c = coachFlow(KASUYA_LIKE, P2_MID, true, 70, ramp(10)); // >1.5× the 6 g/s target
+  assert.equal(c.cue, "pour-slower");
+});
+
+test("fallback: a string recipe (no authored durations) still targets ~4 g/s", () => {
+  // PERC is built from a pourSequence STRING → no durations → house 4 g/s.
+  const c = coachFlow(PERC, ELAPSED_MID, true, 90, ramp(4));
+  assert.ok(Math.abs(c.targetRateGPS - 4) < 0.6, `fallback target ~4, got ${c.targetRateGPS}`);
+  // And 6 g/s on that fallback recipe still nags (4×1.5=6 threshold).
+  assert.equal(coachFlow(PERC, ELAPSED_MID, true, 90, ramp(7)).cue, "pour-slower");
+});
+
 test("immersion: the water-POUR step gets scale coaching (AeroPress fix)", () => {
   // At t=8 the active step is "Add water → 200g" (start 0, 15s). The scale must
   // coach the pour just like a pour-over, not stay silent.


### PR DESCRIPTION
## Why

The live flow coach targeted **one house constant — `POUR_RATE_GPS = 4 g/s`** — for every recipe, and flagged anything above 6 g/s as "Slower". A computation over the **whole corpus** (363 individual pours in 132 recipes: grams ÷ each pour's authored pour time, rests excluded) proves that's wrong for most real recipes:

- Median **5.2 g/s**; p25–p75 = **4.0–6.7**; **31% of all pours are above 6 g/s**.
- Kasuya 4:6 pours **60 g in 10 s = 6.0 g/s** flat. Hoffmann V60 and Chemex reach **10**. Only immersion (Clever/AeroPress) dumps faster.

So a *correct* Kasuya or Hoffmann pour got nagged "too fast" by the app's own coach — the rigid-rule behavior the owner flagged.

## Change

The coach now derives the target rate **per pour, from the recipe's own authored pour time** (`grams ÷ durationSec`), threaded `pourSteps → timeline → flowCoach`:

- New shared **`intendedPourDurationSec()`** uses the recipe's authored time only when it reads as a real pour (**≥2 g/s**), and falls back to the ~4 g/s house estimate otherwise — a rest folded into a bloom step, or no duration at all. **So 4 g/s is now the fallback, not the law.**
- "Slower" fires at **>1.5× the recipe's own rate** (never below a gentle 4 g/s floor), with the target clamped to a sane **2–11 g/s** band so a mis-authored duration can't set an absurd goal.
- `expectedGramsAt` ramps over the same intended time, so "where you should be" matches the recipe's pace.

## Honesty note

This also corrects my own earlier over-claim: the reported 235 g/30 s ≈ 7.8 g/s was *fast*, but within a real Origami-wave's range (3–10 g/s) — not "physically impossible". The genuine defects there were the single monolithic pour + no drawdown room (fixed in #488); the coach fighting legit fast pours is this PR.

## Tests
`tests/dataflow/brew-flowcoach.test.mjs`: a 6 g/s recipe reads **steady** (not "Slower"), still catches >10 g/s, and a string recipe (no durations) keeps the ~4 g/s fallback. Full suite **237 pass**, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UzVG8eC4Es29ZuSL33w8P4)_