### PR TITLE
fix: a chat-added bag lands with its photo

### DIFF
--- a/src/app/(light)/page.tsx
+++ b/src/app/(light)/page.tsx
@@ -10,6 +10,7 @@ import { useVoicePlayback } from "@/hooks/useVoicePlayback";
 import { useFlowStore } from "@/store/flowStore";
 import type { Session } from "@/lib/types/session";
 import type { NavAction } from "@/app/api/explore-agent/route";
+import { lastAttachedPhoto } from "@/lib/chat/addCoffee";
 
 // Extract the first complete sentence from the front of `buf`. "Complete" =
 // terminating punctuation (`.!?` or newline) followed by whitespace. We deny
@@ -257,6 +258,16 @@ export default function HomePage() {
     setMessages(next);
     setLoading(true);
 
+    // The bag photo almost never arrives on the same turn as the add — the
+    // chat asks for the roast date first — so the server has no
+    // `attachedImageUrl` to hand over and bags landed with no picture.
+    // See lastAttachedPhoto().
+    const lastPhotoUrl = lastAttachedPhoto(next);
+    const withBagPhoto = (a: NavAction): NavAction =>
+      a.destination === "add_coffee" && a.coffee && !a.coffee.bagPhotoUrl && lastPhotoUrl
+        ? { ...a, coffee: { ...a.coffee, bagPhotoUrl: lastPhotoUrl } }
+        : a;
+
     // Persist the user message in parallel with the agent request.
     void persistMessage("user", text, {
       ...(imageUrl ? { imageUrl } : {}),
@@ -378,13 +389,14 @@ export default function HomePage() {
             try {
               const payload = JSON.parse(data) as { actions?: NavAction[] };
               if (payload.actions && payload.actions.length > 0) {
-                assistantActions = payload.actions;
+                const actions = payload.actions.map(withBagPhoto);
+                assistantActions = actions;
                 setMessages((prev) => {
                   const copy = prev.slice();
                   const lastIdx = copy.length - 1;
                   const last = copy[lastIdx];
                   if (last?.role === "assistant") {
-                    copy[lastIdx] = { ...last, actions: payload.actions };
+                    copy[lastIdx] = { ...last, actions };
                   }
                   return copy;
                 });

--- a/src/app/api/explore-agent/route.ts
+++ b/src/app/api/explore-agent/route.ts
@@ -152,7 +152,7 @@ Hard rules:
 - The bag has **no id until it is added**. So in the same turn, do NOT call remember_advice, coffee_detail, or start_brew for it — you have no id to pass and the button would do nothing. If you have durable brewing guidance for it, put it in this call's observation + suggestion instead: the same tap saves it as that coffee's coach note, and the recipe builder reads it from then on.
 - Once the bag is added it behaves like any other library bag — the user can ask for a recipe next turn and you'll have its id.
 
-Do NOT call it for: a coffee they're merely curious about or considering buying, a café's coffee they drank out, or anything already in the Coffee Library block (link to it with coffee_detail instead).
+Do NOT call it for: a coffee they're merely curious about or considering buying, or a café's coffee they drank out. For a bag that IS already in the library, link to it with coffee_detail — with ONE exception: if the user is supplying something that bag is missing (its photo, a roast date, the variety), call add_coffee again with what you now know. Adding an existing bag only ever FILLS BLANKS — it never overwrites anything already recorded — so it is the safe way to complete a half-filled entry.
 
 ## When to call remember_advice
 

--- a/src/lib/chat/addCoffee.ts
+++ b/src/lib/chat/addCoffee.ts
@@ -59,6 +59,33 @@ export function buildNewCoffeePayload(
   };
 }
 
+/** Minimal shape of a chat message for photo lookup. */
+interface MessageLike {
+  role: string;
+  imageUrl?: string;
+}
+
+/**
+ * The bag photo for an `add_coffee` action, taken from the conversation rather
+ * than the current turn.
+ *
+ * The server can only attach the photo sent on the SAME turn as the tool call,
+ * and that is almost never the turn that adds: the chat is instructed to ask
+ * for the roast date first, so the add pill is offered a turn or two after the
+ * photo. The result was bags landing in the library with no picture. The most
+ * recent photo in the thread is the bag being discussed.
+ *
+ * Only ever FILLS a missing photo — a bagPhotoUrl the server already set (the
+ * same-turn case) wins.
+ */
+export function lastAttachedPhoto(messages: MessageLike[]): string | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m.role === "user" && m.imageUrl) return m.imageUrl;
+  }
+  return undefined;
+}
+
 /**
  * A coach note only exists when the model supplied BOTH halves — an
  * observation with no suggestion is a statement, not advice, and would write a

--- a/tests/dataflow/chat-add-coffee.test.mjs
+++ b/tests/dataflow/chat-add-coffee.test.mjs
@@ -31,7 +31,7 @@ const ROOT = process.cwd();
 const entry = `
 export { coffeeKeyFor } from ${JSON.stringify(path.join(ROOT, "src/lib/coffee/coffeeKey.ts"))};
 export { guardRoastYear } from ${JSON.stringify(path.join(ROOT, "src/lib/coffee/roastDate.ts"))};
-export { buildNewCoffeePayload, coachNoteFrom } from ${JSON.stringify(
+export { buildNewCoffeePayload, coachNoteFrom, lastAttachedPhoto } from ${JSON.stringify(
   path.join(ROOT, "src/lib/chat/addCoffee.ts"),
 )};
 `;
@@ -45,9 +45,8 @@ await build({
   outfile: out,
   logLevel: "silent",
 });
-const { coffeeKeyFor, guardRoastYear, buildNewCoffeePayload, coachNoteFrom } = await import(
-  pathToFileURL(out).href
-);
+const { coffeeKeyFor, guardRoastYear, buildNewCoffeePayload, coachNoteFrom, lastAttachedPhoto } =
+  await import(pathToFileURL(out).href);
 
 // The expression POST /api/sessions used inline before it was extracted. If
 // coffeeKeyFor ever stops matching this, chat-added bags fork duplicate rows.
@@ -176,6 +175,38 @@ test("coachNoteFrom requires both halves", () => {
   assert.equal(note.observation, "Currant Mood is a Kenyan natural.");
   assert.equal(note.suggestion, "Brew at 92–93°C.");
   assert.deepEqual(note.citationFields, ["origin", "process"]);
+});
+
+// The bag photo is attached a turn or two BEFORE the add, because the chat is
+// told to ask for the roast date first. The first shipped version only used the
+// current turn's attachment, so a real add landed in the library with no photo.
+test("lastAttachedPhoto finds the bag photo from an earlier turn", () => {
+  const thread = [
+    { role: "user", content: "What do you think of this DAK?", imageUrl: "https://cdn/bag.jpg" },
+    { role: "assistant", content: "DAK Coffee Roasters — Currant Mood…" },
+    { role: "user", content: "Roasted 30 July. Add it." },
+    { role: "assistant", content: "Ready to add." },
+  ];
+  assert.equal(lastAttachedPhoto(thread), "https://cdn/bag.jpg");
+});
+
+test("lastAttachedPhoto takes the MOST RECENT photo, not the first", () => {
+  const thread = [
+    { role: "user", content: "this one?", imageUrl: "https://cdn/old.jpg" },
+    { role: "assistant", content: "…" },
+    { role: "user", content: "and this one", imageUrl: "https://cdn/new.jpg" },
+  ];
+  assert.equal(lastAttachedPhoto(thread), "https://cdn/new.jpg");
+});
+
+test("lastAttachedPhoto ignores assistant messages and empty threads", () => {
+  assert.equal(lastAttachedPhoto([]), undefined);
+  assert.equal(lastAttachedPhoto([{ role: "user", content: "no photo here" }]), undefined);
+  // An assistant message carrying an image must never become the bag photo.
+  assert.equal(
+    lastAttachedPhoto([{ role: "assistant", content: "x", imageUrl: "https://cdn/nope.jpg" }]),
+    undefined,
+  );
 });
 
 test("guardRoastYear pulls an ambiguous month/day stamp into the current year", () => {


### PR DESCRIPTION
Reported with screenshots: the DAK Currant Mood added from the chat shows a placeholder on the library card and on the detail page — no bag photo, even though the photo was in the conversation.

## Cause — a flaw in the feature's own design

`add_coffee` is instructed to **ask for the roast date first**, so the add pill is offered a turn or two *after* the photo was sent. The server can only attach the image from the same turn as the tool call (`attachedImageUrl`), and by then there isn't one — so `bagPhotoUrl` was empty almost every time.

The one case that would have worked (adding in the same message as the photo) is precisely the case the prompt discourages. So the two rules fought each other, and the photo lost.

## Fix

The client has the whole thread, so it fills the gap. `lastAttachedPhoto()` takes the most recent **user** photo in the conversation — the bag being discussed — and it only ever **fills a missing** photo: a same-turn photo the server already attached still wins.

Also relaxes one prompt rule: the chat may now re-add a bag that is **already** in the library when the user supplies something it's missing. The create merges and fills blanks only — it never overwrites — so re-adding with the photo is how an already-added bag gets its picture. Without this there is no way to repair a half-filled entry from the chat at all, which matters right now because Currant Mood is already in the library without its photo.

**To fix the existing bag:** send the photo again and ask to add Currant Mood. The merge fills the blank photo and leaves everything else exactly as it is.

## Verification

`tsc` clean, **224/224** tests pass (3 new). The new tests cover the exact failure rather than the happy path:

- photo sent on an earlier turn is still found at add time
- the most recent photo wins over an older one in the same thread
- an assistant-side image is never mistaken for the bag photo
- no photo anywhere → still `undefined`, never a broken URL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xa9FQMFKubt6ptbiYmnV6n)_