### PR TITLE
fix: insight never restates recipe numbers; patterns grind reads brewed candidate

### DIFF
--- a/src/app/api/brew-insight/route.ts
+++ b/src/app/api/brew-insight/route.ts
@@ -178,7 +178,9 @@ ${brewedRecipe ? `- Recipe: ${brewedRecipe.doseGrams}g / ${brewedRecipe.waterGra
 ${brew?.grindSettingUsed ? `- Grind used: ${brew.grindSettingUsed}` : ""}
 ${brew?.followedAgitation ? `- Agitation: ${brew.followedAgitation}` : ""}
 
-Write 1–2 sentences of personal, specific insight about this session. No generic praise. No emojis. Speak like a knowledgeable coffee friend. Reference an expert only when it genuinely adds value (Rao, Perger, Gagné, Solis). No numbers in your response.`;
+Write 1–2 sentences of personal, specific insight about this session. No generic praise. No emojis. Speak like a knowledgeable coffee friend. Reference an expert only when it genuinely adds value (Rao, Perger, Gagné, Solis).
+
+Do NOT restate the recipe's temperature, dose, water, grind, or time back to the brewer — not as digits AND not as spelled-out words (never write "96", "ninety-six degrees", "15 grams", etc.). Give the DIRECTION to change instead (hotter/cooler, finer/coarser, longer/shorter, a richer/leaner ratio). The recipe line above is context for your reasoning only.`;
 
       try {
         const msg = await client.messages.create({

--- a/src/lib/claude/patterns.ts
+++ b/src/lib/claude/patterns.ts
@@ -1,4 +1,5 @@
 import type { Session } from "../types/session";
+import { resolveBrewedRecipe } from "../utils/resolveRecipe";
 
 // ─── Output types ────────────────────────────────────────────────────────────
 
@@ -96,7 +97,9 @@ function detectOscillation(sessions: Session[]): OscillationPattern[] {
     // Check grind oscillation (Niche° values — extract number)
     const grindValues = group
       .map(s => {
-        const g = s.recommendation?.primaryRecipe?.grindSize as string | undefined;
+        // The grind the user ACTUALLY brewed (selected candidate), not the
+        // primary — matching resolveBrewedRecipe everywhere else.
+        const g = resolveBrewedRecipe(s).recipe?.grindSize as string | undefined;
         if (!g) return null;
         const match = g.match(/(\d+(?:\.\d+)?)/);
         return match ? parseFloat(match[1]) : null;


### PR DESCRIPTION
Follow-up to #495 (the post-brew insight citing the wrong recipe temp).

## 1. Prompt no longer restates the recipe's numbers

The screenshot proof showed the insight writing "at **ninety-six degrees** you might be under-extracting" while the recipe card correctly read 85°C. #495 fixed the *value* fed in (now the brewed candidate), but this also revealed the prompt's `No numbers` guard was bypassed because the model **spelled the number out as words**.

The prompt now explicitly forbids restating temp/dose/water/grind/time as digits **or** words, and tells the model to give the *direction* to change (hotter/cooler, finer/coarser, longer/shorter). The recipe line stays as reasoning context only.

## 2. patterns.ts grind detector was the same bug class

`detectOscillation` read `recommendation.primaryRecipe.grindSize` instead of the brewed candidate's grind — so on the Taste page, grind-drift pattern analysis used the primary recipe's grind even when an alternative was brewed. Now uses `resolveBrewedRecipe` like every other surface.

## Audit result

Checked all post-brew surfaces: `insights.ts`, `coffeeInsight.ts`, `historyUtils.ts`, `brewSignature.ts` already resolve the selected candidate correctly. `escher.ts` never names recipe numbers. `patterns.ts` was the last straggler.

- `tsc --noEmit` clean
- `node --test` 194/194 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017FVkFhFvL3XVbG3ptz531J)_