### PR TITLE
fix: scan pulled no data — components:null rejected by bag schema

### DIFF
--- a/src/lib/claude/analyzeBag.ts
+++ b/src/lib/claude/analyzeBag.ts
@@ -3,7 +3,7 @@ import { parseClaudeJson, z } from "./parseJson";
 
 const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
-const BagAnalysisSchema = z.object({
+export const BagAnalysisSchema = z.object({
   extracted: z
     .object({
       roaster: z.string().nullable().optional(),
@@ -18,6 +18,10 @@ const BagAnalysisSchema = z.object({
       cuppingScore: z.number().nullable().optional(),
       tastingNotesFromBag: z.array(z.string()).optional(),
       // Blend components — present ONLY when the bag is a blend (2+ origins).
+      // MUST be `.nullable()` too: the prompt tells the model to return
+      // `"components": null` for a single-origin bag, and a plain `.optional()`
+      // rejects null → the whole parse fails → every single-origin scan returns
+      // empty. (This is the scan-data-export bug from PR #498.)
       components: z
         .array(
           z.object({
@@ -28,6 +32,7 @@ const BagAnalysisSchema = z.object({
             ratio: z.number().nullable().optional(),
           }),
         )
+        .nullable()
         .optional(),
     })
     .passthrough(),

--- a/tests/dataflow/analyze-bag-schema.test.mjs
+++ b/tests/dataflow/analyze-bag-schema.test.mjs
@@ -1,0 +1,85 @@
+// Regression guard for the scan-data-export bug (PR #498 → this fix).
+//
+// The blend feature added `components` to the bag-analysis schema but as a
+// plain `.optional()`, while the prompt tells the model to return
+// `"components": null` for a SINGLE-ORIGIN bag. `.optional()` rejects null, so
+// parseClaudeJson failed on every single-origin scan → the whole extraction
+// came back empty and the app "couldn't pull any data".
+//
+// This bundles the REAL BagAnalysisSchema + the REAL parseClaudeJson and proves
+// a normal single-origin model response (with components:null) parses and keeps
+// its fields. If someone drops the `.nullable()` again, this goes red.
+//
+//   node --test tests/dataflow/analyze-bag-schema.test.mjs
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { build } from "esbuild";
+import { pathToFileURL } from "node:url";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import path from "node:path";
+
+const ROOT = process.cwd();
+const entry = `
+export { BagAnalysisSchema } from ${JSON.stringify(path.join(ROOT, "src/lib/claude/analyzeBag.ts"))};
+export { parseClaudeJson } from ${JSON.stringify(path.join(ROOT, "src/lib/claude/parseJson.ts"))};
+`;
+const dir = await mkdtemp(join(tmpdir(), "analyzebag-"));
+const out = join(dir, "b.mjs");
+await build({
+  stdin: { contents: entry, resolveDir: ROOT, loader: "ts" },
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  outfile: out,
+  logLevel: "silent",
+});
+const { BagAnalysisSchema, parseClaudeJson } = await import(pathToFileURL(out).href);
+
+// Exactly what the model returns for a normal single-origin bag: the prompt
+// instructs "For a SINGLE-ORIGIN coffee, set components to null".
+const singleOrigin = JSON.stringify({
+  extracted: {
+    roaster: "HIGHER.",
+    name: "Rwanda - Gakenke",
+    origin: "Rwanda",
+    region: "Gakenke",
+    process: "Natural",
+    roastLevel: "Medium",
+    cuppingScore: 87,
+    tastingNotesFromBag: ["Currant", "Cacao Nib", "Red Apple"],
+    components: null,
+  },
+  confidence: { roaster: "bag" },
+  clarifications: [],
+  isCoffeeBag: true,
+});
+
+test("single-origin bag with components:null parses (does not fall back to empty)", () => {
+  const parsed = parseClaudeJson(singleOrigin, BagAnalysisSchema);
+  assert.ok(parsed, "parseClaudeJson must NOT return null for a single-origin bag");
+  assert.equal(parsed.extracted.roaster, "HIGHER.");
+  assert.equal(parsed.extracted.name, "Rwanda - Gakenke");
+  assert.equal(parsed.extracted.origin, "Rwanda");
+});
+
+test("a real blend (2+ components) still parses", () => {
+  const blend = JSON.stringify({
+    extracted: {
+      roaster: "La Cabra",
+      name: "Terra",
+      origin: "Brazil, Ethiopia",
+      process: "Natural",
+      components: [
+        { origin: "Brazil", process: "Natural" },
+        { origin: "Ethiopia", process: "Natural" },
+      ],
+    },
+    isCoffeeBag: true,
+  });
+  const parsed = parseClaudeJson(blend, BagAnalysisSchema);
+  assert.ok(parsed, "a blend must parse");
+  assert.equal(parsed.extracted.components.length, 2);
+});


### PR DESCRIPTION
## What broke

Since PR #498 (blend support) merged, **scanning a bag pulled no data** — the photo showed but roaster/name/origin/notes came back empty and the flow jumped straight to a clarification question.

## Root cause

#498 added `components` to the bag-analysis Zod schema as a plain `.optional()`:

```ts
components: z.array(...).optional()   // accepts array | undefined — NOT null
```

But the analyze-bag prompt tells the model, for every **single-origin** bag: *"set components to null"*. `.optional()` rejects `null`, so `schema.safeParse` failed → `parseClaudeJson` returned `null` → `analyzeBagImage` fell back to `{ extracted: {} }`. Since almost every bag is single-origin, **almost every scan** returned nothing.

Proven against the real schema: `components: null` → `Invalid input: expected array, received null`. Every *other* extracted field was already `.nullable().optional()`; `components` was the one that wasn't.

## Fix

Make `components` `.nullable().optional()` like the rest. One line. The existing null-strip + `Array.isArray` guard downstream already handle `null`, and blends (2+ components) are unaffected.

## Tests

- New `tests/dataflow/analyze-bag-schema.test.mjs` bundles the **real** `BagAnalysisSchema` + `parseClaudeJson` and asserts a single-origin response (`components: null`) parses and keeps its fields, and a 2-component blend still parses.
- `tsc --noEmit` clean; full `node --test` suite green (248 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KBxXKfR3Qh6ExGbtHovdyH

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBxXKfR3Qh6ExGbtHovdyH)_