### PR TITLE
fix: post-brew insight reads the brewed candidate, not primaryRecipe

### DIFF
--- a/src/app/api/brew-insight/route.ts
+++ b/src/app/api/brew-insight/route.ts
@@ -7,6 +7,8 @@ export const dynamic = "force-dynamic";
 
 const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
+type RecipeNumbers = { doseGrams?: number; waterGrams?: number; waterTempC?: number };
+
 // ─── Adaptive adjustment — computed from actual result, no pre-stated rules ──
 
 function computeAdjustment(draft: {
@@ -99,8 +101,13 @@ export async function POST(req: NextRequest) {
           grindSettingUsed?: string;
           actualTempC?: number;
           followedAgitation?: string;
+          selectedCandidateIdx?: number;
         };
-        recommendation?: { primaryMethod?: string; primaryRecipe?: { doseGrams?: number; waterGrams?: number; waterTempC?: number } };
+        recommendation?: {
+          primaryMethod?: string;
+          primaryRecipe?: RecipeNumbers;
+          candidates?: { method?: string; recipe?: RecipeNumbers }[];
+        };
       };
       recentSessions?: Session[];
     };
@@ -111,6 +118,17 @@ export async function POST(req: NextRequest) {
     const rec = draft?.recommendation;
     const place = draft?.place;
     const isExternal = draft?.mode === "external";
+
+    // Resolve the recipe the user ACTUALLY brewed — the selected candidate,
+    // NOT primaryRecipe. Feeding the primary's numbers when an alternative was
+    // brewed made the insight cite the wrong temp (96°C when 85°C was brewed).
+    // Mirrors resolveBrewedRecipe / LightStepSummary's own resolution.
+    const idx = brew?.selectedCandidateIdx;
+    const brewedCandidate =
+      (idx != null ? rec?.candidates?.[idx] : undefined) ??
+      (brew?.methodUsed ? rec?.candidates?.find((c) => c.method === brew.methodUsed) : undefined);
+    const brewedRecipe = brewedCandidate?.recipe ?? rec?.primaryRecipe;
+    const brewedMethod = brewedCandidate?.method || brew?.methodUsed || rec?.primaryMethod;
 
     if (!coffee?.name || result?.rating == null) {
       return NextResponse.json({ terrain: null, adjustment: null });
@@ -152,11 +170,11 @@ Write 1–2 sentences of personal, specific insight about this coffee — what m
 This session:
 - Coffee: ${coffee.name} by ${coffee.roaster || "?"}
 - Origin: ${[coffee.origin, coffee.region].filter(Boolean).join(", ") || "unknown"} | Process: ${coffee.process || "unknown"}
-- Method: ${brew?.methodUsed || rec?.primaryMethod || "unknown"}
+- Method: ${brewedMethod || "unknown"}
 - Rating: ${result.rating}/5
 - Flavor notes: ${result.flavorNotes?.join(", ") || "none"}
 - Free notes: ${result.freeNotes || "none"}
-${rec ? `- Recipe: ${rec.primaryRecipe?.doseGrams}g / ${rec.primaryRecipe?.waterGrams}g / ${rec.primaryRecipe?.waterTempC}°C` : ""}
+${brewedRecipe ? `- Recipe: ${brewedRecipe.doseGrams}g / ${brewedRecipe.waterGrams}g / ${brewedRecipe.waterTempC}°C` : ""}
 ${brew?.grindSettingUsed ? `- Grind used: ${brew.grindSettingUsed}` : ""}
 ${brew?.followedAgitation ? `- Agitation: ${brew.followedAgitation}` : ""}
 


### PR DESCRIPTION
## The bug

The post-brew insight (`/api/brew-insight`) was citing the **wrong recipe**: it referenced 96°C when the brew was actually at 85°C.

Root cause is the primary-vs-selected bug class (same as PR #193/#198). The insight route's prompt was fed `recommendation.primaryRecipe` (candidate 0) instead of the candidate the user actually selected (`brew.selectedCandidateIdx`):

```
- Recipe: ${rec.primaryRecipe?.doseGrams}g / ... / ${rec.primaryRecipe?.waterTempC}°C
```

## When it bit

- Brewed the **primary** recipe → numbers happened to match, insight fine.
- Picked an **alternative** candidate (e.g. the 85°C one when the primary was 96°C) → the insight reasoned over the wrong temp/dose/water.

`LightStepSummary` right next to it already resolved the correct brewed recipe (`summaryRecipe`); only the insight route was left reading the primary.

## Fix

Resolve the selected candidate exactly like `resolveBrewedRecipe` / `LightStepSummary` do — `recommendation.candidates[selectedCandidateIdx].recipe`, falling back to method-name match, then `primaryRecipe` for legacy drafts. The prompt now gets the actually-brewed recipe's numbers and method.

- `tsc --noEmit` clean
- `node --test` 194/194 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017FVkFhFvL3XVbG3ptz531J)_