### PR TITLE
fix: coffee detail crashed to the error boundary on a candidates-only session

### DIFF
--- a/src/components/session/SessionCard.tsx
+++ b/src/components/session/SessionCard.tsx
@@ -5,6 +5,7 @@ import type { Session } from "@/lib/types/session";
 import StarRating from "@/components/ui/light/StarRating";
 import BrewMethodIcon from "@/components/ui/BrewMethodIcon";
 import { formatSeconds } from "@/lib/utils/formatTime";
+import { resolveBrewedRecipe } from "@/lib/utils/resolveRecipe";
 
 interface SessionCardProps {
   session: Session;
@@ -15,13 +16,24 @@ const DELETE_THRESHOLD = 80;
 
 export default function SessionCard({ session, onDeleted }: SessionCardProps) {
   const router = useRouter();
-  const { brew, result, recommendation, createdAt } = session;
+  const { brew, result, createdAt } = session;
 
-  const method = brew?.methodUsed || recommendation?.primaryMethod || "Brew";
-  const dose = brew?.doseGrams ?? recommendation?.primaryRecipe.doseGrams;
-  const water = brew?.waterGrams ?? recommendation?.primaryRecipe.waterGrams;
-  const timeSec = brew?.actualTimeSec ?? recommendation?.primaryRecipe.targetTimeSec;
-  const grind = brew?.grindSettingUsed ?? recommendation?.primaryRecipe.grindSize;
+  // The recipe the user ACTUALLY brewed (selected candidate), via the shared
+  // resolver — not `recommendation.primaryRecipe`. Two reasons:
+  //   1. Crash safety. `recommendation?.primaryRecipe.doseGrams` only guarded
+  //      `recommendation`, so a stored session whose recommendation carries
+  //      `candidates` but no `primaryRecipe` threw "Cannot read properties of
+  //      undefined" and took the whole coffee-detail page to the error boundary.
+  //      The field is typed required but comes back from JSONB, where an older /
+  //      differently-written row may simply not have it.
+  //   2. Correctness. Reading the primary showed the FIRST candidate's numbers
+  //      even when a different candidate was brewed — the same bug class PRs
+  //      #193/#198 fixed everywhere else by routing through this resolver.
+  const { recipe: brewedRecipe, method } = resolveBrewedRecipe(session);
+  const dose = brew?.doseGrams ?? brewedRecipe?.doseGrams;
+  const water = brew?.waterGrams ?? brewedRecipe?.waterGrams;
+  const timeSec = brew?.actualTimeSec ?? brewedRecipe?.targetTimeSec;
+  const grind = brew?.grindSettingUsed ?? brewedRecipe?.grindSize;
   const rating = result?.rating;
   const tags = result?.flavorNotes?.slice(0, 4) ?? [];
 

--- a/src/lib/types/session.ts
+++ b/src/lib/types/session.ts
@@ -155,8 +155,14 @@ export interface RecommendationCandidate {
 
 export interface Recommendation {
   candidates: RecommendationCandidate[]; // 2–4 entries
-  primaryMethod: string;                 // = candidates[0].method (backward compat)
-  primaryRecipe: BrewRecipe;             // = candidates[0].recipe (backward compat)
+  // OPTIONAL ON PURPOSE — these two are read back from a `jsonb` column, not
+  // constructed fresh, so the type must describe what a stored row can actually
+  // hold. Typing them required let `recommendation?.primaryRecipe.doseGrams`
+  // type-check while throwing at runtime on a row that only carried
+  // `candidates` — it crashed the coffee-detail page into the error boundary.
+  // Read the brewed recipe via resolveBrewedRecipe(session) instead of these.
+  primaryMethod?: string;                // = candidates[0].method (backward compat)
+  primaryRecipe?: BrewRecipe;            // = candidates[0].recipe (backward compat)
   alternativeMethod?: string;            // = candidates[1]?.method (backward compat)
   alternativeRecipe?: BrewRecipe;        // = candidates[1]?.recipe (backward compat)
   reasoning: string;

--- a/tests/dataflow/resolve.test.mjs
+++ b/tests/dataflow/resolve.test.mjs
@@ -80,3 +80,45 @@ test("basedOnReference sentinel handling", () => {
   assert.equal(basedOnReference("  "), undefined);
   assert.equal(basedOnReference("April 1-2-3", "Reduced agitation"), "April 1-2-3");
 });
+
+// ── Degenerate stored shapes (the coffee-detail crash, July 2026) ───────────
+// `recommendation` is a jsonb column, so a stored row can carry `candidates`
+// without the "backward compat" `primaryMethod`/`primaryRecipe` mirrors. The
+// session card used to read `recommendation?.primaryRecipe.doseGrams` — the
+// optional chain guarded the recommendation but NOT primaryRecipe, so such a
+// row threw "Cannot read properties of undefined" and took the whole
+// /coffees/[id] page to the error boundary. Every reader must degrade to
+// undefined instead. (Types made primaryMethod/primaryRecipe optional so tsc
+// catches a new unguarded deref.)
+
+test("candidates-only recommendation resolves without throwing", () => {
+  const r = resolveBrewedRecipe({
+    id: "s2", type: "brew", mode: "home",
+    recommendation: { candidates: [{ method: "V60", title: "T", recipe: { _tag: "CAND0", doseGrams: 15 } }] },
+    brew: { methodUsed: "V60" },
+  });
+  assert.equal(r.recipe._tag, "CAND0");
+  assert.equal(r.method, "V60");
+});
+
+test("candidates-only with no brew block still resolves (no primaryRecipe to fall back on)", () => {
+  const r = resolveBrewedRecipe({
+    id: "s3", type: "brew", mode: "home",
+    recommendation: { candidates: [{ method: "Clever", recipe: { _tag: "C" } }] },
+  });
+  // No index and no methodUsed → nothing matches; must be undefined, not a throw.
+  assert.equal(r.recipe, undefined);
+  assert.equal(r.method, "Brew");
+});
+
+test("empty recommendation object degrades to undefined", () => {
+  const r = resolveBrewedRecipe({ id: "s4", type: "brew", mode: "home", recommendation: {}, brew: { methodUsed: "V60" } });
+  assert.equal(r.recipe, undefined);
+  assert.equal(r.method, "V60");
+});
+
+test("missing recommendation entirely (café visit) degrades to undefined", () => {
+  const r = resolveBrewedRecipe({ id: "s5", type: "brew", mode: "cafe" });
+  assert.equal(r.recipe, undefined);
+  assert.equal(r.method, "Brew");
+});


### PR DESCRIPTION
## The crash

Opening a coffee from the library threw and dropped the whole `/coffees/[id]` page into the `(light)` error boundary — the "This screen hit a snag." screen. **Try Again re-rendered the same session and crashed again**, which is why it read as constant.

```
TypeError: Cannot read properties of undefined (reading 'doseGrams')
    at SessionCard
```

## Root cause

`SessionCard` (rendered once per past brew on the coffee-detail page) read:

```ts
const dose = brew?.doseGrams ?? recommendation?.primaryRecipe.doseGrams;
```

The optional chain guards `recommendation` but **not** `primaryRecipe`. A stored session whose recommendation carries `candidates` without the "backward compat" `primaryMethod`/`primaryRecipe` mirrors throws on dereference.

Three things kept this hidden:

- `recommendation` is a **jsonb** column read straight back into a type that declared `primaryRecipe` as **required** — so `tsc` could never flag the deref.
- It only throws when the matching `brew` field is *also* absent (the `??` then evaluates the right-hand side). That's why it hit some coffees and not others.
- CI's `screenshots` job drives an **empty** database, so no session card ever renders there. Green CI, crashing app.

`SessionCard` was the only unguarded reader — every other consumer already used the safe `rec?.primaryRecipe`.

## Fix

- **`SessionCard` resolves through `resolveBrewedRecipe(session)`**, the documented single source of truth. Null-safe, and it fixes a correctness bug sitting in the same four lines: the card showed the **first** candidate's dose/water/time/grind even when a different candidate was brewed — the exact bug class PRs #193/#198 removed everywhere else.
- **`Recommendation.primaryMethod` / `primaryRecipe` are now optional**, so the type describes what a stored row can actually hold and `tsc` rejects a new unguarded deref. Everything else type-checks unchanged, which confirms the single-offender finding.
- **Four regression cases** in `tests/dataflow/resolve.test.mjs` for the degenerate stored shapes.

## Verification

Reproduced the crash locally against a seeded Postgres (all 22 migrations applied) and drove the real app with a headless mobile browser, capturing uncaught exceptions — 8 stored-session shapes:

| shape | before | after |
|---|---|---|
| full recommendation + grind | ok | ok |
| full, no grind logged | ok | ok |
| **candidates-only** | ❌ crash | ok |
| **empty recommendation `{}`** | ❌ crash | ok |
| **candidates-only, no brew block** | ❌ crash | ok |
| no recommendation (café visit) | ok | ok |
| recommendation, brew null | ok | ok |
| no result | ok | ok |

Full route sweep (`/`, `/coffees`, `/coffees/[id]` ×2, `/brew/[id]` ×3, `/taste`, `/cafes`, `/brew/new`, `/past-conversations`) clean with the crashing shape present, plus the brew flow across 5 recipe shapes × 4 steps.

`npx tsc --noEmit` clean · `node --test` 261/261 · recipe corpus 0 warnings.

## Noted, not fixed here

`/coffees` logs a hydration warning — a `<button>` nested inside a `<button>` via `LightStarRating`. Pre-existing and unrelated to this crash, so it's left out of a surgical fix. Happy to take it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KyphSr46b1ofBjpWip1Dx4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KyphSr46b1ofBjpWip1Dx4)_