### PR TITLE
fix: screens could be dragged sideways and snapped back

### DIFF
--- a/src/app/(light)/past-conversations/page.tsx
+++ b/src/app/(light)/past-conversations/page.tsx
@@ -84,7 +84,9 @@ export default function PastConversationsPage() {
           </button>
         </header>
 
-        <section className="flex-1 min-h-0 overflow-y-auto px-5 py-5">
+        {/* scroll-y-only: `overflow-y-auto` alone promotes the x-axis from
+            `visible` to `auto`, which made this list draggable sideways. */}
+        <section className="scroll-y-only flex-1 min-h-0 overflow-y-auto px-5 py-5">
           {loading ? (
             <p className="font-chivo text-[15px] text-light-muted-foreground">Loading…</p>
           ) : rows.length === 0 ? (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -94,6 +94,30 @@
     overscroll-behavior: none;
   }
 
+  /* Vertical scrollers that must never pan sideways.
+   *
+   * A box with `overflow-y: auto` and nothing said about x does NOT keep
+   * `overflow-x: visible` — CSS promotes the visible axis to `auto` whenever
+   * the other one scrolls. So every `overflow-y-auto` box in the app was
+   * silently a HORIZONTAL scroll container too, and on iOS a finger could drag
+   * it and it snapped back on release. That was the Past Conversations list
+   * sliding under its own header.
+   *
+   * `overflow-x: hidden` is the fix here and can't be improved by `clip`:
+   * per spec `clip` computes back to `hidden` when the other axis scrolls
+   * (measured — the computed value really does come back `hidden`), so it
+   * would be a no-op dressed up as a fix.
+   *
+   * This only removes an axis that was never meant to scroll; nothing about
+   * painting or vertical scrolling changes. Anything that genuinely needs
+   * horizontal scrolling (the chip carousels) is a separate element and is
+   * untouched.
+   */
+  .scroll-y-only {
+    overflow-x: hidden;
+    overscroll-behavior-x: none;
+  }
+
   /* Light System v1.0 hybrid-repo override.
    *
    * The root layout sets body bg = #0E0B0A so every Dark route renders on

--- a/src/components/layout/ScrollContainer.tsx
+++ b/src/components/layout/ScrollContainer.tsx
@@ -36,7 +36,15 @@ export default function ScrollContainer({ children }: { children: React.ReactNod
       style={{
         height: "100dvh",
         overflowY: "auto",
+        // Hides the axis, but note this box is STILL a horizontal scroll
+        // container — WebKit will let a finger drag it if anything inside
+        // exceeds the width. So the real defence is upstream: nothing may
+        // extend past the viewport (see CTAWarmth, which used to bleed ~50px
+        // beyond it and made the brew screens draggable).
         overflowX: "hidden",
+        // Stops a horizontal drag from rubber-banding here or chaining to the
+        // page behind it.
+        overscrollBehaviorX: "none",
       }}
       className="[&::-webkit-scrollbar]:hidden"
     >

--- a/src/components/ui/light/CTAWarmth.tsx
+++ b/src/components/ui/light/CTAWarmth.tsx
@@ -14,12 +14,23 @@
  * Positioned ABSOLUTE inside a `relative` CTA wrapper (not page-level).
  * The wrapper's relative + this layer's absolute keep the warmth glued
  * to the CTA when the CTA scrolls (§8 hybrid gradient scroll).
+ *
+ * HORIZONTAL BLEED IS EXACTLY THE PAGE GUTTER (`-inset-x-5` cancels the
+ * container's `px-5`), i.e. edge to edge and not one pixel further. It used to
+ * be `inset-x-[-20%]`, which pushed ~50px BEYOND the viewport on a phone. Those
+ * pixels were never visible — the viewport clipped them — but they made the
+ * root scroll container 440px wide against a 390px screen, and a scroll
+ * container with hidden overflow is still draggable in WebKit. That is what let
+ * the brew/recommend screens be dragged sideways and snap back ("the page moves
+ * by itself"). Keep this flush with the gutter: the warmth must reach the screen
+ * edges, never extend past them. The container is capped at max-w-[430px], so
+ * on a wide screen this spans the container, not the window.
  */
 export default function CTAWarmth() {
   return (
     <div
       aria-hidden
-      className="pointer-events-none absolute inset-x-[-20%] -bottom-10 -top-16 -z-10"
+      className="pointer-events-none absolute -inset-x-5 -bottom-10 -top-16 -z-10"
       style={{
         background:
           "radial-gradient(ellipse at 50% 100%, hsl(12 88% 66% / 0.85) 0%, hsl(18 82% 74% / 0.5) 35%, transparent 70%)",

--- a/src/components/ui/light/ChatThread.tsx
+++ b/src/components/ui/light/ChatThread.tsx
@@ -115,7 +115,7 @@ export default function ChatThread({ messages, loading }: ChatThreadProps) {
     <div
       ref={scrollRef}
       onScroll={handleScroll}
-      className="h-full overflow-y-auto [-webkit-mask-image:linear-gradient(to_bottom,transparent_0,black_80px)] [mask-image:linear-gradient(to_bottom,transparent_0,black_80px)]"
+      className="scroll-y-only h-full overflow-y-auto [-webkit-mask-image:linear-gradient(to_bottom,transparent_0,black_80px)] [mask-image:linear-gradient(to_bottom,transparent_0,black_80px)]"
     >
       <div className="flex min-h-full flex-col justify-end">
         <div className="flex w-full flex-col gap-3 px-5 py-5">

--- a/src/components/ui/light/ReferenceCoffeePicker.tsx
+++ b/src/components/ui/light/ReferenceCoffeePicker.tsx
@@ -86,7 +86,7 @@ export default function ReferenceCoffeePicker({
           />
         </div>
 
-        <div className="flex-1 overflow-y-auto px-5 py-3 pb-[max(1rem,env(safe-area-inset-bottom))]">
+        <div className="scroll-y-only flex-1 overflow-y-auto px-5 py-3 pb-[max(1rem,env(safe-area-inset-bottom))]">
           {filtered.length === 0 ? (
             <p className="py-6 text-center font-chivo text-[13px] text-light-muted-foreground">
               No matching coffees


### PR DESCRIPTION
Reported: some screens aren't fixed in view — they can be moved sideways and jump back — and the brew timer / recommend screen sometimes moves by itself.

Two separate causes. Both measured in a real browser, not guessed.

## 1. The brew and recommend screens genuinely overflowed

`CTAWarmth` bled 20% past each side of its container **by design** — about **50px beyond the screen** on a phone. Those pixels were never visible; the viewport clipped them. But they made the root scroll container **440px wide against a 390px screen**.

The trap: `overflow-x: hidden` does not mean "not scrollable". It makes the box a scroll container on that axis and only hides the scrollbar — WebKit will happily let a finger drag it, and it rubber-bands back on release. That is the "moves by itself / jumps" behaviour, and it appears on exactly the screens that have a CTA.

The bleed is now exactly the page gutter (`-inset-x-5`): edge to edge, not one pixel further. The container is capped at `max-w-[430px]`, so on a wide screen it spans the container rather than the window.

```
before   scrollWidth 440 / clientWidth 390 → scrollLeft could be driven to 50
after    scrollWidth 390 / clientWidth 390 → scrollLeft stays 0
```

## 2. Past Conversations slid under its own header

A box with `overflow-y: auto` does **not** keep `overflow-x: visible` — CSS promotes the visible axis to `auto` whenever the other one scrolls. So every `overflow-y-auto` box in the app was quietly a horizontal scroll container as well. That's the list in the screenshot sliding while the header stayed put.

Added a `.scroll-y-only` helper (`overflow-x: hidden` + `overscroll-behavior-x: none`) and applied it to the three such boxes: the Past Conversations list, `ChatThread`, and `ReferenceCoffeePicker`.

## Two fixes I tried and rejected

- **`overflow-x: clip`** looked tidier and is a no-op here: per spec it computes back to `hidden` when the other axis scrolls. The probe confirmed the computed value really does come back `hidden`, so it would have been a fix in name only.
- **A blanket `touch-action: pan-y`** on the scroll container would have stopped the drag, but `touch-action` intersects down the ancestor chain — it would have broken the horizontal chip carousels on the recommend, log and café screens.

## Verification

A headless-Chromium probe at 320/375/390/430px enumerated every element whose computed `overflow-x` is `auto`/`scroll`, and drove `scrollLeft` to check real pannability.

| | before | after |
|---|---|---|
| `/past-conversations` | section pannable (`overflow-x: auto`) | none |
| brew step | `#app-scroll` pans 50px | 0 |
| recommend step | `#app-scroll` pans 50px | 0 |
| `/`, `/coffees`, `/taste`, `/cafes` | none | none |

**Visual check:** before/after screenshots of the recommend screen differ by at most **5/255 on one channel across 0.7% of pixels**, at the extreme left edge — the glow is a hair tighter and nothing else moved.

`tsc` clean, 221/221 tests pass, `next build` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xa9FQMFKubt6ptbiYmnV6n)_