### PR TITLE
feat: concrete pour rate under the grams row on the brew card

### DIFF
--- a/src/components/flow/LightStepBrew.tsx
+++ b/src/components/flow/LightStepBrew.tsx
@@ -9,8 +9,10 @@ import {
   isAgitationPourAction,
   poursCompleteAtSec,
   getActiveIdx,
+  pourPace,
   type PourStep,
   type GuideStep,
+  type PourPace,
 } from "@/lib/utils/pourSequence";
 import { buildBrewTimeline, type BrewTimeline } from "@/lib/brew/timeline";
 import type { BrewStepAction } from "@/lib/types/session";
@@ -416,6 +418,24 @@ function showsCoach(coach?: FlowComparison | null): coach is FlowComparison {
   return !!coach && coach.cue !== "none" && coach.cue !== "agitate";
 }
 
+/** Concrete pour-pace line for the active pour step — sits right under the
+ * "+180g → 270g" grams row and turns the recipe's vague "slow pouring" into a
+ * number the user can hold against the live g/s the scale shows: e.g.
+ * "Slow pour · ~4.0 g/s over ~45s". Derived from the recipe's OWN timing (the
+ * same intended-rate model the flow coach grades against), so it's the recipe's
+ * "slow", not a generic one — and it renders whether or not a scale is connected. */
+function PourPaceLine({ pace }: { pace: PourPace }) {
+  const label = pace.descriptor.charAt(0).toUpperCase() + pace.descriptor.slice(1) + " pour";
+  const rate = pace.rateGPS >= 10 ? String(Math.round(pace.rateGPS)) : pace.rateGPS.toFixed(1);
+  return (
+    <div className="mt-1.5 flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+      <span className="font-fraunces text-[15px] leading-none text-light-foreground">{label}</span>
+      <span className="font-mono-num text-[13px] font-semibold text-light-foreground">~{rate} g/s</span>
+      <span className="font-mono-num text-[12px] text-light-muted-foreground">over ~{pace.seconds}s</span>
+    </div>
+  );
+}
+
 /** The cream weight box for the steps that don't fire a pour cue — swirl/agitation
  * and drain. Same surface as CoachCue, but a plain "Hold" readout: live g/s + the
  * big current-grams / target-grams. Keeps the current+target weight visible on
@@ -503,6 +523,14 @@ function LivePourSequence({ steps, elapsed, targetTimeSec, started, waterGrams, 
   const activeStep = activeIdx >= 0 ? steps[activeIdx] : null;
   const nextStep = activeIdx >= 0 && activeIdx < steps.length - 1 ? steps[activeIdx + 1] : null;
   const nextCountdown = nextStep ? Math.max(0, nextStep.startTimeSec - elapsed) : null;
+  // Concrete pour pace for the active MAIN pour (pour/final), shown under the
+  // grams row so "slow" becomes a rate the live g/s can be read against. The
+  // bloom is excluded — its job is even saturation, not a rate (and recipes
+  // author its duration inconsistently), so the coach's "Gentle" carries it.
+  const activePace =
+    activeStep && (activeStep.action === "pour" || activeStep.action === "final")
+      ? pourPace(activeStep.pourGrams, activeStep.pourDurationSec)
+      : null;
   // Draining begins a grace beyond the last step (poursCompleteAtSec covers the time to
   // physically pour it) — purely time-based, so it never waits on a weight reading.
   const drainStartSec = poursCompleteAtSec(steps, targetTimeSec);
@@ -637,6 +665,7 @@ function LivePourSequence({ steps, elapsed, targetTimeSec, started, waterGrams, 
               total {waterGrams}g
             </span>
           </div>
+          {activePace && <PourPaceLine pace={activePace} />}
           <p className="font-chivo text-[13px] text-light-muted-foreground mt-2">
             {activeStep.notes ?? defaultPourNote(activeStep.action)}
             {activeStep.temperatureC != null && (
@@ -978,6 +1007,27 @@ function StepGuide({
   const tag = actionTag(current.action);
   const isSteep = current.action === "wait";
 
+  // Concrete pour pace for an immersion WATER step (AeroPress/Clever "add water"):
+  // this pour's size = cumulative delta from the previous water step, paced by the
+  // recipe's own timing — the same intended-rate model the coach uses, so the
+  // shown target and any coach cue agree.
+  const isWaterPourStep =
+    current.action === "pour" ||
+    current.action === "final" ||
+    current.action === "melodrip";
+  let currentPace: PourPace | null = null;
+  if (isWaterPourStep && current.cumulativeGrams != null) {
+    let prevCumulative = 0;
+    for (let i = currentIdx - 1; i >= 0; i--) {
+      const c = timed[i].cumulativeGrams;
+      if (c != null) {
+        prevCumulative = c;
+        break;
+      }
+    }
+    currentPace = pourPace(current.cumulativeGrams - prevCumulative, current.durationSec);
+  }
+
   const stepCueActive =
     started && elapsed >= current.startTimeSec && elapsed < current.startTimeSec + 10;
   const stepRemaining = started
@@ -1033,6 +1083,7 @@ function StepGuide({
                 {current.temperatureC != null && <span>{current.temperatureC}°C water</span>}
               </p>
             )}
+            {currentPace && <PourPaceLine pace={currentPace} />}
             <p className="font-chivo text-[13px] text-light-muted-foreground mt-2">
               {current.notes ?? defaultGuideNote(current.action)}
             </p>

--- a/src/lib/brew/flowCoach.ts
+++ b/src/lib/brew/flowCoach.ts
@@ -16,7 +16,7 @@
  * guidance, never presented as hard law.
  */
 import { activeStepAt, expectedGramsAt, type BrewTimeline } from "@/lib/brew/timeline";
-import { intendedPourDurationSec } from "@/lib/utils/pourSequence";
+import { pourTargetRateGPS } from "@/lib/utils/pourSequence";
 
 export interface WeightSample {
   /** Wall-clock ms when the sample was read. */
@@ -65,11 +65,9 @@ const SLOW_MULT = 0.6;
 // Never cry "Slower" below this even at 1.5× a very gentle target — a genuinely
 // slow pour is never "too fast". Keeps the coach quiet on clarity brews.
 const FAST_FLOOR = 4; // g/s
-// The recipe's intended rate is clamped to this sane pour band before coaching,
-// so a mis-authored durationSec (a 1 s "pour 200 g" = 200 g/s) can't set an
-// absurd target. Wide by design — the corpus spans ~3–10 g/s on pour-overs.
-const TARGET_MIN = 2; // g/s
-const TARGET_MAX = 11; // g/s — a hard gooseneck can't gently exceed this
+// The recipe's intended rate is clamped to a sane pour band (2–11 g/s) before
+// coaching — see pourTargetRateGPS, the shared source of truth the brew screen
+// also displays, so the coached target and the shown target can never drift.
 
 const NO_DATA: FlowComparison = {
   cue: "none",
@@ -189,14 +187,11 @@ export function coachFlow(
   const pourGrams = step.pourGrams != null && step.pourGrams > 0 ? step.pourGrams : stepTarget;
   // Coach against the RECIPE'S OWN intended pour rate — grams ÷ its intended
   // pour time (Kasuya 60 g / 10 s = 6 g/s; a Hoffmann swing ~10; a clarity brew
-  // ~3–4). `intendedPourDurationSec` uses the recipe's authored time when it
-  // reads as a real pour (≥2 g/s) and falls back to the ~4 g/s house estimate
-  // otherwise (rest folded into the step, or no duration). Clamped to a sane
-  // pour band so a bad duration can't set an impossible target. This replaces
-  // the old global 4 g/s that flagged every legit fast pour as "too fast".
-  const dur = intendedPourDurationSec(pourGrams, step.pourDurationSec);
-  const rawTargetRate = pourGrams / dur;
-  const targetRate = Math.min(TARGET_MAX, Math.max(TARGET_MIN, rawTargetRate));
+  // ~3–4), clamped to a sane band. `pourTargetRateGPS` is the shared source of
+  // truth the brew screen also displays, so the target you're coached to and the
+  // target shown on the card are the same number. Replaces the old global 4 g/s
+  // that flagged every legit fast pour as "too fast".
+  const targetRate = pourTargetRateGPS(pourGrams, step.pourDurationSec);
 
   const partial: Omit<FlowComparison, "cue" | "message" | "detail" | "state"> = {
     liveGrams,

--- a/src/lib/brew/timeline.ts
+++ b/src/lib/brew/timeline.ts
@@ -137,6 +137,19 @@ export function buildBrewTimeline(
   const guideSteps = hasImmersionShape(recipe) ? buildGuideSteps(recipe) : null;
   if (guideSteps) {
     const normalized = guideSteps.map(fromGuideStep);
+    // Fill each immersion WATER step's `pourGrams` with the cumulative delta — the
+    // size of THIS pour, not the running total — so the live flow coach (and the
+    // brew screen's pace line) target the actual pour. Single-pour immersion (the
+    // common AeroPress/Clever "add all water", delta == total) is unchanged; a
+    // rare second pour now coaches against its own increment instead of the total.
+    let prevCumulative = 0;
+    for (const s of normalized) {
+      if (s.targetCumulativeGrams == null) continue;
+      if (s.action === "bloom" || s.action === "pour" || s.action === "final" || s.action === "melodrip") {
+        s.pourGrams = Math.max(0, s.targetCumulativeGrams - prevCumulative);
+      }
+      prevCumulative = s.targetCumulativeGrams;
+    }
     return {
       shape: "immersion",
       pourSteps: null,

--- a/src/lib/utils/pourSequence.test.mjs
+++ b/src/lib/utils/pourSequence.test.mjs
@@ -20,7 +20,8 @@ const entry = `
 export {
   getBloomDuration, parsePourSteps, pourStepsFromStructured, buildGuideSteps,
   hasImmersionShape, getActiveIdx, isAgitationPourAction, pourDurationSec,
-  poursCompleteAtSec, POUR_RATE_GPS,
+  poursCompleteAtSec, POUR_RATE_GPS, pourPace, pourTargetRateGPS,
+  PACE_RATE_MIN_GPS, PACE_RATE_MAX_GPS,
 } from ${JSON.stringify(path.join(ROOT, "src/lib/utils/pourSequence.ts"))};
 `;
 const dir = await mkdtemp(join(tmpdir(), "pourseq-"));
@@ -44,6 +45,10 @@ const {
   pourDurationSec,
   poursCompleteAtSec,
   POUR_RATE_GPS,
+  pourPace,
+  pourTargetRateGPS,
+  PACE_RATE_MIN_GPS,
+  PACE_RATE_MAX_GPS,
 } = await import(pathToFileURL(out).href);
 
 // Fixed clock: Apr 17 2026. Lets roast-date branches be exercised deterministically.
@@ -563,3 +568,54 @@ test("proportional spacing: the final pour still lands at target − reserve", (
 // advances purely on the recipe's TIME schedule (`getActiveIdx`, tested above),
 // with the live weight box on each step showing poured-vs-target. No peak, no
 // weight-hold, so there is nothing to "freeze".
+
+// ── pourPace / pourTargetRateGPS ──────────────────────────────────────────────
+// The concrete pour-pace the brew screen shows under the grams row, and the
+// single target-rate source the flow coach ALSO grades against.
+
+test("pourTargetRateGPS: authored pour time drives the rate (Kasuya 60g/10s = 6 g/s)", () => {
+  assert.ok(Math.abs(pourTargetRateGPS(60, 10) - 6) < 1e-9);
+});
+
+test("pourTargetRateGPS: no authored time → the ~4 g/s house fallback", () => {
+  // 180g / pourDurationSec(180)=round(180/4)=45s → 4.0 g/s.
+  assert.ok(Math.abs(pourTargetRateGPS(180) - 4) < 1e-9);
+});
+
+test("pourTargetRateGPS: an absurd authored time is clamped to the ceiling", () => {
+  // "pour 200g in 1s" = 200 g/s → clamped to the 11 g/s ceiling.
+  assert.equal(pourTargetRateGPS(200, 1), PACE_RATE_MAX_GPS);
+});
+
+test("pourTargetRateGPS: an implausibly SLOW authored time is ignored (falls to ~4 g/s)", () => {
+  // 10g authored at 60s = 0.17 g/s < MIN_POUR_RATE_GPS → not a real pour time, so
+  // intendedPourDurationSec drops back to the house estimate (~4 g/s), never a
+  // near-zero rate.
+  const r = pourTargetRateGPS(10, 60);
+  assert.ok(r > PACE_RATE_MIN_GPS && r <= 4.5, `expected ~4 g/s house fallback, got ${r}`);
+});
+
+test("pourPace: descriptor bands (house 4 g/s reads 'slow', Kasuya 6 'brisk')", () => {
+  assert.equal(pourPace(180).descriptor, "slow"); // 4.0 g/s house fallback
+  assert.equal(pourPace(20, 10).descriptor, "very slow"); // 2.0 g/s
+  assert.equal(pourPace(40, 10).descriptor, "slow"); // 4.0 g/s
+  assert.equal(pourPace(50, 10).descriptor, "steady"); // 5.0 g/s
+  assert.equal(pourPace(60, 10).descriptor, "brisk"); // 6.0 g/s (band boundary: <6 = steady)
+  assert.equal(pourPace(70, 10).descriptor, "brisk"); // 7.0 g/s
+  assert.equal(pourPace(90, 10).descriptor, "fast"); // 9.0 g/s
+});
+
+test("pourPace: seconds stay consistent with a clamped rate", () => {
+  // 200g authored at 1s → rate clamps to 11 g/s; the shown seconds must re-derive
+  // from the clamp (≈18s), never the impossible 1s.
+  const p = pourPace(200, 1);
+  assert.equal(p.rateGPS, PACE_RATE_MAX_GPS);
+  assert.equal(p.seconds, Math.round(200 / PACE_RATE_MAX_GPS)); // 18
+  // And an un-clamped pace keeps its authored seconds exactly.
+  assert.equal(pourPace(60, 10).seconds, 10);
+});
+
+test("pourPace: zero-gram step (agitation / steep) has no pace", () => {
+  assert.equal(pourPace(0), null);
+  assert.equal(pourPace(undefined), null);
+});

--- a/src/lib/utils/pourSequence.ts
+++ b/src/lib/utils/pourSequence.ts
@@ -66,6 +66,71 @@ export function intendedPourDurationSec(grams: number, authoredSec?: number): nu
   return pourDurationSec(g);
 }
 
+/** The intended pour rate is clamped to this sane pour band for BOTH display and
+ * coaching, so a mis-authored `durationSec` (a 1 s "pour 200 g" = 200 g/s) can't
+ * set an absurd target. Wide by design — the corpus spans ~3–10 g/s on pour-overs
+ * (median 5.2). Shared with the live flow coach so the shown and coached targets
+ * never drift. */
+export const PACE_RATE_MIN_GPS = 2;
+export const PACE_RATE_MAX_GPS = 11;
+
+/**
+ * The recipe's intended pour RATE (g/s) for a pour of `grams`, clamped to the
+ * sane pour band. This is the SINGLE source of truth for "how fast this pour
+ * should go" — used by the live flow coach (what it grades your pour against)
+ * AND by the brew screen (what it displays), so the target you're shown and the
+ * target you're coached to are always the same number.
+ */
+export function pourTargetRateGPS(grams: number, authoredSec?: number): number {
+  const g = Math.max(1, grams);
+  const raw = g / intendedPourDurationSec(g, authoredSec);
+  return Math.min(PACE_RATE_MAX_GPS, Math.max(PACE_RATE_MIN_GPS, raw));
+}
+
+export interface PourPace {
+  /** Grams added by this pour. */
+  grams: number;
+  /** Seconds to pour it at the intended rate (kept consistent with `rateGPS`). */
+  seconds: number;
+  /** Intended pour rate (g/s), clamped to the sane pour band. */
+  rateGPS: number;
+  /** Plain pace word mapped from the rate. Owner-calibrated to the house pour:
+   * the ~4 g/s gentle gooseneck reads "slow", Kasuya's ~6 "steady", a Hoffmann
+   * swing "fast". Turns a recipe's vague "slow"/"gentle" into a word AND a number
+   * the user can hold against the live g/s the scale shows. */
+  descriptor: "very slow" | "slow" | "steady" | "brisk" | "fast";
+}
+
+/**
+ * Concrete pour-pace for a single pour — how fast (g/s), how long (s), and a
+ * plain descriptor — derived from the recipe's OWN timing (the same intended-rate
+ * model the flow coach uses). Lets the brew screen replace a vague "slow pouring"
+ * with "Slow pour · ~4 g/s over ~45s". Returns null for a zero-gram step
+ * (agitation / steep / press), which has no pour to pace.
+ */
+export function pourPace(grams: number, authoredSec?: number): PourPace | null {
+  if (!grams || grams <= 0) return null;
+  const rateGPS = pourTargetRateGPS(grams, authoredSec);
+  const rawSeconds = intendedPourDurationSec(grams, authoredSec);
+  // If the raw rate got clamped, re-derive seconds from the clamped rate so the
+  // displayed pair "~18s · ~11 g/s" is never internally impossible.
+  const seconds =
+    Math.abs(grams / rawSeconds - rateGPS) < 1e-6
+      ? rawSeconds
+      : Math.max(1, Math.round(grams / rateGPS));
+  const descriptor: PourPace["descriptor"] =
+    rateGPS < 3
+      ? "very slow"
+      : rateGPS < 4.5
+        ? "slow"
+        : rateGPS < 6
+          ? "steady"
+          : rateGPS < 8
+            ? "brisk"
+            : "fast";
+  return { grams, seconds, rateGPS, descriptor };
+}
+
 /** Discrete agitation actions that now get their OWN timed step in the
  * percolation timeline (instead of being folded onto a pour as an attribute). */
 export type AgitationAction = "swirl" | "stir" | "tap";

--- a/tests/dataflow/brew-flowcoach.test.mjs
+++ b/tests/dataflow/brew-flowcoach.test.mjs
@@ -199,3 +199,32 @@ test("immersion: the water-POUR step gets scale coaching (AeroPress fix)", () =>
   assert.equal(over.cue, "overshot");
   assert.equal(over.detail, "+15g");
 });
+
+// A two-pour immersion (bloom 60g, then a top-up to 250g). The second pour's own
+// size is 190g — the coach must target THAT delta, not the 250g running total.
+const IMMERSION_2POUR = buildBrewTimeline(
+  {
+    doseGrams: 18, waterGrams: 250, waterTempC: 90, grindSize: "medium", targetTimeSec: 180,
+    pourSteps: [
+      { label: "Bloom", action: "bloom", waterGramsAtEnd: 60, durationSec: 15 },
+      { label: "Steep", action: "wait", durationSec: 30 },
+      { label: "Top up", action: "pour", waterGramsAtEnd: 250, durationSec: 30 },
+      { label: "Steep", action: "wait", durationSec: 60 },
+      { label: "Press", action: "press", durationSec: 25 },
+    ],
+  },
+  ROAST,
+  NOW,
+);
+
+test("immersion multi-pour: pourGrams is the cumulative DELTA, not the total", () => {
+  const topUp = IMMERSION_2POUR.steps.find((s) => s.targetCumulativeGrams === 250);
+  assert.equal(topUp.pourGrams, 190, "top-up pour is 250 − 60 = 190g");
+});
+
+test("immersion multi-pour: coach targets the pour delta's rate, not the total's", () => {
+  const topUp = IMMERSION_2POUR.steps.find((s) => s.targetCumulativeGrams === 250);
+  const c = coachFlow(IMMERSION_2POUR, topUp.startSec + 1, true, 120, ramp(6));
+  // 190g over its authored 30s = ~6.3 g/s — NOT the 250/30 = ~8.3 the total gives.
+  assert.ok(Math.abs(c.targetRateGPS - 190 / 30) < 0.05, `expected ~6.3, got ${c.targetRateGPS}`);
+});


### PR DESCRIPTION
## What & why

On the active brew card the pour-flow note only ever said things like **"Slow spiral from centre outward"** / "gentle". You see the live g/s from the Acaia, but there was no way to tell whether "slow" meant 3 g/s or 5 g/s — or how it related to *this* recipe. "Is it really super slow, or just generally slow?"

This surfaces the recipe's **own** intended pour rate as a concrete line, right underneath the `+180g → 270g / total 450g` grams row on the active pour card:

```
Now
Pour 2
+180g → 270g                 total 450g
Slow pour   ~4.0 g/s   over ~45s      ← new
Slow spiral from centre outward
[Steady   5.2 g/s          270 g / 270g]   ← live coach (when scale connected)
```

Now "slow" has a number you can hold against the live reading.

## How

The recipe's intended pour rate was **already computed internally** by the flow coach (`intendedPourDurationSec`, PR #489) — it just wasn't shown. This surfaces it and makes the shown/coached target one number.

- **`pourPace()` / `pourTargetRateGPS()`** in `pourSequence.ts` — the single source of truth for "how fast this pour should go", derived from the recipe's authored pour time (Kasuya ~6 g/s, Hoffmann ~10, house fallback ~4), clamped to a sane 2–11 g/s band. The descriptor word is owner-calibrated (the ~4 g/s house pour reads **"slow"**).
- **`flowCoach`** now grades against the same `pourTargetRateGPS()`, so the target shown on the card and the target the coach coaches to can never drift.
- Shown on the **main pours** (pour/final) in both renderers — percolation (`LivePourSequence`) and immersion water steps (`StepGuide`). The **bloom is excluded** (its job is even saturation, not a rate; the coach's "Gentle" carries it). Renders **with or without a scale** connected — it's a property of the recipe.
- **`timeline`**: immersion water steps now carry `pourGrams` as the cumulative delta (this pour's size), so a multi-pour immersion coaches against the actual pour, not the running total.

## Tests

- `pourSequence.test.mjs` — pace bands, ceiling/floor clamp, seconds-consistency when a rate is clamped, zero-gram → no pace.
- `brew-flowcoach.test.mjs` — immersion multi-pour delta + coach targeting the delta's rate, not the total's.
- `tsc --noEmit` clean; full `node --test` (257) green.

No AI-prompt / model change — this only surfaces numbers the pipeline already produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1K6NKY7GwBjSDcfUjRv1c)_