### PR TITLE
feat: support coffee blends (multiple origins/processes per bag)

### DIFF
--- a/src/app/(light)/coffees/[id]/page.tsx
+++ b/src/app/(light)/coffees/[id]/page.tsx
@@ -184,18 +184,25 @@ export default function CoffeeDetailPage() {
           ?.tastingNotesFromBag) ?? [];
   const commonNotes = coffee.commonNotes ?? [];
   const origin = latestCoffee?.origin || coffee.origin;
+  // Blend breakdown — prefer the richest source (a scanned session identity has
+  // per-component variety); fall back to the aggregate row's column.
+  const blendComponents = latestCoffee?.components?.length
+    ? latestCoffee.components
+    : coffee.components ?? undefined;
+  const isBlendCoffee = (blendComponents?.length ?? 0) >= 2;
 
   const brewThis = () => {
     // Prefer the most-recent scanned CoffeeIdentity (has variety, tasting notes,
     // roast level). Fall back to the aggregate if the coffee somehow has no
     // sessions yet — defaults match the user's profile (light roast).
     const identity: CoffeeIdentity = latestCoffee
-      ? { ...latestCoffee, coffeeId: coffee.id }
+      ? { ...latestCoffee, components: latestCoffee.components ?? coffee.components, coffeeId: coffee.id }
       : {
           roaster: coffee.roaster,
           name: coffee.name,
           origin: coffee.origin,
           process: coffee.process,
+          components: coffee.components,
           roastLevel: "Light",
           roastDate: coffee.latestRoastDate,
           bagPhotoUrl: coffee.bagPhotoUrl,
@@ -349,8 +356,32 @@ export default function CoffeeDetailPage() {
       {(roastDate || variety || roastLevel || region || process || fermentationStyle || cuppingScore || tastingNotes.length > 0 || commonNotes.length > 0) && (
         <div className="px-5 py-4 border-b border-light-foreground/15 space-y-2">
           <p className="text-light-muted-foreground text-xs uppercase tracking-widest mb-3">Coffee Details</p>
-          {variety && <DetailRow label="Variety" value={variety} />}
-          {process && <DetailRow label="Process" value={process} />}
+          {isBlendCoffee ? (
+            <div className="flex items-baseline gap-3 pt-0.5">
+              <span className="text-light-muted-foreground text-sm shrink-0 w-24">Blend</span>
+              <div className="flex-1 space-y-1.5">
+                {blendComponents!.map((c, i) => (
+                  <div key={i} className="text-light-foreground text-sm">
+                    {c.ratio != null && (
+                      <span className="text-light-muted-foreground">{c.ratio}% </span>
+                    )}
+                    {c.origin || "Unknown"}
+                    {[c.region, c.variety, c.process].filter(Boolean).length > 0 && (
+                      <span className="text-light-muted-foreground">
+                        {" — "}
+                        {[c.region, c.variety, c.process].filter(Boolean).join(", ")}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <>
+              {variety && <DetailRow label="Variety" value={variety} />}
+              {process && <DetailRow label="Process" value={process} />}
+            </>
+          )}
           {fermentationStyle && <DetailRow label="Fermentation" value={fermentationStyle} />}
           {roastLevel && <DetailRow label="Roast" value={roastLevel} />}
           {region && <DetailRow label="Region" value={region} />}

--- a/src/app/(light)/coffees/page.tsx
+++ b/src/app/(light)/coffees/page.tsx
@@ -99,6 +99,7 @@ export default function CoffeesPage() {
       name: coffee.name,
       origin: coffee.origin,
       process: coffee.process,
+      components: coffee.components,
       roastLevel: "Light",
       roastDate: coffee.latestRoastDate,
       bagPhotoUrl: coffee.bagPhotoUrl,

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -8,6 +8,7 @@ import { rowToSession } from "@/lib/db/helpers";
 import type { Session } from "@/lib/types/session";
 import { FieldZonesSchema } from "@/lib/field/schema";
 import { pushCaffeineToHealthSync } from "@/lib/health/healthsyncPush";
+import { deriveIdentitySummary } from "@/lib/coffee/blend";
 
 const SessionPostSchema = z.object({
   type: z.enum(["coffee", "wine"]),
@@ -20,6 +21,21 @@ const SessionPostSchema = z.object({
     region: z.string().max(200).optional(),
     variety: z.string().max(200).optional(),
     process: z.string().max(100).optional().default(""),
+    // Blend components (migration 0021). 2+ ⇒ the bag is a blend; the scalar
+    // origin/region/variety/process above are then re-derived server-side as a
+    // comma-joined summary of these (deriveIdentitySummary). Absent ⇒ single-origin.
+    components: z
+      .array(
+        z.object({
+          origin: z.string().max(200),
+          region: z.string().max(200).optional(),
+          variety: z.string().max(200).optional(),
+          process: z.string().max(100).optional(),
+          ratio: z.number().min(0).max(100).optional(),
+        }),
+      )
+      .max(8)
+      .optional(),
     fermentationStyle: z.string().max(200).optional(),
     roastLevel: z.string().max(100).optional().default(""),
     roastDate: z.string().optional(),
@@ -148,6 +164,29 @@ export async function POST(req: NextRequest) {
     // the coffees table separately, not into sessions.coffee JSONB.
     const { fieldZones: incomingFieldZones, ...sessionData } = parsed.data;
     const data = sessionData as Omit<Session, "id">;
+
+    // Blend normalisation (migration 0021). When the identity carries 2+
+    // components it's a blend: re-derive the scalar origin/region/variety/
+    // process as a comma-joined summary of them, server-side, so the single
+    // source every free-text + keyword consumer reads can't drift from the
+    // components. Fewer than 2 ⇒ not a blend; drop any stray array so a
+    // single-origin bag never stores an empty/one-item components list.
+    if (data.coffee) {
+      const comps = data.coffee.components;
+      if (Array.isArray(comps) && comps.filter((c) => c?.origin?.trim()).length >= 2) {
+        const summary = deriveIdentitySummary(comps);
+        data.coffee = {
+          ...data.coffee,
+          origin: summary.origin || data.coffee.origin,
+          region: summary.region || data.coffee.region,
+          variety: summary.variety || data.coffee.variety,
+          process: summary.process || data.coffee.process,
+        };
+      } else if (comps !== undefined) {
+        data.coffee = { ...data.coffee, components: undefined };
+      }
+    }
+
     const sessionId = randomUUID();
     const createdAtMs = Date.now();
     const createdAt = new Date(data.createdAt);
@@ -223,6 +262,7 @@ export async function POST(req: NextRequest) {
           name: data.coffee.name,
           origin: data.coffee.origin || "",
           process: data.coffee.process || "",
+          components: data.coffee.components ?? undefined,
           fermentationStyle: data.coffee.fermentationStyle,
           cuppingScore: data.coffee.cuppingScore != null ? String(data.coffee.cuppingScore) : undefined,
           firstSeenAt: data.createdAt,
@@ -269,6 +309,17 @@ export async function POST(req: NextRequest) {
         // (a scan / re-scan). A note-less Brew Again leaves them intact.
         if (bagFlavors.length > 0) {
           updates.bagFlavors = bagFlavors;
+        }
+
+        // Blend: when this save identifies a blend (2+ components), refresh the
+        // stored components AND the derived scalar summary (origin/process). A
+        // note-less Brew Again omits components, leaving the stored blend intact
+        // — same "only when carried" policy as bagFlavors, so a shortcut save
+        // never wipes a blend a scan established.
+        if (data.coffee.components && data.coffee.components.length >= 2) {
+          updates.components = data.coffee.components;
+          if (data.coffee.origin) updates.origin = data.coffee.origin;
+          if (data.coffee.process) updates.process = data.coffee.process;
         }
 
         await db

--- a/src/components/flow/BlendComponentsEditor.tsx
+++ b/src/components/flow/BlendComponentsEditor.tsx
@@ -1,0 +1,152 @@
+"use client";
+import Chip from "@/components/ui/light/Chip";
+import { Plus, X } from "lucide-react";
+import type { BlendComponent } from "@/lib/types/session";
+
+/**
+ * Per-component editor for a coffee blend. Each component pairs its own
+ * origin / region / variety / process (a blend can mix processes) plus an
+ * optional percentage. Used inside LightStepScan when the user marks a bag as
+ * a blend.
+ *
+ * This is a controlled component: it never derives the scalar origin/process
+ * summary itself — the caller does that in `onChange` (via
+ * deriveIdentitySummary) so the draft's scalar fields stay in sync for every
+ * downstream consumer that reads them.
+ */
+export default function BlendComponentsEditor({
+  components,
+  processes,
+  onChange,
+}: {
+  components: BlendComponent[];
+  /** Process options (shared with the single-origin picker). */
+  processes: string[];
+  onChange: (next: BlendComponent[]) => void;
+}) {
+  const patch = (i: number, p: Partial<BlendComponent>) =>
+    onChange(components.map((c, idx) => (idx === i ? { ...c, ...p } : c)));
+
+  const add = () =>
+    onChange([...components, { origin: "" }]);
+
+  const remove = (i: number) =>
+    onChange(components.filter((_, idx) => idx !== i));
+
+  const fieldStyle = {
+    background: "var(--secondary)",
+    border: "1px solid var(--border)",
+    color: "var(--foreground)",
+  } as const;
+
+  return (
+    <div className="space-y-3">
+      {components.map((c, i) => (
+        <div
+          key={i}
+          className="rounded-2xl p-3 space-y-2.5"
+          style={{ background: "var(--card)", border: "1px solid var(--border)" }}
+        >
+          <div className="flex items-center justify-between">
+            <span
+              className="label-eyebrow"
+              style={{ color: "var(--muted-foreground)" }}
+            >
+              Origin {i + 1}
+            </span>
+            {components.length > 1 && (
+              <button
+                type="button"
+                aria-label={`Remove origin ${i + 1}`}
+                onClick={() => remove(i)}
+                className="opacity-60 active:opacity-100"
+                style={{ color: "var(--muted-foreground)" }}
+              >
+                <X size={16} />
+              </button>
+            )}
+          </div>
+
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={c.origin}
+              placeholder="Country (e.g. Brazil)"
+              className="flex-1 min-w-0 rounded-xl px-3 py-2 text-base focus:outline-none"
+              style={fieldStyle}
+              onChange={(e) => patch(i, { origin: e.target.value })}
+            />
+            <div className="relative w-20 shrink-0">
+              <input
+                type="number"
+                inputMode="numeric"
+                min={0}
+                max={100}
+                value={c.ratio ?? ""}
+                placeholder="%"
+                className="w-full rounded-xl pl-3 pr-6 py-2 text-base focus:outline-none"
+                style={fieldStyle}
+                onChange={(e) => {
+                  const n = parseInt(e.target.value, 10);
+                  patch(i, { ratio: Number.isFinite(n) ? n : undefined });
+                }}
+              />
+              <span
+                className="pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-sm"
+                style={{ color: "var(--muted-foreground)" }}
+              >
+                %
+              </span>
+            </div>
+          </div>
+
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={c.region ?? ""}
+              placeholder="Region (optional)"
+              className="flex-1 min-w-0 rounded-xl px-3 py-2 text-base focus:outline-none"
+              style={fieldStyle}
+              onChange={(e) => patch(i, { region: e.target.value || undefined })}
+            />
+            <input
+              type="text"
+              value={c.variety ?? ""}
+              placeholder="Variety (optional)"
+              className="flex-1 min-w-0 rounded-xl px-3 py-2 text-base focus:outline-none"
+              style={fieldStyle}
+              onChange={(e) => patch(i, { variety: e.target.value || undefined })}
+            />
+          </div>
+
+          <div>
+            <p className="text-xs mb-1.5" style={{ color: "var(--muted-foreground)" }}>
+              Process
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {processes.map((p) => (
+                <Chip
+                  key={p}
+                  selected={c.process === p}
+                  onClick={() => patch(i, { process: c.process === p ? undefined : p })}
+                  size="sm"
+                >
+                  {p}
+                </Chip>
+              ))}
+            </div>
+          </div>
+        </div>
+      ))}
+
+      <button
+        type="button"
+        onClick={add}
+        className="w-full flex items-center justify-center gap-1.5 rounded-2xl py-2.5 text-sm"
+        style={{ border: "1px dashed var(--border)", color: "var(--foreground)" }}
+      >
+        <Plus size={15} /> Add origin
+      </button>
+    </div>
+  );
+}

--- a/src/components/flow/LightStepScan.tsx
+++ b/src/components/flow/LightStepScan.tsx
@@ -10,6 +10,9 @@ import Hero from "@/components/ui/light/Hero";
 import { nextHeroQuestion, SCAN_QUESTIONS } from "@/lib/heroQuestions";
 import type { BagAnalysisResult, RoasterPriorSummary } from "@/lib/claude/analyzeBag";
 import type { Coffee as CoffeeLibEntry } from "@/lib/types/coffee";
+import type { BlendComponent } from "@/lib/types/session";
+import BlendComponentsEditor from "@/components/flow/BlendComponentsEditor";
+import { deriveIdentitySummary } from "@/lib/coffee/blend";
 import {
   buildClarifications,
   applyClarificationAnswer,
@@ -490,6 +493,43 @@ export default function LightStepScan() {
   const hasCoffeeInfo = !!(draft.coffee?.name || draft.coffee?.roaster || draft.coffee?.origin)
     || !!(showManualForm && (manualRoaster || manualName || manualOrigin));
 
+  // ── Blend editing ────────────────────────────────────────────────────────
+  // A blend carries a `components` array; the scalar origin/region/variety/
+  // process are kept as a comma-joined SUMMARY of it so every downstream
+  // consumer (recommend prompt, library display, matchers) reads the scalar
+  // unchanged. setComponents writes both in one patch so the draft never drifts.
+  const blendActive = (draft.coffee?.components?.length ?? 0) > 0;
+
+  const setComponents = (next: BlendComponent[]) => {
+    if (next.length === 0) {
+      setCoffee({ components: undefined });
+      return;
+    }
+    const s = deriveIdentitySummary(next);
+    setCoffee({
+      components: next,
+      origin: s.origin,
+      region: s.region || undefined,
+      variety: s.variety || undefined,
+      process: s.process || undefined,
+    });
+  };
+
+  const enableBlend = () =>
+    // Seed the first two components from whatever single-origin values already
+    // exist, so switching to a blend never loses what the scan found.
+    setComponents([
+      {
+        origin: draft.coffee?.origin || "",
+        region: draft.coffee?.region || undefined,
+        variety: draft.coffee?.variety || undefined,
+        process: draft.coffee?.process || undefined,
+      },
+      { origin: "" },
+    ]);
+
+  const disableBlend = () => setCoffee({ components: undefined });
+
   // Shared "Identified" editable panel — rendered by BOTH the photo and
   // URL flows so the user sees the full set of extracted/inferred fields
   // (and can correct any of them) regardless of which scan path they
@@ -507,23 +547,55 @@ export default function LightStepScan() {
           or add a missing roaster on a photo-extracted bag. */}
       <EditableRow label="Roaster" value={draft.coffee?.roaster || ""} onChange={v => setCoffee({ roaster: v })} suggestions={existingRoasters} />
       <EditableRow label="Coffee" value={draft.coffee?.name || ""} onChange={v => setCoffee({ name: v })} />
-      {draft.coffee?.origin !== undefined && (
-        <EditableRow
-          label="Origin"
-          value={[draft.coffee.origin, draft.coffee.region].filter(Boolean).join(" · ")}
-          onChange={v => {
-            const parts = v.split("·").map(s => s.trim());
-            setCoffee({ origin: parts[0] || "", region: parts[1] || undefined });
-          }}
-        />
-      )}
-      {draft.coffee?.process && (
-        <div>
-          <p className="text-xs mb-2" style={{ color: "var(--muted-foreground)" }}>Process</p>
-          <div className="flex flex-wrap gap-2">
-            {PROCESSES.map(p => <Chip key={p} selected={draft.coffee?.process === p} onClick={() => setCoffee({ process: p })} size="sm">{p}</Chip>)}
+      {/* Origin / process / variety — one single-origin set, OR a per-component
+          blend editor. A blend can mix origins AND processes; the scalar fields
+          above are kept as a comma-joined summary of the components. */}
+      {blendActive ? (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <p className="text-xs" style={{ color: "var(--muted-foreground)" }}>Blend — origins &amp; processes</p>
+            <button type="button" onClick={disableBlend} className="text-xs active:opacity-70" style={{ color: "var(--primary)" }}>
+              Single origin
+            </button>
           </div>
+          <BlendComponentsEditor
+            components={draft.coffee?.components ?? []}
+            processes={PROCESSES}
+            onChange={setComponents}
+          />
         </div>
+      ) : (
+        <>
+          {draft.coffee?.origin !== undefined && (
+            <EditableRow
+              label="Origin"
+              value={[draft.coffee.origin, draft.coffee.region].filter(Boolean).join(" · ")}
+              onChange={v => {
+                const parts = v.split("·").map(s => s.trim());
+                setCoffee({ origin: parts[0] || "", region: parts[1] || undefined });
+              }}
+            />
+          )}
+          {draft.coffee?.process && (
+            <div>
+              <p className="text-xs mb-2" style={{ color: "var(--muted-foreground)" }}>Process</p>
+              <div className="flex flex-wrap gap-2">
+                {PROCESSES.map(p => <Chip key={p} selected={draft.coffee?.process === p} onClick={() => setCoffee({ process: p })} size="sm">{p}</Chip>)}
+              </div>
+            </div>
+          )}
+          {draft.coffee?.variety !== undefined && (
+            <EditableRow label="Variety" value={draft.coffee.variety || ""} onChange={v => setCoffee({ variety: v })} />
+          )}
+          <button
+            type="button"
+            onClick={enableBlend}
+            className="flex items-center gap-1.5 text-xs active:opacity-70"
+            style={{ color: "var(--primary)" }}
+          >
+            <span className="text-sm leading-none">+</span> This is a blend (multiple origins)
+          </button>
+        </>
       )}
       {draft.coffee?.roastLevel && (
         <div>
@@ -532,9 +604,6 @@ export default function LightStepScan() {
             {ROAST_LEVELS.map(r => <Chip key={r} selected={draft.coffee?.roastLevel === r} onClick={() => setCoffee({ roastLevel: r })} size="sm">{r}</Chip>)}
           </div>
         </div>
-      )}
-      {draft.coffee?.variety !== undefined && (
-        <EditableRow label="Variety" value={draft.coffee.variety || ""} onChange={v => setCoffee({ variety: v })} />
       )}
       {draft.coffee?.fermentationStyle !== undefined && (
         <EditableRow label="Fermentation" value={draft.coffee.fermentationStyle || ""} onChange={v => setCoffee({ fermentationStyle: v || undefined })} />

--- a/src/components/ui/light/ActionPill.tsx
+++ b/src/components/ui/light/ActionPill.tsx
@@ -36,6 +36,7 @@ interface CoffeeRow {
   name: string;
   origin: string;
   process: string;
+  components?: import("@/lib/types/session").BlendComponent[] | null;
   latestRoastDate?: string;
   bagPhotoUrl?: string;
   // Generative Field v1.1 — present on the /api/coffees/[id] response
@@ -142,6 +143,7 @@ export default function ActionPill({ action }: { action: NavAction }) {
               name: row.name,
               origin: row.origin,
               process: row.process,
+              components: row.components ?? undefined,
               roastLevel: "Light",
               roastDate: row.latestRoastDate,
               bagPhotoUrl: row.bagPhotoUrl,

--- a/src/lib/claude/analyzeBag.ts
+++ b/src/lib/claude/analyzeBag.ts
@@ -17,6 +17,18 @@ const BagAnalysisSchema = z.object({
       roastDate: z.string().nullable().optional(),
       cuppingScore: z.number().nullable().optional(),
       tastingNotesFromBag: z.array(z.string()).optional(),
+      // Blend components — present ONLY when the bag is a blend (2+ origins).
+      components: z
+        .array(
+          z.object({
+            origin: z.string(),
+            region: z.string().nullable().optional(),
+            variety: z.string().nullable().optional(),
+            process: z.string().nullable().optional(),
+            ratio: z.number().nullable().optional(),
+          }),
+        )
+        .optional(),
     })
     .passthrough(),
   confidence: z.record(z.string(), z.string()).optional(),
@@ -62,7 +74,8 @@ Return this exact JSON structure:
     "roastLevel": "Light" | "Medium-Light" | "Medium" | "Dark" | null,
     "roastDate": string | null,
     "cuppingScore": number | null,
-    "tastingNotesFromBag": string[]
+    "tastingNotesFromBag": string[],
+    "components": [ { "origin": string, "region": string | null, "variety": string | null, "process": "Natural" | "Washed" | "Honey" | "Anaerobic" | "Other" | null, "ratio": number | null } ] | null
   },
   "confidence": {
     "roaster": "bag" | "researched" | "unknown",
@@ -75,6 +88,7 @@ Return this exact JSON structure:
   "isCoffeeBag": boolean
 }
 
+components: ONLY for a BLEND — a bag that names 2+ origins (e.g. "Brazil + Ethiopia") and/or 2+ processes. Return one entry per origin, each with its own origin, region, variety, process, and ratio (percentage) if the bag prints one. Also fill the top-level "origin" and "process" with a comma-joined summary (e.g. origin "Brazil, Ethiopia", process "Natural, Washed"). For a SINGLE-ORIGIN coffee, set components to null and fill the scalar fields as usual — do NOT invent a blend.
 fermentationStyle: for modern/experimental coffees the sub-style is the real differentiator. Examples: "Spontaneous Anaerobic", "Starter-culture Natural (Lalcafé Cima)", "Thermal-shock Washed", "Carbonic Maceration 72h", "Co-fermented with cascara". Only fill this if the bag names a specific sub-style or fermentation protocol — don't guess from the broad process category alone.
 cuppingScore: numeric SCA / Q-grade if printed on the bag (e.g. 87.5, 89). Null if not shown.
 tastingNotesFromBag: ALWAYS return these in English. If the bag prints the flavour notes in another language, translate each one to its standard English specialty-coffee descriptor — e.g. "Groseille" → "Redcurrant", "Cassis" → "Blackcurrant", "Rhabarbe"/"Rhabarber" → "Rhubarb", "Agrumes" → "Citrus", "Myrtille" → "Blueberry", "Pfirsich" → "Peach", "Honig" → "Honey", "Noisette" → "Hazelnut". Keep each note short; don't invent notes that aren't on the bag.
@@ -111,6 +125,13 @@ export interface BagAnalysisResult {
     roastDate?: string;
     cuppingScore?: number;
     tastingNotesFromBag?: string[];
+    components?: {
+      origin: string;
+      region?: string;
+      variety?: string;
+      process?: string;
+      ratio?: number;
+    }[];
   };
   confidence: Record<string, "bag" | "researched" | "unknown">;
   clarifications: string[];
@@ -160,6 +181,39 @@ export async function analyzeBagImage(imageBase64: string, mimeType: string): Pr
     if (typeof rd === "string" && /^\d{4}-\d{2}-\d{2}/.test(rd)) {
       const cleaned = guardRoastYear(rd);
       if (cleaned !== rd) (cleanExtracted as { roastDate?: string }).roastDate = cleaned;
+    }
+
+    // Blend components: drop nested nulls (the schema allows them) → undefined,
+    // and drop entries with no origin, so the downstream write schema (which
+    // wants string | undefined, not null) accepts them. A blend needs 2+
+    // components; anything less collapses back to single-origin.
+    const rawComponents = (cleanExtracted as { components?: unknown }).components;
+    if (Array.isArray(rawComponents)) {
+      const cleaned = rawComponents
+        .map((c) => {
+          const comp = c as Record<string, unknown>;
+          const str = (k: string) =>
+            typeof comp[k] === "string" && (comp[k] as string).trim()
+              ? (comp[k] as string).trim()
+              : undefined;
+          const ratio =
+            typeof comp.ratio === "number" && Number.isFinite(comp.ratio)
+              ? (comp.ratio as number)
+              : undefined;
+          return {
+            origin: str("origin") ?? "",
+            region: str("region"),
+            variety: str("variety"),
+            process: str("process"),
+            ratio,
+          };
+        })
+        .filter((c) => c.origin);
+      if (cleaned.length >= 2) {
+        (cleanExtracted as { components?: unknown }).components = cleaned;
+      } else {
+        delete (cleanExtracted as { components?: unknown }).components;
+      }
     }
 
     return {

--- a/src/lib/claude/brewSignature.ts
+++ b/src/lib/claude/brewSignature.ts
@@ -107,7 +107,12 @@ export function buildSignature(session: Session): BrewSignature | null {
   const process = session.coffee?.process ?? "";
   const origin = session.coffee?.origin ?? "";
 
-  const originRegion = classifyOriginRegion(origin);
+  // A blend has no single growing region — bucketing it by its first-listed
+  // origin keyword would mis-file it with single-origins (a Brazil/Ethiopia
+  // blend read as pure "east-africa"). Give blends their own region bucket so
+  // pattern detection keeps them distinct.
+  const isBlendCoffee = (session.coffee?.components?.length ?? 0) >= 2;
+  const originRegion = isBlendCoffee ? "blend" : classifyOriginRegion(origin);
   const normalizedProcess = normalizeProcess(process);
   const normalizedMethod = normalizeMethod(method);
 

--- a/src/lib/claude/escher.ts
+++ b/src/lib/claude/escher.ts
@@ -32,7 +32,7 @@ OUTPUT FORMAT: Return valid JSON only. No markdown outside the JSON.
 
 export async function buildEscherTerrain(
   sessions: Session[],
-  currentCoffee?: Pick<CoffeeIdentity, "name" | "roaster" | "origin" | "process">
+  currentCoffee?: Pick<CoffeeIdentity, "name" | "roaster" | "origin" | "process" | "components">
 ): Promise<string> {
   const signatures = buildSignatures(sessions);
 
@@ -41,8 +41,13 @@ export async function buildEscherTerrain(
       (currentCoffee.roaster ? ")" : "")
     : undefined;
 
+  // A blend gets its own "blend-*" cluster (matches buildSignature) so it isn't
+  // filed with single-origins of its first-listed component.
+  const isBlendCoffee = (currentCoffee?.components?.length ?? 0) >= 2;
   const typeCluster = currentCoffee
-    ? buildTypeCluster(currentCoffee.origin ?? "", currentCoffee.process ?? "")
+    ? isBlendCoffee
+      ? `blend-${normalizeProcess(currentCoffee.process ?? "")}`
+      : buildTypeCluster(currentCoffee.origin ?? "", currentCoffee.process ?? "")
     : undefined;
 
   const output = extract(signatures, {

--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -33,6 +33,7 @@ import { TECHNIQUES } from "../knowledge/techniques";
 import { reconcileToReference, reconcileWaterToPourPlan } from "./recipeFidelity";
 import { buildMethodRecency } from "./methodRotation";
 import { sanitizePourSteps } from "../utils/pourSteps";
+import { componentsOf } from "../coffee/blend";
 import { parseClaudeJson, z } from "./parseJson";
 
 const CandidateSchema = z.object({
@@ -561,6 +562,17 @@ export async function generateRecommendation(
       lockedBrewers,
       roastLevel: normaliseRoastLevel(coffee.roastLevel),
       process: normaliseProcess(coffee.process),
+      // Blend: score the process match against EVERY component's process, so a
+      // "Natural + Washed" blend credits recipes suited to either — the single
+      // `process` above (a comma-joined summary) would otherwise collapse to the
+      // first keyword. Empty for a single-origin bag.
+      processes: Array.from(
+        new Set(
+          componentsOf(coffee)
+            .map((c) => normaliseProcess(c.process))
+            .filter((p): p is NonNullable<typeof p> => !!p),
+        ),
+      ),
       variety: coffee.variety,
       goal: normaliseGoal(context.intent),
       occasion: context.occasion,

--- a/src/lib/claude/recommend.ts
+++ b/src/lib/claude/recommend.ts
@@ -33,7 +33,7 @@ import { TECHNIQUES } from "../knowledge/techniques";
 import { reconcileToReference, reconcileWaterToPourPlan } from "./recipeFidelity";
 import { buildMethodRecency } from "./methodRotation";
 import { sanitizePourSteps } from "../utils/pourSteps";
-import { componentsOf } from "../coffee/blend";
+import { componentsOf, describeBlend } from "../coffee/blend";
 import { parseClaudeJson, z } from "./parseJson";
 
 const CandidateSchema = z.object({
@@ -622,9 +622,18 @@ export async function generateRecommendation(
     "\nAVAILABLE TECHNIQUES (atomic moves you can compose with — cite by id when adapting a recipe):\n" +
     TECHNIQUES.map((t) => `  - ${t.id}: ${t.description}`).join("\n");
 
+  // Blend note — appended to the user message ONLY when this bag is a real
+  // blend (2+ components). For every single-origin bag the message is
+  // byte-identical to before, so non-blend behaviour (and the prompt cache) is
+  // unchanged.
+  const blendDesc = describeBlend(coffee);
+  const blendNote = blendDesc
+    ? `\nBLEND — this bag is ${componentsOf(coffee).length} components: ${blendDesc}. There is no single origin or process. Reason about the composite cup: extract to serve the component that needs the MOST care (typically the lightest-roasted / washed / most delicate one) without under-serving the others, and name that trade-off in your reasoning. Do not treat it as a single-origin of just one component.`
+    : "";
+
   const userMessage = `Coffee: ${coffee.name || "Unknown"} by ${coffee.roaster || "Unknown roaster"}
 Origin: ${coffee.origin || "Unknown"}${coffee.region ? `, ${coffee.region}` : ""}${coffee.variety ? ` · Variety: ${coffee.variety}` : ""}
-Process: ${coffee.process || "Unknown"}${coffee.fermentationStyle ? ` (${coffee.fermentationStyle})` : ""} | Roast: ${coffee.roastLevel || "Unknown"}${coffee.cuppingScore ? ` | Score: ${coffee.cuppingScore}` : ""}
+Process: ${coffee.process || "Unknown"}${coffee.fermentationStyle ? ` (${coffee.fermentationStyle})` : ""} | Roast: ${coffee.roastLevel || "Unknown"}${coffee.cuppingScore ? ` | Score: ${coffee.cuppingScore}` : ""}${blendNote}
 Roast date: ${coffee.roastDate ?? "unknown"}${daysOld !== null ? ` (${daysOld} days — ${freshnessNote})` : ""}
 Bag tasting notes: ${coffee.tastingNotesFromBag?.join(", ") || "none listed"}
 ${roasterBlock}${historyBlock}${insightsBlock}

--- a/src/lib/coffee/blend.ts
+++ b/src/lib/coffee/blend.ts
@@ -1,0 +1,131 @@
+/**
+ * Blend helpers — the SINGLE source of truth for reading a coffee's origin
+ * components and deriving the scalar summary strings from them.
+ *
+ * Design (see migration 0021 + the BlendComponent doc in types/session.ts):
+ * a coffee stores a `components` array when it's a blend (2+ origins), and the
+ * scalar `origin` / `region` / `variety` / `process` fields are kept as a
+ * comma-joined SUMMARY of those components. This keeps every free-text and
+ * keyword consumer that predates blends working off the scalar unchanged; the
+ * blend-aware consumers call `componentsOf()` to get the real per-component
+ * breakdown.
+ *
+ * A single-origin bag never carries `components`; `componentsOf()` synthesises
+ * a one-element array from its scalar fields so callers have one shape to read.
+ */
+
+/** The minimal fields a blend component carries. Structurally compatible with
+ * BlendComponent (types/session.ts) — kept local so this module has no import
+ * cycle with the session types. */
+export interface Component {
+  origin: string;
+  region?: string;
+  variety?: string;
+  process?: string;
+  ratio?: number;
+}
+
+/** The scalar identity fields this module reads/derives. Both CoffeeIdentity
+ * and Coffee satisfy this (they carry these fields plus `components`). */
+interface BlendableCoffee {
+  origin?: string;
+  region?: string;
+  variety?: string;
+  process?: string;
+  components?: Component[] | null;
+}
+
+function cleanComponents(raw: Component[] | null | undefined): Component[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((c) => ({
+      origin: (c?.origin ?? "").trim(),
+      region: c?.region?.trim() || undefined,
+      variety: c?.variety?.trim() || undefined,
+      process: c?.process?.trim() || undefined,
+      ratio:
+        typeof c?.ratio === "number" && Number.isFinite(c.ratio)
+          ? c.ratio
+          : undefined,
+    }))
+    // A component with no origin AND no process/variety is empty noise from a
+    // half-filled editor row — drop it so it never becomes a blank blend.
+    .filter((c) => c.origin || c.process || c.variety);
+}
+
+/** True when the coffee is a real blend (2+ meaningful components). */
+export function isBlend(coffee: BlendableCoffee): boolean {
+  return cleanComponents(coffee.components).length >= 2;
+}
+
+/**
+ * The coffee's origin components as a uniform array. A blend returns its
+ * cleaned components; a single-origin bag returns a one-element array
+ * synthesised from the scalar fields (so callers have one code path).
+ */
+export function componentsOf(coffee: BlendableCoffee): Component[] {
+  const cleaned = cleanComponents(coffee.components);
+  if (cleaned.length >= 2) return cleaned;
+  // 0 or 1 component ⇒ single-origin view from the scalars.
+  const origin = (coffee.origin ?? "").trim();
+  if (!origin && !(coffee.process ?? "").trim()) return [];
+  return [
+    {
+      origin,
+      region: coffee.region?.trim() || undefined,
+      variety: coffee.variety?.trim() || undefined,
+      process: coffee.process?.trim() || undefined,
+    },
+  ];
+}
+
+/** Distinct, order-preserving join of a component field. */
+function joinDistinct(values: (string | undefined)[]): string {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of values) {
+    const t = (v ?? "").trim();
+    if (!t) continue;
+    const key = t.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(t);
+  }
+  return out.join(", ");
+}
+
+/**
+ * Derive the scalar summary fields from a set of components. Used by the write
+ * path so the stored `origin`/`region`/`variety`/`process` always reflect the
+ * blend. Returns empty strings for fields no component fills.
+ */
+export function deriveIdentitySummary(components: Component[]): {
+  origin: string;
+  region: string;
+  variety: string;
+  process: string;
+} {
+  return {
+    origin: joinDistinct(components.map((c) => c.origin)),
+    region: joinDistinct(components.map((c) => c.region)),
+    variety: joinDistinct(components.map((c) => c.variety)),
+    process: joinDistinct(components.map((c) => c.process)),
+  };
+}
+
+/**
+ * A one-line human summary of a blend for prompts / display, e.g.
+ * "Brazil (Natural) + Ethiopia (Washed)" or "60% Brazil + 40% Colombia".
+ * Returns "" for a non-blend (callers show the scalar origin instead).
+ */
+export function describeBlend(coffee: BlendableCoffee): string {
+  const comps = cleanComponents(coffee.components);
+  if (comps.length < 2) return "";
+  return comps
+    .map((c) => {
+      const pct = c.ratio != null ? `${c.ratio}% ` : "";
+      const proc = c.process ? ` (${c.process})` : "";
+      return `${pct}${c.origin || "Unknown"}${proc}`;
+    })
+    .join(" + ");
+}

--- a/src/lib/db/helpers.ts
+++ b/src/lib/db/helpers.ts
@@ -10,6 +10,7 @@ export function rowToCoffee(r: typeof coffees.$inferSelect): Coffee {
     name: r.name,
     origin: r.origin,
     process: r.process,
+    components: r.components ?? undefined,
     firstSeenAt: r.firstSeenAt,
     sessionCount: r.sessionCount,
     sessionIds: r.sessionIds ?? [],

--- a/src/lib/db/migrations/0021_add_coffee_components.sql
+++ b/src/lib/db/migrations/0021_add_coffee_components.sql
@@ -1,0 +1,29 @@
+-- Migration 0021 — blend components on the coffee row.
+--
+-- Until now a coffee carried exactly one `origin` and one `process` (single
+-- text columns). Blends — multiple origins and/or processes in one bag
+-- (e.g. "Brazil Natural + Ethiopia Washed") — could only be stored by jamming
+-- everything into those single strings, which the keyword matchers
+-- (recipe process scoring, brew-signature region bucketing) then silently
+-- collapsed to ONE value, losing the rest.
+--
+-- This adds a first-class `components jsonb` array. Each element is a
+-- BlendComponent: { origin, region?, variety?, process?, ratio? }
+-- (src/lib/types/session.ts).
+--
+-- BACKWARDS COMPATIBLE BY CONSTRUCTION:
+--   * Every existing row keeps components = NULL ⇒ treated as single-origin.
+--   * The scalar origin/process columns STAY POPULATED and become a
+--     comma-joined SUMMARY of the components (written by the sessions POST
+--     route from deriveIdentitySummary). So all the free-text-into-prompt and
+--     display consumers keep reading the scalar unchanged; only the
+--     blend-aware consumers read `components`.
+-- No backfill: pre-existing single-origin rows are correctly represented by
+-- NULL components, so there is nothing to migrate.
+--
+-- Run on the VPS via the "Run SQL Migration" workflow (migration_file =
+-- 0021_add_coffee_components.sql), or the psql fallback:
+--   cat src/lib/db/migrations/0021_add_coffee_components.sql \
+--     | docker compose exec -T postgres psql -U brewlog -d brewlog
+
+ALTER TABLE coffees ADD COLUMN IF NOT EXISTS components jsonb;

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -30,6 +30,7 @@ import type {
   ExternalPlace,
   SessionMode,
   SessionType,
+  BlendComponent,
 } from "@/lib/types/session";
 
 export const sessions = pgTable(
@@ -58,6 +59,13 @@ export const coffees = pgTable("coffees", {
   name: text("name").notNull(),
   origin: text("origin").notNull(),
   process: text("process").notNull(),
+  // Blend components (migration 0021). NULL/empty ⇒ single-origin bag — read
+  // the scalar origin/process above. When set (2+ components), origin/process
+  // are kept as a comma-joined SUMMARY of these so every free-text and keyword
+  // consumer that predates blends keeps working off the scalar unchanged; the
+  // blend-aware consumers (recipe process scoring, variety priors, brew
+  // signature) read this array. Shape: BlendComponent[] (src/lib/types/session).
+  components: jsonb("components").$type<BlendComponent[] | null>(),
   fermentationStyle: text("fermentation_style"),
   cuppingScore: numeric("cupping_score"),
   firstSeenAt: text("first_seen_at").notNull(),

--- a/src/lib/knowledge/recipes/helpers.ts
+++ b/src/lib/knowledge/recipes/helpers.ts
@@ -220,6 +220,13 @@ export interface RecipeSelectionInput {
   brewersAvailable: Set<BrewerType>;
   roastLevel?: RoastLevel;
   process?: Process;
+  /**
+   * Blend processes — a coffee with 2+ components can span processes
+   * (e.g. Natural + Washed). When set, a recipe scores the process match if it
+   * suits ANY component's process, instead of the single `process` collapsing
+   * to the first one. Single-origin bags leave this empty and use `process`.
+   */
+  processes?: Process[];
   variety?: string;
   goal: Goal;
   occasion?: string;
@@ -332,9 +339,18 @@ function scoreRecipe(
     reasons.push(`roast match (${input.roastLevel})`);
   }
 
-  if (input.process && recipe.bestFor.processes?.includes(input.process)) {
+  // Process match — union over blend components when present, else the single
+  // process. A blend "Natural + Washed" credits a recipe suited to either.
+  const wantProcesses =
+    input.processes && input.processes.length
+      ? input.processes
+      : input.process
+        ? [input.process]
+        : [];
+  const processHit = wantProcesses.some((p) => recipe.bestFor.processes?.includes(p));
+  if (processHit) {
     score += 2;
-    reasons.push(`process match (${input.process})`);
+    reasons.push(`process match (${wantProcesses.filter((p) => recipe.bestFor.processes?.includes(p)).join("/")})`);
   } else if (recipe.bestFor.processes?.includes("any")) {
     score += 1;
   }

--- a/src/lib/scan/clarifications.ts
+++ b/src/lib/scan/clarifications.ts
@@ -52,6 +52,15 @@ export function isFieldEmpty(coffee: CoffeeLike, field: ClarificationField): boo
   if (field === "tastingNotesFromBag") {
     return (coffee.tastingNotesFromBag?.length ?? 0) === 0;
   }
+  // A blend (2+ components) carries origin/region/variety/process per component
+  // and derives the scalar summary from them — the per-component editor already
+  // collected these, so never ask a follow-up about them for a blend.
+  if (
+    (coffee.components?.length ?? 0) >= 2 &&
+    (field === "origin" || field === "region" || field === "variety" || field === "process")
+  ) {
+    return false;
+  }
   const v = (coffee[field] as string | undefined)?.trim();
   if (!v) return true;
   // "Other" / "Unknown" are non-answers the scan falls back to — worth asking.

--- a/src/lib/storage/offlineLibrary.ts
+++ b/src/lib/storage/offlineLibrary.ts
@@ -98,6 +98,7 @@ function synthesizeIdentity(coffee: Coffee): CoffeeIdentity {
     name: coffee.name,
     origin: coffee.origin,
     process: coffee.process,
+    components: coffee.components,
     roastLevel: "Light",
     roastDate: coffee.latestRoastDate,
     bagPhotoUrl: coffee.bagPhotoUrl,

--- a/src/lib/types/coffee.ts
+++ b/src/lib/types/coffee.ts
@@ -1,4 +1,5 @@
 import type { FieldZones } from "@/lib/field/types";
+import type { BlendComponent } from "@/lib/types/session";
 
 export interface Coffee {
   id: string;
@@ -6,6 +7,10 @@ export interface Coffee {
   name: string;
   origin: string;
   process: string;
+  /** Blend components (2+). Absent/empty ⇒ single-origin; read the scalar
+   * origin/process. When present, origin/process mirror a comma-joined
+   * summary of these. See src/lib/coffee/blend.ts. */
+  components?: BlendComponent[];
   firstSeenAt: string;
   sessionCount: number;
   sessionIds: string[];

--- a/src/lib/types/session.ts
+++ b/src/lib/types/session.ts
@@ -3,6 +3,28 @@ import type { FlowAnalysis } from "@/lib/brew/flowAnalysis";
 export type SessionMode = "home" | "external";
 export type SessionType = "coffee" | "wine";
 
+/**
+ * One origin component of a coffee. A single-origin bag is one component; a
+ * blend is several. Each component pairs its own origin with its own region /
+ * variety / process (a blend can mix processes — "Brazil Natural + Ethiopia
+ * Washed") plus an optional percentage of the blend.
+ *
+ * The scalar `origin` / `region` / `variety` / `process` fields on
+ * `CoffeeIdentity` remain the SINGLE SOURCE for display + all the free-text and
+ * keyword-matching consumers; when `components` is present they are kept in sync
+ * as a comma-joined SUMMARY (see src/lib/coffee/blend.ts `deriveIdentitySummary`).
+ * So a single-origin bag never carries `components`, and every consumer that
+ * predates blends keeps working off the scalar unchanged.
+ */
+export interface BlendComponent {
+  origin: string;
+  region?: string;
+  variety?: string;
+  process?: string;
+  /** Share of the blend, 0–100. Optional — many bags don't print ratios. */
+  ratio?: number;
+}
+
 export interface CoffeeIdentity {
   roaster: string;
   name: string;
@@ -10,6 +32,12 @@ export interface CoffeeIdentity {
   region?: string;
   variety?: string;
   process: string; // Natural | Washed | Honey | Anaerobic | Other
+  /**
+   * Blend components (2+). Absent/empty ⇒ single-origin: read the scalar
+   * origin/region/variety/process instead. When present, the scalars mirror a
+   * comma-joined summary of these. See src/lib/coffee/blend.ts.
+   */
+  components?: BlendComponent[];
   fermentationStyle?: string; // e.g. "Spontaneous Anaerobic", "Starter-culture Natural", "Thermal-shock Washed"
   roastLevel: string; // Light | Medium-Light | Medium | Dark
   roastDate?: string; // ISO date string

--- a/tests/dataflow/blend.test.mjs
+++ b/tests/dataflow/blend.test.mjs
@@ -1,0 +1,125 @@
+// Blend helpers + recipe process-union tests — bundles the REAL
+// src/lib/coffee/blend.ts and src/lib/knowledge/recipes/helpers.ts so the test
+// tracks the actual logic. Covers migration 0021: a coffee with 2+ components
+// is a blend, its scalar origin/process are a comma-joined summary, and a
+// recipe scores the process match against ANY component's process.
+//
+//   node --test tests/dataflow/blend.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const entry = `
+export { isBlend, componentsOf, deriveIdentitySummary, describeBlend } from ${JSON.stringify(
+  path.join(ROOT, "src/lib/coffee/blend.ts"),
+)};
+export { selectRecipes, normaliseProcess } from ${JSON.stringify(
+  path.join(ROOT, "src/lib/knowledge/recipes/index.ts"),
+)};
+`;
+const dir = await mkdtemp(join(tmpdir(), "blend-"));
+const out = join(dir, "b.mjs");
+await build({
+  stdin: { contents: entry, resolveDir: ROOT, loader: "ts" },
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  outfile: out,
+  logLevel: "silent",
+});
+const { isBlend, componentsOf, deriveIdentitySummary, describeBlend, selectRecipes, normaliseProcess } =
+  await import(pathToFileURL(out).href);
+
+const BRAZIL = { origin: "Brazil", process: "Natural" };
+const ETHIOPIA = { origin: "Ethiopia", process: "Washed", variety: "Heirloom" };
+
+test("a single-origin bag is not a blend", () => {
+  assert.equal(isBlend({ origin: "Kenya", process: "Washed" }), false);
+  assert.equal(isBlend({ origin: "Kenya", process: "Washed", components: [] }), false);
+  // One component still counts as single-origin.
+  assert.equal(isBlend({ origin: "Kenya", process: "Washed", components: [BRAZIL] }), false);
+});
+
+test("2+ components is a blend", () => {
+  assert.equal(isBlend({ components: [BRAZIL, ETHIOPIA] }), true);
+});
+
+test("componentsOf synthesises a single component from scalars for a non-blend", () => {
+  const comps = componentsOf({ origin: "Kenya", region: "Nyeri", process: "Washed" });
+  assert.equal(comps.length, 1);
+  assert.equal(comps[0].origin, "Kenya");
+  assert.equal(comps[0].region, "Nyeri");
+});
+
+test("componentsOf returns the real components for a blend", () => {
+  const comps = componentsOf({ components: [BRAZIL, ETHIOPIA] });
+  assert.equal(comps.length, 2);
+  assert.equal(comps[1].variety, "Heirloom");
+});
+
+test("deriveIdentitySummary joins distinct origins + processes", () => {
+  const s = deriveIdentitySummary([BRAZIL, ETHIOPIA]);
+  assert.equal(s.origin, "Brazil, Ethiopia");
+  assert.equal(s.process, "Natural, Washed");
+  assert.equal(s.variety, "Heirloom");
+});
+
+test("deriveIdentitySummary dedupes a shared process", () => {
+  const s = deriveIdentitySummary([
+    { origin: "Brazil", process: "Natural" },
+    { origin: "Ethiopia", process: "Natural" },
+  ]);
+  assert.equal(s.origin, "Brazil, Ethiopia");
+  assert.equal(s.process, "Natural"); // not "Natural, Natural"
+});
+
+test("describeBlend renders a human line with ratios + processes", () => {
+  const line = describeBlend({
+    components: [
+      { origin: "Brazil", process: "Natural", ratio: 60 },
+      { origin: "Ethiopia", process: "Washed", ratio: 40 },
+    ],
+  });
+  assert.equal(line, "60% Brazil (Natural) + 40% Ethiopia (Washed)");
+  // non-blend → empty
+  assert.equal(describeBlend({ origin: "Kenya", process: "Washed" }), "");
+});
+
+test("normaliseProcess collapses a blend summary to ONE process (the bug the union fixes)", () => {
+  // "Natural, Washed" keyword-matches natural first → washed is lost. This is
+  // exactly why selectRecipes takes a `processes` array, verified below.
+  assert.equal(normaliseProcess("Natural, Washed"), "natural");
+});
+
+test("selectRecipes scores the process union so a washed-suited recipe surfaces for a Natural+Washed blend", () => {
+  const brewers = new Set(["v60"]);
+  const base = {
+    brewersAvailable: brewers,
+    roastLevel: "light",
+    goal: "balanced",
+  };
+  // Single process collapsed to "natural" (the summary) — a washed component
+  // gets no credit.
+  const collapsed = selectRecipes({ ...base, process: "natural" }, 6);
+  // Same brew, but passing BOTH component processes.
+  const union = selectRecipes(
+    { ...base, process: "natural", processes: ["natural", "washed"] },
+    6,
+  );
+  // The union must never surface FEWER recipes than the collapsed single —
+  // crediting an extra process can only add matches, never remove them.
+  assert.ok(union.length >= collapsed.length);
+  // And at least one returned recipe should list "washed" among its processes,
+  // proving the washed half now scores.
+  const anyWashed = union.some(
+    (r) => r.recipe?.bestFor?.processes?.includes("washed"),
+  );
+  assert.ok(anyWashed, "expected a washed-suited recipe in the union selection");
+});


### PR DESCRIPTION
Adds first-class support for **blends** — a coffee with multiple origins and/or processes in one bag (e.g. Brazil Natural + Ethiopia Washed).

### Design: backwards-compatible by construction
A coffee gains a `components` array (each component = origin + region + variety + process + optional %). The scalar `origin`/`process` columns **stay populated as a comma-joined summary** of the components, so every free-text and display consumer that predates blends keeps reading the scalar unchanged. Only the blend-aware consumers read the array. Single-origin bags never carry `components` → `NULL` → behave exactly as before.

### What changed
- **Migration `0021_add_coffee_components.sql`** — additive `coffees.components jsonb`, nullable, no backfill (NULL == single-origin). ⚠️ **Must run on the VPS before this merges/deploys** (Drizzle is column-strict). Run via *Run SQL Migration* with `ref = claude/coffee-blend-schema-0gofnc`.
- **Data model** — `BlendComponent` on `CoffeeIdentity` + `Coffee`, schema column, `rowToCoffee`. Single source of truth in `src/lib/coffee/blend.ts` (`componentsOf` / `isBlend` / `deriveIdentitySummary` / `describeBlend`).
- **Write path** (`/api/sessions`) — Zod-validates `components`; re-derives the scalar summary server-side so it can't drift; persists the column with the same "only when carried" policy as `bagFlavors`.
- **Matchers** — recipe process-scoring takes a `processes` **union** (a Natural+Washed blend credits recipes suited to either, instead of keyword-collapsing to the first process); brew-signature + escher give blends their own `blend-*` cluster.
- **Scan** — per-component editor (`BlendComponentsEditor`) behind a "This is a blend" toggle; the bag scanner extracts a `components` array for blends (nested nulls sanitised, <2 collapses to single-origin); post-scan clarifications skip origin/process for blends.
- **Prompt** (own commit) — `/recommend` gets a BLEND note when the bag has 2+ components; **byte-identical for single-origin bags** (prompt cache + non-blend behaviour unchanged).
- **Brew Again / offline cache** thread `components` through; **coffee detail** renders a per-component breakdown.
- **Tests** — `tests/dataflow/blend.test.mjs` (9 cases). `tsc` clean, full suite green (255).

### Deploy order
1. Run migration `0021` on the VPS against this branch.
2. Merge → auto-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013qR4pNM9XbtTLrawsSe9sX)_