### PR TITLE
feat: variety, region and roast level as first-class coffee columns

### DIFF
--- a/.github/migrate
+++ b/.github/migrate
@@ -1,2 +1,1 @@
-0022_set_la_cabra_terra_blend.sql
-# re-fire dfec30f
+0023_add_coffee_variety_region_roast.sql

--- a/src/lib/db/migrations/0023_add_coffee_variety_region_roast.sql
+++ b/src/lib/db/migrations/0023_add_coffee_variety_region_roast.sql
@@ -1,0 +1,131 @@
+-- Migration 0023 — variety, region and roast level as first-class coffee columns.
+--
+-- THE GAP: `coffees` carried roaster/name/origin/process but NOT variety,
+-- region or roast level. Those three lived ONLY inside a session's `coffee`
+-- JSONB, so a coffee could not describe itself without a brew attached to it.
+-- Consequences that were live in the app:
+--   * /coffees "Brew this" hardcoded roastLevel: "Light" because the row had no
+--     roast level to read (src/app/(light)/coffees/page.tsx).
+--   * src/lib/claude/coffeeInsight.ts had to dig variety/roast/region out of the
+--     latest session instead of reading the coffee.
+--   * /recommend's getVarietyPriorsForBag() got `undefined` for any brew started
+--     from the library, so variety priors never reached the recipe prompt.
+--   * A coffee added WITHOUT a session (the new chat "add to library" path) had
+--     nowhere to put SL28/SL34 or Nyeri at all.
+--
+-- BACKWARDS COMPATIBLE BY CONSTRUCTION: all three columns are nullable and every
+-- consumer keeps its existing "read the latest session" path as the preferred
+-- source, falling back to these columns only when there is no session carrying
+-- the field. Nothing that works today starts reading differently.
+--
+-- BACKFILL SAFETY (the DB hard rule — never a broad overwrite):
+--   * Each UPDATE is gated on `c.<col> IS NULL`, so a value already present is
+--     never touched. Re-running the migration is a no-op.
+--   * Rows are matched by the coffee's OWN primary key, reconstructed from the
+--     session identity with the exact same slug function that generates it in
+--     src/app/api/sessions/route.ts (lower + non-[a-z0-9] -> "_"). That is the
+--     definition of the coffee<->session relationship, so it cannot bind the
+--     wrong row.
+--   * Per column we take the most recent session that ACTUALLY CARRIES that
+--     field — not simply the newest session. A "Brew Again" save carries no scan
+--     identity, so newest-session-wins would blank out a variety the original
+--     scan established. Same reasoning as the tastingNotesFromBag lookup in
+--     /api/coffees/[id].
+--   * Every step RAISEs the row count it changed, so the workflow run log shows
+--     exactly what moved.
+--   * ZERO rows is a no-op, never an error — the CI screenshots job applies
+--     every migration to an empty throwaway Postgres (this is what red-lined the
+--     run on migration 0022).
+--
+-- Applied via the push-triggered runner (.github/migrate) or the manual
+-- "Run SQL Migration" workflow. MUST run before the code that reads these
+-- columns deploys — Drizzle is column-strict and would 500 every coffee read.
+
+ALTER TABLE coffees ADD COLUMN IF NOT EXISTS variety     text;
+ALTER TABLE coffees ADD COLUMN IF NOT EXISTS region      text;
+ALTER TABLE coffees ADD COLUMN IF NOT EXISTS roast_level text;
+
+DO $$
+DECLARE
+  n_total   int;
+  n_variety int;
+  n_region  int;
+  n_roast   int;
+BEGIN
+  SELECT count(*) INTO n_total FROM coffees;
+  RAISE NOTICE 'coffees rows before backfill: %', n_total;
+
+  IF n_total = 0 THEN
+    RAISE NOTICE 'No coffees — nothing to backfill (skipping)';
+    RETURN;
+  END IF;
+
+  -- Variety
+  UPDATE coffees c
+  SET variety = sub.val
+  FROM (
+    SELECT DISTINCT ON (s.coffee_key) s.coffee_key, s.val
+    FROM (
+      SELECT
+        regexp_replace(
+          lower(concat(se.coffee->>'roaster', '__', se.coffee->>'name')),
+          '[^a-z0-9]', '_', 'g'
+        ) AS coffee_key,
+        NULLIF(btrim(se.coffee->>'variety'), '') AS val,
+        se.created_at_ms
+      FROM sessions se
+    ) s
+    WHERE s.val IS NOT NULL
+    ORDER BY s.coffee_key, s.created_at_ms DESC
+  ) sub
+  WHERE c.id = sub.coffee_key AND c.variety IS NULL;
+  GET DIAGNOSTICS n_variety = ROW_COUNT;
+  RAISE NOTICE 'variety backfilled on % row(s)', n_variety;
+
+  -- Region
+  UPDATE coffees c
+  SET region = sub.val
+  FROM (
+    SELECT DISTINCT ON (s.coffee_key) s.coffee_key, s.val
+    FROM (
+      SELECT
+        regexp_replace(
+          lower(concat(se.coffee->>'roaster', '__', se.coffee->>'name')),
+          '[^a-z0-9]', '_', 'g'
+        ) AS coffee_key,
+        NULLIF(btrim(se.coffee->>'region'), '') AS val,
+        se.created_at_ms
+      FROM sessions se
+    ) s
+    WHERE s.val IS NOT NULL
+    ORDER BY s.coffee_key, s.created_at_ms DESC
+  ) sub
+  WHERE c.id = sub.coffee_key AND c.region IS NULL;
+  GET DIAGNOSTICS n_region = ROW_COUNT;
+  RAISE NOTICE 'region backfilled on % row(s)', n_region;
+
+  -- Roast level
+  UPDATE coffees c
+  SET roast_level = sub.val
+  FROM (
+    SELECT DISTINCT ON (s.coffee_key) s.coffee_key, s.val
+    FROM (
+      SELECT
+        regexp_replace(
+          lower(concat(se.coffee->>'roaster', '__', se.coffee->>'name')),
+          '[^a-z0-9]', '_', 'g'
+        ) AS coffee_key,
+        NULLIF(btrim(se.coffee->>'roastLevel'), '') AS val,
+        se.created_at_ms
+      FROM sessions se
+    ) s
+    WHERE s.val IS NOT NULL
+    ORDER BY s.coffee_key, s.created_at_ms DESC
+  ) sub
+  WHERE c.id = sub.coffee_key AND c.roast_level IS NULL;
+  GET DIAGNOSTICS n_roast = ROW_COUNT;
+  RAISE NOTICE 'roast_level backfilled on % row(s)', n_roast;
+
+  SELECT count(*) INTO n_total FROM coffees WHERE variety IS NOT NULL;
+  RAISE NOTICE 'coffees with a variety after backfill: %', n_total;
+END $$;


### PR DESCRIPTION
Migration 0023. Ships **alone, ahead of the code that reads these columns** — Drizzle is column-strict, so the columns must exist on the VPS before any select mentions them.

## The gap

`coffees` carried roaster/name/origin/process but **not** variety, region or roast level. Those three only ever lived inside a session's `coffee` JSONB, so a coffee could not describe itself without a brew attached to it. Live consequences:

- `/coffees` "Brew this" hardcodes `roastLevel: "Light"` because the row has no roast level to read.
- `src/lib/claude/coffeeInsight.ts` has to dig variety/roast/region out of the latest session.
- `/recommend`'s `getVarietyPriorsForBag()` gets `undefined` for any brew started from the library, so variety priors never reach the recipe prompt.
- A coffee added *without* a session — the chat "add to library" path being built next — has nowhere to put SL28/SL34 or Nyeri at all.

## What this does

Adds three nullable columns and backfills them from existing sessions.

Per column the backfill takes the most recent session that **actually carries that field**, not simply the newest. A Brew-Again save carries no scan identity, so newest-session-wins would blank out a variety the original scan established — the same reasoning as the `tastingNotesFromBag` lookup in `/api/coffees/[id]`.

Backwards compatible by construction: every consumer keeps its current "read the latest session" path as the preferred source and falls back to these columns only when no session carries the field. Nothing that works today starts reading differently.

## Backfill safety

- Every `UPDATE` is gated on `c.<col> IS NULL` — a value already present is never touched, and a re-run is a no-op.
- Rows are matched by the coffee's own primary key, reconstructed with the exact slug function that generates it in the sessions route, so it cannot bind the wrong row.
- Each step `RAISE`s the row count it changed, so the run log shows exactly what moved.
- Zero rows is a no-op, never an error — the CI screenshots job applies every migration to an empty throwaway Postgres, which is what red-lined the run on 0022.

## Verification

Ran against a throwaway Postgres 16 with all migrations applied in order:

| Case | Result |
|---|---|
| Empty database (the CI case) | all migrations apply clean |
| Coffee whose older *scan* session has variety and whose newer Brew-Again session does not | takes the scan's `Pink Bourbon` / `Huila` / `Light` — the trap avoided |
| Coffee with only a roast level in its sessions | `roast_level` set, variety and region stay NULL |
| Coffee with no sessions at all | stays NULL |
| Hand-corrected value, migration re-run | value survives, all three steps report `0 row(s)` |

The SQL slug was checked byte-for-byte against the JS one on `DAK Coffee Roasters`, `Rösterei Vier / The Commonage` / `Süßhang`, `Rolf's 4:6` and `Quiquira — Lot #3` — identical, umlauts and ß included.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xa9FQMFKubt6ptbiYmnV6n)_