### PR TITLE
fix: unbreak CI screenshots — migration 0022 no-ops on zero rows

### DIFF
--- a/src/lib/db/migrations/0022_set_la_cabra_terra_blend.sql
+++ b/src/lib/db/migrations/0022_set_la_cabra_terra_blend.sql
@@ -11,9 +11,13 @@
 -- bag's batch differs, correct via a follow-up — nothing here is fabricated
 -- beyond what the roaster lists.
 --
--- SAFETY: targets exactly one coffee row and RAISEs (aborting the whole
--- statement under ON_ERROR_STOP) unless the roaster+name match is unique, so it
--- can never touch the wrong bag. Idempotent — re-running sets the same values.
+-- SAFETY: aborts (under ON_ERROR_STOP) only when the roaster+name match is
+-- AMBIGUOUS (>1 row), so it can never touch the wrong bag. A ZERO-row match is a
+-- no-op, not an error — there's nothing to touch, and the migration must stay
+-- safe to apply against ANY database state, including the empty throwaway
+-- Postgres the CI screenshots job spins up (which applies every migration to a
+-- fresh DB with no seed data — the hard "exactly 1" guard used to abort that run
+-- and red the whole job). Idempotent — re-running sets the same values.
 --
 -- Applied via the push-triggered runner (.github/migrate) or the manual
 -- "Run SQL Migration" workflow.
@@ -27,8 +31,13 @@ BEGIN
   FROM coffees
   WHERE roaster ILIKE '%la cabra%' AND name ILIKE '%terra%';
 
-  IF n <> 1 THEN
-    RAISE EXCEPTION 'Expected exactly 1 La Cabra Terra coffee row, found % — aborting so no wrong row is touched', n;
+  IF n = 0 THEN
+    RAISE NOTICE 'No La Cabra Terra coffee row found — nothing to update (skipping)';
+    RETURN;
+  END IF;
+
+  IF n > 1 THEN
+    RAISE EXCEPTION 'Expected at most 1 La Cabra Terra coffee row, found % — aborting so no wrong row is touched', n;
   END IF;
 
   SELECT id INTO target_id


### PR DESCRIPTION
## What & why

The CI **screenshots** job has been red on every PR (it failed the pour-pace PR #500 too, though that change was unrelated — its `check` gate passed). Root cause:

The screenshots job applies **every** migration to a fresh, empty throwaway Postgres before booting the app. Migration `0022_set_la_cabra_terra_blend.sql` is a production **data-fix** that guarded `n <> 1` and hard-`RAISE`d:

```
── applying src/lib/db/migrations/0022_set_la_cabra_terra_blend.sql
ERROR: Expected exactly 1 La Cabra Terra coffee row, found 0 — aborting
##[error]Process completed with exit code 3
```

On the empty CI DB there are 0 coffee rows, so the guard aborts the whole migration run under `ON_ERROR_STOP` — before the app ever starts, so no screens are captured.

## Fix

The safety that matters is **"never touch the wrong row"** — i.e. abort on an *ambiguous* match (`n > 1`). A zero-row match has nothing to touch, so it should be a **no-op**, not an error. Split the guard:

- `n = 0` → `RAISE NOTICE` + `RETURN` (skip cleanly)
- `n > 1` → abort (unchanged safety)
- `n = 1` → apply (unchanged; production behaves identically)

The file already ran on production, so this only changes how a **fresh** application (CI's empty DB) behaves — data-fix migrations must be safe against any DB state, and this makes 0022 conform.

No app code changed; `check` (tsc + tests) unaffected. This restores the `screenshots` artifact so PR layouts can be eyeballed again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1K6NKY7GwBjSDcfUjRv1c)_